### PR TITLE
Improve comment explaining the neccessity of `write_default_spec` method

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -461,6 +461,9 @@ class Gem::Installer
   ##
   # Writes the full .gemspec specification (in Ruby) to the gem home's
   # specifications/default directory.
+  #
+  # In contrast to #write_spec, this keeps file lists, so the `gem contents`
+  # command works.
 
   def write_default_spec
     Gem.write_binary(default_spec_file, spec.to_ruby)


### PR DESCRIPTION
The intention is not obvious from the commit log and it might avoid temptation to remove the method without further consideration.

This is extracted from #2909 to make that a bit lighter