### PR TITLE
Enable Performance/RegexpMatch cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,10 +48,6 @@ Naming/VariableNumber:
 
 Performance/RegexpMatch:
   Enabled: true
-  Exclude:
-    - Rakefile
-    - lib/**/*
-    - test/**/*
 
 # Style
 

--- a/Rakefile
+++ b/Rakefile
@@ -458,7 +458,7 @@ module Rubygems
 
       tracked_files.each do |path|
         next unless File.file?(path)
-        next if path =~ exclude
+        next if path&.match?(exclude)
         files << path
       end
 

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -795,7 +795,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     if @ruby.nil?
       @ruby = RbConfig.ruby
 
-      @ruby = "\"#{@ruby}\"" if @ruby =~ /\s/
+      @ruby = "\"#{@ruby}\"" if /\s/.match?(@ruby)
     end
 
     @ruby
@@ -1008,7 +1008,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
       # Skip older versions of the GemCutter plugin: Its commands are in
       # RubyGems proper now.
 
-      next if plugin =~ /gemcutter-0\.[0-3]/
+      next if /gemcutter-0\.[0-3]/.match?(plugin)
 
       begin
         load plugin

--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -457,7 +457,7 @@ class Gem::Command
     until extra.empty? do
       ex = []
       ex << extra.shift
-      ex << extra.shift if extra.first.to_s =~ /^[^-]/
+      ex << extra.shift if /^[^-]/.match?(extra.first.to_s)
       result << ex if handles?(ex)
     end
 

--- a/lib/rubygems/commands/unpack_command.rb
+++ b/lib/rubygems/commands/unpack_command.rb
@@ -151,7 +151,7 @@ command help for an example.
   # source directories?
 
   def get_path(dependency)
-    return dependency.name if dependency.name =~ /\.gem$/i
+    return dependency.name if /\.gem$/i.match?(dependency.name)
 
     specs = dependency.matching_specs
 
@@ -160,7 +160,7 @@ command help for an example.
     return Gem::RemoteFetcher.fetcher.download_to_cache(dependency) unless
       selected
 
-    return unless dependency.name =~ /^#{selected.name}$/i
+    return unless /^#{selected.name}$/i.match?(dependency.name)
 
     # We expect to find (basename).gem in the 'cache' directory.  Furthermore,
     # the name match must be exact (ignoring case).

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -483,7 +483,7 @@ if you believe they were disclosed to a third party.
 
     @hash.each do |key, value|
       key = key.to_s
-      next if key =~ re
+      next if key&.match?(re)
       yaml_hash[key.to_s] = value
     end
 
@@ -534,7 +534,7 @@ if you believe they were disclosed to a third party.
         need_config_file_name = false
       elsif arg =~ /^--config-file=(.*)/
         @config_file_name = $1
-      elsif arg =~ /^--config-file$/
+      elsif /^--config-file$/.match?(arg)
         need_config_file_name = true
       end
     end

--- a/lib/rubygems/dependency_installer.rb
+++ b/lib/rubygems/dependency_installer.rb
@@ -291,7 +291,7 @@ class Gem::DependencyInstaller
         src = Gem::Source::SpecificFile.new dep_or_name
         installer_set.add_local dep_or_name, src.spec, src
         version = src.spec.version if version == Gem::Requirement.default
-      elsif dep_or_name =~ /\.gem$/
+      elsif dep_or_name =~ /\.gem$/ # rubocop:disable Performance/RegexpMatch
         Dir[dep_or_name].each do |name|
           src = Gem::Source::SpecificFile.new name
           installer_set.add_local dep_or_name, src.spec, src

--- a/lib/rubygems/doctor.rb
+++ b/lib/rubygems/doctor.rb
@@ -111,7 +111,7 @@ class Gem::Doctor
 
       basename = File.basename(child, extension)
       next if installed_specs.include? basename
-      next if /^rubygems-\d/ =~ basename
+      next if /^rubygems-\d/.match?(basename)
       next if sub_directory == "specifications" && basename == "default"
       next if sub_directory == "plugins" && Gem.plugin_suffix_regexp =~ (basename)
 

--- a/lib/rubygems/ext/rake_builder.rb
+++ b/lib/rubygems/ext/rake_builder.rb
@@ -8,7 +8,7 @@
 
 class Gem::Ext::RakeBuilder < Gem::Ext::Builder
   def self.build(extension, dest_path, results, args=[], lib_dir=nil, extension_dir=Dir.pwd)
-    if File.basename(extension) =~ /mkrf_conf/i
+    if /mkrf_conf/i.match?(File.basename(extension))
       run([Gem.ruby, File.basename(extension), *args], results, class_name, extension_dir)
     end
 

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -230,7 +230,7 @@ class Gem::Installer
         end
       end
 
-      next unless line =~ shebang
+      next unless line&.match?(shebang)
 
       io.gets # blankline
 
