### PR TITLE
Enable Naming/VariableName cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,9 +33,6 @@ Naming/MethodName:
 
 Naming/VariableName:
   Enabled: true
-  Exclude:
-    - lib/**/*
-    - test/**/*
 
 Naming/VariableNumber:
   Enabled: true

--- a/test/rubygems/bundler_test_gem.rb
+++ b/test/rubygems/bundler_test_gem.rb
@@ -138,15 +138,15 @@ class TestBundlerGem < Gem::TestCase
       ENV["GEM_PATH"] = path
 
       with_rubygems_gemdeps("-") do
-        new_PATH = [File.join(path, "bin"), ENV["PATH"]].join(File::PATH_SEPARATOR)
-        new_RUBYOPT = "-I#{rubygems_path} -I#{bundler_path}"
+        new_path = [File.join(path, "bin"), ENV["PATH"]].join(File::PATH_SEPARATOR)
+        new_rubyopt = "-I#{rubygems_path} -I#{bundler_path}"
 
         path = File.join @tempdir, "gem.deps.rb"
 
         File.open path, "w" do |f|
           f.puts "gem 'a'"
         end
-        out0 = with_path_and_rubyopt(new_PATH, new_RUBYOPT) do
+        out0 = with_path_and_rubyopt(new_path, new_rubyopt) do
           IO.popen("foo", &:read).split(/\n/)
         end
 
@@ -154,7 +154,7 @@ class TestBundlerGem < Gem::TestCase
           f.puts "gem 'b'"
           f.puts "gem 'c'"
         end
-        out = with_path_and_rubyopt(new_PATH, new_RUBYOPT) do
+        out = with_path_and_rubyopt(new_path, new_rubyopt) do
           IO.popen("foo", &:read).split(/\n/)
         end
 
@@ -192,15 +192,15 @@ class TestBundlerGem < Gem::TestCase
       with_rubygems_gemdeps("-") do
         Dir.mkdir "sub1"
 
-        new_PATH = [File.join(path, "bin"), ENV["PATH"]].join(File::PATH_SEPARATOR)
-        new_RUBYOPT = "-I#{rubygems_path} -I#{bundler_path}"
+        new_path = [File.join(path, "bin"), ENV["PATH"]].join(File::PATH_SEPARATOR)
+        new_rubyopt = "-I#{rubygems_path} -I#{bundler_path}"
 
         path = File.join @tempdir, "gem.deps.rb"
 
         File.open path, "w" do |f|
           f.puts "gem 'a'"
         end
-        out0 = with_path_and_rubyopt(new_PATH, new_RUBYOPT) do
+        out0 = with_path_and_rubyopt(new_path, new_rubyopt) do
           IO.popen("foo", :chdir => "sub1", &:read).split(/\n/)
         end
 
@@ -208,7 +208,7 @@ class TestBundlerGem < Gem::TestCase
           f.puts "gem 'b'"
           f.puts "gem 'c'"
         end
-        out = with_path_and_rubyopt(new_PATH, new_RUBYOPT) do
+        out = with_path_and_rubyopt(new_path, new_rubyopt) do
           IO.popen("foo", :chdir => "sub1", &:read).split(/\n/)
         end
 

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -308,7 +308,7 @@ class Gem::TestCase < Test::Unit::TestCase
     # capture output
     Gem::DefaultUserInteraction.ui = Gem::MockGemUi.new
 
-    @orig_SYSTEM_WIDE_CONFIG_FILE = Gem::ConfigFile::SYSTEM_WIDE_CONFIG_FILE
+    @orig_system_wide_config_file = Gem::ConfigFile::SYSTEM_WIDE_CONFIG_FILE
     Gem::ConfigFile.send :remove_const, :SYSTEM_WIDE_CONFIG_FILE
     Gem::ConfigFile.send :const_set, :SYSTEM_WIDE_CONFIG_FILE,
                          File.join(@tempdir, "system-gemrc")
@@ -329,7 +329,7 @@ class Gem::TestCase < Test::Unit::TestCase
     Gem.ensure_gem_subdirectories @gemhome
     Gem.ensure_default_gem_subdirectories @gemhome
 
-    @orig_LOAD_PATH = $LOAD_PATH.dup
+    @orig_load_path = $LOAD_PATH.dup
     $LOAD_PATH.map! do |s|
       expand_path = begin
                       File.realpath(s)
@@ -415,7 +415,7 @@ class Gem::TestCase < Test::Unit::TestCase
     end
 
     @marshal_version = "#{Marshal::MAJOR_VERSION}.#{Marshal::MINOR_VERSION}"
-    @orig_LOADED_FEATURES = $LOADED_FEATURES.dup
+    @orig_loaded_features = $LOADED_FEATURES.dup
   end
 
   ##
@@ -423,14 +423,14 @@ class Gem::TestCase < Test::Unit::TestCase
   # tempdir
 
   def teardown
-    $LOAD_PATH.replace @orig_LOAD_PATH if @orig_LOAD_PATH
-    if @orig_LOADED_FEATURES
-      if @orig_LOAD_PATH
-        ($LOADED_FEATURES - @orig_LOADED_FEATURES).each do |feat|
+    $LOAD_PATH.replace @orig_load_path if @orig_load_path
+    if @orig_loaded_features
+      if @orig_load_path
+        ($LOADED_FEATURES - @orig_loaded_features).each do |feat|
           $LOADED_FEATURES.delete(feat) if feat.start_with?(@tmp)
         end
       else
-        $LOADED_FEATURES.replace @orig_LOADED_FEATURES
+        $LOADED_FEATURES.replace @orig_loaded_features
       end
     end
 
@@ -448,7 +448,7 @@ class Gem::TestCase < Test::Unit::TestCase
 
     Gem::ConfigFile.send :remove_const, :SYSTEM_WIDE_CONFIG_FILE
     Gem::ConfigFile.send :const_set, :SYSTEM_WIDE_CONFIG_FILE,
-                         @orig_SYSTEM_WIDE_CONFIG_FILE
+                         @orig_system_wide_config_file
 
     Gem.ruby = @orig_ruby if @orig_ruby
 
@@ -1084,12 +1084,12 @@ Also, a list:
       Gem.send :remove_instance_variable, :@ruby_version
     end
 
-    @RUBY_VERSION        = RUBY_VERSION
-    @RUBY_PATCHLEVEL     = RUBY_PATCHLEVEL
-    @RUBY_REVISION       = RUBY_REVISION
-    @RUBY_DESCRIPTION    = RUBY_DESCRIPTION
-    @RUBY_ENGINE         = RUBY_ENGINE
-    @RUBY_ENGINE_VERSION = RUBY_ENGINE_VERSION
+    @ruby_version        = RUBY_VERSION
+    @ruby_patchlevel     = RUBY_PATCHLEVEL
+    @ruby_revision       = RUBY_REVISION
+    @ruby_description    = RUBY_DESCRIPTION
+    @ruby_engine         = RUBY_ENGINE
+    @ruby_engine_version = RUBY_ENGINE_VERSION
 
     util_clear_RUBY_VERSION
 
@@ -1104,12 +1104,12 @@ Also, a list:
   def util_restore_RUBY_VERSION
     util_clear_RUBY_VERSION
 
-    Object.const_set :RUBY_VERSION,        @RUBY_VERSION
-    Object.const_set :RUBY_PATCHLEVEL,     @RUBY_PATCHLEVEL
-    Object.const_set :RUBY_REVISION,       @RUBY_REVISION
-    Object.const_set :RUBY_DESCRIPTION,    @RUBY_DESCRIPTION
-    Object.const_set :RUBY_ENGINE,         @RUBY_ENGINE
-    Object.const_set :RUBY_ENGINE_VERSION, @RUBY_ENGINE_VERSION
+    Object.const_set :RUBY_VERSION,        @ruby_version
+    Object.const_set :RUBY_PATCHLEVEL,     @ruby_patchlevel
+    Object.const_set :RUBY_REVISION,       @ruby_revision
+    Object.const_set :RUBY_DESCRIPTION,    @ruby_description
+    Object.const_set :RUBY_ENGINE,         @ruby_engine
+    Object.const_set :RUBY_ENGINE_VERSION, @ruby_engine_version
   end
 
   def util_clear_RUBY_VERSION

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1713,14 +1713,14 @@ class TestGem < Gem::TestCase
 
   def ruby_install_name(name)
     with_clean_path_to_ruby do
