### PR TITLE
Fix another incorrect removal of "ruby" platform from lockfile when changing path sources

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -941,6 +941,7 @@ module Bundler
                 Bundler.local_platform == Gem::Platform::RUBY ||
                 !platforms.include?(Gem::Platform::RUBY) ||
                 (@new_platform && platforms.last == Gem::Platform::RUBY) ||
+                @path_changes ||
                 @dependency_changes ||
                 !@originally_locked_specs.incomplete_ruby_specs?(dependencies)
 

--- a/bundler/spec/install/gemfile/path_spec.rb
+++ b/bundler/spec/install/gemfile/path_spec.rb
@@ -782,6 +782,52 @@ RSpec.describe "bundle install with explicit source paths" do
 
       expect(the_bundle).to include_gems "rack 0.9.1"
     end
+
+    it "does not remove existing ruby platform" do
+      build_lib "foo", "1.0", :path => lib_path("foo") do |s|
+        s.add_dependency "rack", "0.9.1"
+      end
+
+      lockfile <<~L
+        PATH
+          remote: #{lib_path("foo")}
+          specs:
+            foo (1.0)
+
+        PLATFORMS
+          #{lockfile_platforms("ruby")}
+
+        DEPENDENCIES
+          foo!
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "lock"
+
+      expect(lockfile).to eq <<~G
+        PATH
+          remote: #{lib_path("foo")}
+          specs:
+            foo (1.0)
+              rack (= 0.9.1)
+
+        GEM
+          remote: #{file_uri_for(gem_repo1)}/
+          specs:
+            rack (0.9.1)
+
+        PLATFORMS
+          #{lockfile_platforms("ruby")}
+
+        DEPENDENCIES
+          foo!
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      G
+    end
   end
 
   describe "switching sources" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When dependencies in path sources have changed, and lockfile includes the RUBY platform among others, we'll incorrectly remove the RUBY platform.

## What is your fix for the problem, implemented in this PR?

In this case, we'll be re-resolving, and we can't really know whether the resolution will be valid or invalid for the Ruby platform, so skip the removal in that case.

This is very similar to [a previous bug fix](https://github.com/rubygems/rubygems/pull/6540) and I think it's the last bug fix in preparation for [Universal lockfiles](https://github.com/rubygems/rubygems/pull/5700), which I expect to finish up very soon!

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
