### PR TITLE
Suppress warnings for extension build

### DIFF
--- a/test/rubygems/test_gem_gem_runner.rb
+++ b/test/rubygems/test_gem_gem_runner.rb
@@ -11,11 +11,16 @@ class TestGemGemRunner < Gem::TestCase
 
     super
 
+    @orig_gem_home = ENV["GEM_HOME"]
+    ENV["GEM_HOME"] = @gemhome
+
     require "rubygems/gem_runner"
     @runner = Gem::GemRunner.new
   end
 
   def teardown
+    ENV["GEM_HOME"] = @orig_gem_home
+
     super
 
     Gem::Command.build_args = @orig_args


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I got extension warnings like:

```
$ rake test
Loaded suite /Users/hsbt/.local/share/rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/gems/rake-13.0.6/lib/rake/rake_test_loader
Started
P
====================================================================================================================================================================================
Pending: test_extract_symlink_parent_doesnt_delete_user_dir(TestGemPackage): TMPDIR seems too long to add it as symlink into tar
/Users/hsbt/Documents/github.com/rubygems/rubygems/test/rubygems/test_gem_package.rb:643:in `test_extract_symlink_parent_doesnt_delete_user_dir'
     640:     destination_user_subdir = File.join destination_user_dir, "dir"
     641:     FileUtils.mkdir_p destination_user_subdir
     642:
  => 643:     pend "TMPDIR seems too long to add it as symlink into tar" if destination_user_dir.size > 90
     644:
     645:     tgz_io = util_tar_gz do |tar|
     646:       tar.add_symlink "link", destination_user_dir, 16_877
====================================================================================================================================================================================
P
====================================================================================================================================================================================
Pending: test_operating_system_customizing_default_dir(GemTest): Temporary pending custom default_dir test
/Users/hsbt/Documents/github.com/rubygems/rubygems/test/rubygems/test_rubygems.rb:50:in `rescue in test_operating_system_customizing_default_dir'
/Users/hsbt/Documents/github.com/rubygems/rubygems/test/rubygems/test_rubygems.rb:47:in `test_operating_system_customizing_default_dir'
     44:       "require \"rubygems\"; puts Gem::Specification.stubs.map(&:full_name)",
     45:       { :err => [:child, :out] }
     46:     ).strip
  => 47:     begin
     48:       assert_empty output
     49:     rescue Test::Unit::AssertionFailedError
     50:       pend "Temporary pending custom default_dir test"
====================================================================================================================================================================================
/Ignoring RedCloth-4.3.2 because its extensions are not built. Try: gem pristine RedCloth --version 4.3.2
Ignoring aliyun-sdk-0.8.0 because its extensions are not built. Try: gem pristine aliyun-sdk --version 0.8.0
Ignoring appsignal-3.4.4 because its extensions are not built. Try: gem pristine appsignal --version 3.4.4
(snip)
```

## What is your fix for the problem, implemented in this PR?

I tried again with https://github.com/rubygems/rubygems/pull/6693.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
