### PR TITLE
Exclude Bundler from missing locked dependencies check

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -700,7 +700,7 @@ module Bundler
       return if @dependency_changes
 
       current_dependencies.find do |d|
-        @locked_specs[d.name].empty?
+        @locked_specs[d.name].empty? && d.name != "bundler"
       end&.name
     end
 

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -639,6 +639,16 @@ RSpec.describe "Bundler.setup" do
       expect(err).to be_empty
     end
 
+    it "doesn't fail in frozen mode when bundler is a Gemfile dependency" do
+      install_gemfile <<~G
+        source "#{file_uri_for(gem_repo4)}"
+        gem "bundler"
+      G
+
+      bundle "install --verbose", :env => { "BUNDLE_FROZEN" => "true" }
+      expect(err).to be_empty
+    end
+
     it "doesn't re-resolve when deleting dependencies" do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We recently regressed and now show an error in frozen mode when Bundler is an explicit Gemfile dependency.

## What is your fix for the problem, implemented in this PR?

Bundler is special since it's not actually locked in the lockfile as a regular gem (only via `BUNDLED WITH`). So exclude it from that check.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
