### PR TITLE
Simplify code by Gem::Specification#runtime_dependencies

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1692,7 +1692,7 @@ class Gem::Specification < Gem::BasicSpecification
 
   def conficts_when_loaded_with?(list_of_specs) # :nodoc:
     result = list_of_specs.any? do |spec|
-      spec.dependencies.any? {|dep| dep.runtime? && (dep.name == name) && !satisfies_requirement?(dep) }
+      spec.runtime_dependencies.any? {|dep| (dep.name == name) && !satisfies_requirement?(dep) }
     end
     result
   end
@@ -1702,13 +1702,9 @@ class Gem::Specification < Gem::BasicSpecification
 
   def has_conflicts?
     return true unless Gem.env_requirement(name).satisfied_by?(version)
-    dependencies.any? do |dep|
-      if dep.runtime?
-        spec = Gem.loaded_specs[dep.name]
-        spec && !spec.satisfies_requirement?(dep)
-      else
-        false
-      end
+    runtime_dependencies.any? do |dep|
+      spec = Gem.loaded_specs[dep.name]
+      spec && !spec.satisfies_requirement?(dep)
     end
   rescue ArgumentError => e
     raise e, "#{name} #{version}: #{e.message}"
@@ -2595,8 +2591,7 @@ class Gem::Specification < Gem::BasicSpecification
   def traverse(trail = [], visited = {}, &block)
     trail.push(self)
     begin
-      dependencies.each do |dep|
-        next unless dep.runtime?
+      runtime_dependencies.each do |dep|
         dep.matching_specs(true).each do |dep_spec|
           next if visited.key?(dep_spec)
           visited[dep_spec] = true


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

As a end-user or a developer debugging RubyGems issues,
I have found out `runtime_dependencies` are not fully utilized inside `lib/rubygems/specification.rb`.

https://github.com/rubygems/rubygems/blob/2e94a6ae5f92a89a83bce942911f8e0525fe177b/lib/rubygems/specification.rb#L2366-L2371

If `runtime_dependencies` are utilized, it takes a little bit shorter time to read code and debug issues.

## What is your fix for the problem, implemented in this PR?

I replaced code like `dependencies.select(&:runtime?)` with `runtime_dependencies`

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

I thought existing tests are enough to validate this PR.
All the tests except those relates to rust have been passed in my local mac.