### PR TITLE
Use pure-ruby YAML parser for loading configuration at RubyGems

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -541,6 +541,7 @@ lib/rubygems/version.rb
 lib/rubygems/version_option.rb
 lib/rubygems/webauthn_listener.rb
 lib/rubygems/webauthn_listener/response.rb
+lib/rubygems/yaml_serializer.rb
 rubygems-update.gemspec
 setup.rb
 test/rubygems/alternate_cert.pem

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -461,7 +461,7 @@ module Bundler
             new_k = k.gsub("-", "___")
           end
 
-          config[new_k] = v
+          config[new_k] = v.to_s
           config
         end
       end

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -461,7 +461,7 @@ module Bundler
             new_k = k.gsub("-", "___")
           end
 
-          config[new_k] = v.to_s
+          config[new_k] = v
           config
         end
       end

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -386,8 +386,7 @@ module Bundler
       return unless file
       SharedHelpers.filesystem_access(file) do |p|
         FileUtils.mkdir_p(p.dirname)
-        require_relative "yaml_serializer"
-        p.open("w") {|f| f.write(YAMLSerializer.dump(hash)) }
+        p.open("w") {|f| f.write(serializer_class.dump(hash)) }
       end
     end
 
@@ -449,8 +448,7 @@ module Bundler
       SharedHelpers.filesystem_access(config_file, :read) do |file|
         valid_file = file.exist? && !file.size.zero?
         return {} unless valid_file
-        require_relative "yaml_serializer"
-        YAMLSerializer.load(file.read).inject({}) do |config, (k, v)|
+        serializer_class.load(file.read).inject({}) do |config, (k, v)|
           new_k = k
 
           if k.include?("-")
@@ -465,6 +463,15 @@ module Bundler
           config
         end
       end
