### PR TITLE
Use double-quotes instead of single-quotes in warnings

### DIFF
--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -162,7 +162,7 @@ class Gem::SpecificationPolicy
       if prev = seen[dep.type][dep.name]
         error_messages << <<-MESSAGE
 duplicate dependency on #{dep}, (#{prev.requirement}) use:
-    add_#{dep.type}_dependency '#{dep.name}', '#{dep.requirement}', '#{prev.requirement}'
+    add_#{dep.type}_dependency \"#{dep.name}\", \"#{dep.requirement}\", \"#{prev.requirement}\"
         MESSAGE
       end
 
@@ -205,16 +205,16 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
       base = segments.first 2
 
       recommendation = if [">", ">="].include?(op) && segments == [0]
-        "  use a bounded requirement, such as '~> x.y'"
+        "  use a bounded requirement, such as \"~> x.y\""
       else
         bugfix = if op == ">"
-          ", '> #{dep_version}'"
+          ", \"> #{dep_version}\""
         elsif op == ">=" && base != segments
-          ", '>= #{dep_version}'"
+          ", \">= #{dep_version}\""
         end
 
         "  if #{dep.name} is semantically versioned, use:\n" \
-        "    add_#{dep.type}_dependency '#{dep.name}', '~> #{base.join "."}'#{bugfix}"
+        "    add_#{dep.type}_dependency \"#{dep.name}\", \"~> #{base.join "."}\"#{bugfix}"
       end
 
       warning_messages << ["open-ended dependency on #{dep} is not recommended", recommendation].join("\n") + "\n"

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2610,18 +2610,18 @@ end
 #{w}:  prerelease dependency on c (>= 2.0.rc2, development) is not recommended
 #{w}:  open-ended dependency on i (>= 1.2) is not recommended
   if i is semantically versioned, use:
-    add_runtime_dependency 'i', '~> 1.2'
+    add_runtime_dependency "i", "~> 1.2"
 #{w}:  open-ended dependency on j (>= 1.2.3) is not recommended
   if j is semantically versioned, use:
-    add_runtime_dependency 'j', '~> 1.2', '>= 1.2.3'
+    add_runtime_dependency "j", "~> 1.2", ">= 1.2.3"
 #{w}:  open-ended dependency on k (> 1.2) is not recommended
   if k is semantically versioned, use:
-    add_runtime_dependency 'k', '~> 1.2', '> 1.2'
+    add_runtime_dependency "k", "~> 1.2", "> 1.2"
 #{w}:  open-ended dependency on l (> 1.2.3) is not recommended
   if l is semantically versioned, use:
-    add_runtime_dependency 'l', '~> 1.2', '> 1.2.3'
+    add_runtime_dependency "l", "~> 1.2", "> 1.2.3"
 #{w}:  open-ended dependency on o (>= 0) is not recommended
-  use a bounded requirement, such as '~> x.y'
+  use a bounded requirement, such as "~> x.y"
 #{w}:  See https://guides.rubygems.org/specification-reference/ for help
       EXPECTED
 
@@ -2645,9 +2645,9 @@ end
 
         expected = <<-EXPECTED
 duplicate dependency on b (>= 1.2.3), (~> 1.2) use:
-    add_runtime_dependency 'b', '>= 1.2.3', '~> 1.2'
+    add_runtime_dependency "b", ">= 1.2.3", "~> 1.2"
 duplicate dependency on c (>= 1.2.3, development), (~> 1.2) use:
-    add_development_dependency 'c', '>= 1.2.3', '~> 1.2'
+    add_development_dependency "c", ">= 1.2.3", "~> 1.2"
         EXPECTED
 
         assert_equal expected, e.message


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Fix inconsistency usage warnings for `add_*_dependency`.

Fixes https://github.com/rubygems/rubygems.org/issues/3317

## What is your fix for the problem, implemented in this PR?

Replaced double quotes.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
