### PR TITLE
Fix api key loading if RubyGems host is development

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -535,7 +535,7 @@ if you believe they were disclosed to a third party.
     content.transform_keys! do |k|
       if k.match?(/\A:(.*)\Z/)
         k[1..-1].to_sym
-      elsif k.include?("__")
+      elsif k.include?("__") || k.match?(%r{/\Z})
         if k.is_a?(Symbol)
           k.to_s.gsub(/__/,".").gsub(%r{/\Z}, "").to_sym
         else

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -348,7 +348,7 @@ if you believe they were disclosed to a third party.
 
     begin
       config = self.class.load_with_rubygems_config_hash(File.read(filename))
-      if config.keys.any? {|k| k.to_s.gsub(%r{https?:\/\/}, "").include?(":") }
+      if config.keys.any? {|k| k.to_s.gsub(%r{https?:\/\/}, "").include?(": ") }
         warn "Failed to load #{filename} because it doesn't contain valid YAML hash"
         return {}
       else

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -324,14 +324,19 @@ if you believe they were disclosed to a third party.
     temp_cred = File.join Gem.user_home, ".gem", "credentials"
     FileUtils.mkdir_p File.dirname(temp_cred)
     File.open temp_cred, "w", 0o600 do |fp|
-      fp.puts ":rubygems_api_key: 701229f217cdf23b1344c7b4b54ca97"
-      fp.puts ":other: a5fdbb6ba150cbb83aad2bb2fede64c"
+      fp.puts ":rubygems_api_key: rubygems_b9ce70c306b3a2e248679fbbbd66722d408d3c8c4f00566c"
+      fp.puts ":other: rubygems_9636a120106ea8b81fbc792188251738665711d2ece160c5"
+      fp.puts "http://localhost:3000: rubygems_be293ad9dd71550a012b17d848893b41960b811ce9312b47"
     end
 
     util_config_file
 
-    assert_equal({ :rubygems => "701229f217cdf23b1344c7b4b54ca97",
-                   :other => "a5fdbb6ba150cbb83aad2bb2fede64c" }, @cfg.api_keys)
+    assert_equal(
+      { :rubygems => "rubygems_b9ce70c306b3a2e248679fbbbd66722d408d3c8c4f00566c",
+        :other => "rubygems_9636a120106ea8b81fbc792188251738665711d2ece160c5",
+        "http://localhost:3000" => "rubygems_be293ad9dd71550a012b17d848893b41960b811ce9312b47" },
+      @cfg.api_keys
+    )
   end
 
   def test_load_api_keys_bad_permission


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

From: https://github.com/rubygems/rubygems/pull/6624#issuecomment-1546185377

The `gem signin` fails with a warning if the host is `localhost:3000`
```
RUBYGEMS_HOST=http://localhost:3000 ruby -Ilib bin/gem signin
Failed to load /Users/jennyshen/.local/share/gem/credentials because it doesn't contain valid YAML hash
Failed to load /Users/jennyshen/.local/share/gem/credentials because it doesn't contain valid YAML hash
Enter your http://localhost:3000 credentials.
Don't have an account yet? Create one at http://localhost:3000/sign_up
   Email:   test2@example.com
Password:   

API Key name [Jennys-MacBook-Pro-2.local-jennyshen-20230516143333]:   
Please select scopes you want to enable for the API key (y/n)
index_rubygems [yN]  
...
Signed in with API key: Jennys-MacBook-Pro-2.local-jennyshen-20230516143333.
Failed to load /Users/jennyshen/.local/share/gem/credentials because it doesn't contain valid YAML hash
Failed to load /Users/jennyshen/.local/share/gem/credentials because it doesn't contain valid YAML hash
```

The original PR checks for invalid yaml like `invalid: foo: bar` by checking if there is `:` in the key. It is possible to have `:` as a part of the key like `http://localhost:3000`.

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?
Change the `includes?(":")` to `includes?(": ")` as that would prompt invalid yaml.

Furthermore, after the warning was fixed, keys with `http://localhost:3000` still aren't successfully loaded. This is because

When the api keys gets loaded, the localhost key has a trailing `/` causing  `Gem.configuration.api_keys.key?(host)` to fail.

```
[41, 50] in /Users/jennyshen/src/github.com/Shopify/rubygems/lib/rubygems/gemcutter_utilities.rb
   41:   ##
   42:   # The API key from the command options or from the user's configuration.
   43: 
   44:   def api_key
   45:     byebug
=> 46:     if ENV["GEM_HOST_API_KEY"]
   47:       ENV["GEM_HOST_API_KEY"]
   48:     elsif options[:key]
   49:       verify_api_key options[:key]
   50:     elsif Gem.configuration.api_keys.key?(host)
(byebug) Gem.configuration.api_keys
{"http://localhost:3000/"=>"rubygems_"}
(byebug) Gem.configuration.api_keys.key?(host)
false
```

The serialized key gets converted back [here](https://github.com/rubygems/rubygems/blob/5351e01b32cd8a84d27f0d2dff27a229905543e1/lib/rubygems/config_file.rb#L529)

  - If the key contains `__`, it gets replaced with `.` and removes the trailing forward slash.

In the case of `localhost:3000`, since there aren't any `__` because the original host doesn't contain any `.` , the forward slash never gets removed. I changed the elsif to remove any trailing forward slash.

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

cc: @hsbt 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