-      orig_RUBY_INSTALL_NAME = RbConfig::CONFIG["ruby_install_name"]
+      orig_ruby_install_name = RbConfig::CONFIG["ruby_install_name"]
       RbConfig::CONFIG["ruby_install_name"] = name
 
       begin
         yield
       ensure
-        if orig_RUBY_INSTALL_NAME
-          RbConfig::CONFIG["ruby_install_name"] = orig_RUBY_INSTALL_NAME
+        if orig_ruby_install_name
+          RbConfig::CONFIG["ruby_install_name"] = orig_ruby_install_name
         else
           RbConfig::CONFIG.delete "ruby_install_name"
         end

--- a/test/rubygems/test_gem_command.rb
+++ b/test/rubygems/test_gem_command.rb
@@ -234,7 +234,7 @@ class TestGemCommand < Gem::TestCase
 WARNING:  The \"--test\" option has been deprecated and will be removed in Rubygems 3.1.
     EXPECTED
 
-    testCommand = Class.new(Gem::Command) do
+    test_command = Class.new(Gem::Command) do
       def initialize
         super("test", "Gem::Command instance for testing")
 
@@ -250,7 +250,7 @@ WARNING:  The \"--test\" option has been deprecated and will be removed in Rubyg
       end
     end
 
-    cmd = testCommand.new
+    cmd = test_command.new
 
     use_ui @ui do
       cmd.invoke("--test")
@@ -263,7 +263,7 @@ WARNING:  The \"--test\" option has been deprecated and will be removed in Rubyg
 WARNING:  The \"--test\" option has been deprecated and will be removed in future versions of Rubygems.
     EXPECTED
 
-    testCommand = Class.new(Gem::Command) do
+    test_command = Class.new(Gem::Command) do
       def initialize
         super("test", "Gem::Command instance for testing")
 
@@ -279,7 +279,7 @@ WARNING:  The \"--test\" option has been deprecated and will be removed in futur
       end
     end
 
-    cmd = testCommand.new
+    cmd = test_command.new
 
     use_ui @ui do
       cmd.invoke("--test")
@@ -292,7 +292,7 @@ WARNING:  The \"--test\" option has been deprecated and will be removed in futur
 WARNING:  The \"--test\" option has been deprecated and will be removed in Rubygems 3.1. Whether you set `--test` mode or not, this dummy app always runs in test mode.
     EXPECTED
 
-    testCommand = Class.new(Gem::Command) do
+    test_command = Class.new(Gem::Command) do
       def initialize
         super("test", "Gem::Command instance for testing")
 
@@ -308,7 +308,7 @@ WARNING:  The \"--test\" option has been deprecated and will be removed in Rubyg
       end
     end
 
-    cmd = testCommand.new
+    cmd = test_command.new
 
     use_ui @ui do
       cmd.invoke("--test")
@@ -321,7 +321,7 @@ WARNING:  The \"--test\" option has been deprecated and will be removed in Rubyg
 WARNING:  The \"--test\" option has been deprecated and will be removed in future versions of Rubygems. Whether you set `--test` mode or not, this dummy app always runs in test mode.
     EXPECTED
 
-    testCommand = Class.new(Gem::Command) do
+    test_command = Class.new(Gem::Command) do
       def initialize
         super("test", "Gem::Command instance for testing")
 
@@ -337,7 +337,7 @@ WARNING:  The \"--test\" option has been deprecated and will be removed in futur
       end
     end
 
-    cmd = testCommand.new
+    cmd = test_command.new
 
     use_ui @ui do
       cmd.invoke("--test")

--- a/test/rubygems/test_gem_dependency_resolution_error.rb
+++ b/test/rubygems/test_gem_dependency_resolution_error.rb
@@ -6,16 +6,14 @@ class TestGemDependencyResolutionError < Gem::TestCase
   def setup
     super
 
-    @DR = Gem::Resolver
-
     @spec = util_spec "a", 2
 
-    @a1_req = @DR::DependencyRequest.new dep("a", "= 1"), nil
-    @a2_req = @DR::DependencyRequest.new dep("a", "= 2"), nil
+    @a1_req = Gem::Resolver::DependencyRequest.new dep("a", "= 1"), nil
+    @a2_req = Gem::Resolver::DependencyRequest.new dep("a", "= 2"), nil
 
-    @activated = @DR::ActivationRequest.new @spec, @a2_req
+    @activated = Gem::Resolver::ActivationRequest.new @spec, @a2_req
 
-    @conflict = @DR::Conflict.new @a1_req, @activated
+    @conflict = Gem::Resolver::Conflict.new @a1_req, @activated
 
     @error = Gem::DependencyResolutionError.new @conflict
   end

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -6,7 +6,7 @@ require "rubygems/installer"
 
 class TestGemExtBuilder < Gem::TestCase
   def setup
-    @orig_DESTDIR = ENV["DESTDIR"]
+    @orig_destdir = ENV["DESTDIR"]
     @orig_make = ENV["make"]
     super
 
@@ -23,7 +23,7 @@ class TestGemExtBuilder < Gem::TestCase
 
   def teardown
     super
-    ENV["DESTDIR"] = @orig_DESTDIR
+    ENV["DESTDIR"] = @orig_destdir
     ENV["make"] = @orig_make
   end
 

--- a/test/rubygems/test_gem_ext_ext_conf_builder.rb
+++ b/test/rubygems/test_gem_ext_ext_conf_builder.rb
@@ -65,11 +65,11 @@ class TestGemExtExtConfBuilder < Gem::TestCase
     end
   end
 
-  def test_class_build_env_MAKE
+  def test_class_build_env_make
     env_make = ENV.delete "make"
     ENV["make"] = nil
 
-    env_MAKE = ENV.delete "MAKE"
+    env_large_make = ENV.delete "MAKE"
     ENV["MAKE"] = "anothermake"
 
     if Gem.java_platform?
@@ -91,7 +91,7 @@ class TestGemExtExtConfBuilder < Gem::TestCase
       assert_contains_make_command "clean", output[4]
     end
   ensure
-    ENV["MAKE"] = env_MAKE
+    ENV["MAKE"] = env_large_make
     ENV["make"] = env_make
   end
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -204,7 +204,7 @@ gem 'other', version
       bin_dir = bin_dir.downcase
     end
 
-    orig_PATH = ENV["PATH"]
+    orig_path = ENV["PATH"]
     ENV["PATH"] = [ENV["PATH"], bin_dir].join(File::PATH_SEPARATOR)
 
     use_ui @ui do
@@ -215,7 +215,7 @@ gem 'other', version
 
     return unless Gem.win_platform?
 
-    ENV["PATH"] = [orig_PATH, bin_dir.tr(File::SEPARATOR, File::ALT_SEPARATOR)].join(File::PATH_SEPARATOR)
+    ENV["PATH"] = [orig_path, bin_dir.tr(File::SEPARATOR, File::ALT_SEPARATOR)].join(File::PATH_SEPARATOR)
 
     use_ui @ui do
       installer.check_that_user_bin_dir_is_in_path
@@ -223,13 +223,13 @@ gem 'other', version
 
     assert_empty @ui.error
   ensure
-    ENV["PATH"] = orig_PATH
+    ENV["PATH"] = orig_path
   end
 
   def test_check_that_user_bin_dir_is_in_path_tilde
     pend "Tilde is PATH is not supported under MS Windows" if Gem.win_platform?
 
-    orig_PATH = ENV["PATH"]
+    orig_path = ENV["PATH"]
     ENV["PATH"] = [ENV["PATH"], "~/bin"].join(File::PATH_SEPARATOR)
 
     installer = setup_base_installer