@@ -717,7 +717,7 @@ class Gem::Installer
   end
 
   def verify_spec
-    unless spec.name =~ Gem::Specification::VALID_NAME_PATTERN
+    unless Gem::Specification::VALID_NAME_PATTERN.match?(spec.name)
       raise Gem::InstallError, "#{spec} has an invalid name"
     end
 
@@ -729,11 +729,11 @@ class Gem::Installer
       raise Gem::InstallError, "#{spec} has an invalid extensions"
     end
 
-    if spec.platform.to_s =~ /\R/
+    if /\R/.match?(spec.platform.to_s)
       raise Gem::InstallError, "#{spec.platform} is an invalid platform"
     end
 
-    unless spec.specification_version.to_s =~ /\A\d+\z/
+    unless /\A\d+\z/.match?(spec.specification_version.to_s)
       raise Gem::InstallError, "#{spec} has an invalid specification_version"
     end
 

--- a/lib/rubygems/local_remote_options.rb
+++ b/lib/rubygems/local_remote_options.rb
@@ -103,7 +103,7 @@ module Gem::LocalRemoteOptions
 
     add_option(:"Local/Remote", "-s", "--source URL", URI::HTTP,
                "Append URL to list of remote gem sources") do |source, options|
-      source << "/" if !/\/\z/.match?(source)
+      source << "/" unless source.end_with?("/")
 
       if options.delete :sources_cleared
         Gem.sources = [source]

--- a/lib/rubygems/local_remote_options.rb
+++ b/lib/rubygems/local_remote_options.rb
@@ -103,7 +103,7 @@ module Gem::LocalRemoteOptions
 
     add_option(:"Local/Remote", "-s", "--source URL", URI::HTTP,
                "Append URL to list of remote gem sources") do |source, options|
-      source << "/" if source !~ /\/\z/
+      source << "/" if !/\/\z/.match?(source)
 
       if options.delete :sources_cleared
         Gem.sources = [source]

--- a/lib/rubygems/package/tar_header.rb
+++ b/lib/rubygems/package/tar_header.rb
@@ -127,7 +127,7 @@ class Gem::Package::TarHeader
   end
 
   def self.strict_oct(str)
-    return str.strip.oct if str.strip =~ /\A[0-7]*\z/
+    return str.strip.oct if /\A[0-7]*\z/.match?(str.strip)
 
     raise ArgumentError, "#{str.inspect} is not an octal string"
   end
@@ -137,7 +137,7 @@ class Gem::Package::TarHeader
     # \ff flags a negative 256-based number
     # In case we have a match, parse it as a signed binary value
     # in big-endian order, except that the high-order bit is ignored.
-    return str.unpack("N2").last if str =~ /\A[\x80\xff]/n
+    return str.unpack("N2").last if /\A[\x80\xff]/n.match?(str)
     strict_oct(str)
   end
 

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -53,7 +53,7 @@ class Gem::PathSupport
       gem_path = gpaths.split(Gem.path_separator)
       # Handle the path_separator being set to a regexp, which will cause
       # end_with? to error
-      if gpaths =~ /#{Gem.path_separator}\z/
+      if /#{Gem.path_separator}\z/.match?(gpaths)
         gem_path += default_path
       end
 

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -14,7 +14,7 @@ class Gem::Platform
 
   def self.local
     arch = RbConfig::CONFIG["arch"]
-    arch = "#{arch}_60" if arch =~ /mswin(?:32|64)$/
+    arch = "#{arch}_60" if /mswin(?:32|64)$/.match?(arch)
     @local ||= new(arch)
   end
 

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -136,7 +136,7 @@ class Gem::RemoteFetcher
     scheme = source_uri.scheme
 
     # URI.parse gets confused by MS Windows paths with forward slashes.
-    scheme = nil if scheme =~ /^[a-z]$/i
+    scheme = nil if /^[a-z]$/i.match?(scheme)
 
     # REFACTOR: split this up and dispatch on scheme (eg download_http)
     # REFACTOR: be sure to clean up fake fetcher when you do this... cleaner

--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -247,7 +247,7 @@ class Gem::Resolver
 
     sources.each do |source|
       groups[source].
-        sort_by {|spec| [spec.version, spec.platform =~ Gem::Platform.local ? 1 : 0] }.
+        sort_by {|spec| [spec.version, spec.platform =~ Gem::Platform.local ? 1 : 0] }. # rubocop:disable Performance/RegexpMatch
         map {|spec| ActivationRequest.new spec, dependency }.
         each {|activation_request| activation_requests << activation_request }
     end

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -144,7 +144,7 @@ class Gem::SpecificationPolicy
       end
 
       next unless METADATA_LINK_KEYS.include? key
-      if value !~ VALID_URI_PATTERN
+      if !VALID_URI_PATTERN.match?(value)
         error "#{entry} has invalid link: #{value.inspect}"
       end
     end
