### PR TITLE
Show an error when trying to update bundler in frozen mode

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -886,7 +886,8 @@ module Bundler
       if preserve_unknown_sections
         sections_to_ignore = LockfileParser.sections_to_ignore(@locked_bundler_version)
         sections_to_ignore += LockfileParser.unknown_sections_in_lockfile(current)
-        sections_to_ignore += LockfileParser::ENVIRONMENT_VERSION_SECTIONS
+        sections_to_ignore << LockfileParser::RUBY
+        sections_to_ignore << LockfileParser::BUNDLED unless @unlocking_bundler
         pattern = /#{Regexp.union(sections_to_ignore)}\n(\s{2,}.*\n)+/
         whitespace_cleanup = /\n{2,}/
         current = current.gsub(pattern, "\n").gsub(whitespace_cleanup, "\n\n").strip

--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -90,7 +90,7 @@ module Bundler
 
         Gem::Specification.reset # invalidate gem specification cache so that installed gems are immediately available
 
-        lock unless Bundler.frozen_bundle?
+        lock
         Standalone.new(options[:standalone], @definition).generate if options[:standalone]
       end
     end

--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -26,6 +26,7 @@ module Bundler
     KNOWN_SECTIONS = SECTIONS_BY_VERSION_INTRODUCED.values.flatten.freeze
 
     ENVIRONMENT_VERSION_SECTIONS = [BUNDLED, RUBY].freeze
+    deprecate_constant(:ENVIRONMENT_VERSION_SECTIONS)
 
     def self.sections_in_lockfile(lockfile_contents)
       lockfile_contents.scan(/^\w[\w ]*$/).uniq

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -1451,6 +1451,31 @@ RSpec.describe "bundle update --bundler" do
       expect(out).to include("Using bundler 2.3.9")
     end
   end
+
+  it "prints an error when trying to update bundler in frozen mode" do
+    system_gems "bundler-2.3.9"
+
+    gemfile <<~G
+      source "#{file_uri_for(gem_repo2)}"
+    G
+
+    lockfile <<-L
+      GEM
+        remote: #{file_uri_for(gem_repo2)}/
+        specs:
+
+      PLATFORMS
+        ruby
+
+      DEPENDENCIES
+
+      BUNDLED WITH
+         2.1.4
+    L
+
+    bundle "update --bundler=2.3.9", :env => { "BUNDLE_FROZEN" => "true" }
+    expect(err).to include("Cannot write a changed lockfile while frozen")
+  end
 end
 
 # these specs are slow and focus on integration and therefore are not exhaustive. unit specs elsewhere handle that.


### PR DESCRIPTION



## What was the end-user or developer problem that led to this PR?

When running `bundle update --bundler` in frozen mode, the command would succeed but fail to update the lockfile.

## What is your fix for the problem, implemented in this PR?

My fix is to wire things up so that a warning is printed in this case.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
