### PR TITLE
Fix failures when the build directory name contains `+`

### DIFF
--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1254,8 +1254,8 @@ class TestGem < Gem::TestCase
       Gem.try_activate "a_file"
     end
 
-    assert_match(/Could not find 'b' /, e.message)
-    assert_match(/at: #{a.spec_file}/, e.message)
+    assert_include(e.message, "Could not find 'b' ")
+    assert_include(e.message, "at: #{a.spec_file}")
   end
 
   def test_self_try_activate_missing_prerelease

--- a/test/rubygems/test_gem_command_manager.rb
+++ b/test/rubygems/test_gem_command_manager.rb
@@ -150,7 +150,7 @@ class TestGemCommandManager < Gem::TestCase
       end
     end
 
-    assert_match(/install isn't a directory./i, @ui.error)
+    assert_match(/install isn't a directory\./i, @ui.error)
   end
 
   def test_process_args_with_c_flag_path_not_found
@@ -164,7 +164,7 @@ class TestGemCommandManager < Gem::TestCase
       end
     end
 
-    assert_match(/#{custom_start_point} isn't a directory./i, @ui.error)
+    assert_match(/#{Regexp.quote(custom_start_point)} isn't a directory\./i, @ui.error)
   end
 
   def test_process_args_bad_arg
@@ -368,7 +368,7 @@ class TestGemCommandManager < Gem::TestCase
     end
 
     assert_equal "pew pew!\n", @ui.output
-    assert_match(/WARNING:  foo command is deprecated. It will be removed in Rubygems [0-9]+/, @ui.error)
+    assert_match(/WARNING:  foo command is deprecated\. It will be removed in Rubygems [0-9]+/, @ui.error)
   ensure
     Gem::Commands.send(:remove_const, :FooCommand)
   end
@@ -393,7 +393,7 @@ class TestGemCommandManager < Gem::TestCase
     end
 
     assert_equal "pew pew!\n", @ui.output
-    assert_match(/WARNING:  foo command is deprecated. It will be removed in Rubygems 9.9.9/, @ui.error)
+    assert_match(/WARNING:  foo command is deprecated\. It will be removed in Rubygems 9\.9\.9/, @ui.error)
   ensure
     Gem::Commands.send(:remove_const, :FooCommand)
   end

--- a/test/rubygems/test_gem_commands_cert_command.rb
+++ b/test/rubygems/test_gem_commands_cert_command.rb
@@ -677,8 +677,9 @@ ERROR:  --private-key not specified and ~/.gem/gem-private_key.pem does not exis
 
     expected_path = File.join(gem_path, "#{File.basename(tmp_expired_cert_file)}.expired")
 
+    assert_include(@ui.output, "INFO:  Your certificate #{tmp_expired_cert_file} has been re-signed\n")
     assert_match(
-      /INFO:  Your certificate #{tmp_expired_cert_file} has been re-signed\nINFO:  Your expired certificate will be located at: #{expected_path}\.[0-9]+/,
+      /INFO:  Your expired certificate will be located at: #{Regexp.quote(expected_path)}\.[0-9]+/,
       @ui.output
     )
     assert_equal "", @ui.error

--- a/test/rubygems/test_gem_commands_info_command.rb
+++ b/test/rubygems/test_gem_commands_info_command.rb
@@ -33,12 +33,12 @@ class TestGemCommandsInfoCommand < Gem::TestCase
       @cmd.execute
     end
 
-    assert_match %r{#{@gem.name} \(#{@gem.version}\)\n}, @ui.output
-    assert_match(/Authors: #{@gem.authors.join(', ')}\n/, @ui.output)
-    assert_match(/Homepage: #{@gem.homepage}\n/, @ui.output)
-    assert_match(/License: #{@gem.license}\n/, @ui.output)
-    assert_match(/Installed at: #{@gem.base_dir}\n/, @ui.output)
-    assert_match(/#{@gem.summary}\n/, @ui.output)
+    assert_include(@ui.output, "#{@gem.name} (#{@gem.version})\n")
+    assert_include(@ui.output, "Authors: #{@gem.authors.join(", ")}\n")
+    assert_include(@ui.output, "Homepage: #{@gem.homepage}\n")
+    assert_include(@ui.output, "License: #{@gem.license}\n")
+    assert_include(@ui.output, "Installed at: #{@gem.base_dir}\n")
+    assert_include(@ui.output, "#{@gem.summary}\n")
     assert_match "", @ui.error
   end
 

--- a/test/rubygems/test_gem_ext_ext_conf_builder.rb
+++ b/test/rubygems/test_gem_ext_ext_conf_builder.rb
@@ -34,7 +34,7 @@ class TestGemExtExtConfBuilder < Gem::TestCase
     assert_same result, output
 
     assert_match(/^current directory:/, output[0])
-    assert_match(/^#{Gem.ruby}.* extconf.rb/, output[1])
+    assert_match(/^#{Regexp.quote(Gem.ruby)}.* extconf.rb/, output[1])
     assert_equal "creating Makefile\n", output[2]
     assert_match(/^current directory:/, output[3])
     assert_contains_make_command "clean", output[4]
@@ -114,7 +114,7 @@ class TestGemExtExtConfBuilder < Gem::TestCase
 
     assert_equal "extconf failed, exit code 1", error.message
 
-    assert_match(/^#{Gem.ruby}.* extconf.rb/, output[1])
+    assert_match(/^#{Regexp.quote(Gem.ruby)}.* extconf.rb/, output[1])
     assert_match(File.join(@dest_path, "mkmf.log"), output[4])
     assert_includes(output, "To see why this extension failed to compile, please check the mkmf.log which can be found here:\n")
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -738,9 +738,9 @@ gem 'other', version
       installer.generate_bin
 
       default_shebang = Gem.ruby
-      shebang_line = File.open("#{@gemhome}/bin/executable") {|f| f.readlines.first }
+      shebang_line = File.open("#{@gemhome}/bin/executable", &:gets)
       assert_match(/\A#!/, shebang_line)
-      assert_match(/#{default_shebang}/, shebang_line)
+      assert_include(shebang_line, default_shebang)
     end
   end
 

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -311,6 +311,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
   end
 
   def test_download_local
+    omit "doesn't work if tempdir has +" if @tempdir.include?("+")
     FileUtils.mv @a1_gem, @tempdir
     local_path = File.join @tempdir, @a1.file_name
     inst = nil
@@ -323,6 +324,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
   end
 
   def test_download_local_space
+    omit "doesn't work if tempdir has +" if @tempdir.include?("+")
     space_path = File.join @tempdir, "space path"
     FileUtils.mkdir space_path
     FileUtils.mv @a1_gem, space_path
@@ -356,6 +358,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
 
   unless Gem.win_platform? || Process.uid.zero? # File.chmod doesn't work
     def test_download_local_read_only
+      omit "doesn't work if tempdir has +" if @tempdir.include?("+")
       FileUtils.mv @a1_gem, @tempdir
       local_path = File.join @tempdir, @a1.file_name
       inst = nil
@@ -374,8 +377,10 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
       assert_equal(File.join(@tempdir, @a1.file_name),
                    inst.download(@a1, local_path))
     ensure
-      FileUtils.chmod 0o755, File.join(Gem.user_dir, "cache")
-      FileUtils.chmod 0o755, @a1.cache_dir
+      if local_path
+        FileUtils.chmod 0o755, File.join(Gem.user_dir, "cache")
+        FileUtils.chmod 0o755, @a1.cache_dir
+      end
     end
 
     def test_download_read_only
@@ -418,6 +423,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
   end
 
   def test_download_same_file
+    omit "doesn't work if tempdir has +" if @tempdir.include?("+")
     FileUtils.mv @a1_gem, @tempdir
     local_path = File.join @tempdir, @a1.file_name
     inst = nil


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Fixes #6749.

## What is your fix for the problem, implemented in this PR?

1. Use `assert_include` instead of `assert_match` if the expected string doesn't contain regexp metacharacters,
   Or escape the expected string with `Regexp.quote`.
2. Skip `@tempdir` contains `+`.
 
## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