@@ -241,7 +241,7 @@ gem 'other', version
 
     assert_empty @ui.error
   ensure
-    ENV["PATH"] = orig_PATH unless Gem.win_platform?
+    ENV["PATH"] = orig_path unless Gem.win_platform?
   end
 
   def test_check_that_user_bin_dir_is_in_path_not_in_path
@@ -2462,11 +2462,11 @@ gem 'other', version
   end
 
   def load_relative(value)
-    orig_LIBRUBY_RELATIVE = RbConfig::CONFIG["LIBRUBY_RELATIVE"]
+    orig_libruby_relative = RbConfig::CONFIG["LIBRUBY_RELATIVE"]
     RbConfig::CONFIG["LIBRUBY_RELATIVE"] = value
 
     yield
   ensure
-    RbConfig::CONFIG["LIBRUBY_RELATIVE"] = orig_LIBRUBY_RELATIVE
+    RbConfig::CONFIG["LIBRUBY_RELATIVE"] = orig_libruby_relative
   end
 end

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -175,7 +175,7 @@ class TestGemPlatform < Gem::TestCase
   end
 
   def test_initialize_mswin32_vc6
-    orig_RUBY_SO_NAME = RbConfig::CONFIG["RUBY_SO_NAME"]
+    orig_ruby_so_name = RbConfig::CONFIG["RUBY_SO_NAME"]
     RbConfig::CONFIG["RUBY_SO_NAME"] = "msvcrt-ruby18"
 
     expected = ["x86", "mswin32", nil]
@@ -184,8 +184,8 @@ class TestGemPlatform < Gem::TestCase
 
     assert_equal expected, platform.to_a, "i386-mswin32 VC6"
   ensure
-    if orig_RUBY_SO_NAME
-      RbConfig::CONFIG["RUBY_SO_NAME"] = orig_RUBY_SO_NAME
+    if orig_ruby_so_name
+      RbConfig::CONFIG["RUBY_SO_NAME"] = orig_ruby_so_name
     else
       RbConfig::CONFIG.delete "RUBY_SO_NAME"
     end

--- a/test/rubygems/test_gem_request.rb
+++ b/test/rubygems/test_gem_request.rb
@@ -479,19 +479,19 @@ ERROR:  Certificate  is an invalid CA certificate
 
   def util_restore_version
     Object.send :remove_const, :RUBY_ENGINE
-    Object.send :const_set,    :RUBY_ENGINE, @orig_RUBY_ENGINE
+    Object.send :const_set,    :RUBY_ENGINE, @orig_ruby_engine
 
     Object.send :remove_const, :RUBY_PATCHLEVEL
-    Object.send :const_set,    :RUBY_PATCHLEVEL, @orig_RUBY_PATCHLEVEL
+    Object.send :const_set,    :RUBY_PATCHLEVEL, @orig_ruby_patchlevel
 
     Object.send :remove_const, :RUBY_REVISION
-    Object.send :const_set,    :RUBY_REVISION, @orig_RUBY_REVISION
+    Object.send :const_set,    :RUBY_REVISION, @orig_ruby_revision
   end
 
   def util_save_version
-    @orig_RUBY_ENGINE     = RUBY_ENGINE
-    @orig_RUBY_PATCHLEVEL = RUBY_PATCHLEVEL
-    @orig_RUBY_REVISION   = RUBY_REVISION
+    @orig_ruby_engine     = RUBY_ENGINE
+    @orig_ruby_patchlevel = RUBY_PATCHLEVEL
+    @orig_ruby_revision   = RUBY_REVISION
   end
 
   def util_stub_net_http(hash)

--- a/test/rubygems/test_gem_request_set.rb
+++ b/test/rubygems/test_gem_request_set.rb
@@ -8,8 +8,6 @@ class TestGemRequestSet < Gem::TestCase
     super
 
     Gem::RemoteFetcher.fetcher = @fetcher = Gem::FakeFetcher.new
-
-    @DR = Gem::Resolver
   end
 
   def test_gem
@@ -415,7 +413,7 @@ ruby "0"
 
     assert_equal %w[a-1], names
 
-    assert_equal [@DR::BestSet, @DR::GitSet, @DR::VendorSet, @DR::SourceSet],
+    assert_equal [Gem::Resolver::BestSet, Gem::Resolver::GitSet, Gem::Resolver::VendorSet, Gem::Resolver::SourceSet],
                  rs.sets.map(&:class)
   end
 
@@ -479,7 +477,7 @@ ruby "0"
 
     assert_equal ["a-1", "b-2"], names
 
-    assert_equal [@DR::BestSet, @DR::GitSet, @DR::VendorSet, @DR::SourceSet],
+    assert_equal [Gem::Resolver::BestSet, Gem::Resolver::GitSet, Gem::Resolver::VendorSet, Gem::Resolver::SourceSet],
                  rs.sets.map(&:class)
   end
 

--- a/test/rubygems/test_gem_request_set_gem_dependency_api.rb
+++ b/test/rubygems/test_gem_request_set_gem_dependency_api.rb
@@ -7,14 +7,12 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
   def setup
     super
 
-    @GDA = Gem::RequestSet::GemDependencyAPI
-
     @set = Gem::RequestSet.new
 
     @git_set    = Gem::Resolver::GitSet.new
     @vendor_set = Gem::Resolver::VendorSet.new
 
-    @gda = @GDA.new @set, "gem.deps.rb"
+    @gda = Gem::RequestSet::GemDependencyAPI.new @set, "gem.deps.rb"
     @gda.instance_variable_set :@git_set,    @git_set
     @gda.instance_variable_set :@vendor_set, @vendor_set
   end
@@ -264,7 +262,7 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
 
     with_engine_version "ruby", "2.0.0" do
       set = Gem::RequestSet.new
-      gda = @GDA.new set, "gem.deps.rb"
+      gda = Gem::RequestSet::GemDependencyAPI.new set, "gem.deps.rb"
       gda.gem "a", :platforms => :ruby
 
       refute_empty set.dependencies
@@ -272,7 +270,7 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
 
     with_engine_version "rbx", "2.0.0" do
       set = Gem::RequestSet.new
-      gda = @GDA.new set, "gem.deps.rb"
+      gda = Gem::RequestSet::GemDependencyAPI.new set, "gem.deps.rb"
       gda.gem "a", :platforms => :ruby
 
       refute_empty set.dependencies
@@ -280,7 +278,7 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
 
     with_engine_version "truffleruby", "2.0.0" do
       set = Gem::RequestSet.new
-      gda = @GDA.new set, "gem.deps.rb"
+      gda = Gem::RequestSet::GemDependencyAPI.new set, "gem.deps.rb"
       gda.gem "a", :platforms => :ruby
 
       refute_empty set.dependencies
@@ -288,7 +286,7 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
 
     with_engine_version "jruby", "1.7.6" do
       set = Gem::RequestSet.new
-      gda = @GDA.new set, "gem.deps.rb"
+      gda = Gem::RequestSet::GemDependencyAPI.new set, "gem.deps.rb"
       gda.gem "a", :platforms => :ruby
 
       assert_empty set.dependencies
@@ -298,7 +296,7 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
 
     with_engine_version "ruby", "2.0.0" do
       set = Gem::RequestSet.new
-      gda = @GDA.new set, "gem.deps.rb"
+      gda = Gem::RequestSet::GemDependencyAPI.new set, "gem.deps.rb"
       gda.gem "a", :platforms => :ruby
 
       assert_empty set.dependencies
@@ -327,13 +325,13 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
 
     with_engine_version "maglev", "1.0.0" do
       set = Gem::RequestSet.new
-      gda = @GDA.new set, "gem.deps.rb"
+      gda = Gem::RequestSet::GemDependencyAPI.new set, "gem.deps.rb"
       gda.gem "a", :platforms => :ruby
 
       refute_empty set.dependencies
 
       set = Gem::RequestSet.new
-      gda = @GDA.new set, "gem.deps.rb"
+      gda = Gem::RequestSet::GemDependencyAPI.new set, "gem.deps.rb"
       gda.gem "a", :platforms => :maglev
 
       refute_empty set.dependencies
