### PR TITLE
Partly reverted rubocop rule at GH-6541 

### DIFF
--- a/bundler/lib/bundler/templates/newgem/rubocop.yml.tt
+++ b/bundler/lib/bundler/templates/newgem/rubocop.yml.tt
@@ -9,9 +9,5 @@ Style/StringLiteralsInInterpolation:
   Enabled: true
   EnforcedStyle: double_quotes
 
-Style/GlobalVars:
-  Exclude:
-    - ext/**/extconf.rb
-
 Layout/LineLength:
   Max: 120


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

#6541 added new rubocop template. After #6549, It's unnecessary now. 

## What is your fix for the problem, implemented in this PR?

Applied https://github.com/rubygems/rubygems/pull/6549#issuecomment-1484965287

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
