### PR TITLE
Load plugin immediately

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -343,6 +343,8 @@ class Gem::Installer
 
     Gem::Specification.add_spec(spec)
 
+    load_plugin
+
     run_post_install_hooks
 
     spec
@@ -1005,5 +1007,18 @@ TEXT
     else
       ""
     end
+  end
+
+  def load_plugin
+    specs = Gem::Specification.find_all_by_name(spec.name)
+    # If old version already exists, this plugin isn't loaded
+    # immediately. It's for avoiding a case that multiple versions
+    # are loaded at the same time.
+    return unless specs.size == 1
+
+    plugin_files = spec.plugins.map do |plugin|
+      File.join(@plugins_dir, "#{spec.name}_plugin#{File.extname(plugin)}")
+    end
+    Gem.load_plugin_files(plugin_files)
   end
 end

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1449,6 +1449,8 @@ class TestGem < Gem::TestCase
   def test_load_plugins
     plugin_path = File.join "lib", "rubygems_plugin.rb"
 
+    foo1_plugin_path = nil
+    foo2_plugin_path = nil
     Dir.chdir @tempdir do
       FileUtils.mkdir_p "lib"
       File.open plugin_path, "w" do |fp|
@@ -1458,17 +1460,22 @@ class TestGem < Gem::TestCase
       foo1 = util_spec "foo", "1" do |s|
         s.files << plugin_path
       end
+      foo1_plugin_path = File.join(foo1.gem_dir, plugin_path)
 
       install_gem foo1
 
       foo2 = util_spec "foo", "2" do |s|
         s.files << plugin_path
       end
+      foo2_plugin_path = File.join(foo2.gem_dir, plugin_path)
 
       install_gem foo2
     end
 
     Gem::Specification.reset
+    PLUGINS_LOADED.clear
+    $LOADED_FEATURES.delete(foo1_plugin_path)
+    $LOADED_FEATURES.delete(foo2_plugin_path)
 
     gem "foo"
 

--- a/test/rubygems/test_gem_commands_pristine_command.rb
+++ b/test/rubygems/test_gem_commands_pristine_command.rb
@@ -546,7 +546,7 @@ class TestGemCommandsPristineCommand < Gem::TestCase
       fp.puts "puts __FILE__"
     end
     write_file File.join(@tempdir, "lib", "rubygems_plugin.rb") do |fp|
-      fp.puts "puts __FILE__"
+      fp.puts "# do nothing"
     end
     write_file File.join(@tempdir, "bin", "foo") do |fp|
       fp.puts "#!/usr/bin/ruby"

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -431,7 +431,7 @@ class TestGemCommandsSetupCommand < Gem::TestCase
       s.files = %W[lib/rubygems_plugin.rb]
     end
     write_file File.join @tempdir, "lib", "rubygems_plugin.rb" do |f|
-      f.puts "require '#{gem.plugins.first}'"
+      f.puts "# do nothing"
     end
     install_gem gem
 

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -173,7 +173,7 @@ class TestGemUninstaller < Gem::InstallerTestCase
 
   def test_remove_plugins
     write_file File.join(@tempdir, "lib", "rubygems_plugin.rb") do |io|
-      io.write "puts __FILE__"
+      io.write "# do nothing"
     end
 
     @spec.files += %w[lib/rubygems_plugin.rb]
@@ -190,7 +190,7 @@ class TestGemUninstaller < Gem::InstallerTestCase
 
   def test_remove_plugins_with_install_dir
     write_file File.join(@tempdir, "lib", "rubygems_plugin.rb") do |io|
-      io.write "puts __FILE__"
+      io.write "# do nothing"
     end
 
     @spec.files += %w[lib/rubygems_plugin.rb]
@@ -208,7 +208,7 @@ class TestGemUninstaller < Gem::InstallerTestCase
 
   def test_regenerate_plugins_for
     write_file File.join(@tempdir, "lib", "rubygems_plugin.rb") do |io|
-      io.write "puts __FILE__"
+      io.write "# do nothing"
     end
 
     @spec.files += %w[lib/rubygems_plugin.rb]
@@ -635,7 +635,7 @@ create_makefile '#{@spec.name}'
 
   def test_uninstall_keeps_plugins_up_to_date
     write_file File.join(@tempdir, "lib", "rubygems_plugin.rb") do |io|
-      io.write "puts __FILE__"
+      io.write "# do nothing"
     end
 
     plugin_path = File.join Gem.plugindir, "a_plugin.rb"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We can install RubyGems plugin by "gem install XXX". The installed plugin is used from the NEXT "gem ...".

For example, "gem install gem-src kaminari" doesn't use gem-src plugin for kaminari. "gem install gem-src && gem install kaminari" uses gem-src plugin for kaminari.

## What is your fix for the problem, implemented in this PR?

How about loading a plugin immediately when the plugin is installed? If this proposal is implemented, "gem install gem-src kaminari" works like "gem install gem-src && gem install kaminari".

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
