### PR TITLE
Warn invalid gemrc with Psych version

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -348,7 +348,7 @@ if you believe they were disclosed to a third party.
 
     begin
       config = self.class.load_with_rubygems_config_hash(File.read(filename))
-      if config.keys.any? { |k| k.include?(":") }
+      if config.keys.any? { |k| k.to_s.gsub(%r{https?:\/\/}, "").include?(":") }
         warn "Failed to load #{filename} because it doesn't contain valid YAML hash"
         return {}
       else

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -347,7 +347,13 @@ if you believe they were disclosed to a third party.
     return {} unless filename && !filename.empty? && File.exist?(filename)
 
     begin
-      return self.class.load_with_rubygems_config_hash(File.read(filename))
+      config = self.class.load_with_rubygems_config_hash(File.read(filename))
+      if config.keys.any? { |k| k.include?(":") }
+        warn "Failed to load #{filename} because it doesn't contain valid YAML hash"
+        return {}
+      else
+        return config
+      end
     rescue *yaml_errors => e
       warn "Failed to load #{filename}, #{e}"
     rescue Errno::EACCES

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -348,7 +348,7 @@ if you believe they were disclosed to a third party.
 
     begin
       config = self.class.load_with_rubygems_config_hash(File.read(filename))
-      if config.keys.any? { |k| k.to_s.gsub(%r{https?:\/\/}, "").include?(":") }
+      if config.keys.any? {|k| k.to_s.gsub(%r{https?:\/\/}, "").include?(":") }
         warn "Failed to load #{filename} because it doesn't contain valid YAML hash"
         return {}
       else

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -465,6 +465,21 @@ if you believe they were disclosed to a third party.
     assert_equal %w[http://even-more-gems.example.com], Gem.sources
   end
 
+  def test_ignore_invalid_config_file
+    File.open @temp_conf, "w" do |fp|
+      fp.puts "invalid: yaml:"
+    end
+
+    begin
+      verbose = $VERBOSE
+      $VERBOSE = nil
+
+      util_config_file
+    ensure
+      $VERBOSE = verbose
+    end
+  end
+
   def test_load_ssl_verify_mode_from_config
     File.open @temp_conf, "w" do |fp|
       fp.puts ":ssl_verify_mode: 1"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I removed test and change behavior when RubyGems handled invalid gemrc at https://github.com/rubygems/rubygems/commit/cfcfde04c783bfd090c718978f9899fe261135eb.

## What is your fix for the problem, implemented in this PR?

I restored test and warn message when invalid yaml like `invalid: foo: bar`. But we can't cover all of invalid pattern same as libyaml.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
