### PR TITLE
Fix CI timeouts

### DIFF
--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -302,7 +302,7 @@ module Spec
     def install_gem(path, default = false)
       raise "OMG `#{path}` does not exist!" unless File.exist?(path)
 
-      args = "--no-document --ignore-dependencies --verbose"
+      args = "--no-document --ignore-dependencies --verbose --local"
       args += " --default --install-dir #{system_gem_path}" if default
 
       gem_command "install #{args} '#{path}'"

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -302,7 +302,7 @@ module Spec
     def install_gem(path, default = false)
       raise "OMG `#{path}` does not exist!" unless File.exist?(path)
 
-      args = "--no-document --ignore-dependencies"
+      args = "--no-document --ignore-dependencies --verbose"
       args += " --default --install-dir #{system_gem_path}" if default
 
       gem_command "install #{args} '#{path}'"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Recently, running Bundler specs against Rubygems system version (3.1) on Ruby 2.7 has gotten fast. I believe that's because RubyGems 3.1 lacks the fix in #3968.

## What is your fix for the problem, implemented in this PR?

Explicitly force that this `gem install` command does not touch the network.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