+    end
+
+    def serializer_class
+      require "rubygems/yaml_serializer"
+      Gem::YAMLSerializer
+    rescue LoadError
+      # TODO: Remove this when RubyGems 3.4 is EOL
+      require_relative "yaml_serializer"
+      YAMLSerializer
     end
 
     PER_URI_OPTIONS = %w[

--- a/bundler/lib/bundler/yaml_serializer.rb
+++ b/bundler/lib/bundler/yaml_serializer.rb
@@ -58,7 +58,7 @@ module Bundler
       str.split(/\r?\n/).each do |line|
         if match = HASH_REGEX.match(line)
           indent, key, quote, val = match.captures
-          key = convert_to_backward_compatible_key(key) if key.match?(/__/)
+          key = convert_to_backward_compatible_key(key)
           key = key[1..-1].to_sym if key.start_with?(":")
           depth = indent.scan(/  /).length
           if quote.empty? && val.empty?
@@ -77,22 +77,7 @@ module Bundler
           last_hash[last_empty_key].push(convert_to_ruby_value(val))
         end
       end
-      deep_transform_values_with_empty_hash!(res)
       res
-    end
-
-    def deep_transform_values_with_empty_hash!(hash)
-      hash.transform_values! do |v|
-        if v.is_a?(Hash)
-          if v.empty?
-            nil
-          else
-            deep_transform_values_with_empty_hash!(v)
-          end
-        else
-          v
-        end
-      end
     end
 
     def convert_to_ruby_value(val)
@@ -102,8 +87,6 @@ module Bundler
         val.to_i
       elsif val.match?(/\Atrue|false\Z/)
         val == "true"
-      elsif val.empty?
-        nil
       else
         val
       end

--- a/bundler/lib/bundler/yaml_serializer.rb
+++ b/bundler/lib/bundler/yaml_serializer.rb
@@ -13,11 +13,7 @@ module Bundler
     def dump_hash(hash)
       yaml = String.new("\n")
       hash.each do |k, v|
-        if k.is_a?(Symbol)
-          yaml << ":#{k}:"
-        else
-          yaml << k << ":"
-        end
+        yaml << k << ":"
         if v.is_a?(Hash)
           yaml << dump_hash(v).gsub(/^(?!$)/, "  ") # indent all non-empty lines
         elsif v.is_a?(Array) # Expected to be array of strings
@@ -50,7 +46,7 @@ module Bundler
       $
     /xo.freeze
 
-    def load(str, is_rubygems: false)
+    def load(str)
       res = {}
       stack = [res]
       last_hash = nil
@@ -58,8 +54,7 @@ module Bundler
       str.split(/\r?\n/).each do |line|
         if match = HASH_REGEX.match(line)
           indent, key, quote, val = match.captures
-          key = convert_to_backward_compatible_key(key) unless is_rubygems
-          key = key[1..-1].to_sym if key.start_with?(":")
+          key = convert_to_backward_compatible_key(key)
           depth = indent.scan(/  /).length
           if quote.empty? && val.empty?
             new_hash = {}
@@ -68,28 +63,16 @@ module Bundler
             last_empty_key = key
             last_hash = stack[depth]
           else
-            stack[depth][key] = convert_to_ruby_value(val)
+            stack[depth][key] = val
           end
         elsif match = ARRAY_REGEX.match(line)
           _, val = match.captures
           last_hash[last_empty_key] = [] unless last_hash[last_empty_key].is_a?(Array)
 
-          last_hash[last_empty_key].push(convert_to_ruby_value(val))
+          last_hash[last_empty_key].push(val)
         end
       end
       res
-    end
-
-    def convert_to_ruby_value(val)
-      if val.match?(/\A:(.*)\Z/)
-        val[1..-1].to_sym
-      elsif val.match?(/\A[+-]?\d+\Z/)
-        val.to_i
-      elsif val.match?(/\Atrue|false\Z/)
-        val == "true"
-      else
-        val
-      end
     end
 
     # for settings' keys

--- a/bundler/lib/bundler/yaml_serializer.rb
+++ b/bundler/lib/bundler/yaml_serializer.rb
@@ -50,7 +50,7 @@ module Bundler
       $
     /xo.freeze
 
-    def load(str)
+    def load(str, is_rubygems: false)
       res = {}
       stack = [res]
       last_hash = nil
@@ -58,7 +58,7 @@ module Bundler
       str.split(/\r?\n/).each do |line|
         if match = HASH_REGEX.match(line)
           indent, key, quote, val = match.captures
-          key = convert_to_backward_compatible_key(key)
+          key = convert_to_backward_compatible_key(key) unless is_rubygems
           key = key[1..-1].to_sym if key.start_with?(":")
           depth = indent.scan(/  /).length
           if quote.empty? && val.empty?

--- a/bundler/lib/bundler/yaml_serializer.rb
+++ b/bundler/lib/bundler/yaml_serializer.rb
@@ -81,7 +81,9 @@ module Bundler
     end
 
     def convert_to_ruby_value(val)
-      if val.match?(/\A[+-]?\d+\Z/)
+      if val.match?(/\A:(.*)\Z/)
+        $1.to_sym
+      elsif val.match?(/\A[+-]?\d+\Z/)
         val.to_i
       elsif val.match?(/\Atrue|false\Z/)
         val == "true"

--- a/bundler/lib/bundler/yaml_serializer.rb
+++ b/bundler/lib/bundler/yaml_serializer.rb
@@ -82,7 +82,7 @@ module Bundler
 
     def convert_to_ruby_value(val)
       if val.match?(/\A:(.*)\Z/)
-        $1.to_sym
+        val[1..-1].to_sym
       elsif val.match?(/\A[+-]?\d+\Z/)
         val.to_i
       elsif val.match?(/\Atrue|false\Z/)

--- a/bundler/lib/bundler/yaml_serializer.rb
+++ b/bundler/lib/bundler/yaml_serializer.rb
@@ -58,7 +58,7 @@ module Bundler
       str.split(/\r?\n/).each do |line|
         if match = HASH_REGEX.match(line)
           indent, key, quote, val = match.captures
-          key = convert_to_backward_compatible_key(key)
+          key = convert_to_backward_compatible_key(key) if key.match?(/__/)
           key = key[1..-1].to_sym if key.start_with?(":")
           depth = indent.scan(/  /).length
           if quote.empty? && val.empty?

--- a/bundler/lib/bundler/yaml_serializer.rb
+++ b/bundler/lib/bundler/yaml_serializer.rb
@@ -77,7 +77,22 @@ module Bundler
           last_hash[last_empty_key].push(convert_to_ruby_value(val))
         end
       end
+      deep_transform_values_with_empty_hash!(res)
       res
+    end
+
+    def deep_transform_values_with_empty_hash!(hash)
+      hash.transform_values! do |v|
+        if v.is_a?(Hash)
+          if v.empty?
+            nil
+          else
+            deep_transform_values_with_empty_hash!(v)
+          end
+        else
+          v
+        end
+      end
     end
 
     def convert_to_ruby_value(val)

--- a/bundler/lib/bundler/yaml_serializer.rb
+++ b/bundler/lib/bundler/yaml_serializer.rb
@@ -87,6 +87,8 @@ module Bundler
         val.to_i
       elsif val.match?(/\Atrue|false\Z/)
         val == "true"
+      elsif val.empty?
+        nil
       else
         val
       end

--- a/bundler/spec/bundler/friendly_errors_spec.rb
+++ b/bundler/spec/bundler/friendly_errors_spec.rb
@@ -5,29 +5,6 @@ require "bundler/friendly_errors"
 require "cgi"
 
 RSpec.describe Bundler, "friendly errors" do
-  context "with invalid YAML in .gemrc" do
-    before do
-      File.open(home(".gemrc"), "w") do |f|
-        f.write "invalid: yaml: hah"
-      end
-    end
-
-    after do
-      FileUtils.rm(home(".gemrc"))
-    end
-
-    it "reports a relevant friendly error message" do
-      gemfile <<-G
-        source "#{file_uri_for(gem_repo1)}"
-        gem "rack"
-      G
-
-      bundle :install, :env => { "DEBUG" => "true" }
-
-      expect(err).to include("Failed to load #{home(".gemrc")}")
-    end
-  end
-
   it "calls log_error in case of exception" do
     exception = Exception.new
     expect(Bundler::FriendlyErrors).to receive(:exit_status).with(exception).and_return(1)

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -357,39 +357,7 @@ if you believe they were disclosed to a third party.
     begin
       content = Bundler::YAMLSerializer.load(File.read(filename))
       if content.is_a? Hash
-        content.transform_keys! do |k|
-          if k.match?(/\A:(.*)\Z/)
-            k[1..-1].to_sym
-          elsif k.match?(/__/)
-            if k.is_a?(Symbol)
-              k.to_s.gsub(/__/,".").to_sym
-            else
-              k.dup.gsub(/__/,".")
-            end
-          else
-            k
-          end
-        end
-
-        content.transform_values! do |v|
-          if v.is_a?(String)
-            if v.match?(/\A:(.*)\Z/)
-              v[1..-1].to_sym
-            elsif v.match?(/\A[+-]?\d+\Z/)
-              v.to_i
-            elsif v.match?(/\Atrue|false\Z/)
-              v == "true"
-            elsif v.empty?
-              nil
-            else
-              v
-            end
-          elsif v.is_a?(Hash) && v.empty?
-            nil
-          else
-            v
-          end
-        end
+        content = self.class.convert_rubygems_config_hash(content)
       else
         warn "Failed to load #{filename} because it doesn't contain valid YAML hash"
         return {}
@@ -563,6 +531,44 @@ if you believe they were disclosed to a third party.
 
   attr_reader :hash
   protected :hash
+
+  def self.convert_rubygems_config_hash(content)
+    content.transform_keys! do |k|
+      if k.match?(/\A:(.*)\Z/)
+        k[1..-1].to_sym
+      elsif k.match?(/__/)
+        if k.is_a?(Symbol)
+          k.to_s.gsub(/__/,".").to_sym
+        else
+          k.dup.gsub(/__/,".")
+        end
+      else
+        k
+      end
+    end
+
+    content.transform_values! do |v|
+      if v.is_a?(String)
+        if v.match?(/\A:(.*)\Z/)
+          v[1..-1].to_sym
+        elsif v.match?(/\A[+-]?\d+\Z/)
+          v.to_i
+        elsif v.match?(/\Atrue|false\Z/)
+          v == "true"
+        elsif v.empty?
+          nil
+        else
+          v
+        end
+      elsif v.is_a?(Hash) && v.empty?
+        nil
+      else
+        v
+      end
+    end
+
+    content
+  end
 
   private
 

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -486,6 +486,7 @@ if you believe they were disclosed to a third party.
       yaml_hash[key.to_s] = value
     end
 
+    require "bundler/yaml_serializer"
     Bundler::YAMLSerializer.dump(yaml_hash)
   end
 

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -324,11 +324,11 @@ if you believe they were disclosed to a third party.
     require "fileutils"
     FileUtils.mkdir_p(dirname)
 
-    Gem.load_yaml
+    require "bundler/yaml_serializer"
 
     permissions = 0o600 & (~File.umask)
     File.open(credentials_path, "w", permissions) do |f|
-      f.write config.to_yaml
+      f.write Bundler::YAMLSerializer.dump(config)
     end
 
     load_api_keys # reload
@@ -344,15 +344,14 @@ if you believe they were disclosed to a third party.
   end
 
   def load_file(filename)
-    Gem.load_yaml
+    require "bundler/yaml_serializer"
 
     yaml_errors = [ArgumentError]
-    yaml_errors << Psych::SyntaxError if defined?(Psych::SyntaxError)
 
     return {} unless filename && !filename.empty? && File.exist?(filename)
 
     begin
-      content = Gem::SafeYAML.load(File.read(filename))
+      content = Bundler::YAMLSerializer.load(File.read(filename))
       unless content.is_a? Hash
         warn "Failed to load #{filename} because it doesn't contain valid YAML hash"
         return {}
@@ -487,7 +486,7 @@ if you believe they were disclosed to a third party.
       yaml_hash[key.to_s] = value
     end
 
-    yaml_hash.to_yaml
+    Bundler::YAMLSerializer.dump(yaml_hash)
   end
 
   # Writes out this config file, replacing its source.

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -521,51 +521,46 @@ if you believe they were disclosed to a third party.
     Bundler::YAMLSerializer.dump(content)
   end
 
-  def self.load_with_rubygems_config_hash(hash)
+  def self.load_with_rubygems_config_hash(yaml)
     require "bundler/yaml_serializer"
 
-    content = Bundler::YAMLSerializer.load(hash)
+    content = Bundler::YAMLSerializer.load(yaml)
 
-    if content.is_a? Hash
-      content.transform_keys! do |k|
-        if k.match?(/\A:(.*)\Z/)
-          k[1..-1].to_sym
-        elsif k.include?("__")
-          if k.is_a?(Symbol)
-            k.to_s.gsub(/__/,".").gsub(%r{/\Z}, "").to_sym
-          else
-            k.dup.gsub(/__/,".").gsub(%r{/\Z}, "")
-          end
+    content.transform_keys! do |k|
+      if k.match?(/\A:(.*)\Z/)
+        k[1..-1].to_sym
+      elsif k.include?("__")
+        if k.is_a?(Symbol)
+          k.to_s.gsub(/__/,".").gsub(%r{/\Z}, "").to_sym
         else
-          k
+          k.dup.gsub(/__/,".").gsub(%r{/\Z}, "")
         end
+      else
+        k
       end
+    end
 
-      content.transform_values! do |v|
-        if v.is_a?(String)
-          if v.match?(/\A:(.*)\Z/)
-            v[1..-1].to_sym
-          elsif v.match?(/\A[+-]?\d+\Z/)
-            v.to_i
-          elsif v.match?(/\Atrue|false\Z/)
-            v == "true"
-          elsif v.empty?
-            nil
-          else
-            v
-          end
-        elsif v.is_a?(Hash) && v.empty?
+    content.transform_values! do |v|
+      if v.is_a?(String)
+        if v.match?(/\A:(.*)\Z/)
+          v[1..-1].to_sym
+        elsif v.match?(/\A[+-]?\d+\Z/)
+          v.to_i
+        elsif v.match?(/\Atrue|false\Z/)
+          v == "true"
+        elsif v.empty?
           nil
         else
           v
         end
+      elsif v.is_a?(Hash) && v.empty?
+        nil
+      else
+        v
       end
-
-      content
-    else
-      warn "Failed to load #{filename} because it doesn't contain valid YAML hash"
-      {}
     end
+
+    content
   end
 
   private

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -320,19 +320,13 @@ if you believe they were disclosed to a third party.
 
     config = load_file(credentials_path).merge(host => api_key)
 
-    config.transform_keys! do |k|
-      k.is_a?(Symbol) ? ":#{k}" : k
-    end
-
     dirname = File.dirname credentials_path
     require "fileutils"
     FileUtils.mkdir_p(dirname)
 
-    require "bundler/yaml_serializer"
-
     permissions = 0o600 & (~File.umask)
     File.open(credentials_path, "w", permissions) do |f|
-      f.write Bundler::YAMLSerializer.dump(config)
+      f.write self.class.dump_with_rubygems_yaml(config)
     end
 
     load_api_keys # reload
@@ -492,12 +486,7 @@ if you believe they were disclosed to a third party.
       yaml_hash[key.to_s] = value
     end
 
-    yaml_hash.transform_keys! do |k|
-      k.is_a?(Symbol) ? ":#{k}" : k
-    end
-
-    require "bundler/yaml_serializer"
-    Bundler::YAMLSerializer.dump(yaml_hash)
+    self.class.dump_with_rubygems_yaml(yaml_hash)
   end
 
   # Writes out this config file, replacing its source.
@@ -531,6 +520,15 @@ if you believe they were disclosed to a third party.
 
   attr_reader :hash
   protected :hash
+
+  def self.dump_with_rubygems_yaml(content)
+    content.transform_keys! do |k|
+      k.is_a?(Symbol) ? ":#{k}" : k
+    end
+
+    require "bundler/yaml_serializer"
+    Bundler::YAMLSerializer.dump(content)
+  end
 
   def self.convert_rubygems_config_hash(content)
     content.transform_keys! do |k|

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -536,11 +536,11 @@ if you believe they were disclosed to a third party.
     content.transform_keys! do |k|
       if k.match?(/\A:(.*)\Z/)
         k[1..-1].to_sym
-      elsif k.match?(/__/)
+      elsif k.include?("__")
         if k.is_a?(Symbol)
-          k.to_s.gsub(/__/,".").to_sym
+          k.to_s.gsub(/__/,".").gsub(%r{/\Z}, "").to_sym
         else
-          k.dup.gsub(/__/,".")
+          k.dup.gsub(/__/,".").gsub(%r{/\Z}, "")
         end
       else
         k

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -517,14 +517,14 @@ if you believe they were disclosed to a third party.
       k.is_a?(Symbol) ? ":#{k}" : k
     end
 
-    require "bundler/yaml_serializer"
-    Bundler::YAMLSerializer.dump(content)
+    require_relative "yaml_serializer"
+    Gem::YAMLSerializer.dump(content)
   end
 
   def self.load_with_rubygems_config_hash(yaml)
-    require "bundler/yaml_serializer"
+    require_relative "yaml_serializer"
 
-    content = Bundler::YAMLSerializer.load(yaml)
+    content = Gem::YAMLSerializer.load(yaml)
 
     content.transform_keys! do |k|
       if k.match?(/\A:(.*)\Z/)

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -351,20 +351,8 @@ if you believe they were disclosed to a third party.
     return {} unless filename && !filename.empty? && File.exist?(filename)
 
     begin
-      content = Bundler::YAMLSerializer.load(File.read(filename))
+      content = Bundler::YAMLSerializer.load(File.read(filename), is_rubygems: true)
       if content.is_a? Hash
-        content.transform_keys! do |k|
-          if k.match?(/__/)
-            if k.is_a?(Symbol)
-              k.to_s.gsub(/__/,".").to_sym
-            else
-              k.dup.gsub(/__/,".")
-            end
-          else
-            k
-          end
-        end
-
         content.transform_values! do |v|
           if (v.is_a?(Hash) || v.is_a?(String)) && v.empty?
             nil

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -352,7 +352,27 @@ if you believe they were disclosed to a third party.
 
     begin
       content = Bundler::YAMLSerializer.load(File.read(filename))
-      unless content.is_a? Hash
+      if content.is_a? Hash
+        content.transform_keys! do |k|
+          if k.match?(/__/)
+            if k.is_a?(Symbol)
+              k.to_s.gsub(/__/,".").to_sym
+            else
+              k.dup.gsub(/__/,".")
+            end
+          else
+            k
+          end
+        end
+
+        content.transform_values! do |v|
+          if (v.is_a?(Hash) || v.is_a?(String)) && v.empty?
+            nil
+          else
+            v
+          end
+        end
+      else
         warn "Failed to load #{filename} because it doesn't contain valid YAML hash"
         return {}
       end

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -332,6 +332,8 @@ module Gem::GemcutterUtilities
       request.basic_auth email, password
     end
 
+    Gem.load_yaml
+
     with_response response do |resp|
       Gem::SafeYAML.load clean_text(resp.body)
     end

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -332,10 +332,9 @@ module Gem::GemcutterUtilities
       request.basic_auth email, password
     end
 
-    Gem.load_yaml
-
+    require "bundler/yaml_serializer"
     with_response response do |resp|
-      Gem::SafeYAML.load clean_text(resp.body)
+      Bundler::YAMLSerializer.load clean_text(resp.body)
     end
   end
 

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -332,10 +332,8 @@ module Gem::GemcutterUtilities
       request.basic_auth email, password
     end
 
-    require "bundler/yaml_serializer"
     with_response response do |resp|
-      profile = Bundler::YAMLSerializer.load clean_text(resp.body)
-      Gem::ConfigFile.convert_rubygems_config_hash profile
+      Gem::ConfigFile.load_with_rubygems_config_hash(clean_text(resp.body))
     end
   end
 

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -334,7 +334,8 @@ module Gem::GemcutterUtilities
 
     require "bundler/yaml_serializer"
     with_response response do |resp|
-      Bundler::YAMLSerializer.load clean_text(resp.body)
+      profile = Bundler::YAMLSerializer.load clean_text(resp.body)
+      Gem::ConfigFile.convert_rubygems_config_hash profile
     end
   end
 

--- a/lib/rubygems/yaml_serializer.rb
+++ b/lib/rubygems/yaml_serializer.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Gem
+  # A stub yaml serializer that can handle only hashes and strings (as of now).
+  module YAMLSerializer
+    module_function
+
+    def dump(hash)
+      yaml = String.new("---")
+      yaml << dump_hash(hash)
+    end
+
+    def dump_hash(hash)
+      yaml = String.new("\n")
+      hash.each do |k, v|
+        yaml << k << ":"
+        if v.is_a?(Hash)
+          yaml << dump_hash(v).gsub(/^(?!$)/, "  ") # indent all non-empty lines
+        elsif v.is_a?(Array) # Expected to be array of strings
+          yaml << "\n- " << v.map {|s| s.to_s.gsub(/\s+/, " ").inspect }.join("\n- ") << "\n"
+        else
+          yaml << " " << v.to_s.gsub(/\s+/, " ").inspect << "\n"
+        end
+      end
+      yaml
+    end
+
+    ARRAY_REGEX = /
+      ^
+      (?:[ ]*-[ ]) # '- ' before array items
+      (['"]?) # optional opening quote
+      (.*) # value
+      \1 # matching closing quote
+      $
+    /xo.freeze
+
+    HASH_REGEX = /
+      ^
+      ([ ]*) # indentations
+      (.+) # key
+      (?::(?=(?:\s|$))) # :  (without the lookahead the #key includes this when : is present in value)
+      [ ]?
+      (['"]?) # optional opening quote
+      (.*) # value
+      \3 # matching closing quote
+      $
+    /xo.freeze
+
+    def load(str)
+      res = {}
+      stack = [res]
+      last_hash = nil
+      last_empty_key = nil
+      str.split(/\r?\n/).each do |line|
+        if match = HASH_REGEX.match(line)
+          indent, key, quote, val = match.captures
+          key = convert_to_backward_compatible_key(key)
+          depth = indent.scan(/  /).length
+          if quote.empty? && val.empty?
+            new_hash = {}
+            stack[depth][key] = new_hash
+            stack[depth + 1] = new_hash
+            last_empty_key = key
+            last_hash = stack[depth]
+          else
+            stack[depth][key] = val
+          end
+        elsif match = ARRAY_REGEX.match(line)
+          _, val = match.captures
+          last_hash[last_empty_key] = [] unless last_hash[last_empty_key].is_a?(Array)
+
+          last_hash[last_empty_key].push(val)
+        end
+      end
+      res
+    end
+
+    # for settings' keys
+    def convert_to_backward_compatible_key(key)
+      key = "#{key}/" if key =~ /https?:/i && key !~ %r{/\Z}
+      key = key.gsub(".", "__") if key.include?(".")
+      key
+    end
+
+    class << self
+      private :dump_hash, :convert_to_backward_compatible_key
+    end
+  end
+end

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -680,7 +680,7 @@ class Gem::TestCase < Test::Unit::TestCase
 
   def load_yaml_file(file)
     require "bundler/yaml_serializer"
-    Bundler::YAMLSerializer.load(File.read(file), is_rubygems: true)
+    Bundler::YAMLSerializer.load(File.read(file))
   end
 
   def all_spec_names

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -679,10 +679,8 @@ class Gem::TestCase < Test::Unit::TestCase
   # Load a YAML file, the psych 3 way
 
   def load_yaml_file(file)
-    require "bundler/yaml_serializer"
     require "rubygems/config_file"
-    yaml = Bundler::YAMLSerializer.load(File.read(file))
-    Gem::ConfigFile.convert_rubygems_config_hash(yaml)
+    Gem::ConfigFile.load_with_rubygems_config_hash(File.read(file))
   end
 
   def all_spec_names

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -679,11 +679,8 @@ class Gem::TestCase < Test::Unit::TestCase
   # Load a YAML file, the psych 3 way
 
   def load_yaml_file(file)
-    if Psych.respond_to?(:unsafe_load_file)
-      Psych.unsafe_load_file(file)
-    else
-      Psych.load_file(file)
-    end
+    require "bundler/yaml_serializer"
+    Bundler::YAMLSerializer.load(File.read(file))
   end
 
   def all_spec_names

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -680,7 +680,9 @@ class Gem::TestCase < Test::Unit::TestCase
 
   def load_yaml_file(file)
     require "bundler/yaml_serializer"
-    Bundler::YAMLSerializer.load(File.read(file))
+    require "rubygems/config_file"
+    yaml = Bundler::YAMLSerializer.load(File.read(file))
+    Gem::ConfigFile.convert_rubygems_config_hash(yaml)
   end
 
   def all_spec_names

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -680,7 +680,7 @@ class Gem::TestCase < Test::Unit::TestCase
 
   def load_yaml_file(file)
     require "bundler/yaml_serializer"
-    Bundler::YAMLSerializer.load(File.read(file))
+    Bundler::YAMLSerializer.load(File.read(file), is_rubygems: true)
   end
 
   def all_spec_names

--- a/test/rubygems/test_gem_commands_push_command.rb
+++ b/test/rubygems/test_gem_commands_push_command.rb
@@ -2,6 +2,7 @@
 
 require_relative "helper"
 require "rubygems/commands/push_command"
+require "rubygems/config_file"
 
 class TestGemCommandsPushCommand < Gem::TestCase
   def setup
@@ -157,7 +158,7 @@ class TestGemCommandsPushCommand < Gem::TestCase
     }
 
     File.open Gem.configuration.credentials_path, "w" do |f|
-      f.write keys.to_yaml
+      f.write Gem::ConfigFile.dump_with_rubygems_yaml(keys)
     end
     Gem.configuration.load_api_keys
 
@@ -191,7 +192,7 @@ class TestGemCommandsPushCommand < Gem::TestCase
     }
 
     File.open Gem.configuration.credentials_path, "w" do |f|
-      f.write keys.to_yaml
+      f.write Gem::ConfigFile.dump_with_rubygems_yaml(keys)
     end
     Gem.configuration.load_api_keys
 
@@ -232,7 +233,7 @@ class TestGemCommandsPushCommand < Gem::TestCase
     }
 
     File.open Gem.configuration.credentials_path, "w" do |f|
-      f.write keys.to_yaml
+      f.write Gem::ConfigFile.dump_with_rubygems_yaml(keys)
     end
     Gem.configuration.load_api_keys
 
@@ -273,7 +274,7 @@ class TestGemCommandsPushCommand < Gem::TestCase
     }
 
     File.open Gem.configuration.credentials_path, "w" do |f|
-      f.write keys.to_yaml
+      f.write Gem::ConfigFile.dump_with_rubygems_yaml(keys)
     end
     Gem.configuration.load_api_keys
 
@@ -303,7 +304,7 @@ class TestGemCommandsPushCommand < Gem::TestCase
     }
 
     File.open Gem.configuration.credentials_path, "w" do |f|
