### PR TITLE
Close the server for test

### DIFF
--- a/test/rubygems/test_webauthn_listener.rb
+++ b/test/rubygems/test_webauthn_listener.rb
@@ -10,6 +10,12 @@ class WebauthnListenerTest < Gem::TestCase
     @port = @server.addr[1].to_s
   end
 
+  def teardown
+    @thread.kill.join if @thread
+    @server&.close
+    super
+  end
+
   def test_wait_for_otp_code_get_follows_options
     wait_for_otp_code
     assert Gem::MockBrowser.options(URI("http://localhost:#{@port}?code=xyz")).is_a? Net::HTTPNoContent


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

https://github.com/ruby/ruby/actions/runs/4675091329/jobs/8279854567#step:15:101
https://github.com/rubygems/rubygems/actions/runs/4147910960/jobs/7175336193#step:10:19
`TCPServer`s are left open.

## What is your fix for the problem, implemented in this PR?

Ensure to stop the server thread and close the server.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
