### PR TITLE
Make some specs locale independent

### DIFF
--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -1148,7 +1148,7 @@ RSpec.describe "bundle install with git sources" do
     it "gives a helpful error message when the remote branch no longer exists" do
       build_git "foo"
 
-      install_gemfile <<-G, :raise_on_error => false
+      install_gemfile <<-G, :env => { "LANG" => "en" }, :raise_on_error => false
         source "#{file_uri_for(gem_repo1)}"
         gem "foo", :git => "#{file_uri_for(lib_path("foo-1.0"))}", :branch => "deadbeef"
       G

--- a/bundler/spec/lock/git_spec.rb
+++ b/bundler/spec/lock/git_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "bundle lock with git gems" do
       gem 'foo', :git => "#{lib_path("foo-1.0")}", :branch => "bad"
     G
 
-    bundle "lock --update foo", :raise_on_error => false
+    bundle "lock --update foo", :env => { "LANG" => "en" }, :raise_on_error => false
 
     expect(err).to include("Revision bad does not exist in the repository")
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Some change on my system made `git` start printing messages in Spanish. That made some specs start failing.

## What is your fix for the problem, implemented in this PR?

Force English to be used, since we are asserting for messages in English coming from git.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