-      f.write keys.to_yaml
+      f.write Gem::ConfigFile.dump_with_rubygems_yaml(keys)
     end
     Gem.configuration.load_api_keys
 

--- a/test/rubygems/test_gem_commands_signin_command.rb
+++ b/test/rubygems/test_gem_commands_signin_command.rb
@@ -109,7 +109,7 @@ class TestGemCommandsSigninCommand < Gem::TestCase
   def test_execute_with_key_name_and_scope
     email     = "you@example.com"
     password  = "secret"
-    api_key   = "1234"
+    api_key   = "1234abcd"
     fetcher   = Gem::RemoteFetcher.fetcher
 
     key_name_ui = Gem::MockGemUi.new "#{email}\n#{password}\ntest-key\n\ny\n\n\n\n\n\n"
@@ -134,7 +134,7 @@ class TestGemCommandsSigninCommand < Gem::TestCase
   def test_execute_with_key_name_scope_and_mfa_level_of_ui_only
     email     = "you@example.com"
     password  = "secret"
-    api_key   = "1234"
+    api_key   = "1234abcd"
     fetcher   = Gem::RemoteFetcher.fetcher
     mfa_level = "ui_only"
 
@@ -161,7 +161,7 @@ class TestGemCommandsSigninCommand < Gem::TestCase
   def test_execute_with_key_name_scope_and_mfa_level_of_gem_signin
     email     = "you@example.com"
     password  = "secret"
