### PR TITLE
Don't switch locked version when using prerelease Bundler

### DIFF
--- a/bundler/lib/bundler/self_manager.rb
+++ b/bundler/lib/bundler/self_manager.rb
@@ -76,7 +76,8 @@ module Bundler
     end
 
     def needs_switching?
-      autoswitching_applies? &&
+      !Gem::Version.new(Bundler::VERSION).prerelease? &&
+        autoswitching_applies? &&
         released?(lockfile_version) &&
         !running?(lockfile_version) &&
         !updating?

--- a/bundler/spec/runtime/self_management_spec.rb
+++ b/bundler/spec/runtime/self_management_spec.rb
@@ -16,6 +16,13 @@ RSpec.describe "Self management", :rubygems => ">= 3.3.0.dev", :realworld => tru
       G
     end
 
+    it "don't install locked version when using prerelease version" do
+      lockfile_bundled_with(previous_minor)
+
+      bundle "install", :artifice => "vcr"
+      expect(out).to_not include("Bundler #{Bundler::VERSION} is running, but your lockfile was generated with #{previous_minor}")
+    end
+
     it "installs locked version when using system path and uses it" do
       lockfile_bundled_with(previous_minor)
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I used pre-released version of Bundler like `2.5.0.dev` every day for testing development version. But auto-switching feature change released version of `BUNDLED WITH`.

So, I can't test prereleased version with production application. I always set `BUNDLER_VERSION=2.5.0.dev bundle ...`. 

## What is your fix for the problem, implemented in this PR?

I disabled auto-switching feature when we use prerelease version of Bundler. So, the users who used prereleased version always want to test prereleased version of Bundler with their application.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
