### PR TITLE
Disabled to test rustc in msys2 platform

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1176,6 +1176,20 @@ Also, a list:
   end
 
   ##
+  # Is this test being run on a version of Ruby built with mingw?
+
+  def self.mingw_windows?
+    RUBY_PLATFORM.match("mingw")
+  end
+
+  ##
+  # Is this test being run on a version of Ruby built with mingw?
+
+  def mingw_windows?
+    RUBY_PLATFORM.match("mingw")
+  end
+
+  ##
   # Is this test being run on a ruby/ruby repository?
   #
 

--- a/test/rubygems/test_gem_ext_cargo_builder.rb
+++ b/test/rubygems/test_gem_ext_cargo_builder.rb
@@ -145,6 +145,7 @@ class TestGemExtCargoBuilder < Gem::TestCase
     system(@rust_envs, "cargo", "-V", out: IO::NULL, err: [:child, :out])
     pend "cargo not present" unless $?.success?
     pend "ruby.h is not provided by ruby repo" if ruby_repo?
+    pend "rust toolchain of mingw is broken" if mingw_windows?
   end
 
   def assert_ffi_handle(bundle, name)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

https://github.com/rubygems/rubygems/actions/runs/4598776839/jobs/8123290246

I have no idea to fix this in this repository. It may caused with upstream.

## What is your fix for the problem, implemented in this PR?

Disabled to install rust toolchain for msys2 platform.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
