### PR TITLE
Always rely on `$LOAD_PATH` when jumping from `exe/` to `lib/`

### DIFF
--- a/bundler/exe/bundle
+++ b/bundler/exe/bundle
@@ -10,10 +10,10 @@ end
 base_path = File.expand_path("../lib", __dir__)
 
 if File.exist?(base_path)
-  require_relative "../lib/bundler"
-else
-  require "bundler"
+  $LOAD_PATH.unshift(base_path)
 end
+
+require "bundler"
 
 if Gem.rubygems_version < Gem::Version.new("3.2.3") && Gem.ruby_version < Gem::Version.new("2.7.a") && !ENV["BUNDLER_NO_OLD_RUBYGEMS_WARNING"]
   Bundler.ui.warn \
@@ -24,18 +24,10 @@ if Gem.rubygems_version < Gem::Version.new("3.2.3") && Gem.ruby_version < Gem::V
     "and silence this warning by running `gem update --system 3.2.3`"
 end
 
-if File.exist?(base_path)
-  require_relative "../lib/bundler/friendly_errors"
-else
-  require "bundler/friendly_errors"
-end
+require "bundler/friendly_errors"
 
 Bundler.with_friendly_errors do
-  if File.exist?(base_path)
-    require_relative "../lib/bundler/cli"
-  else
-    require "bundler/cli"
-  end
+  require "bundler/cli"
 
   # Allow any command to use --help flag to show help for that command
   help_flags = %w[--help -h]


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Normally, we use `require_relative` when requiring internal code. However, Bundler may also load external code (for example, bundler plugins), and when that external code loads Bundler itself, using `require_relative` without setting up the `$LOAD_PATH` may lead into double load errors.

For example, when testing a Gemfile using plugins using our source code tree, I get the following:

```
➜ plugins-dup ~/Code/rubygems/rubygems/bundler/exe/bundle
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Using bundler 2.5.0.dev
Installing extended_bundler-errors 0.3.3
/Users/deivid/.asdf/installs/ruby/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/version.rb:4: warning: already initialized constant Bundler::VERSION
/Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/version.rb:4: warning: previous definition of VERSION was here
/Users/deivid/.asdf/installs/ruby/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/worker.rb:5: warning: already initialized constant Bundler::Worker::POISON
/Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/worker.rb:5: warning: previous definition of POISON was here
/Users/deivid/.asdf/installs/ruby/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/vendor/fileutils/lib/fileutils.rb:183: warning: already initialized constant Bundler::FileUtils::VERSION
/Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/vendor/fileutils/lib/fileutils.rb:183: warning: previous definition of VERSION was here
/Users/deivid/.asdf/installs/ruby/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/vendor/fileutils/lib/fileutils.rb:2165: warning: already initialized constant Bundler::FileUtils::Entry_::S_IF_DOOR
/Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/vendor/fileutils/lib/fileutils.rb:2165: warning: previous definition of S_IF_DOOR was here
/Users/deivid/.asdf/installs/ruby/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/vendor/fileutils/lib/fileutils.rb:2461: warning: already initialized constant Bundler::FileUtils::Entry_::DIRECTORY_TERM
/Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/vendor/fileutils/lib/fileutils.rb:2461: warning: previous definition of DIRECTORY_TERM was here
/Users/deivid/.asdf/installs/ruby/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/vendor/fileutils/lib/fileutils.rb:2569: warning: already initialized constant Bundler::FileUtils::OPT_TABLE
/Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/vendor/fileutils/lib/fileutils.rb:2569: warning: previous definition of OPT_TABLE was here
/Users/deivid/.asdf/installs/ruby/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/vendor/fileutils/lib/fileutils.rb:2627: warning: already initialized constant Bundler::FileUtils::LOW_METHODS
/Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/vendor/fileutils/lib/fileutils.rb:2627: warning: previous definition of LOW_METHODS was here
/Users/deivid/.asdf/installs/ruby/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/vendor/fileutils/lib/fileutils.rb:2634: warning: already initialized constant Bundler::FileUtils::METHODS
/Users/deivid/Code/rubygems/rubygems/bundler/lib/bundler/vendor/fileutils/lib/fileutils.rb:2634: warning: previous definition of METHODS was here
Failed to install plugin `extended_bundler-errors`, due to Bundler::Plugin::MalformattedPlugin (ArgumentError: Trying to register Bundler::GemfileError for status code 4 but
Bundler::GemfileError is already registered)
```

## What is your fix for the problem, implemented in this PR?

Changing `exe/bundle` to always use `$LOAD_PATH`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
