### PR TITLE
Clarify what the `rubygems-update` gem is for, and link to source code and guides

### DIFF
--- a/rubygems-update.gemspec
+++ b/rubygems-update.gemspec
@@ -6,14 +6,14 @@ Gem::Specification.new do |s|
   s.authors = ["Jim Weirich", "Chad Fowler", "Eric Hodel", "Luis Lavena", "Aaron Patterson", "Samuel Giddins", "André Arko", "Evan Phoenix", "Hiroshi SHIBATA"]
   s.email = ["", "", "drbrain@segment7.net", "luislavena@gmail.com", "aaron@tenderlovemaking.com", "segiddins@segiddins.me", "andre@arko.net", "evan@phx.io", "hsbt@ruby-lang.org"]
 
-  s.summary = "RubyGems is a package management framework for Ruby."
+  s.summary = "RubyGems is a package management framework for Ruby—this gem allows the gem command to update itself."
   s.description = "A package (also known as a library) contains a set of functionality
   that can be invoked by a Ruby program, such as reading and parsing an XML file. We call
   these packages 'gems' and RubyGems is a tool to install, create, manage and load these
   packages in your Ruby environment. RubyGems is also a client for RubyGems.org, a public
   repository of Gems that allows you to publish a Gem that can be shared and used by other
   developers. See our guide on publishing a Gem at guides.rubygems.org"
-  s.homepage = "https://rubygems.org"
+  s.homepage = "https://github.com/rubygems/rubygems/"
   s.licenses = ["Ruby", "MIT"]
 
   s.files = File.read("Manifest.txt").split

--- a/rubygems-update.gemspec
+++ b/rubygems-update.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |s|
   packages in your Ruby environment. RubyGems is also a client for RubyGems.org, a public
   repository of Gems that allows you to publish a Gem that can be shared and used by other
   developers. See our guide on publishing a Gem at guides.rubygems.org"
-  s.homepage = "https://github.com/rubygems/rubygems/"
+  s.homepage = "https://guides.rubygems.org"
+  s.metadata = { "source_code_uri" => "https://github.com/rubygems/rubygems" }
   s.licenses = ["Ruby", "MIT"]
 
   s.files = File.read("Manifest.txt").split

--- a/rubygems-update.gemspec
+++ b/rubygems-update.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.authors = ["Jim Weirich", "Chad Fowler", "Eric Hodel", "Luis Lavena", "Aaron Patterson", "Samuel Giddins", "André Arko", "Evan Phoenix", "Hiroshi SHIBATA"]
   s.email = ["", "", "drbrain@segment7.net", "luislavena@gmail.com", "aaron@tenderlovemaking.com", "segiddins@segiddins.me", "andre@arko.net", "evan@phx.io", "hsbt@ruby-lang.org"]
 
-  s.summary = "RubyGems is a package management framework for Ruby—this gem allows the gem command to update itself."
+  s.summary = "RubyGems is a package management framework for Ruby. This gem is downloaded and installed by `gem update --system`, so that the `gem` CLI can update itself."
   s.description = "A package (also known as a library) contains a set of functionality
   that can be invoked by a Ruby program, such as reading and parsing an XML file. We call
   these packages 'gems' and RubyGems is a tool to install, create, manage and load these


### PR DESCRIPTION
`https://rubygems.org/gems/rubygems-update/` is the first google search for "update rubygems" (at least for me) and that gem page for this gem appears to be an impersonation since the homepage goes to rubygems and the description is a general description of the concept of rubygems and not of the rubygems-update gem itself.

I have no idea if these proposed changes would trickle down to somewhere else, so I will not die on this hill, but FWIW if `https://rubygems.org/gems/rubygems-update/` had both a small statement as to the purpose of the gem *and* the homepage went to the source code, it would've been very obviously not an impersonation to me.

## What was the end-user or developer problem that led to this PR?

Google search led to a gem most devs don’t' interact with and that gem's page had no link to source code and the description seemed like copy/paste from documentation and, upon clarification from other people in the know, doesn't match what the gem is for.

## What is your fix for the problem, implemented in this PR?

* Augment the summary to indicate what the gem is for
* Change the gem's homepage to the GitHub page instead of the RubyGems home page

## Make sure the following tasks are checked

- [X] Describe the problem / feature