@@ -345,13 +343,13 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
   def test_gem_platforms_truffleruby
     with_engine_version "truffleruby", "1.0.0" do
       set = Gem::RequestSet.new
-      gda = @GDA.new set, "gem.deps.rb"
+      gda = Gem::RequestSet::GemDependencyAPI.new set, "gem.deps.rb"
       gda.gem "a", :platforms => :truffleruby
 
       refute_empty set.dependencies
 
       set = Gem::RequestSet.new
-      gda = @GDA.new set, "gem.deps.rb"
+      gda = Gem::RequestSet::GemDependencyAPI.new set, "gem.deps.rb"
       gda.gem "a", :platforms => :maglev
 
       assert_empty set.dependencies
@@ -457,7 +455,7 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
   def test_gem_source_mismatch
     name, _, directory = vendor_gem
 
-    gda = @GDA.new @set, nil
+    gda = Gem::RequestSet::GemDependencyAPI.new @set, nil
     gda.gem name
 
     e = assert_raise ArgumentError do
@@ -467,7 +465,7 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
     assert_equal "duplicate source path: #{directory} for gem #{name}",
                  e.message
 
-    gda = @GDA.new @set, nil
+    gda = Gem::RequestSet::GemDependencyAPI.new @set, nil
     gda.instance_variable_set :@vendor_set, @vendor_set
     gda.gem name, :path => directory
 
@@ -482,7 +480,7 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
   def test_gem_deps_file
     assert_equal "gem.deps.rb", @gda.gem_deps_file
 
-    gda = @GDA.new @set, "foo/Gemfile"
+    gda = Gem::RequestSet::GemDependencyAPI.new @set, "foo/Gemfile"
 
     assert_equal "Gemfile", gda.gem_deps_file
   end
@@ -647,7 +645,7 @@ end
       GEM_DEPS
       io.flush
 
-      gda = @GDA.new @set, io.path
+      gda = Gem::RequestSet::GemDependencyAPI.new @set, io.path
 
       assert_equal gda, gda.load
 
@@ -658,7 +656,7 @@ end
   end
 
   def test_pin_gem_source
-    gda = @GDA.new @set, nil
+    gda = Gem::RequestSet::GemDependencyAPI.new @set, nil
 
     gda.send :pin_gem_source, "a"
     gda.send :pin_gem_source, "a"
@@ -703,7 +701,7 @@ end
     win_platform = Gem.win_platform?
     Gem.win_platform = false
 
-    gda = @GDA.new @set, nil
+    gda = Gem::RequestSet::GemDependencyAPI.new @set, nil
 
     with_engine_version "ruby", "1.8.7" do
       gda.platform :mri_19, :mri_20 do
@@ -713,7 +711,7 @@ end
 
     assert_empty @set.dependencies
 
-    gda = @GDA.new @set, nil
+    gda = Gem::RequestSet::GemDependencyAPI.new @set, nil
 
     with_engine_version "ruby", "2.0.0" do
       gda.platform :mri_19, :mri_20 do

--- a/test/rubygems/test_gem_resolver.rb
+++ b/test/rubygems/test_gem_resolver.rb
@@ -779,29 +779,29 @@ class TestGemResolver < Gem::TestCase
   end
 
   def test_sorts_by_source_then_version
-    sourceA = Gem::Source.new "http://example.com/a"
-    sourceB = Gem::Source.new "http://example.com/b"
-    sourceC = Gem::Source.new "http://example.com/c"
+    source_a = Gem::Source.new "http://example.com/a"
+    source_b = Gem::Source.new "http://example.com/b"
+    source_c = Gem::Source.new "http://example.com/c"
 
-    spec_A_1 = util_spec "some-dep", "0.0.1"
-    spec_A_2 = util_spec "some-dep", "1.0.0"
-    spec_B_1 = util_spec "some-dep", "0.0.1"
-    spec_B_2 = util_spec "some-dep", "0.0.2"
-    spec_C_1 = util_spec "some-dep", "0.1.0"
+    spec_a_1 = util_spec "some-dep", "0.0.1"
+    spec_a_2 = util_spec "some-dep", "1.0.0"
+    spec_b_1 = util_spec "some-dep", "0.0.1"
+    spec_b_2 = util_spec "some-dep", "0.0.2"
+    spec_c_1 = util_spec "some-dep", "0.1.0"
 
     set = StaticSet.new [
-      Gem::Resolver::SpecSpecification.new(nil, spec_B_1, sourceB),
-      Gem::Resolver::SpecSpecification.new(nil, spec_B_2, sourceB),
-      Gem::Resolver::SpecSpecification.new(nil, spec_C_1, sourceC),
-      Gem::Resolver::SpecSpecification.new(nil, spec_A_2, sourceA),
-      Gem::Resolver::SpecSpecification.new(nil, spec_A_1, sourceA),
+      Gem::Resolver::SpecSpecification.new(nil, spec_b_1, source_b),
+      Gem::Resolver::SpecSpecification.new(nil, spec_b_2, source_b),
+      Gem::Resolver::SpecSpecification.new(nil, spec_c_1, source_c),
+      Gem::Resolver::SpecSpecification.new(nil, spec_a_2, source_a),
+      Gem::Resolver::SpecSpecification.new(nil, spec_a_1, source_a),
     ]
 
     dependency = make_dep "some-dep", "> 0"
 
     resolver = Gem::Resolver.new [dependency], set
 
-    assert_resolves_to [spec_B_2], resolver
+    assert_resolves_to [spec_b_2], resolver
   end
 
   def test_select_local_platforms

--- a/test/rubygems/test_gem_resolver.rb
+++ b/test/rubygems/test_gem_resolver.rb
@@ -3,12 +3,6 @@
 require_relative "helper"
 
 class TestGemResolver < Gem::TestCase
-  def setup
-    super
-
-    @DR = Gem::Resolver
-  end
-
   def make_dep(name, *req)
     Gem::Dependency.new(name, *req)
   end
@@ -37,18 +31,18 @@ class TestGemResolver < Gem::TestCase
   end
 
   def test_self_compose_sets_best_set
-    best_set = @DR::BestSet.new
+    best_set = Gem::Resolver::BestSet.new
 
-    composed = @DR.compose_sets best_set
+    composed = Gem::Resolver.compose_sets best_set
 
     assert_equal best_set, composed
   end
 
   def test_self_compose_sets_multiple
-    index_set  = @DR::IndexSet.new
-    vendor_set = @DR::VendorSet.new
+    index_set  = Gem::Resolver::IndexSet.new
+    vendor_set = Gem::Resolver::VendorSet.new
 
-    composed = @DR.compose_sets index_set, vendor_set
+    composed = Gem::Resolver.compose_sets index_set, vendor_set
 
     assert_kind_of Gem::Resolver::ComposedSet, composed
 
@@ -56,14 +50,14 @@ class TestGemResolver < Gem::TestCase
   end
 
   def test_self_compose_sets_nest
-    index_set  = @DR::IndexSet.new
-    vendor_set = @DR::VendorSet.new
+    index_set  = Gem::Resolver::IndexSet.new
+    vendor_set = Gem::Resolver::VendorSet.new
 
-    inner = @DR.compose_sets index_set, vendor_set
+    inner = Gem::Resolver.compose_sets index_set, vendor_set
 
-    current_set = @DR::CurrentSet.new
+    current_set = Gem::Resolver::CurrentSet.new
 
-    composed = @DR.compose_sets inner, current_set
+    composed = Gem::Resolver.compose_sets inner, current_set
 
     assert_kind_of Gem::Resolver::ComposedSet, composed
 
@@ -71,23 +65,23 @@ class TestGemResolver < Gem::TestCase
   end
 
   def test_self_compose_sets_nil
-    index_set = @DR::IndexSet.new
+    index_set = Gem::Resolver::IndexSet.new
 
-    composed = @DR.compose_sets index_set, nil
+    composed = Gem::Resolver.compose_sets index_set, nil
 
     assert_same index_set, composed
 
     e = assert_raise ArgumentError do
