### PR TITLE
Autoload shellwords when it's needed.

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -508,6 +508,7 @@ lib/rubygems/security/policy.rb
 lib/rubygems/security/signer.rb
 lib/rubygems/security/trust_dir.rb
 lib/rubygems/security_option.rb
+lib/rubygems/shellwords.rb
 lib/rubygems/source.rb
 lib/rubygems/source/git.rb
 lib/rubygems/source/installed.rb

--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -7,6 +7,7 @@
 #++
 
 require_relative "../user_interaction"
+require_relative "../shellwords"
 
 class Gem::Ext::Builder
   include Gem::UserInteraction
@@ -55,9 +56,8 @@ class Gem::Ext::Builder
   end
 
   def self.ruby
-    require "shellwords"
     # Gem.ruby is quoted if it contains whitespace
-    cmd = Gem.ruby.shellsplit
+    cmd = Shellwords.split(Gem.ruby)
 
     # This load_path is only needed when running rubygems test without a proper installation.
     # Prepending it in a normal installation will cause problem with order of $LOAD_PATH.
@@ -82,8 +82,7 @@ class Gem::Ext::Builder
         p(command)
       end
       results << "current directory: #{dir}"
-      require "shellwords"
-      results << command.shelljoin
+      results << Shellwords.join(command)
 
       require "open3"
       # Set $SOURCE_DATE_EPOCH for the subprocess.

--- a/lib/rubygems/ext/cargo_builder.rb
+++ b/lib/rubygems/ext/cargo_builder.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../shellwords"
+
 # This class is used by rubygems to build Rust extensions. It is a thin-wrapper
 # over the `cargo rustc` command which takes care of building Rust code in a way
 # that Ruby can use.
@@ -73,8 +75,6 @@ class Gem::Ext::CargoBuilder < Gem::Ext::Builder
   end
 
   def cargo_command(cargo_toml, dest_path, args = [], crate_name = nil)
-    require "shellwords"
-
     cmd = []
     cmd += [cargo, "rustc"]
     cmd += ["--crate-type", "cdylib"]

--- a/lib/rubygems/ext/rake_builder.rb
+++ b/lib/rubygems/ext/rake_builder.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../shellwords"
+
 #--
 # Copyright 2006 by Chad Fowler, Rich Kilmer, Jim Weirich and others.
 # All rights reserved.
@@ -15,8 +17,7 @@ class Gem::Ext::RakeBuilder < Gem::Ext::Builder
     rake = ENV["rake"]
 
     if rake
-      require "shellwords"
-      rake = rake.shellsplit
+      rake = Shellwords.split(rake)
     else
       begin
         rake = ruby << "-rrubygems" << Gem.bin_path("rake", "rake")

--- a/lib/rubygems/shellwords.rb
+++ b/lib/rubygems/shellwords.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+autoload :Shellwords, "shellwords"


### PR DESCRIPTION
Attempt to fix <https://github.com/rubygems/rubygems/issues/6568>.

Some code paths weren't loading `shellwords` and I experienced some errors because of this. So, adding a top level autoload avoids this problem.

@fxn is it safe to add an autoload like this? i.e. are we at risk of clobbering anything if another project decided to do the same?