### PR TITLE
Use `File::NULL` instead of hard coded null device names

### DIFF
--- a/bundler/lib/bundler/constants.rb
+++ b/bundler/lib/bundler/constants.rb
@@ -3,5 +3,5 @@
 module Bundler
   WINDOWS = RbConfig::CONFIG["host_os"] =~ /(msdos|mswin|djgpp|mingw)/
   FREEBSD = RbConfig::CONFIG["host_os"].to_s.include?("bsd")
-  NULL    = WINDOWS ? "NUL" : "/dev/null"
+  NULL    = File::NULL
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`git grep '"/dev/null"'`.

## What is your fix for the problem, implemented in this PR?

Use the dedicated constant `File::NULL`, which has been defined since 1.9.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