-      @DR.compose_sets nil
+      Gem::Resolver.compose_sets nil
     end
 
     assert_equal "one set in the composition must be non-nil", e.message
   end
 
   def test_self_compose_sets_single
-    index_set = @DR::IndexSet.new
+    index_set = Gem::Resolver::IndexSet.new
 
-    composed = @DR.compose_sets index_set
+    composed = Gem::Resolver.compose_sets index_set
 
     assert_same index_set, composed
   end

--- a/test/rubygems/test_gem_resolver_activation_request.rb
+++ b/test/rubygems/test_gem_resolver_activation_request.rb
@@ -6,24 +6,22 @@ class TestGemResolverActivationRequest < Gem::TestCase
   def setup
     super
 
-    @DR = Gem::Resolver
-
-    @dep = @DR::DependencyRequest.new dep("a", ">= 0"), nil
+    @dep = Gem::Resolver::DependencyRequest.new dep("a", ">= 0"), nil
 
     source   = Gem::Source::Local.new
     platform = Gem::Platform::RUBY
 
-    @a3 = @DR::IndexSpecification.new nil, "a", v(3), source, platform
+    @a3 = Gem::Resolver::IndexSpecification.new nil, "a", v(3), source, platform
 
-    @req = @DR::ActivationRequest.new @a3, @dep
+    @req = Gem::Resolver::ActivationRequest.new @a3, @dep
   end
 
   def test_development_eh
     refute @req.development?
 
-    dep_req = @DR::DependencyRequest.new dep("a", ">= 0", :development), nil
+    dep_req = Gem::Resolver::DependencyRequest.new dep("a", ">= 0", :development), nil
 
-    act_req = @DR::ActivationRequest.new @a3, dep_req
+    act_req = Gem::Resolver::ActivationRequest.new @a3, dep_req
 
     assert act_req.development?
   end
@@ -36,7 +34,7 @@ class TestGemResolverActivationRequest < Gem::TestCase
   def test_installed_eh
     v_spec = Gem::Resolver::VendorSpecification.new nil, @a3
 
-    @req = @DR::ActivationRequest.new v_spec, @dep
+    @req = Gem::Resolver::ActivationRequest.new v_spec, @dep
 
     assert @req.installed?
   end

--- a/test/rubygems/test_gem_resolver_api_set.rb
+++ b/test/rubygems/test_gem_resolver_api_set.rb
@@ -6,12 +6,11 @@ class TestGemResolverAPISet < Gem::TestCase
   def setup
     super
 
-    @DR = Gem::Resolver
     @dep_uri = URI "#{@gem_repo}info/"
   end
 
   def test_initialize
-    set = @DR::APISet.new
+    set = Gem::Resolver::APISet.new
 
     assert_equal URI("https://index.rubygems.org/info/"),            set.dep_uri
     assert_equal URI("https://index.rubygems.org/"),                 set.uri
@@ -19,7 +18,7 @@ class TestGemResolverAPISet < Gem::TestCase
   end
 
   def test_initialize_deeper_uri
-    set = @DR::APISet.new "https://rubygemsserver.com/mygems/info"
+    set = Gem::Resolver::APISet.new "https://rubygemsserver.com/mygems/info"
 
     assert_equal URI("https://rubygemsserver.com/mygems/info"),       set.dep_uri
     assert_equal URI("https://rubygemsserver.com/"),                  set.uri
@@ -27,7 +26,7 @@ class TestGemResolverAPISet < Gem::TestCase
   end
 
   def test_initialize_uri
-    set = @DR::APISet.new @dep_uri
+    set = Gem::Resolver::APISet.new @dep_uri
 
     assert_equal URI("#{@gem_repo}info/"), set.dep_uri
     assert_equal URI(@gem_repo.to_s), set.uri
@@ -45,12 +44,12 @@ class TestGemResolverAPISet < Gem::TestCase
 
     @fetcher.data["#{@dep_uri}a"] = "---\n1  "
 
-    set = @DR::APISet.new @dep_uri
+    set = Gem::Resolver::APISet.new @dep_uri
 
-    a_dep = @DR::DependencyRequest.new dep("a"), nil
+    a_dep = Gem::Resolver::DependencyRequest.new dep("a"), nil
 
     expected = [
-      @DR::APISpecification.new(set, data.first),
+      Gem::Resolver::APISpecification.new(set, data.first),
     ]
 
     assert_equal expected, set.find_all(a_dep)
@@ -72,14 +71,14 @@ class TestGemResolverAPISet < Gem::TestCase
 
     @fetcher.data["#{@dep_uri}a"] = "---\n1\n2.a"
 
-    set = @DR::APISet.new @dep_uri
+    set = Gem::Resolver::APISet.new @dep_uri
     set.prerelease = true
 
-    a_dep = @DR::DependencyRequest.new dep("a"), nil
+    a_dep = Gem::Resolver::DependencyRequest.new dep("a"), nil
 
     expected = [
-      @DR::APISpecification.new(set, data.first),
-      @DR::APISpecification.new(set, data.last),
+      Gem::Resolver::APISpecification.new(set, data.first),
+      Gem::Resolver::APISpecification.new(set, data.last),
     ]
 
     assert_equal expected, set.find_all(a_dep)
@@ -97,14 +96,14 @@ class TestGemResolverAPISet < Gem::TestCase
 
     @fetcher.data["#{@dep_uri}a"] = "---\n1  "
 
-    set = @DR::APISet.new @dep_uri
+    set = Gem::Resolver::APISet.new @dep_uri
 
-    a_dep = @DR::DependencyRequest.new dep("a"), nil
+    a_dep = Gem::Resolver::DependencyRequest.new dep("a"), nil
 
     set.prefetch [a_dep]
 
     expected = [
-      @DR::APISpecification.new(set, data.first),
+      Gem::Resolver::APISpecification.new(set, data.first),
     ]
 
     assert_equal expected, set.find_all(a_dep)
@@ -113,10 +112,10 @@ class TestGemResolverAPISet < Gem::TestCase
   end
 
   def test_find_all_local
-    set = @DR::APISet.new @dep_uri
+    set = Gem::Resolver::APISet.new @dep_uri
     set.remote = false
 
-    a_dep = @DR::DependencyRequest.new dep("a"), nil
+    a_dep = Gem::Resolver::DependencyRequest.new dep("a"), nil
 
     assert_empty set.find_all(a_dep)
   end
@@ -126,9 +125,9 @@ class TestGemResolverAPISet < Gem::TestCase
 
     @fetcher.data["#{@dep_uri}a"] = "---"
 
-    set = @DR::APISet.new @dep_uri
+    set = Gem::Resolver::APISet.new @dep_uri
 
-    a_dep = @DR::DependencyRequest.new dep("a"), nil
+    a_dep = Gem::Resolver::DependencyRequest.new dep("a"), nil
 
     assert_empty set.find_all(a_dep)
 
@@ -143,10 +142,10 @@ class TestGemResolverAPISet < Gem::TestCase
     @fetcher.data["#{@dep_uri}a"] = "---\n1  \n"
     @fetcher.data["#{@dep_uri}b"] = "---"
 
-    set = @DR::APISet.new @dep_uri
+    set = Gem::Resolver::APISet.new @dep_uri
 
-    a_dep = @DR::DependencyRequest.new dep("a"), nil
-    b_dep = @DR::DependencyRequest.new dep("b"), nil
+    a_dep = Gem::Resolver::DependencyRequest.new dep("a"), nil
+    b_dep = Gem::Resolver::DependencyRequest.new dep("b"), nil
 
     set.prefetch [a_dep, b_dep]
 
@@ -159,10 +158,10 @@ class TestGemResolverAPISet < Gem::TestCase
 
     @fetcher.data["#{@dep_uri}a"] = "---\n1  \n"
 
-    set = @DR::APISet.new @dep_uri
+    set = Gem::Resolver::APISet.new @dep_uri
 
