### PR TITLE
Show webauthn warning if default browser is Safari

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1491,6 +1491,23 @@ Also, a list:
     "#{__dir__}/#{key_name}_key.pem"
   end
 
+  ##
+  # Sets default browser to Safari in macOS by saving current configuration and overwriting LSHandlers
+
+  def set_default_browser_safari
+    @launch_services = `defaults read com.apple.LaunchServices/com.apple.launchservices.secure LSHandlers`
+    default_browser_setting = "{ LSHandlerURLScheme = \"https\"; LSHandlerRoleAll = \"com.apple.safari\"; }"
+
+    `defaults write com.apple.LaunchServices/com.apple.launchservices.secure LSHandlers -array '#{default_browser_setting}'`
+  end
+
+  ##
+  # Resets default browser to previous configuration set in set_default_browser_safari
+
+  def restore_default_browser
+    `defaults write com.apple.LaunchServices/com.apple.launchservices.secure LSHandlers "#{@launch_services}"`
+  end
+
   # :stopdoc:
   # only available in RubyGems tests
 

--- a/test/rubygems/test_gem_commands_owner_command.rb
+++ b/test/rubygems/test_gem_commands_owner_command.rb
@@ -425,6 +425,43 @@ EOF
     refute_match response_success, @stub_ui.output
   end
 
+  def test_with_webauthn_enabled_with_safari_as_default_browser
+    omit("Safari is only available on macOS") unless RUBY_PLATFORM.include?("darwin")
+
+    set_default_browser_safari
+    webauthn_verification_url = "rubygems.org/api/v1/webauthn_verification/odow34b93t6aPCdY"
+    response_fail = "You have enabled multifactor authentication but your request doesn't have the correct OTP code. Please check it and retry."
+    response_success = "Owner added successfully."
+    port = 5678
+    server = TCPServer.new(port)
+
+    @stub_fetcher.data["#{Gem.host}/api/v1/webauthn_verification"] = HTTPResponseFactory.create(body: webauthn_verification_url, code: 200, msg: "OK")
+    @stub_fetcher.data["#{Gem.host}/api/v1/gems/freewill/owners"] = [
+      HTTPResponseFactory.create(body: response_fail, code: 401, msg: "Unauthorized"),
+      HTTPResponseFactory.create(body: response_success, code: 200, msg: "OK"),
+    ]
+
+    TCPServer.stub(:new, server) do
+      Gem::WebauthnListener.stub(:wait_for_otp_code, "Uvh6T57tkWuUnWYo") do
+        use_ui @stub_ui do
+          @cmd.add_owners("freewill", ["user-new1@example.com"])
+        end
+      end
+    ensure
+      server.close
+    end
+
+    url_with_port = "#{webauthn_verification_url}?port=#{port}"
+
+    assert_match "You have enabled multi-factor authentication. Please visit #{url_with_port} to authenticate " \
+      "via security device. If you can't verify using WebAuthn but have OTP enabled, you can re-run the gem signin " \
+      "command with the `--otp [your_code]` option.", @stub_ui.output
+    assert_match "\n[WARNING] It looks like your default browser is Safari. Due to limitations within Safari, " \
+      "you will be unable to authenticate using this browser. Please visit the link in another browser.", @stub_ui.output
+  ensure
+    restore_default_browser if RUBY_PLATFORM.include?("darwin")
+  end
+
   def test_remove_owners_unathorized_api_key
     response_forbidden = "The API key doesn't have access"
     response_success   = "Owner removed successfully."


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

From: https://github.com/rubygems/rubygems.org/pull/3674#issuecomment-1494447858
Enhancement of: https://github.com/rubygems/rubygems/pull/6560

After discovering that Safari does not allow connection to localhost https://bugs.webkit.org/show_bug.cgi?id=186039, we're displaying browser warnings to say that Safari isn't support with the feature (https://github.com/rubygems/rubygems.org/pull/3674).

It would be nice to have a warning in the command line mentioning that the user's default browser doesn't support this feature.

## What is your fix for the problem, implemented in this PR

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Checked the browser using LaunchServices plist by using `plutil` to retrieve the list and parse it to json. If the application assigned to the https scheme is safari, an error is displayed.

The alternative would be read the LSHandlers and to grab the browser using sed eg.
```
defaults read com.apple.LaunchServices/com.apple.launchservices.secure LSHandlers \
  | sed -n -e '/LSHandlerURLScheme = https;/{x;p;d;}' -e 's/.*=[^"]"\(.*\)";/\1/g' -e x
```
## Testing
1. Add a security device to the user
2. Set your default browser to Safari
3. When `gem signin` is run, a warning is displayed that the default browser isn't supported
4. Set your default browser to another browser and the warning won't be displayed

<img width="916" alt="Screenshot 2023-04-06 at 9 53 42 AM" src="https://user-images.githubusercontent.com/42748004/230399161-51088824-11b9-4bad-a7bd-548cc9217b3b.png">

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