-    api_key   = "1234"
+    api_key   = "1234abcd"
     fetcher   = Gem::RemoteFetcher.fetcher
     mfa_level = "ui_and_gem_signin"
 
@@ -188,7 +188,7 @@ class TestGemCommandsSigninCommand < Gem::TestCase
   def test_execute_with_warnings
     email     = "you@example.com"
     password  = "secret"
-    api_key   = "1234"
+    api_key   = "1234abcd"
     fetcher   = Gem::RemoteFetcher.fetcher
     mfa_level = "disabled"
     warning   = "/[WARNING/] For protection of your account and gems"
@@ -204,7 +204,7 @@ class TestGemCommandsSigninCommand < Gem::TestCase
 
     email     = "you@example.com"
     password  = "secret"
-    api_key   = "1234"
+    api_key   = "1234abcd"
     fetcher   = Gem::RemoteFetcher.fetcher
 
     key_name_ui = Gem::MockGemUi.new "#{email}\n#{password}\ntest-key\n\ny\n\n\n\n\n\ny"

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -465,21 +465,6 @@ if you believe they were disclosed to a third party.
     assert_equal %w[http://even-more-gems.example.com], Gem.sources
   end
 
-  def test_ignore_invalid_config_file
-    File.open @temp_conf, "w" do |fp|
-      fp.puts "invalid: yaml:"
-    end
-
-    begin
-      verbose = $VERBOSE
-      $VERBOSE = nil
-
-      util_config_file
-    ensure
-      $VERBOSE = verbose
-    end
-  end
-
   def test_load_ssl_verify_mode_from_config
     File.open @temp_conf, "w" do |fp|
       fp.puts ":ssl_verify_mode: 1"

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -500,4 +500,32 @@ if you believe they were disclosed to a third party.
     util_config_file
     assert_equal(true, @cfg.disable_default_gem_server)
   end
+
+  def test_load_with_rubygems_config_hash
+    yaml = <<~YAML
+      ---
+      :foo: bar
+      bar: 100
+      buzz: true
+      alpha: :bravo
+      charlie: ""
+      delta:
+    YAML
+    actual = Gem::ConfigFile.load_with_rubygems_config_hash(yaml)
+
+    assert_equal "bar", actual[:foo]
+    assert_equal 100, actual["bar"]
+    assert_equal true, actual["buzz"]
+    assert_equal :bravo, actual["alpha"]
+    assert_equal nil, actual["charlie"]
+    assert_equal nil, actual["delta"]
+  end
+
+  def test_dump_with_rubygems_yaml
+    symbol_key_hash = { :foo => "bar" }
+
+    actual = Gem::ConfigFile.dump_with_rubygems_yaml(symbol_key_hash)
+
+    assert_equal("---\n:foo: \"bar\"\n", actual)
+  end
 end

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -4,6 +4,7 @@ require_relative "helper"
 require "rubygems"
 require "rubygems/command"
 require "rubygems/gemcutter_utilities"
+require "rubygems/config_file"
 
 class TestGemGemcutterUtilities < Gem::TestCase
   def setup
@@ -39,7 +40,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
     }
 
     File.open Gem.configuration.credentials_path, "w" do |f|