-    a_dep = @DR::DependencyRequest.new dep("a"), nil
-    b_dep = @DR::DependencyRequest.new dep("b"), nil
+    a_dep = Gem::Resolver::DependencyRequest.new dep("a"), nil
+    b_dep = Gem::Resolver::DependencyRequest.new dep("b"), nil
 
     set.prefetch [a_dep]
 
@@ -178,10 +177,10 @@ class TestGemResolverAPISet < Gem::TestCase
     @fetcher.data["#{@dep_uri}a"] = "---\n1  \n"
     @fetcher.data["#{@dep_uri}b"] = "---"
 
-    set = @DR::APISet.new @dep_uri
+    set = Gem::Resolver::APISet.new @dep_uri
 
-    a_dep = @DR::DependencyRequest.new dep("a"), nil
-    b_dep = @DR::DependencyRequest.new dep("b"), nil
+    a_dep = Gem::Resolver::DependencyRequest.new dep("a"), nil
+    b_dep = Gem::Resolver::DependencyRequest.new dep("b"), nil
 
     set.prefetch [a_dep, b_dep]
 
@@ -197,11 +196,11 @@ class TestGemResolverAPISet < Gem::TestCase
     @fetcher.data["#{@dep_uri}a"] = "---\n1  \n"
     @fetcher.data["#{@dep_uri}b"] = "---"
 
-    set = @DR::APISet.new @dep_uri
+    set = Gem::Resolver::APISet.new @dep_uri
     set.remote = false
 
-    a_dep = @DR::DependencyRequest.new dep("a"), nil
-    b_dep = @DR::DependencyRequest.new dep("b"), nil
+    a_dep = Gem::Resolver::DependencyRequest.new dep("a"), nil
+    b_dep = Gem::Resolver::DependencyRequest.new dep("b"), nil
 
     set.prefetch [a_dep, b_dep]
 

--- a/test/rubygems/test_gem_resolver_best_set.rb
+++ b/test/rubygems/test_gem_resolver_best_set.rb
@@ -3,14 +3,8 @@
 require_relative "helper"
 
 class TestGemResolverBestSet < Gem::TestCase
-  def setup
-    super
-
-    @DR = Gem::Resolver
-  end
-
   def test_initialize
-    set = @DR::BestSet.new
+    set = Gem::Resolver::BestSet.new
 
     assert_empty set.sets
   end
@@ -22,11 +16,11 @@ class TestGemResolverBestSet < Gem::TestCase
       fetcher.spec "b", 1
     end
 
-    set = @DR::BestSet.new
+    set = Gem::Resolver::BestSet.new
 
     dependency = dep "a", "~> 1"
 
-    req = @DR::DependencyRequest.new dependency, nil
+    req = Gem::Resolver::DependencyRequest.new dependency, nil
 
     found = set.find_all req
 
@@ -38,7 +32,7 @@ class TestGemResolverBestSet < Gem::TestCase
       fetcher.spec "a", 1
     end
 
-    set = @DR::BestSet.new
+    set = Gem::Resolver::BestSet.new
 
     api_uri = URI(@gem_repo)
 
@@ -46,7 +40,7 @@ class TestGemResolverBestSet < Gem::TestCase
 
     dependency = dep "a", "~> 1"
 
-    req = @DR::DependencyRequest.new dependency, nil
+    req = Gem::Resolver::DependencyRequest.new dependency, nil
 
     found = set.find_all req
 
@@ -60,12 +54,12 @@ class TestGemResolverBestSet < Gem::TestCase
       fetcher.spec "b", 1
     end
 
-    set = @DR::BestSet.new
+    set = Gem::Resolver::BestSet.new
     set.remote = false
 
     dependency = dep "a", "~> 1"
 
-    req = @DR::DependencyRequest.new dependency, nil
+    req = Gem::Resolver::DependencyRequest.new dependency, nil
 
     found = set.find_all req
 
@@ -77,7 +71,7 @@ class TestGemResolverBestSet < Gem::TestCase
       fetcher.spec "a", 1
     end
 
-    set = @DR::BestSet.new
+    set = Gem::Resolver::BestSet.new
 
     set.prefetch []
 
@@ -89,7 +83,7 @@ class TestGemResolverBestSet < Gem::TestCase
       fetcher.spec "a", 1
     end
 
-    set = @DR::BestSet.new
+    set = Gem::Resolver::BestSet.new
     set.remote = false
 
     set.prefetch []
@@ -98,7 +92,7 @@ class TestGemResolverBestSet < Gem::TestCase
   end
 
   def test_replace_failed_api_set
-    set = @DR::BestSet.new
+    set = Gem::Resolver::BestSet.new
 
     api_uri = URI(@gem_repo) + "./info/"
     api_set = Gem::Resolver::APISet.new api_uri
@@ -119,7 +113,7 @@ class TestGemResolverBestSet < Gem::TestCase
   end
 
   def test_replace_failed_api_set_no_api_set
-    set = @DR::BestSet.new
+    set = Gem::Resolver::BestSet.new
 
     index_set = Gem::Resolver::IndexSet.new Gem::Source.new @gem_repo
 
@@ -135,7 +129,7 @@ class TestGemResolverBestSet < Gem::TestCase
   end
 
   def test_replace_failed_api_set_uri_with_credentials
-    set = @DR::BestSet.new
+    set = Gem::Resolver::BestSet.new
 
     api_uri = URI(@gem_repo) + "./info/"
     api_uri.user = "user"

--- a/test/rubygems/test_gem_resolver_conflict.rb
+++ b/test/rubygems/test_gem_resolver_conflict.rb
@@ -36,16 +36,14 @@ class TestGemResolverConflict < Gem::TestCase
   end
 
   def test_explanation_user_request
-    @DR = Gem::Resolver
-
     spec = util_spec "a", 2
 
-    a1_req = @DR::DependencyRequest.new dep("a", "= 1"), nil
-    a2_req = @DR::DependencyRequest.new dep("a", "= 2"), nil
+    a1_req = Gem::Resolver::DependencyRequest.new dep("a", "= 1"), nil
+    a2_req = Gem::Resolver::DependencyRequest.new dep("a", "= 2"), nil
 
-    activated = @DR::ActivationRequest.new spec, a2_req
+    activated = Gem::Resolver::ActivationRequest.new spec, a2_req
 
-    conflict = @DR::Conflict.new a1_req, activated
+    conflict = Gem::Resolver::Conflict.new a1_req, activated
 
     expected = <<-EXPECTED
   Activated a-2

--- a/test/rubygems/test_gem_resolver_dependency_request.rb
+++ b/test/rubygems/test_gem_resolver_dependency_request.rb
@@ -3,22 +3,16 @@
 require_relative "helper"
 
 class TestGemResolverDependencyRequest < Gem::TestCase
-  def setup
-    super
-
-    @DR = Gem::Resolver::DependencyRequest
-  end
-
   def test_development_eh
     a_dep = dep "a", ">= 1"
 
-    a_dep_req = @DR.new a_dep, nil
+    a_dep_req = Gem::Resolver::DependencyRequest.new a_dep, nil
 
     refute a_dep_req.development?
 
     b_dep = dep "b", ">= 1", :development
 
-    b_dep_req = @DR.new b_dep, nil
+    b_dep_req = Gem::Resolver::DependencyRequest.new b_dep, nil
 
     assert b_dep_req.development?
   end
@@ -27,7 +21,7 @@ class TestGemResolverDependencyRequest < Gem::TestCase
     spec = util_spec "a", 1
     dependency = dep "a", ">= 1"
 
-    dr = @DR.new dependency, nil
+    dr = Gem::Resolver::DependencyRequest.new dependency, nil
 
     assert dr.match? spec
   end
@@ -36,12 +30,12 @@ class TestGemResolverDependencyRequest < Gem::TestCase
     spec = util_spec "a", "1.a"
 
     a_dep = dep "a", ">= 1"
-    a_dr = @DR.new a_dep, nil
+    a_dr = Gem::Resolver::DependencyRequest.new a_dep, nil
 
     refute a_dr.match? spec
 
     a_pre_dep = dep "a", ">= 1.a"
