### PR TITLE
Cherry-pick ruby-core changes

### DIFF
--- a/bundler/spec/commands/info_spec.rb
+++ b/bundler/spec/commands/info_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe "bundle info" do
       G
 
       bundle "info rac"
-      expect(out).to match(/\A1 : rack\n2 : rack-obama\n0 : - exit -(\n>)?\z/)
+      expect(out).to match(/\A1 : rack\n2 : rack-obama\n0 : - exit -(\n>.*)?\z/)
     end
   end
 

--- a/bundler/spec/commands/show_spec.rb
+++ b/bundler/spec/commands/show_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
       G
 
       bundle "show rac"
-      expect(out).to match(/\A1 : rack\n2 : rack-obama\n0 : - exit -(\n>)?\z/)
+      expect(out).to match(/\A1 : rack\n2 : rack-obama\n0 : - exit -(\n>.*)?\z/)
     end
   end
 


### PR DESCRIPTION
This _may_ be a real issue in Ruby 3.3.0? The failing spec suggests that the readline prompt is now being printed twice.

In any case, I'll cherry-pick the ruby-core commit to "fix" this, just to get our CI back to green.