### PR TITLE
Fix resolver hangs when dealing with an incomplete lockfile

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -668,8 +668,16 @@ module Bundler
     def check_missing_lockfile_specs
       all_locked_specs = @locked_specs.map(&:name) << "bundler"
 
-      @locked_specs.any? do |s|
+      missing = @locked_specs.select do |s|
         s.dependencies.any? {|dep| !all_locked_specs.include?(dep.name) }
+      end
+
+      if missing.any?
+        @locked_specs.delete(missing)
+
+        true
+      else
+        false
       end
     end
 

--- a/bundler/lib/bundler/resolver/base.rb
+++ b/bundler/lib/bundler/resolver/base.rb
@@ -35,9 +35,7 @@ module Bundler
       end
 
       def delete(specs)
-        specs.each do |spec|
-          @base.delete(spec)
-        end
+        @base.delete(specs)
       end
 
       def get_package(name)

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -63,8 +63,8 @@ module Bundler
       @sorted = nil
     end
 
-    def delete(spec)
-      @specs.delete(spec)
+    def delete(specs)
+      specs.each {|spec| @specs.delete(spec) }
       @lookup = nil
       @sorted = nil
     end

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -1008,6 +1008,29 @@ RSpec.describe "bundle lock" do
           So, because Gemfile depends on rails >= 7.0.2.3,
             version solving has failed.
     ERR
+
+    lockfile lockfile.gsub(/PLATFORMS\n  #{lockfile_platforms}/m, "PLATFORMS\n  #{lockfile_platforms("ruby")}")
+
+    bundle "lock", :raise_on_error => false
+
+    expect(err).to eq <<~ERR.strip
+      Could not find compatible versions
+
+      Because rails >= 7.0.3.1, < 7.0.4 depends on activemodel = 7.0.3.1
+        and rails >= 7.0.2.3, < 7.0.3.1 depends on activemodel = 7.0.2.3,
+        rails >= 7.0.2.3, < 7.0.4 requires activemodel = 7.0.2.3 OR = 7.0.3.1.
+      And because every version of activemodel depends on activesupport = 6.0.4,
+        rails >= 7.0.2.3, < 7.0.4 requires activesupport = 6.0.4.
+      Because rails >= 7.0.3.1, < 7.0.4 depends on activesupport = 7.0.3.1
+        and rails >= 7.0.2.3, < 7.0.3.1 depends on activesupport = 7.0.2.3,
+        rails >= 7.0.2.3, < 7.0.4 requires activesupport = 7.0.2.3 OR = 7.0.3.1.
+      Thus, rails >= 7.0.2.3, < 7.0.4 cannot be used.
+      And because rails >= 7.0.4 depends on activemodel = 7.0.4,
+        rails >= 7.0.2.3 requires activemodel = 7.0.4.
+      So, because activemodel = 7.0.4 could not be found in rubygems repository #{file_uri_for(gem_repo4)}/ or installed locally
+        and Gemfile depends on rails >= 7.0.2.3,
+        version solving has failed.
+    ERR
   end
 
   it "does not accidentally resolves to prereleases" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

While working on locking multiple platforms by default, I got an infinite resolution loop in one of our resolver specs.

The culprit ended up being that when dealing with lockfile specs with incomplete dependencies (spec appears in lockfile, but its dependencies don't), those specs were not being properly expired and that tripped up resolution.

The issue for some reason only manifests when dealing with multiple lockfile platforms, that's why it only manifested when working on locking multiple platforms by default.

## What is your fix for the problem, implemented in this PR?

Properly expire lockfile specs incomplete in the way explained above, so that resolver does not get confused.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
