### PR TITLE
Fix changelog generation edge case

### DIFF
--- a/util/release.rb
+++ b/util/release.rb
@@ -47,17 +47,25 @@ class Release
     end
 
     def previous_version
-      @previous_version ||= latest_release.tag_name.gsub(/^#{@tag_prefix}/, "")
+      @previous_version ||= remove_tag_prefix(latest_release.tag_name)
     end
 
     def latest_release
-      @latest_release ||= gh_client.releases("rubygems/rubygems").select {|release| release.tag_name.start_with?(@tag_prefix) }.max_by(&:tag_name)
+      @latest_release ||= gh_client.releases("rubygems/rubygems").select {|release| release.tag_name.start_with?(@tag_prefix) }.max_by do |release|
+        Gem::Version.new(remove_tag_prefix(release.tag_name))
+      end
     end
 
     attr_reader :relevant_pull_requests
 
     def set_relevant_pull_requests_from(pulls)
       @relevant_pull_requests = pulls.select {|pull| @changelog.relevant_label_for(pull) }
+    end
+
+    private
+
+    def remove_tag_prefix(name)
+      name.gsub(/^#{@tag_prefix}/, "")
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Changelog generation script was overwriting the previous release entry, not adding a new one.

## What is your fix for the problem, implemented in this PR?

When previous version has two patch level digits, we were not sorting versions properly. Fix the sorting to be version number friendly, instead of just lexicographical.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
