### PR TITLE
Small refactor for Gem::Resolver

### DIFF
--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -38,8 +38,6 @@ class Gem::Resolver
   ##
   # List of dependencies that could not be found in the configured sources.
 
-  attr_reader :missing
-
   attr_reader :stats
 
   ##
@@ -106,7 +104,6 @@ class Gem::Resolver
     @development         = false
     @development_shallow = false
     @ignore_dependencies = false
-    @missing             = []
     @skip_gems           = {}
     @soft_missing        = false
     @stats               = Gem::Resolver::Stats.new
@@ -227,7 +224,6 @@ class Gem::Resolver
   def search_for(dependency)
     possibles, all = find_possible(dependency)
     if !@soft_missing && possibles.empty?
-      @missing << dependency
       exc = Gem::UnsatisfiableDependencyError.new dependency, all
       exc.errors = @set.errors
       raise exc
@@ -274,7 +270,6 @@ class Gem::Resolver
   end
 
   def allow_missing?(dependency)
-    @missing << dependency
     @soft_missing
   end
 

--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -187,8 +187,7 @@ class Gem::Resolver
   # Proceed with resolution! Returns an array of ActivationRequest objects.
 
   def resolve
-    locking_dg = Molinillo::DependencyGraph.new
-    Molinillo::Resolver.new(self, self).resolve(@needed.map {|d| DependencyRequest.new d, nil }, locking_dg).tsort.map(&:payload).compact
+    Molinillo::Resolver.new(self, self).resolve(@needed.map {|d| DependencyRequest.new d, nil }).tsort.map(&:payload).compact
   rescue Molinillo::VersionConflict => e
     conflict = e.conflicts.values.first
     raise Gem::DependencyResolutionError, Conflict.new(conflict.requirement_trees.first.first, conflict.existing, conflict.requirement)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`Gem::Resolver` have some of unused or unnecessary variables.

## What is your fix for the problem, implemented in this PR?

I removed them.

* `@missing` is unused variable in RubyGems.
* The default 2nd argument of `Molinillo::Resolver#resolve` is instance of `Molinillo::DependencyGraph`. So, we don't need to pass it from `Gem::Resolver`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
