### PR TITLE
Merge URI-0.12.2 for Bundler

### DIFF
--- a/bundler/lib/bundler/vendor/uri/lib/uri/rfc2396_parser.rb
+++ b/bundler/lib/bundler/vendor/uri/lib/uri/rfc2396_parser.rb
@@ -497,8 +497,8 @@ module Bundler::URI
       ret = {}
 
       # for Bundler::URI::split
-      ret[:ABS_URI] = Regexp.new('\A\s*' + pattern[:X_ABS_URI] + '\s*\z', Regexp::EXTENDED)
-      ret[:REL_URI] = Regexp.new('\A\s*' + pattern[:X_REL_URI] + '\s*\z', Regexp::EXTENDED)
+      ret[:ABS_URI] = Regexp.new('\A\s*+' + pattern[:X_ABS_URI] + '\s*\z', Regexp::EXTENDED)
+      ret[:REL_URI] = Regexp.new('\A\s*+' + pattern[:X_REL_URI] + '\s*\z', Regexp::EXTENDED)
 
       # for Bundler::URI::extract
       ret[:URI_REF]     = Regexp.new(pattern[:URI_REF])

--- a/bundler/lib/bundler/vendor/uri/lib/uri/rfc3986_parser.rb
+++ b/bundler/lib/bundler/vendor/uri/lib/uri/rfc3986_parser.rb
@@ -100,7 +100,7 @@ module Bundler::URI
         QUERY: /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*\z/,
         FRAGMENT: /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*\z/,
         OPAQUE: /\A(?:[^\/].*)?\z/,
-        PORT: /\A[\x09\x0a\x0c\x0d ]*\d*[\x09\x0a\x0c\x0d ]*\z/,
+        PORT: /\A[\x09\x0a\x0c\x0d ]*+\d*[\x09\x0a\x0c\x0d ]*\z/,
       }
     end
 

--- a/bundler/lib/bundler/vendor/uri/lib/uri/version.rb
+++ b/bundler/lib/bundler/vendor/uri/lib/uri/version.rb
@@ -1,6 +1,6 @@
 module Bundler::URI
   # :stopdoc:
-  VERSION_CODE = '001201'.freeze
+  VERSION_CODE = '001202'.freeze
   VERSION = VERSION_CODE.scan(/../).collect{|n| n.to_i}.join('.').freeze
   # :startdoc:
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Our vendored URI is vulnerable version. see https://www.ruby-lang.org/en/news/2023/06/29/redos-in-uri-CVE-2023-36617/

## What is your fix for the problem, implemented in this PR?

Update URI-0.12.2.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
