### PR TITLE
Update rdiscount gem version from 2.2.7 to 2.2.7.1

### DIFF
--- a/tool/bundler/dev26_gems.rb.lock
+++ b/tool/bundler/dev26_gems.rb.lock
@@ -10,7 +10,7 @@ GEM
     power_assert (2.0.3)
     rake (13.0.6)
     rb_sys (0.9.78)
-    rdiscount (2.2.7)
+    rdiscount (2.2.7.1)
     ronn (0.7.3)
       hpricot (>= 0.8.2)
       mustache (>= 0.7.0)

--- a/tool/bundler/dev_gems.rb.lock
+++ b/tool/bundler/dev_gems.rb.lock
@@ -11,7 +11,7 @@ GEM
     power_assert (2.0.3)
     rake (13.0.6)
     rb_sys (0.9.79)
-    rdiscount (2.2.7)
+    rdiscount (2.2.7.1)
     ronn (0.7.3)
       hpricot (>= 0.8.2)
       mustache (>= 0.7.0)


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Rubygems CI builds (daily-rubygems) fail on TruffleRuby ([example](https://github.com/rubygems/rubygems/actions/runs/5306405480/jobs/9603964418)).

Error message from a job output:

```
gethopt.c:48:13: error: parameter 'val' was not declared, defaults to 'int'; ISO
C99 and later do not support implicit int [-Wimplicit-int]
hopterr(ctx,val)
            ^
```

## What is your fix for the problem, implemented in this PR?

CI fails on TruffleRuby on the `bundle install` step because building a native extension of `rdiscount` gem fails. A new version of `rdiscount` (2.2.7.1) was released recently with a [fix](https://github.com/davidfstr/rdiscount/issues/155).

In this PR `rdiscount` is upgraded to the latest version.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
