### PR TITLE
Sort by hash when expiring sources

### DIFF
--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -105,6 +105,10 @@ module Bundler
       get(source) || default_source
     end
 
+    def unsorted_lock_sources
+      other_sources + lock_rubygems_sources
+    end
+
     def lock_sources
       lock_other_sources + lock_rubygems_sources
     end
@@ -128,14 +132,14 @@ module Bundler
       @rubygems_sources, @path_sources, @git_sources, @plugin_sources = map_sources(replacement_sources)
       @global_rubygems_source = global_replacement_source(replacement_sources)
 
-      different_sources?(lock_sources, replacement_sources)
+      different_sources?(unsorted_lock_sources, replacement_sources)
     end
 
     # Returns true if there are changes
     def expired_sources?(replacement_sources)
       return false if replacement_sources.empty?
 
-      lock_sources = dup_with_replaced_sources(replacement_sources).lock_sources
+      lock_sources = dup_with_replaced_sources(replacement_sources).unsorted_lock_sources
 
       different_sources?(lock_sources, replacement_sources)
     end
@@ -225,7 +229,7 @@ module Bundler
     end
 
     def equivalent_sources?(lock_sources, replacement_sources)
-      lock_sources.sort_by(&:identifier) == replacement_sources.sort_by(&:identifier)
+      lock_sources.sort_by(&:hash) == replacement_sources.sort_by(&:hash)
     end
 
     def equivalent_source?(source, other_source)

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -90,7 +90,7 @@ module Bundler
     end
 
     def all_sources
-      path_sources + git_sources + plugin_sources + rubygems_sources + [metadata_source]
+      other_sources + rubygems_sources + [metadata_source]
     end
 
     def non_default_explicit_sources
@@ -110,7 +110,7 @@ module Bundler
     end
 
     def lock_other_sources
-      (path_sources + git_sources + plugin_sources).sort_by(&:identifier)
+      other_sources.sort_by(&:identifier)
     end
 
     def lock_rubygems_sources
@@ -153,6 +153,10 @@ module Bundler
     end
 
     private
+
+    def other_sources
+      path_sources + git_sources + plugin_sources
+    end
 
     def dup_with_replaced_sources(replacement_sources)
       new_source_list = dup


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes git source ordering is not stable.

## What is your fix for the problem, implemented in this PR?

Currently, git sources have a `#to_s` method that may leave side effects, since it actually "materialize" the source (it checks it out and figures out HEAD revision, to include it when printing the source).

This caused some surprising breakage when I was moving code around, and it's not necessary as long as the sorting is consistent.

Fixes #6743.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
