### PR TITLE
Remove unnecessary code

### DIFF
--- a/test/rubygems/test_gem_gem_runner.rb
+++ b/test/rubygems/test_gem_gem_runner.rb
@@ -4,9 +4,6 @@ require_relative "helper"
 
 class TestGemGemRunner < Gem::TestCase
   def setup
-    @orig_gem_home = ENV["GEM_HOME"]
-    ENV["GEM_HOME"] = @gemhome
-
     require "rubygems/command"
     @orig_args = Gem::Command.build_args
     @orig_specific_extra_args = Gem::Command.specific_extra_args_hash.dup
@@ -24,8 +21,6 @@ class TestGemGemRunner < Gem::TestCase
     Gem::Command.build_args = @orig_args
     Gem::Command.specific_extra_args_hash = @orig_specific_extra_args
     Gem::Command.extra_args = @orig_extra_args
-
-    ENV["GEM_HOME"] = @orig_gem_home
   end
 
   def test_do_configuration


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Some distracting warnings when running tests on old rubies:

The test suite is showing some warnings on old rubies:

```
/Users/deivid/Code/rubygems/rubygems/test/rubygems/test_gem_gem_runner.rb:8: warning: instance variable @gemhome not initialized
./Users/deivid/Code/rubygems/rubygems/test/rubygems/test_gem_gem_runner.rb:8: warning: instance variable @gemhome not initialized
./Users/deivid/Code/rubygems/rubygems/test/rubygems/test_gem_gem_runner.rb:8: warning: instance variable @gemhome not initialized
./Users/deivid/Code/rubygems/rubygems/test/rubygems/test_gem_gem_runner.rb:8: warning: instance variable @gemhome not initialized
./Users/deivid/Code/rubygems/rubygems/test/rubygems/test_gem_gem_runner.rb:8: warning: instance variable @gemhome not initialized
./Users/deivid/Code/rubygems/rubygems/test/rubygems/test_gem_gem_runner.rb:8: warning: instance variable @gemhome not initialized
```

## What is your fix for the problem, implemented in this PR?

Remove the code generating those warnings, since it seems not needed.


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
