### PR TITLE
Add auto_install support to require "bundler/setup"

### DIFF
--- a/bundler/lib/bundler/setup.rb
+++ b/bundler/lib/bundler/setup.rb
@@ -5,6 +5,9 @@ require_relative "shared_helpers"
 if Bundler::SharedHelpers.in_bundle?
   require_relative "../bundler"
 
+  # try to auto_install first before we get to the `Bundler.ui.silence`, so user knows what is happening
+  Bundler.auto_install
+
   if STDOUT.tty? || ENV["BUNDLER_FORCE_TTY"]
     begin
       Bundler.ui.silence { Bundler.setup }

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1599,4 +1599,19 @@ end
     sys_exec "#{Gem.ruby} #{script}", raise_on_error: false
     expect(out).to include("requiring foo used the monkeypatch")
   end
+
+  it "performs an automatic bundle install" do
+    gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
+      gem "rack", :group => :test
+    G
+
+    bundle "config set auto_install 1"
+
+    ruby <<-RUBY
+      require 'bundler/setup'
+    RUBY
+    expect(err).to be_empty
+    expect(out).to include("Installing rack 1.0.0")
+  end
 end


### PR DESCRIPTION
We have some places that already use `bundle config auto_install true`, ie:

https://github.com/technicalpickles/rubygems/blob/7a144f3374f6a400cc9832f072dc1fc0bca8c724/bundler/lib/bundler/cli.rb#L11

This applies the same logic (copy and pasted) to happen when you `require "bundler/setup"`.

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

As described in https://github.com/rubygems/rubygems/issues/6242

> We work in a large monolith and gems get bumped all the time. This means I find myself bundle installing many times a day. And oftentimes, this is done after seeing a bunch of errors because, well my bundle is out of date.


<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?


@indirect suggested adding `auto_install` support to `require 'bundler/setup', so this is an attempt at that.

_edit_ updated to reflect current implementation

This PR adds a `Bundle.auto_install` to handle the logic of:
- checking that auto_install is configured
- try loading the specs to see if install is needed
- delegate to the `Bundler::CLI::Install` to do the actual installation

Existing uses of auto_install are updated to use this

The reason we settled on using `Bundler::CLI::Install` is because it has quite a bit of logic, including things like [updating the app cache](https://github.com/rubygems/rubygems/blob/7316186db83b87eaa1d6f81531515a5abb5b1f69/bundler/lib/bundler/cli/install.rb#L65-L67)

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
