### PR TITLE
Extract Windows CI of bundler for reducing waiting time of merge queue

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -8,7 +8,7 @@ concurrency:
   group: ci-${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
-permissions:  # added using https://github.com/step-security/secure-workflows
+permissions:
   contents: read
 
 defaults:
@@ -45,11 +45,6 @@ jobs:
           - { os: { name: macOS, value: macos-12 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.3 }, timeout: 90 }
           - { os: { name: macOS, value: macos-12 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.7 }, timeout: 90 }
           - { os: { name: macOS, value: macos-12 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.2, value: 3.2.1 }, timeout: 90 }
-
-          - { os: { name: Windows, value: windows-2022 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-2.7, value: 2.7.7 }, timeout: 150 }
-          - { os: { name: Windows, value: windows-2022 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.5 }, timeout: 150 }
-          - { os: { name: Windows, value: windows-2022 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.3 }, timeout: 150 }
-          - { os: { name: Windows, value: windows-2022 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.2, value: 3.2.1 }, timeout: 150 }
 
     env:
       RGV: ..

--- a/.github/workflows/windows-bundler.yml
+++ b/.github/workflows/windows-bundler.yml
@@ -1,0 +1,47 @@
+name: windows-bundler
+
+on:
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+    working-directory: ./bundler
+
+jobs:
+  bundler:
+    name: Bundler 2 on Windows (${{ matrix.ruby.name }})
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - { name: ruby-2.7, value: 2.7.7 }
+          - { name: ruby-3.0, value: 3.0.5 }
+          - { name: ruby-3.1, value: 3.1.3 }
+          - { name: ruby-3.2, value: 3.2.1 }
+
+    env:
+      RGV: ..
+      RUBYOPT: --disable-gems
+    steps:
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+      - name: Setup ruby
+        uses: ruby/setup-ruby@904f3fef85a9c80a3750cbe7d5159268fd5caa9f # v1.145.0
+        with:
+          ruby-version: ${{ matrix.ruby.value }}
+          bundler: none
+      - name: Prepare dependencies
+        run: |
+          bin/rake spec:parallel_deps
+      - name: Run Test
+        run: |
+          bin/parallel_rspec
+    timeout-minutes: 150


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Windows CI of bundler needs to execution time over the two hours. We should avoid waiting 4 hours for single pull-request.

## What is your fix for the problem, implemented in this PR?

I extracted Windows platform from `bundler.yml` and removed `merge_group` tag. I know this has some of duplicated code of YAML. But this is simple matrix rather than current one.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

----

@deivid-rodriguez @simi 

How about this? Should we remove merge queue instead of this?