-    a_pre_dr = @DR.new a_pre_dep, nil
+    a_pre_dr = Gem::Resolver::DependencyRequest.new a_pre_dep, nil
 
     assert a_pre_dr.match? spec
   end
@@ -50,7 +44,7 @@ class TestGemResolverDependencyRequest < Gem::TestCase
     spec = util_spec "a", "2.a"
 
     a_dep = dep "a", ">= 1"
-    a_dr = @DR.new a_dep, nil
+    a_dr = Gem::Resolver::DependencyRequest.new a_dep, nil
 
     assert a_dr.match? spec, true
   end
@@ -59,7 +53,7 @@ class TestGemResolverDependencyRequest < Gem::TestCase
     spec = util_spec "a", 1
     dependency = dep "a", ">= 1"
 
-    dr = @DR.new dependency, nil
+    dr = Gem::Resolver::DependencyRequest.new dependency, nil
 
     assert dr.matches_spec? spec
   end
@@ -68,7 +62,7 @@ class TestGemResolverDependencyRequest < Gem::TestCase
     spec = util_spec "a", "1.a"
 
     dependency = dep "a", ">= 0"
-    dr = @DR.new dependency, nil
+    dr = Gem::Resolver::DependencyRequest.new dependency, nil
 
     assert dr.matches_spec? spec
   end
@@ -76,7 +70,7 @@ class TestGemResolverDependencyRequest < Gem::TestCase
   def test_requirement
     dependency = dep "a", ">= 1"
 
-    dr = @DR.new dependency, nil
+    dr = Gem::Resolver::DependencyRequest.new dependency, nil
 
     assert_equal dependency, dr.dependency
   end

--- a/test/rubygems/test_gem_resolver_index_set.rb
+++ b/test/rubygems/test_gem_resolver_index_set.rb
@@ -3,14 +3,8 @@
 require_relative "helper"
 
 class TestGemResolverIndexSet < Gem::TestCase
-  def setup
-    super
-
-    @DR = Gem::Resolver
-  end
-
   def test_initialize
-    set = @DR::IndexSet.new
+    set = Gem::Resolver::IndexSet.new
 
     fetcher = set.instance_variable_get :@f
 
@@ -18,7 +12,7 @@ class TestGemResolverIndexSet < Gem::TestCase
   end
 
   def test_initialize_source
-    set = @DR::IndexSet.new "http://alternate.example"
+    set = Gem::Resolver::IndexSet.new "http://alternate.example"
 
     fetcher = set.instance_variable_get :@f
 
@@ -34,11 +28,11 @@ class TestGemResolverIndexSet < Gem::TestCase
       fetcher.spec "b", 1
     end
 
-    set = @DR::IndexSet.new
+    set = Gem::Resolver::IndexSet.new
 
     dependency = dep "a", "~> 1"
 
-    req = @DR::DependencyRequest.new dependency, nil
+    req = Gem::Resolver::DependencyRequest.new dependency, nil
 
     found = set.find_all req
 
@@ -52,12 +46,12 @@ class TestGemResolverIndexSet < Gem::TestCase
       fetcher.spec "b", 1
     end
 
-    set = @DR::IndexSet.new
+    set = Gem::Resolver::IndexSet.new
     set.remote = false
 
     dependency = dep "a", "~> 1"
 
-    req = @DR::DependencyRequest.new dependency, nil
+    req = Gem::Resolver::DependencyRequest.new dependency, nil
 
     assert_empty set.find_all req
   end
@@ -67,11 +61,11 @@ class TestGemResolverIndexSet < Gem::TestCase
       fetcher.spec "a", "1.a"
     end
 
-    set = @DR::IndexSet.new
+    set = Gem::Resolver::IndexSet.new
 
     dependency = dep "a"
 
-    req = @DR::DependencyRequest.new dependency, nil
+    req = Gem::Resolver::DependencyRequest.new dependency, nil
 
     found = set.find_all req
 
@@ -79,7 +73,7 @@ class TestGemResolverIndexSet < Gem::TestCase
 
     dependency.prerelease = true
 
-    req = @DR::DependencyRequest.new dependency, nil
+    req = Gem::Resolver::DependencyRequest.new dependency, nil
 
     found = set.find_all req
 

--- a/test/rubygems/test_gem_resolver_lock_specification.rb
+++ b/test/rubygems/test_gem_resolver_lock_specification.rb
@@ -8,14 +8,12 @@ class TestGemResolverLockSpecification < Gem::TestCase
   def setup
     super
 
-    @LS = Gem::Resolver::LockSpecification
-
     @source = Gem::Source.new @gem_repo
     @set    = Gem::Resolver::LockSet.new [@source]
   end
 
   def test_initialize
-    spec = @LS.new @set, "a", v(2), [@source], Gem::Platform::RUBY
+    spec = Gem::Resolver::LockSpecification.new @set, "a", v(2), [@source], Gem::Platform::RUBY
 
     assert_equal "a",                 spec.name
     assert_equal v(2),                spec.version
@@ -25,7 +23,7 @@ class TestGemResolverLockSpecification < Gem::TestCase
   end
 
   def test_add_dependency
-    l_spec = @LS.new @set, "a", v(2), [@source], Gem::Platform::RUBY
+    l_spec = Gem::Resolver::LockSpecification.new @set, "a", v(2), [@source], Gem::Platform::RUBY
 
     b_dep = dep("b", ">= 0")
 
@@ -39,7 +37,7 @@ class TestGemResolverLockSpecification < Gem::TestCase
       fetcher.download "a", 2
     end
 
-    spec = @LS.new @set, "a", v(2), [@source], Gem::Platform::RUBY
+    spec = Gem::Resolver::LockSpecification.new @set, "a", v(2), [@source], Gem::Platform::RUBY
 
     called = false
 
@@ -51,7 +49,7 @@ class TestGemResolverLockSpecification < Gem::TestCase
   end
 
   def test_install_installed
-    spec = @LS.new @set, "a", v(2), [@source], Gem::Platform::RUBY
+    spec = Gem::Resolver::LockSpecification.new @set, "a", v(2), [@source], Gem::Platform::RUBY
 
     FileUtils.touch File.join(@gemhome, "specifications", spec.spec.spec_name)
 
@@ -67,7 +65,7 @@ class TestGemResolverLockSpecification < Gem::TestCase
   def test_spec
     version = v(2)
 
-    l_spec = @LS.new @set, "a", version, [@source], Gem::Platform::RUBY
+    l_spec = Gem::Resolver::LockSpecification.new @set, "a", version, [@source], Gem::Platform::RUBY
 
     b_dep = dep "b", ">= 0"
     c_dep = dep "c", "~> 1"
@@ -91,7 +89,7 @@ class TestGemResolverLockSpecification < Gem::TestCase
 
     version = v(2)
 
-    l_spec = @LS.new @set, "a", version, [@source], Gem::Platform::RUBY
+    l_spec = Gem::Resolver::LockSpecification.new @set, "a", version, [@source], Gem::Platform::RUBY
 
     assert_same real_spec, l_spec.spec
   end

--- a/test/rubygems/test_gem_security.rb
+++ b/test/rubygems/test_gem_security.rb
@@ -19,17 +19,11 @@ class TestGemSecurity < Gem::TestCase
   CHILD_CERT     = load_cert "child"
   EXPIRED_CERT   = load_cert "expired"
 
-  def setup
-    super
-
-    @SEC = Gem::Security
-  end
-
   def test_class_create_cert
     name = PUBLIC_CERT.subject
     key = PRIVATE_KEY
 
-    cert = @SEC.create_cert name, key, 60, Gem::Security::EXTENSIONS, 5
+    cert = Gem::Security.create_cert name, key, 60, Gem::Security::EXTENSIONS, 5
 
     assert_kind_of OpenSSL::X509::Certificate, cert
 
@@ -62,7 +56,7 @@ class TestGemSecurity < Gem::TestCase
   def test_class_create_cert_self_signed
     subject = PUBLIC_CERT.subject
 
