### PR TITLE
Extract `Base64.encode64` method into test case

### DIFF
--- a/test/rubygems/test_gem_request.rb
+++ b/test/rubygems/test_gem_request.rb
@@ -3,7 +3,6 @@
 require_relative "helper"
 require "rubygems/request"
 require "ostruct"
-require "base64"
 
 unless Gem::HAVE_OPENSSL
   warn "Skipping Gem::Request tests.  openssl not found."
@@ -19,6 +18,12 @@ class TestGemRequest < Gem::TestCase
 
   def make_request(uri, request_class, last_modified, proxy)
     Gem::Request.create_with_proxy uri, request_class, last_modified, proxy
+  end
+
+  # This method is same code as Base64.encode64
+  # We should not use Base64.encode64 because we need to avoid gem activation.
+  def base64_encode64(bin)
+    [bin].pack("m")
   end
 
   def setup
@@ -209,7 +214,7 @@ class TestGemRequest < Gem::TestCase
     end
 
     auth_header = conn.payload["Authorization"]
-    assert_equal "Basic #{Base64.encode64("user:pass")}".strip, auth_header
+    assert_equal "Basic #{base64_encode64("user:pass")}".strip, auth_header
     assert_includes @ui.output, "GET https://user:REDACTED@example.rubygems/specs.#{Gem.marshal_version}"
   end
 
@@ -226,7 +231,7 @@ class TestGemRequest < Gem::TestCase
     end
 
     auth_header = conn.payload["Authorization"]
-    assert_equal "Basic #{Base64.encode64("user:{DEScede}pass")}".strip, auth_header
+    assert_equal "Basic #{base64_encode64("user:{DEScede}pass")}".strip, auth_header
     assert_includes @ui.output, "GET https://user:REDACTED@example.rubygems/specs.#{Gem.marshal_version}"
   end
 
@@ -243,7 +248,7 @@ class TestGemRequest < Gem::TestCase
     end
 
     auth_header = conn.payload["Authorization"]
-    assert_equal "Basic #{Base64.encode64("{DEScede}pass:x-oauth-basic")}".strip, auth_header
+    assert_equal "Basic #{base64_encode64("{DEScede}pass:x-oauth-basic")}".strip, auth_header
     assert_includes @ui.output, "GET https://REDACTED:x-oauth-basic@example.rubygems/specs.#{Gem.marshal_version}"
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I have a plan to promote `base64` as bundled gems at `ruby/ruby`. see https://bugs.ruby-lang.org/issues/19351

After that, the test suite of rubygems is broken because it couldn't load `base64`. So, we need to avoid to use Base64 library at our tests.

## What is your fix for the problem, implemented in this PR?

`Base64.encode64` is simple pure ruby method. I ported it to `test_gem_request.rb`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