@@ -279,11 +279,11 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
 
     if !name.is_a?(String)
       error "invalid value for attribute name: \"#{name.inspect}\" must be a string"
-    elsif name !~ /[a-zA-Z]/
+    elsif !/[a-zA-Z]/.match?(name)
       error "invalid value for attribute name: #{name.dump} must include at least one letter"
-    elsif name !~ VALID_NAME_PATTERN
+    elsif !VALID_NAME_PATTERN.match?(name)
       error "invalid value for attribute name: #{name.dump} can only include letters, numbers, dashes, and underscores"
-    elsif name =~ SPECIAL_CHARACTERS
+    elsif SPECIAL_CHARACTERS.match?(name)
       error "invalid value for attribute name: #{name.dump} can not begin with a period, dash, or underscore"
     end
   end
@@ -397,11 +397,11 @@ http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard li
       error "#{LAZY} is not an email"
     end
 
-    if @specification.description =~ LAZY_PATTERN
+    if LAZY_PATTERN.match?(@specification.description)
       error "#{LAZY} is not a description"
     end
 
-    if @specification.summary =~ LAZY_PATTERN
+    if LAZY_PATTERN.match?(@specification.summary)
       error "#{LAZY} is not a summary"
     end
 

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -144,7 +144,7 @@ class Gem::SpecificationPolicy
       end
 
       next unless METADATA_LINK_KEYS.include? key
-      if !VALID_URI_PATTERN.match?(value)
+      unless VALID_URI_PATTERN.match?(value)
         error "#{entry} has invalid link: #{value.inspect}"
       end
     end

--- a/lib/rubygems/uri_formatter.rb
+++ b/lib/rubygems/uri_formatter.rb
@@ -34,7 +34,7 @@ class Gem::UriFormatter
   # Normalize the URI by adding "http://" if it is missing.
 
   def normalize
-    @uri =~ /^(https?|ftp|file):/i ? @uri : "http://#{@uri}"
+    /^(https?|ftp|file):/i.match?(@uri) ? @uri : "http://#{@uri}"
   end
 
   ##

--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -405,7 +405,7 @@ class Gem::Version
     # since this version object is cached in @@all, its @segments should be frozen
 
     @segments ||= @version.scan(/[0-9]+|[a-z]+/i).map do |s|
-      /^\d+$/ =~ s ? s.to_i : s
+      /^\d+$/.match?(s) ? s.to_i : s
     end.freeze
   end
 

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1340,7 +1340,7 @@ Also, a list:
 
     def escape_path(*path)
       path = File.join(*path)
-      if %r{\A[-+:/=@,.\w]+\z} =~ path
+      if %r{\A[-+:/=@,.\w]+\z}.match?(path)
         path
       else
         "\"#{path.gsub(/[`$"]/, '\\&')}\""

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -52,7 +52,7 @@ install:
     assert_match %r{DESTDIR\\=#{ENV['DESTDIR']}$},         results
     assert_match %r{DESTDIR\\=#{ENV['DESTDIR']} install$}, results
 
-    if !/nmake/.match?(results)
+    unless /nmake/.match?(results)
       assert_match %r{^clean: destination$},   results
       assert_match %r{^all: destination$},     results
       assert_match %r{^install: destination$}, results

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -52,7 +52,7 @@ install:
     assert_match %r{DESTDIR\\=#{ENV['DESTDIR']}$},         results
     assert_match %r{DESTDIR\\=#{ENV['DESTDIR']} install$}, results
 
-    if /nmake/ !~ results
+    if !/nmake/.match?(results)
       assert_match %r{^clean: destination$},   results
       assert_match %r{^all: destination$},     results
       assert_match %r{^install: destination$}, results

--- a/test/rubygems/utilities.rb
+++ b/test/rubygems/utilities.rb
@@ -120,7 +120,7 @@ class Gem::FakeFetcher
     path = path.to_s
     @paths << path
 
-    raise ArgumentError, "need full URI" unless path =~ %r{^http://}
+    raise ArgumentError, "need full URI" unless %r{^http://}.match?(path)
 
     unless @data.key? path
       raise Gem::RemoteFetcher::FetchError.new("no data for #{path}", path)
@@ -141,7 +141,7 @@ class Gem::FakeFetcher
 
     path = File.join path, name
 
-    if source_uri =~ /^http/
+    if /^http/.match?(source_uri)
       File.open(path, "wb") do |f|
         f.write fetch_path(File.join(source_uri, "gems", name))
       end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We disabled Performance/RegexpMatch cop for RubyGems.

## What is your fix for the problem, implemented in this PR?

Enable Performance/RegexpMatch cop with files of RubyGems. We have some of `match?` methods under the `Gem` namespaces. I ignore `Performance/RegexpMatch` cop for them.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
