### PR TITLE
`gemfile.5`: Code format the default glob to escape Markdown

### DIFF
--- a/bundler/lib/bundler/man/gemfile.5.ronn
+++ b/bundler/lib/bundler/man/gemfile.5.ronn
@@ -518,7 +518,7 @@ paths.
 
 The `gemspec` method supports optional `:path`, `:glob`, `:name`, and `:development_group`
 options, which control where bundler looks for the `.gemspec`, the glob it uses to look
-for the gemspec (defaults to: "{,*,*/*}.gemspec"), what named `.gemspec` it uses
+for the gemspec (defaults to: `{,*,*/*}.gemspec`), what named `.gemspec` it uses
 (if more than one is present), and which group development dependencies are included in.
 
 When a `gemspec` dependency encounters version conflicts during resolution, the


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?
The default glob as rendered (`{,,/*}.gemspec`) doesn’t make sense.

## What is your fix for the problem, implemented in this PR?
Quote the default glob in an inline code rather than double-quotes so the `*`s don’t and will never leak out as Markdown for emphasis.

## Make sure the following tasks are checked
* [x] Describe the problem/feature
* [ ] ~~Write tests for features and bug fixes~~
* [x] Write code to solve the problem
* [x] Make sure you follow the current code style and write meaningful commit messages without tags