### PR TITLE
Fix git source lockfile instability

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -394,8 +394,8 @@ module Bundler
         lock_source = lock_dep.source || sources.default_source
         next if lock_source.include?(gemfile_source)
 
-        gemfile_source_name = dep.source ? gemfile_source.identifier : "no specified source"
-        lockfile_source_name = lock_dep.source ? lock_source.identifier : "no specified source"
+        gemfile_source_name = dep.source ? gemfile_source.to_gemfile : "no specified source"
+        lockfile_source_name = lock_dep.source ? lock_source.to_gemfile : "no specified source"
         changed << "* #{name} from `#{lockfile_source_name}` to `#{gemfile_source_name}`"
       end
 

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -46,6 +46,14 @@ module Bundler
         out << "  specs:\n"
       end
 
+      def to_gemfile
+        specifiers = %w[ref branch tag submodules glob].map do |opt|
+          "#{opt}: #{options[opt]}" if options[opt]
+        end
+
+        uri_with_specifiers(specifiers)
+      end
+
       def hash
         [self.class, uri, ref, branch, name, version, glob, submodules].hash
       end
@@ -80,7 +88,12 @@ module Bundler
           ""
         end
 
-        specifiers = [rev, glob_for_display].compact
+        uri_with_specifiers([rev, glob_for_display])
+      end
+
+      def uri_with_specifiers(specifiers)
+        specifiers.compact!
+
         suffix =
           if specifiers.any?
             " (#{specifiers.join(", ")})"

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -123,6 +123,7 @@ module Bundler
         end
       end
       alias_method :name, :identifier
+      alias_method :to_gemfile, :identifier
 
       def specs
         @specs ||= begin

--- a/bundler/spec/bundler/env_spec.rb
+++ b/bundler/spec/bundler/env_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe Bundler::Env do
 
     context "when the git version is OS specific" do
       it "includes OS specific information with the version number" do
-        expect(git_proxy_stub).to receive(:git).with("--version").
+        expect(git_proxy_stub).to receive(:git_local).with("--version").
           and_return("git version 1.2.3 (Apple Git-BS)")
         expect(Bundler::Source::Git::GitProxy).to receive(:new).and_return(git_proxy_stub)
 

--- a/bundler/spec/bundler/source/git/git_proxy_spec.rb
+++ b/bundler/spec/bundler/source/git/git_proxy_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Bundler::Source::Git::GitProxy do
   context "with configured credentials" do
     it "adds username and password to URI" do
       Bundler.settings.temporary(uri => "u:p") do
-        allow(subject).to receive(:git).with("--version").and_return("git version 2.14.0")
+        allow(subject).to receive(:git_local).with("--version").and_return("git version 2.14.0")
         expect(subject).to receive(:capture).with([*base_clone_args, "--", "https://u:p@github.com/rubygems/rubygems.git", path.to_s], nil).and_return(["", "", clone_result])
         subject.checkout
       end
@@ -21,7 +21,7 @@ RSpec.describe Bundler::Source::Git::GitProxy do
 
     it "adds username and password to URI for host" do
       Bundler.settings.temporary("github.com" => "u:p") do
-        allow(subject).to receive(:git).with("--version").and_return("git version 2.14.0")
+        allow(subject).to receive(:git_local).with("--version").and_return("git version 2.14.0")
         expect(subject).to receive(:capture).with([*base_clone_args, "--", "https://u:p@github.com/rubygems/rubygems.git", path.to_s], nil).and_return(["", "", clone_result])
         subject.checkout
       end
@@ -29,7 +29,7 @@ RSpec.describe Bundler::Source::Git::GitProxy do
 
     it "does not add username and password to mismatched URI" do
       Bundler.settings.temporary("https://u:p@github.com/rubygems/rubygems-mismatch.git" => "u:p") do
-        allow(subject).to receive(:git).with("--version").and_return("git version 2.14.0")
+        allow(subject).to receive(:git_local).with("--version").and_return("git version 2.14.0")
         expect(subject).to receive(:capture).with([*base_clone_args, "--", uri, path.to_s], nil).and_return(["", "", clone_result])
         subject.checkout
       end
@@ -39,7 +39,7 @@ RSpec.describe Bundler::Source::Git::GitProxy do
       Bundler.settings.temporary("github.com" => "u:p") do
         original = "https://orig:info@github.com/rubygems/rubygems.git"
         subject = described_class.new(Pathname("path"), original, "HEAD")
-        allow(subject).to receive(:git).with("--version").and_return("git version 2.14.0")
+        allow(subject).to receive(:git_local).with("--version").and_return("git version 2.14.0")
         expect(subject).to receive(:capture).with([*base_clone_args, "--", original, path.to_s], nil).and_return(["", "", clone_result])
         subject.checkout
       end
@@ -49,7 +49,7 @@ RSpec.describe Bundler::Source::Git::GitProxy do
   describe "#version" do
     context "with a normal version number" do
       before do
-        expect(subject).to receive(:git).with("--version").
+        expect(subject).to receive(:git_local).with("--version").
           and_return("git version 1.2.3")
       end
 
@@ -64,7 +64,7 @@ RSpec.describe Bundler::Source::Git::GitProxy do
 
     context "with a OSX version number" do
       before do
-        expect(subject).to receive(:git).with("--version").
+        expect(subject).to receive(:git_local).with("--version").
           and_return("git version 1.2.3 (Apple Git-BS)")
       end
 
@@ -79,7 +79,7 @@ RSpec.describe Bundler::Source::Git::GitProxy do
 
     context "with a msysgit version number" do
       before do
-        expect(subject).to receive(:git).with("--version").
+        expect(subject).to receive(:git_local).with("--version").
           and_return("git version 1.2.3.msysgit.0")
       end
 
@@ -96,7 +96,7 @@ RSpec.describe Bundler::Source::Git::GitProxy do
   describe "#full_version" do
     context "with a normal version number" do
       before do
-        expect(subject).to receive(:git).with("--version").
+        expect(subject).to receive(:git_local).with("--version").
           and_return("git version 1.2.3")
       end
 
@@ -107,7 +107,7 @@ RSpec.describe Bundler::Source::Git::GitProxy do
 
     context "with a OSX version number" do
       before do
-        expect(subject).to receive(:git).with("--version").
+        expect(subject).to receive(:git_local).with("--version").
           and_return("git version 1.2.3 (Apple Git-BS)")
       end
 
@@ -118,7 +118,7 @@ RSpec.describe Bundler::Source::Git::GitProxy do
 
     context "with a msysgit version number" do
       before do
-        expect(subject).to receive(:git).with("--version").
+        expect(subject).to receive(:git_local).with("--version").
           and_return("git version 1.2.3.msysgit.0")
       end
 


### PR DESCRIPTION

## What was the end-user or developer problem that led to this PR?

Sometimes Bundler may print inconsistent git source ordering to the lockfile.

## What is your fix for the problem, implemented in this PR?

We have some flags that limit running git commands under certain situations, for example, when running under `--local`. However, those should only affect remote git operations, not local read-only operations like `git --version`, or `git rev-parse --abbrev-ref HEAD`.

This commit refactors things to achieve that.

By doing this, the `#to_s` representation of a source is more consistent, since we don't get any errors when reading the checked out branch, and we avoid some flip-flop lockfile issues.

Fixes #6743.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
