### PR TITLE
Enabled Performance/FlatMap cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -514,6 +514,9 @@ Performance/Count:
 Performance/Casecmp:
   Enabled: true
 
+Performance/FlatMap:
+  Enabled: true
+
 Performance/StartWith:
   Enabled: true
 

--- a/bundler/lib/bundler/fetcher/compact_index.rb
+++ b/bundler/lib/bundler/fetcher/compact_index.rb
@@ -44,7 +44,7 @@ module Bundler
                    @bundle_worker = nil # reset it.  Not sure if necessary
                    serial_compact_index_client.dependencies(remaining_gems)
                  end
-          next_gems = deps.map {|d| d[3].map(&:first).flatten(1) }.flatten(1).uniq
+          next_gems = deps.flat_map {|d| d[3].flat_map(&:first) }.uniq
           deps.each {|dep| gem_info << dep }
           complete_gems.concat(deps.map(&:first)).uniq!
           remaining_gems = next_gems - complete_gems

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -91,9 +91,9 @@ module Bundler
     def spec_matches_for_glob(spec, glob)
       return spec.matches_for_glob(glob) if spec.respond_to?(:matches_for_glob)
 
-      spec.load_paths.map do |lp|
+      spec.load_paths.flat_map do |lp|
         Dir["#{lp}/#{glob}#{suffix_pattern}"]
-      end.flatten(1)
+      end
     end
 
     def stub_set_spec(stub, spec)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We should use `flat_map` instead of `map{ ... }.flatten` for a bit of performance improvement.

## What is your fix for the problem, implemented in this PR?

I enabled `Performance/FlatMap` cop and run auto-correct.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