-      f.write keys.to_yaml
+      f.write Gem::ConfigFile.dump_with_rubygems_yaml(keys)
     end
 
     ENV["RUBYGEMS_HOST"] = "http://rubygems.engineyard.com"
@@ -53,7 +54,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
     keys = { :rubygems_api_key => "KEY" }
 
     File.open Gem.configuration.credentials_path, "w" do |f|
-      f.write keys.to_yaml
+      f.write Gem::ConfigFile.dump_with_rubygems_yaml(keys)
     end
 
     Gem.configuration.load_api_keys
@@ -65,7 +66,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
     keys = { :rubygems_api_key => "KEY", :other => "OTHER" }
 
     File.open Gem.configuration.credentials_path, "w" do |f|
-      f.write keys.to_yaml
+      f.write Gem::ConfigFile.dump_with_rubygems_yaml(keys)
     end
 
     Gem.configuration.load_api_keys
@@ -167,8 +168,10 @@ class TestGemGemcutterUtilities < Gem::TestCase
     api_key       = "a5fdbb6ba150cbb83aad2bb2fede64cf040453903"
     other_api_key = "f46dbb18bb6a9c97cdc61b5b85c186a17403cdcbf"
 
+    config = Hash[:other_api_key, other_api_key]
+
     File.open Gem.configuration.credentials_path, "w" do |f|
