### PR TITLE
Hide Gem::MockGemUi from users

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -409,7 +409,6 @@ lib/rubygems/install_update_options.rb
 lib/rubygems/installer.rb
 lib/rubygems/installer_uninstaller_utils.rb
 lib/rubygems/local_remote_options.rb
-lib/rubygems/mock_gem_ui.rb
 lib/rubygems/name_tuple.rb
 lib/rubygems/openssl.rb
 lib/rubygems/optparse.rb
@@ -581,6 +580,7 @@ test/rubygems/invalid_signer_cert_32.pem
 test/rubygems/invalidchild_cert.pem
 test/rubygems/invalidchild_cert_32.pem
 test/rubygems/invalidchild_key.pem
+test/rubygems/mock_gem_ui.rb
 test/rubygems/package/tar_test_case.rb
 test/rubygems/packages/Bluebie-legs-0.6.2.gem
 test/rubygems/packages/ascii_binder-0.1.10.1.gem

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -20,7 +20,7 @@ require "tmpdir"
 require "uri"
 require "zlib"
 require "benchmark" # stdlib
-require "rubygems/mock_gem_ui"
+require_relative "mock_gem_ui"
 
 module Gem
   ##

--- a/test/rubygems/mock_gem_ui.rb
+++ b/test/rubygems/mock_gem_ui.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "user_interaction"
+require "rubygems/user_interaction"
 
 ##
 # This Gem::StreamUI subclass records input and output to StringIO for


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`Gem::MockGemUi` is only for RubyGems test, not user usage.

## What is your fix for the problem, implemented in this PR?

We should hide this under `lib` directory same as `Gem::TestCase`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
