### PR TITLE
Deprecate Gem::Platform.match?

### DIFF
--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -22,6 +22,11 @@ class Gem::Platform
     match_platforms?(platform, Gem.platforms)
   end
 
+  class << self
+    extend Gem::Deprecate
+    rubygems_deprecate :match, "Gem::Platform.match_spec? or match_gem?"
+  end
+
   def self.match_platforms?(platform, platforms)
     platform = Gem::Platform.new(platform) unless platform.is_a?(Gem::Platform)
     platforms.any? do |local_platform|

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -483,8 +483,10 @@ class TestGemPlatform < Gem::TestCase
   def test_gem_platform_match_with_string_argument
     util_set_arch "x86_64-linux-musl"
 
-    assert(Gem::Platform.match(Gem::Platform.new("x86_64-linux")), "should match Gem::Platform")
-    assert(Gem::Platform.match("x86_64-linux"), "should match String platform")
+    Gem::Deprecate.skip_during do
+      assert(Gem::Platform.match(Gem::Platform.new("x86_64-linux")), "should match Gem::Platform")
+      assert(Gem::Platform.match("x86_64-linux"), "should match String platform")
+    end
   end
 
   def assert_local_match(name)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This is extracted from https://github.com/rubygems/rubygems/pull/6238. We should deprecate `Gem::Platform.match?` because this method is ambiguous name.

## What is your fix for the problem, implemented in this PR?

I marked `Gem::Platform.match?` as deprecate status.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