-      f.write Hash[:other_api_key, other_api_key].to_yaml
+      f.write Gem::ConfigFile.dump_with_rubygems_yaml(config)
     end
     util_sign_in HTTPResponseFactory.create(body: api_key, code: 200, msg: "OK")
 
@@ -329,7 +332,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
   def test_verify_api_key
     keys = { :other => "a5fdbb6ba150cbb83aad2bb2fede64cf040453903" }
     File.open Gem.configuration.credentials_path, "w" do |f|
-      f.write keys.to_yaml
+      f.write Gem::ConfigFile.dump_with_rubygems_yaml(keys)
     end
     Gem.configuration.load_api_keys
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Related https://github.com/rubygems/rubygems/issues/6611

RubyGems uses Psych(libyaml) for loading/storing configuration that is `.gemrc`. So, Psych is always activate in RubyGems. We can't use specified version of Psych. 

`libyaml` used by Psych have risk for vulnerability today. We should leave depends on Psych in long term.

## What is your fix for the problem, implemented in this PR?

I replaced Psych dependency to `Bundler::YAMLSerializer` at `Gem::ConfigFile`. It has incompatibility that is `Bundler::YAMLSerializer` can parse invalid yaml like `invalid: key: val`. We can't raise it after this.

I have no changes bundler side in this PR. We can replace `Psych` only `Gem::ConfigFile` changes.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
