### PR TITLE
Avoid printing "Using ..." messages when version has not changed

### DIFF
--- a/bundler/lib/bundler/feature_flag.rb
+++ b/bundler/lib/bundler/feature_flag.rb
@@ -37,7 +37,6 @@ module Bundler
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }
     settings_flag(:print_only_version_number) { bundler_3_mode? }
     settings_flag(:setup_makes_kernel_gem_public) { !bundler_3_mode? }
-    settings_flag(:suppress_install_using_messages) { bundler_3_mode? }
     settings_flag(:update_requires_all_flag) { bundler_4_mode? }
 
     settings_option(:default_cli_command) { bundler_3_mode? ? :cli_help : :install }

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -284,9 +284,6 @@ The following is a list of all configuration keys and their purpose\. You can le
 \fBssl_verify_mode\fR (\fBBUNDLE_SSL_VERIFY_MODE\fR): The SSL verification mode Bundler uses when making HTTPS requests\. Defaults to verify peer\.
 .
 .IP "\(bu" 4
-\fBsuppress_install_using_messages\fR (\fBBUNDLE_SUPPRESS_INSTALL_USING_MESSAGES\fR): Avoid printing \fBUsing \.\.\.\fR messages during installation when the version of a gem has not changed\.
-.
-.IP "\(bu" 4
 \fBsystem_bindir\fR (\fBBUNDLE_SYSTEM_BINDIR\fR): The location where RubyGems installs binstubs\. Defaults to \fBGem\.bindir\fR\.
 .
 .IP "\(bu" 4

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -265,9 +265,6 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
 * `ssl_verify_mode` (`BUNDLE_SSL_VERIFY_MODE`):
    The SSL verification mode Bundler uses when making HTTPS requests.
    Defaults to verify peer.
-* `suppress_install_using_messages` (`BUNDLE_SUPPRESS_INSTALL_USING_MESSAGES`):
-   Avoid printing `Using ...` messages during installation when the version of
-   a gem has not changed.
 * `system_bindir` (`BUNDLE_SYSTEM_BINDIR`):
    The location where RubyGems installs binstubs. Defaults to `Gem.bindir`.
 * `timeout` (`BUNDLE_TIMEOUT`):

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -43,7 +43,6 @@ module Bundler
       setup_makes_kernel_gem_public
       silence_deprecations
       silence_root_warning
-      suppress_install_using_messages
       update_requires_all_flag
     ].freeze
 

--- a/bundler/lib/bundler/source.rb
+++ b/bundler/lib/bundler/source.rb
@@ -100,7 +100,7 @@ module Bundler
     end
 
     def print_using_message(message)
-      if !message.include?("(was ") && Bundler.feature_flag.suppress_install_using_messages?
+      if !message.include?("(was ")
         Bundler.ui.debug message
       else
         Bundler.ui.info message

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -772,7 +772,7 @@ RSpec.describe "bundle update" do
     end
   end
 
-  it "shows the previous version of the gem when updated from rubygems source", :bundler => "< 3" do
+  it "shows the previous version of the gem when updated from rubygems source" do
     build_repo2
 
     install_gemfile <<-G
@@ -780,7 +780,7 @@ RSpec.describe "bundle update" do
       gem "activesupport"
     G
 
-    bundle "update", :all => true
+    bundle "update", :all => true, :verbose => true
     expect(out).to include("Using activesupport 2.3.5")
 
     update_repo2 do
@@ -791,32 +791,28 @@ RSpec.describe "bundle update" do
     expect(out).to include("Installing activesupport 3.0 (was 2.3.5)")
   end
 
-  context "with suppress_install_using_messages set" do
-    before { bundle "config set suppress_install_using_messages true" }
-
-    it "only prints `Using` for versions that have changed" do
-      build_repo4 do
-        build_gem "bar"
-        build_gem "foo"
-      end
-
-      install_gemfile <<-G
-        source "#{file_uri_for(gem_repo4)}"
-        gem "bar"
-        gem "foo"
-      G
-
-      bundle "update", :all => true
-      expect(out).to match(/Resolving dependencies\.\.\.\.*\nBundle updated!/)
-
-      update_repo4 do
-        build_gem "foo", "2.0"
-      end
-
-      bundle "update", :all => true
-      out.sub!("Removing foo (1.0)\n", "")
-      expect(out).to match(/Resolving dependencies\.\.\.\.*\nFetching foo 2\.0 \(was 1\.0\)\nInstalling foo 2\.0 \(was 1\.0\)\nBundle updated/)
+  it "only prints `Using` for versions that have changed" do
+    build_repo4 do
+      build_gem "bar"
+      build_gem "foo"
     end
+
+    install_gemfile <<-G
+      source "#{file_uri_for(gem_repo4)}"
+      gem "bar"
+      gem "foo"
+    G
+
+    bundle "update", :all => true
+    expect(out).to match(/Resolving dependencies\.\.\.\.*\nBundle updated!/)
+
+    update_repo4 do
+      build_gem "foo", "2.0"
+    end
+
+    bundle "update", :all => true
+    out.sub!("Removing foo (1.0)\n", "")
+    expect(out).to match(/Resolving dependencies\.\.\.\.*\nFetching foo 2\.0 \(was 1\.0\)\nInstalling foo 2\.0 \(was 1\.0\)\nBundle updated/)
   end
 
   it "shows error message when Gemfile.lock is not preset and gem is specified" do
@@ -1386,7 +1382,7 @@ RSpec.describe "bundle update --bundler" do
       gem "rack"
     G
 
-    bundle :update, :bundler => "2.3.0.dev"
+    bundle :update, :bundler => "2.3.0.dev", :verbose => "true"
 
     # Only updates properly on modern RubyGems.
 
@@ -1423,7 +1419,7 @@ RSpec.describe "bundle update --bundler" do
       gem "rack"
     G
 
-    bundle :update, :bundler => "2.3.9", :raise_on_error => false
+    bundle :update, :bundler => "2.3.9", :raise_on_error => false, :verbose => true
 
     expect(out).not_to include("Fetching gem metadata from https://rubygems.org/")
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Current default output is a bit too verbose.

## What is your fix for the problem, implemented in this PR?

Avoid printing using messages when version has not changed.

Closes #6796.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
