### PR TITLE
Mark Git source as cached when initialized from lockfile

### DIFF
--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -32,7 +32,9 @@ module Bundler
       end
 
       def self.from_lock(options)
-        new(options.merge("uri" => options.delete("remote")))
+        git = new(options.merge("uri" => options.delete("remote")))
+        git.cached!
+        git
       end
 
       def to_lock

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -467,7 +467,7 @@ RSpec.describe "install in deployment or frozen mode" do
       expect(err).to include("frozen mode")
       expect(err).not_to include("You have deleted from the Gemfile")
       expect(err).not_to include("You have added to the Gemfile")
-      expect(err).to include("You have changed in the Gemfile:\n* rack from `#{lib_path("rack-1.0")}` to `no specified source`")
+      expect(err).to include("You have changed in the Gemfile:\n* rack from `#{lib_path("rack-1.0")} (at main@#{revision_for(lib_path("rack-1.0"))[0..6]})` to `no specified source`")
     end
 
     it "explodes if you change a source" do
@@ -489,7 +489,7 @@ RSpec.describe "install in deployment or frozen mode" do
       bundle "config set --local deployment true"
       bundle :install, :raise_on_error => false
       expect(err).to include("frozen mode")
-      expect(err).to include("You have changed in the Gemfile:\n* rack from `#{lib_path("rack")}` to `no specified source`")
+      expect(err).to include("You have changed in the Gemfile:\n* rack from `#{lib_path("rack")} (at main@#{revision_for(lib_path("rack"))[0..6]})` to `no specified source`")
       expect(err).not_to include("You have added to the Gemfile")
       expect(err).not_to include("You have deleted from the Gemfile")
     end


### PR DESCRIPTION
This allows to get the current branch which ensures the identifier for a Git source is stable whether installing gems or not.

## What was the end-user or developer problem that led to this PR?

Fixes #6743 

## What is your fix for the problem, implemented in this PR?

I'm not sure it's the correct fix, I'm not totally clear what the `@allow_remote` and `@allow_cached` flags represent for `Bundler::Source`, `Bundler::Source::Path` and `Bundler::Source::Git`.

All I know is that `allow_git_ops?` use them to decide whether getting the current branch is ok or not.
https://github.com/etiennebarrie/rubygems/blob/f81cc96e33a445597e19a2e5c53017544922f2c5/bundler/lib/bundler/source/git.rb#L238-L240
https://github.com/etiennebarrie/rubygems/blob/f81cc96e33a445597e19a2e5c53017544922f2c5/bundler/lib/bundler/source/git/git_proxy.rb#L314-L315

The only other place that uses `allow_git_ops?` is `requires_checkout?`:
https://github.com/etiennebarrie/rubygems/blob/f81cc96e33a445597e19a2e5c53017544922f2c5/bundler/lib/bundler/source/git.rb#L272-L274

Returning `true` for that will now cause `local?` to be called (just an instance variable get), and `cached_revision_checked_out?`. This last one uses the `GitProxy`, but since it's initialized with the `cached_revision`, and we ask for the `revision`, it's just returned without using Git at all (could that be an issue?). It also checks that the install_path exists, which should add a system call.

Also not sure how to test this yet.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
