### PR TITLE
[Plugin] Fix "Installing" bug when install plugin from Gemfile

### DIFF
--- a/bundler/lib/bundler/plugin.rb
+++ b/bundler/lib/bundler/plugin.rb
@@ -114,6 +114,9 @@ module Bundler
         return if definition.dependencies.empty?
 
         plugins = definition.dependencies.map(&:name).reject {|p| index.installed? p }
+
+        return if plugins.empty?
+
         installed_specs = Installer.new.install_definition(definition)
 
         save_plugins plugins, installed_specs, builder.inferred_plugins

--- a/bundler/lib/bundler/plugin.rb
+++ b/bundler/lib/bundler/plugin.rb
@@ -114,9 +114,6 @@ module Bundler
         return if definition.dependencies.empty?
 
         plugins = definition.dependencies.map(&:name).reject {|p| index.installed? p }
-
-        return if plugins.empty?
-
         installed_specs = Installer.new.install_definition(definition)
 
         save_plugins plugins, installed_specs, builder.inferred_plugins

--- a/bundler/lib/bundler/plugin/index.rb
+++ b/bundler/lib/bundler/plugin/index.rb
@@ -111,6 +111,17 @@ module Bundler
         @commands[command]
       end
 
+      # Plugin cannot be installed and updating to install
+      def cannot_install?(name, version)
+        installed?(name) && !updating?(name, version)
+      end
+
+      # An existing plugin must have a diff version to install again
+      def updating?(name, version)
+        version.to_s != @plugin_paths[name][/#{name}-(.*)$/, 1].to_s
+      end
+
+      # Plugin is already installed?
       def installed?(name)
         @plugin_paths[name]
       end

--- a/bundler/lib/bundler/plugin/index.rb
+++ b/bundler/lib/bundler/plugin/index.rb
@@ -111,14 +111,12 @@ module Bundler
         @commands[command]
       end
 
-      # Plugin cannot be installed and updating to install
+      # Plugin version is already installed?
       def version_already_installed?(name, version)
-        installed?(name) && !updating?(name, version)
-      end
+        plugin_path = @plugin_paths[name]
+        return false unless plugin_path
 
-      # An existing plugin must have a diff version to install again
-      def updating?(name, version)
-        version.to_s != @plugin_paths[name][/#{name}-(.*)$/, 1].to_s
+        File.basename(plugin_path) == "#{name}-#{version}"
       end
 
       # Plugin is already installed?

--- a/bundler/lib/bundler/plugin/index.rb
+++ b/bundler/lib/bundler/plugin/index.rb
@@ -112,7 +112,7 @@ module Bundler
       end
 
       # Plugin cannot be installed and updating to install
-      def cannot_install?(name, version)
+      def version_already_installed?(name, version)
         installed?(name) && !updating?(name, version)
       end
 

--- a/bundler/lib/bundler/plugin/installer.rb
+++ b/bundler/lib/bundler/plugin/installer.rb
@@ -114,7 +114,7 @@ module Bundler
       # @param [String] name of the plugin gem to search in the source
       # @param [String] version of the gem to install
       #
-      # @return [Boolean] true if installed or not updating plugin
+      # @return [Boolean] true if plugin version already installed
       def version_already_installed?(plugin, version)
         Index.new.version_already_installed?(plugin, version)
       end

--- a/bundler/lib/bundler/plugin/installer.rb
+++ b/bundler/lib/bundler/plugin/installer.rb
@@ -100,7 +100,7 @@ module Bundler
         paths = {}
 
         specs.each do |spec|
-          next if cannot_install?(spec.name, spec.version)
+          next if version_already_installed?(spec.name, spec.version)
 
           spec.source.install spec
           paths[spec.name] = spec
@@ -109,14 +109,14 @@ module Bundler
         paths
       end
 
-      # Check if the Plugin is already installed or has a diff version to install
+      # Check if the Plugin version is already installed or has a diff version to install
       #
       # @param [String] name of the plugin gem to search in the source
       # @param [String] version of the gem to install
       #
       # @return [Boolean] true if installed or not updating plugin
-      def cannot_install?(plugin, version)
-        Index.new.cannot_install?(plugin, version)
+      def version_already_installed?(plugin, version)
+        Index.new.version_already_installed?(plugin, version)
       end
     end
   end

--- a/bundler/lib/bundler/plugin/installer.rb
+++ b/bundler/lib/bundler/plugin/installer.rb
@@ -100,12 +100,23 @@ module Bundler
         paths = {}
 
         specs.each do |spec|
-          spec.source.install spec
+          next if cannot_install?(spec.name, spec.version)
 
+          spec.source.install spec
           paths[spec.name] = spec
         end
 
         paths
+      end
+
+      # Check if the Plugin is already installed or has a diff version to install
+      #
+      # @param [String] name of the plugin gem to search in the source
+      # @param [String] version of the gem to install
+      #
+      # @return [Boolean] true if installed or not updating plugin
+      def cannot_install?(plugin, version)
+        Index.new.cannot_install?(plugin, version)
       end
     end
   end

--- a/bundler/spec/bundler/plugin_spec.rb
+++ b/bundler/spec/bundler/plugin_spec.rb
@@ -129,6 +129,14 @@ RSpec.describe Bundler::Plugin do
       subject.gemfile_install(gemfile)
     end
 
+    it "doesn't calls installer when plugins already installed" do
+      allow(index).to receive(:installed?).and_return(true)
+      allow(definition).to receive(:dependencies) { [Bundler::Dependency.new("new-plugin", ">=0")] }
+      allow(installer).to receive(:install_definition).never
+
+      subject.gemfile_install(gemfile)
+    end
+
     context "with dependencies" do
       let(:plugin_specs) do
         {

--- a/bundler/spec/bundler/plugin_spec.rb
+++ b/bundler/spec/bundler/plugin_spec.rb
@@ -129,14 +129,6 @@ RSpec.describe Bundler::Plugin do
       subject.gemfile_install(gemfile)
     end
 
-    it "doesn't calls installer when plugins already installed" do
-      allow(index).to receive(:installed?).and_return(true)
-      allow(definition).to receive(:dependencies) { [Bundler::Dependency.new("new-plugin", ">=0")] }
-      allow(installer).to receive(:install_definition).never
-
-      subject.gemfile_install(gemfile)
-    end
-
     context "with dependencies" do
       let(:plugin_specs) do
         {

--- a/bundler/spec/plugins/install_spec.rb
+++ b/bundler/spec/plugins/install_spec.rb
@@ -232,6 +232,45 @@ RSpec.describe "bundler plugin install" do
       plugin_should_be_installed("foo")
     end
 
+    it "install only plugins not installed yet listed in gemfile" do
+      gemfile <<-G
+        source '#{file_uri_for(gem_repo2)}'
+        plugin 'foo'
+        gem 'rack', "1.0.0"
+      G
+
+      2.times { bundle "install" }
+
+      expect(out).to_not include("Installing foo")
+      expect(out).to_not include("Installed plugin foo")
+
+      expect(out).to include("Bundle complete!")
+
+      expect(the_bundle).to include_gems("rack 1.0.0")
+      plugin_should_be_installed("foo")
+
+      gemfile <<-G
+        source '#{file_uri_for(gem_repo2)}'
+        plugin 'foo'
+        plugin 'kung-foo'
+        gem 'rack', "1.0.0"
+      G
+
+      bundle "install"
+
+      expect(out).to include("Installing kung-foo")
+      expect(out).to include("Installed plugin kung-foo")
+
+      expect(out).to_not include("Installing foo")
+      expect(out).to_not include("Installed plugin foo")
+
+      expect(out).to include("Bundle complete!")
+
+      expect(the_bundle).to include_gems("rack 1.0.0")
+      plugin_should_be_installed("foo")
+      plugin_should_be_installed("kung-foo")
+    end
+
     it "accepts plugin version" do
       update_repo2 do
         build_plugin "foo", "1.1.0"

--- a/bundler/spec/plugins/install_spec.rb
+++ b/bundler/spec/plugins/install_spec.rb
@@ -251,7 +251,7 @@ RSpec.describe "bundler plugin install" do
       expect(out).to include("Bundle complete!")
 
       expect(the_bundle).to include_gems("rack 1.0.0")
-      plugin_should_be_installed("foo", version: "1.4.0")
+      plugin_should_be_installed_with_version("foo", "1.4.0")
 
       gemfile <<-G
         source '#{file_uri_for(gem_repo2)}'
@@ -265,7 +265,7 @@ RSpec.describe "bundler plugin install" do
       expect(out).to include("Bundle complete!")
 
       expect(the_bundle).to include_gems("rack 1.0.0")
-      plugin_should_be_installed("foo", version: "1.5.0")
+      plugin_should_be_installed_with_version("foo", "1.5.0")
     end
 
     it "downgrade plugins version listed in gemfile" do
@@ -287,7 +287,7 @@ RSpec.describe "bundler plugin install" do
       expect(out).to include("Bundle complete!")
 
       expect(the_bundle).to include_gems("rack 1.0.0")
-      plugin_should_be_installed("foo", version: "1.5.0")
+      plugin_should_be_installed_with_version("foo", "1.5.0")
 
       gemfile <<-G
         source '#{file_uri_for(gem_repo2)}'
@@ -301,7 +301,7 @@ RSpec.describe "bundler plugin install" do
       expect(out).to include("Bundle complete!")
 
       expect(the_bundle).to include_gems("rack 1.0.0")
-      plugin_should_be_installed("foo", version: "1.4.0")
+      plugin_should_be_installed_with_version("foo", "1.4.0")
     end
 
     it "install only plugins not installed yet listed in gemfile" do

--- a/bundler/spec/plugins/install_spec.rb
+++ b/bundler/spec/plugins/install_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "bundler plugin install" do
     expect(out).to include("Installing foo 1.1")
 
     bundle "plugin install foo --source #{file_uri_for(gem_repo2)} --verbose"
-    expect(out).to include("Using foo 1.1")
+    expect(out).to_not include("foo 1.1")
   end
 
   it "installs when --branch specified" do
@@ -251,7 +251,7 @@ RSpec.describe "bundler plugin install" do
       expect(out).to include("Bundle complete!")
 
       expect(the_bundle).to include_gems("rack 1.0.0")
-      plugin_should_be_installed("foo")
+      plugin_should_be_installed("foo", version: "1.4.0")
 
       gemfile <<-G
         source '#{file_uri_for(gem_repo2)}'
@@ -265,7 +265,7 @@ RSpec.describe "bundler plugin install" do
       expect(out).to include("Bundle complete!")
 
       expect(the_bundle).to include_gems("rack 1.0.0")
-      plugin_should_be_installed("foo")
+      plugin_should_be_installed("foo", version: "1.5.0")
     end
 
     it "downgrade plugins version listed in gemfile" do
@@ -287,7 +287,7 @@ RSpec.describe "bundler plugin install" do
       expect(out).to include("Bundle complete!")
 
       expect(the_bundle).to include_gems("rack 1.0.0")
-      plugin_should_be_installed("foo")
+      plugin_should_be_installed("foo", version: "1.5.0")
 
       gemfile <<-G
         source '#{file_uri_for(gem_repo2)}'
@@ -301,7 +301,7 @@ RSpec.describe "bundler plugin install" do
       expect(out).to include("Bundle complete!")
 
       expect(the_bundle).to include_gems("rack 1.0.0")
-      plugin_should_be_installed("foo")
+      plugin_should_be_installed("foo", version: "1.4.0")
     end
 
     it "install only plugins not installed yet listed in gemfile" do

--- a/bundler/spec/plugins/install_spec.rb
+++ b/bundler/spec/plugins/install_spec.rb
@@ -232,6 +232,78 @@ RSpec.describe "bundler plugin install" do
       plugin_should_be_installed("foo")
     end
 
+    it "upgrade plugins version listed in gemfile" do
+      update_repo2 do
+        build_plugin "foo", "1.4.0"
+        build_plugin "foo", "1.5.0"
+      end
+
+      gemfile <<-G
+        source '#{file_uri_for(gem_repo2)}'
+        plugin 'foo', "1.4.0"
+        gem 'rack', "1.0.0"
+      G
+
+      bundle "install"
+
+      expect(out).to include("Installing foo 1.4.0")
+      expect(out).to include("Installed plugin foo")
+      expect(out).to include("Bundle complete!")
+
+      expect(the_bundle).to include_gems("rack 1.0.0")
+      plugin_should_be_installed("foo")
+
+      gemfile <<-G
+        source '#{file_uri_for(gem_repo2)}'
+        plugin 'foo', "1.5.0"
+        gem 'rack', "1.0.0"
+      G
+
+      bundle "install"
+
+      expect(out).to include("Installing foo 1.5.0")
+      expect(out).to include("Bundle complete!")
+
+      expect(the_bundle).to include_gems("rack 1.0.0")
+      plugin_should_be_installed("foo")
+    end
+
+    it "downgrade plugins version listed in gemfile" do
+      update_repo2 do
+        build_plugin "foo", "1.4.0"
+        build_plugin "foo", "1.5.0"
+      end
+
+      gemfile <<-G
+        source '#{file_uri_for(gem_repo2)}'
+        plugin 'foo', "1.5.0"
+        gem 'rack', "1.0.0"
+      G
+
+      bundle "install"
+
+      expect(out).to include("Installing foo 1.5.0")
+      expect(out).to include("Installed plugin foo")
+      expect(out).to include("Bundle complete!")
+
+      expect(the_bundle).to include_gems("rack 1.0.0")
+      plugin_should_be_installed("foo")
+
+      gemfile <<-G
+        source '#{file_uri_for(gem_repo2)}'
+        plugin 'foo', "1.4.0"
+        gem 'rack', "1.0.0"
+      G
+
+      bundle "install"
+
+      expect(out).to include("Installing foo 1.4.0")
+      expect(out).to include("Bundle complete!")
+
+      expect(the_bundle).to include_gems("rack 1.0.0")
+      plugin_should_be_installed("foo")
+    end
+
     it "install only plugins not installed yet listed in gemfile" do
       gemfile <<-G
         source '#{file_uri_for(gem_repo2)}'

--- a/bundler/spec/support/matchers.rb
+++ b/bundler/spec/support/matchers.rb
@@ -220,14 +220,20 @@ module Spec
     RSpec::Matchers.define_negated_matcher :not_include_gems, :include_gems
     RSpec::Matchers.alias_matcher :include_gem, :include_gems
 
-    def plugin_should_be_installed(*names, version: nil)
+    def plugin_should_be_installed(*names)
       names.each do |name|
         expect(Bundler::Plugin).to be_installed(name)
         path = Pathname.new(Bundler::Plugin.installed?(name))
-
-        expect(File.basename(path)).to eq("#{name}-#{version}") unless version.nil?
         expect(path + "plugins.rb").to exist
       end
+    end
+
+    def plugin_should_be_installed_with_version(name, version)
+      expect(Bundler::Plugin).to be_installed(name)
+      path = Pathname.new(Bundler::Plugin.installed?(name))
+
+      expect(File.basename(path)).to eq("#{name}-#{version}")
+      expect(path + "plugins.rb").to exist
     end
 
     def plugin_should_not_be_installed(*names)

--- a/bundler/spec/support/matchers.rb
+++ b/bundler/spec/support/matchers.rb
@@ -220,10 +220,12 @@ module Spec
     RSpec::Matchers.define_negated_matcher :not_include_gems, :include_gems
     RSpec::Matchers.alias_matcher :include_gem, :include_gems
 
-    def plugin_should_be_installed(*names)
+    def plugin_should_be_installed(*names, version: nil)
       names.each do |name|
         expect(Bundler::Plugin).to be_installed(name)
         path = Pathname.new(Bundler::Plugin.installed?(name))
+
+        expect(File.basename(path)).to eq("#{name}-#{version}") unless version.nil?
         expect(path + "plugins.rb").to exist
       end
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The problem was initially described [here](https://github.com/rubygems/rubygems/issues/6630). When you install a plugin from a Gemfile (without git or path options), the bundle keep installing it every bundle install run.

## What is your fix for the problem, implemented in this PR?

There is 2 problems to solve. 

The first problem is block an installed plugin to install again, it was fixed the by adding a condition [here](https://github.com/dfop02/rubygems/blob/fix-bundle-plugin-bug/bundler/lib/bundler/plugin.rb#L117), where I confirm if there is any plugin not installed yet before continue to install dependences.

The second problem is when you already have an installed plugin, but add other into your Gemfile, then it keep installing the old one. For this case, I need go a bit far to check if the plugin is installed and if the plugin installed version is the same. For this, I create a `cannot_install?` method on Index class for this propose. You can check the code [here](https://github.com/dfop02/rubygems/blob/fix-bundle-plugin-bug/bundler/lib/bundler/plugin/installer.rb#L103).

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
