### PR TITLE
Make `frozen` setting take precedence over `deployment` setting

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -210,9 +210,10 @@ module Bundler
     end
 
     def frozen_bundle?
-      frozen = settings[:deployment]
-      frozen ||= settings[:frozen]
-      frozen
+      frozen = settings[:frozen]
+      return frozen unless frozen.nil?
+
+      settings[:deployment]
     end
 
     def locked_gems

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -361,10 +361,8 @@ module Bundler
              "updated #{Bundler.default_lockfile.relative_path_from(SharedHelpers.pwd)} to version control."
 
       unless explicit_flag
-        suggested_command = if Bundler.settings.locations("frozen").keys.&([:global, :local]).any?
-          "bundle config unset frozen"
-        elsif Bundler.settings.locations("deployment").keys.&([:global, :local]).any?
-          "bundle config unset deployment"
+        suggested_command = unless Bundler.settings.locations("frozen").keys.include?(:env)
+          "bundle config set frozen false"
         end
         msg << "\n\nIf this is a development machine, remove the #{Bundler.default_gemfile} " \
                "freeze \nby running `#{suggested_command}`." if suggested_command

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -659,21 +659,21 @@ RSpec.describe "bundle update" do
 
       expect(last_command).to be_failure
       expect(err).to match(/You are trying to install in deployment mode after changing.your Gemfile/m)
-      expect(err).to match(/freeze \nby running `bundle config unset deployment`./m)
+      expect(err).to match(/freeze \nby running `bundle config set frozen false`./m)
     end
 
-    it "should suggest different command when frozen is set globally" do
+    it "should fail loudly when frozen is set globally" do
       bundle "config set --global frozen 1"
       bundle "update", :all => true, :raise_on_error => false
       expect(err).to match(/You are trying to install in deployment mode after changing.your Gemfile/m).
-        and match(/freeze \nby running `bundle config unset frozen`./m)
+        and match(/freeze \nby running `bundle config set frozen false`./m)
     end
 
-    it "should suggest different command when frozen is set globally" do
+    it "should fail loudly when deployment is set globally" do
       bundle "config set --global deployment true"
       bundle "update", :all => true, :raise_on_error => false
       expect(err).to match(/You are trying to install in deployment mode after changing.your Gemfile/m).
-        and match(/freeze \nby running `bundle config unset deployment`./m)
+        and match(/freeze \nby running `bundle config set frozen false`./m)
     end
 
     it "should not suggest any command to unfreeze bundler if frozen is set through ENV" do

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -662,14 +662,14 @@ RSpec.describe "bundle update" do
       expect(err).to match(/freeze \nby running `bundle config unset deployment`./m)
     end
 
-    it "should suggest different command when frozen is set globally", :bundler => "< 3" do
+    it "should suggest different command when frozen is set globally" do
       bundle "config set --global frozen 1"
       bundle "update", :all => true, :raise_on_error => false
       expect(err).to match(/You are trying to install in deployment mode after changing.your Gemfile/m).
         and match(/freeze \nby running `bundle config unset frozen`./m)
     end
 
-    it "should suggest different command when frozen is set globally", :bundler => "3" do
+    it "should suggest different command when frozen is set globally" do
       bundle "config set --global deployment true"
       bundle "update", :all => true, :raise_on_error => false
       expect(err).to match(/You are trying to install in deployment mode after changing.your Gemfile/m).


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Relationship between `frozen` and `deployment` setting is unclear.

## What is your fix for the problem, implemented in this PR?

Deployment behaves like `frozen` + `path=vendor/bundle`. Setting `path` explicitly can override this, however, setting `frozen` explicitly would not override frozenness.

This PR makes `frozen` consistent in that regard.

With this change, I no longer see the need of deprecating `deployment`, so this PR closes #4534.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