-    cert = @SEC.create_cert_self_signed subject, PRIVATE_KEY, 60
+    cert = Gem::Security.create_cert_self_signed subject, PRIVATE_KEY, 60
 
     assert_equal "/CN=nobody/DC=example", cert.issuer.to_s
     assert_equal "sha256WithRSAEncryption", cert.signature_algorithm
@@ -73,7 +67,7 @@ class TestGemSecurity < Gem::TestCase
     name = PUBLIC_CERT.subject
     key = PRIVATE_KEY
 
-    cert = @SEC.create_cert_email email, key, 60
+    cert = Gem::Security.create_cert_email email, key, 60
 
     assert_kind_of OpenSSL::X509::Certificate, cert
 
@@ -105,20 +99,20 @@ class TestGemSecurity < Gem::TestCase
   end
 
   def test_class_create_key
-    key = @SEC.create_key "rsa"
+    key = Gem::Security.create_key "rsa"
 
     assert_kind_of OpenSSL::PKey::RSA, key
   end
 
   def test_class_create_key_downcases
-    key = @SEC.create_key "DSA"
+    key = Gem::Security.create_key "DSA"
 
     assert_kind_of OpenSSL::PKey::DSA, key
   end
 
   def test_class_create_key_raises_unknown_algorithm
     e = assert_raise Gem::Security::Exception do
-      @SEC.create_key "NOT_RSA"
+      Gem::Security.create_key "NOT_RSA"
     end
 
     assert_equal "NOT_RSA algorithm not found. RSA, DSA, and EC algorithms are supported.",
@@ -128,27 +122,27 @@ class TestGemSecurity < Gem::TestCase
   def test_class_get_public_key_rsa
     pkey_pem = PRIVATE_KEY.public_key.to_pem
 
-    assert_equal pkey_pem, @SEC.get_public_key(PRIVATE_KEY).to_pem
+    assert_equal pkey_pem, Gem::Security.get_public_key(PRIVATE_KEY).to_pem
   end
 
   def test_class_get_public_key_ec
-    pkey = @SEC.get_public_key(EC_KEY)
+    pkey = Gem::Security.get_public_key(EC_KEY)
 
     assert_respond_to pkey, :to_pem
   end
 
   def test_class_email_to_name
     assert_equal "/CN=nobody/DC=example",
-                 @SEC.email_to_name("nobody@example").to_s
+                 Gem::Security.email_to_name("nobody@example").to_s
 
     assert_equal "/CN=nobody/DC=example/DC=com",
-                 @SEC.email_to_name("nobody@example.com").to_s
+                 Gem::Security.email_to_name("nobody@example.com").to_s
 
     assert_equal "/CN=no.body/DC=example",
-                 @SEC.email_to_name("no.body@example").to_s
+                 Gem::Security.email_to_name("no.body@example").to_s
 
     assert_equal "/CN=no_body/DC=example",
-                 @SEC.email_to_name("no+body@example").to_s
+                 Gem::Security.email_to_name("no+body@example").to_s
   end
 
   def test_class_re_sign
@@ -188,11 +182,11 @@ class TestGemSecurity < Gem::TestCase
   end
 
   def test_class_reset
-    trust_dir = @SEC.trust_dir
+    trust_dir = Gem::Security.trust_dir
 
-    @SEC.reset
+    Gem::Security.reset
 
-    refute_equal trust_dir, @SEC.trust_dir
+    refute_equal trust_dir, Gem::Security.trust_dir
   end
 
   def test_class_sign
@@ -206,7 +200,7 @@ class TestGemSecurity < Gem::TestCase
     cert.subject    = signee
     cert.public_key = key.public_key
 
-    signed = @SEC.sign cert, key, PUBLIC_CERT, 60
+    signed = Gem::Security.sign cert, key, PUBLIC_CERT, 60
 
     assert_equal    key.public_key.to_pem, signed.public_key.to_pem
     assert_equal    signee.to_s,           signed.subject.to_s
@@ -241,9 +235,9 @@ class TestGemSecurity < Gem::TestCase
     issuer = PUBLIC_CERT.subject
     signee = OpenSSL::X509::Name.parse "/CN=signee/DC=example"
 
-    cert = @SEC.create_cert_email "signee@example", PRIVATE_KEY
+    cert = Gem::Security.create_cert_email "signee@example", PRIVATE_KEY
 
-    signed = @SEC.sign cert, PRIVATE_KEY, PUBLIC_CERT, 60
+    signed = Gem::Security.sign cert, PRIVATE_KEY, PUBLIC_CERT, 60
 
     assert_equal    PUBLIC_KEY.to_pem, signed.public_key.to_pem
     assert_equal    signee.to_s,       signed.subject.to_s
@@ -280,7 +274,7 @@ class TestGemSecurity < Gem::TestCase
   end
 
   def test_class_trust_dir
-    trust_dir = @SEC.trust_dir
+    trust_dir = Gem::Security.trust_dir
 
     expected = File.join Gem.user_home, ".gem/trust"
 
@@ -288,11 +282,11 @@ class TestGemSecurity < Gem::TestCase
   end
 
   def test_class_write
-    key = @SEC.create_key "rsa"
+    key = Gem::Security.create_key "rsa"
 
     path = File.join @tempdir, "test-private_key.pem"
 
-    @SEC.write key, path
+    Gem::Security.write key, path
 
     assert_path_exist path
 
@@ -302,13 +296,13 @@ class TestGemSecurity < Gem::TestCase
   end
 
   def test_class_write_encrypted
-    key = @SEC.create_key "rsa"
+    key = Gem::Security.create_key "rsa"
 
     path = File.join @tempdir, "test-private_encrypted_key.pem"
 
     passphrase = "It should be long."
 
-    @SEC.write key, path, 0o600, passphrase
+    Gem::Security.write key, path, 0o600, passphrase
 
     assert_path_exist path
 
@@ -318,7 +312,7 @@ class TestGemSecurity < Gem::TestCase
   end
 
   def test_class_write_encrypted_cipher
-    key = @SEC.create_key "rsa"
+    key = Gem::Security.create_key "rsa"
 
     path = File.join @tempdir, "test-private_encrypted__with_non_default_cipher_key.pem"
 
@@ -326,7 +320,7 @@ class TestGemSecurity < Gem::TestCase
 
     cipher = OpenSSL::Cipher.new "AES-192-CBC"
 
-    @SEC.write key, path, 0o600, passphrase, cipher
+    Gem::Security.write key, path, 0o600, passphrase, cipher
 
     assert_path_exist path
 

--- a/test/rubygems/test_gem_source.rb
+++ b/test/rubygems/test_gem_source.rb
@@ -213,12 +213,12 @@ class TestGemSource < Gem::TestCase
   end
 
   def test_spaceship_order_is_preserved_when_uri_differs
-    sourceA = Gem::Source.new "http://example.com/a"
-    sourceB = Gem::Source.new "http://example.com/b"
+    source_a = Gem::Source.new "http://example.com/a"
+    source_b = Gem::Source.new "http://example.com/b"
 
-    assert_equal(0, sourceA.<=>(sourceA), "sourceA <=> sourceA") # rubocop:disable Lint/BinaryOperatorWithIdenticalOperands
-    assert_equal(1, sourceA.<=>(sourceB), "sourceA <=> sourceB")
-    assert_equal(1, sourceB.<=>(sourceA), "sourceB <=> sourceA")
+    assert_equal(0, source_a.<=>(source_a), "source_a <=> source_a") # rubocop:disable Lint/BinaryOperatorWithIdenticalOperands
+    assert_equal(1, source_a.<=>(source_b), "source_a <=> source_b")
+    assert_equal(1, source_b.<=>(source_a), "source_b <=> source_a")
   end
 
   def test_update_cache_eh


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We still disabled some of cops.

## What is your fix for the problem, implemented in this PR?

I enabled Naming/VariableName cops. It have two types.

* To use camelCase for instance variables.
* To use alias for long name class like `@SEC = Gem::Security`. Today, we can use auto-complete for long name variables. There is no reason to alias them.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
