### PR TITLE
Fix inline mode with multiple sources

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -217,6 +217,7 @@ module Bundler
     rescue BundlerError => e
       @resolve = nil
       @resolver = nil
+      @resolution_packages = nil
       @specs = nil
       @gem_version_promoter = nil
 

--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -191,6 +191,31 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(err).to be_empty
   end
 
+  it "installs subdependencies quietly if necessary when the install option is not set, and multiple sources used" do
+    build_repo4 do
+      build_gem "rack" do |s|
+        s.add_dependency "rackdep"
+      end
+
+      build_gem "rackdep", "1.0.0"
+    end
+
+    script <<-RUBY
+      gemfile do
+        source "#{file_uri_for(gem_repo1)}"
+        source "#{file_uri_for(gem_repo4)}" do
+          gem "rack"
+        end
+      end
+
+      require "rackdep"
+      puts RACKDEP
+    RUBY
+
+    expect(out).to eq("1.0.0")
+    expect(err).to be_empty
+  end
+
   it "installs quietly from git if necessary when the install option is not set" do
     build_git "foo", "1.0.0"
     baz_ref = build_git("baz", "2.0.0").ref_for("HEAD")


### PR DESCRIPTION


## What was the end-user or developer problem that led to this PR?

If we're in inline mode, Bundler first resolves using only local gems, and if some gems are missing, then it re-resolves using remote gems. However, "source resolution" from the initial "local" try was being memoized, resulting in Bundler not looking for some gems remotely in the second resolution.

## What is your fix for the problem, implemented in this PR?

This commit forces a proper re-resolve in this case.

Fixes #6696.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
