### PR TITLE
Don't need to use dtolnay/rust-toolchain for rustfmt for Windows

### DIFF
--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -41,11 +41,7 @@ jobs:
             os: { name: Ubuntu, value: ubuntu-22.04 }
 
           - os: { name: Windows, value: windows-2022 }
-            cargo: { target: x86_64-pc-windows-gnu, toolchain: stable }
-
-          - os: { name: Windows, value: windows-2022 }
             ruby: { name: mswin, value: mswin }
-            cargo: { target: x86_64-pc-windows-msvc, toolchain: stable }
 
     steps:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
@@ -62,12 +58,6 @@ jobs:
           bundler: none
           mingw: clang
         if: matrix.os.name == 'Windows'
-      - uses: dtolnay/rust-toolchain@fc3253060d0c959bea12a59f10f8391454a0b02d
-        with:
-          toolchain: ${{ matrix.cargo.toolchain }}-${{ matrix.cargo.target }}
-          components: rustfmt
-        if: matrix.cargo
-      # Taken from https://github.com/oxidize-rb/actions/blob/0d21ce09c5500315bc61815440f8c4211530f413/setup-ruby-and-rust/action.yml#LL300-L305C116
       - name: Configure bindgen
         shell: pwsh
         run: |


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Runner images of GitHub Actions have rustfmt. We shouldn't install ourselves if it works.

https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md#packages

## What is your fix for the problem, implemented in this PR?

Removed 3rd party setup actions.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
