### PR TITLE
Removed Style/HashSyntax cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,16 +57,6 @@ Style/ClassVars:
 Style/FormatString:
   Enabled: true
 
-# 1.8.7 support
-Style/HashSyntax:
-  Enabled: true
-  EnforcedStyle: hash_rockets
-  Exclude:
-    - Rakefile
-    - lib/**/*
-    - test/**/*
-    - tool/**/*
-
 Style/LineEndConcatenation:
   Enabled: true
 

--- a/bundler/spec/support/build_metadata.rb
+++ b/bundler/spec/support/build_metadata.rb
@@ -15,7 +15,7 @@ module Spec
         :release => true,
       }
 
-      replace_build_metadata(build_metadata, dir: dir) # rubocop:disable Style/HashSyntax
+      replace_build_metadata(build_metadata, dir: dir)
     end
 
     def reset_build_metadata(dir: source_root)
@@ -23,7 +23,7 @@ module Spec
         :release => false,
       }
 
-      replace_build_metadata(build_metadata, dir: dir) # rubocop:disable Style/HashSyntax
+      replace_build_metadata(build_metadata, dir: dir)
     end
 
     private

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -336,9 +336,9 @@ module Spec
           FileUtils.cp shipped_file, target_shipped_file, :preserve => true
         end
 
-        replace_version_file(version, dir: build_path) # rubocop:disable Style/HashSyntax
+        replace_version_file(version, dir: build_path)
 
-        Spec::BuildMetadata.write_build_metadata(dir: build_path) # rubocop:disable Style/HashSyntax
+        Spec::BuildMetadata.write_build_metadata(dir: build_path)
 
         gem_command "build #{relative_gemspec}", :dir => build_path
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler has been ended to support Ruby 1.8 now. We have no reason to use hash rocket style today. We should use `{foo: :bar}` or `{:foo => :bar}` with context of code. 

## What is your fix for the problem, implemented in this PR?

I removed `Style/HashSyntax` cop.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
