### PR TITLE
Suppress Content-Type warnings

### DIFF
--- a/test/rubygems/utilities.rb
+++ b/test/rubygems/utilities.rb
@@ -214,8 +214,9 @@ class Gem::MockBrowser
     end
   end
 
-  def self.post(uri)
-    post = Net::HTTP::Post.new(uri)
+  def self.post(uri, content_type: "application/x-www-form-urlencoded")
+    headers = { "content-type" => content_type } if content_type
+    post = Net::HTTP::Post.new(uri, headers)
     Net::HTTP.start(uri.hostname, uri.port) do |http|
       http.request(post)
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

With `-w` option, there are warnings from test_webauthn_listener.rb.
```
$ ruby -w -I./lib test/rubygems/test_webauthn_listener.rb -v
Loaded suite test/rubygems/test_webauthn_listener
Started
Gem::TestCase: 
  WebauthnListenerTest: 
    test_wait_for_otp_code_get_follows_options:										.: (0.017696)
    test_wait_for_otp_code_get_request:											.: (0.004523)
    test_wait_for_otp_code_incorrect_params:										.: (0.004645)
    test_wait_for_otp_code_incorrect_path:										/opt/local/lib/ruby/3.3.0+0/net/http/generic_request.rb:263: warning: net/http: Content-Type did not set; using application/x-www-form-urlencoded
.: (0.004420)
    test_wait_for_otp_code_invalid_post_req_method:									/opt/local/lib/ruby/3.3.0+0/net/http/generic_request.rb:263: warning: net/http: Content-Type did not set; using application/x-www-form-urlencoded
.: (0.005021)
    test_wait_for_otp_code_no_params_response:										.: (0.005269)
    test_wait_for_otp_code_options_request:										.: (0.004953)

Finished in 0.046978 seconds.
-------------------------------------------------------------------------------------------------------------------------------------------
7 tests, 44 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-------------------------------------------------------------------------------------------------------------------------------------------
149.01 tests/s, 936.61 assertions/s
```

## What is your fix for the problem, implemented in this PR?

Make `Gem::MockBrowser.post` default `Content-Type` to `"application/x-www-form-urlencoded"`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
