### PR TITLE
Avoid unnecessary work for private local gem installation

### DIFF
--- a/lib/rubygems/resolver/installer_set.rb
+++ b/lib/rubygems/resolver/installer_set.rb
@@ -148,6 +148,8 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
       res << Gem::Resolver::InstalledSpecification.new(self, gemspec)
     end unless @ignore_installed
 
+    matching_local = []
+
     if consider_local?
       matching_local = @local.values.select do |spec, _|
         req.match? spec
@@ -169,7 +171,7 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
       end
     end
 
-    res.concat @remote_set.find_all req if consider_remote?
+    res.concat @remote_set.find_all req if consider_remote? && matching_local.empty?
 
     res
   end

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -476,6 +476,40 @@ class TestGemDependencyInstaller < Gem::TestCase
     assert_equal %w[b-1], inst.installed_gems.map(&:full_name)
   end
 
+  def test_install_local_dependency_no_network_for_target_gem
+    a1, a1_gem = util_gem "a", "1"
+    _, b1_gem = util_gem "b", "1" do |s|
+      s.add_dependency "a"
+    end
+
+    util_setup_spec_fetcher(a1)
+
+    a1_data = Gem.read_binary(a1_gem)
+    @fetcher.data["http://gems.example.com/gems/a-1.gem"] = a1_data
+
+    # compact index is available
+    compact_index_response = Net::HTTPResponse.new "1.1", 200, "OK"
+    compact_index_response.uri = URI("http://gems.example.com")
+    @fetcher.data["http://gems.example.com/"] = compact_index_response
+
+    # but private local gem not present there
+    @fetcher.data["http://gems.example.com/info/b"] =
+      proc do
+        raise "should not happen"
+      end
+
+    FileUtils.mv b1_gem, @tempdir
+
+    inst = nil
+
+    Dir.chdir @tempdir do
+      inst = Gem::DependencyInstaller.new
+      inst.install "b-1.gem"
+    end
+
+    assert_equal %w[a-1 b-1], inst.installed_gems.map(&:full_name)
+  end
+
   def test_install_local_subdir
     util_setup_gems
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When installing a local private gem, we were still checking for remote versions of it. That involved checking whether the gem is available in the compact index, and if not, use the full index for resolution instead.

This is slow, and unnecessary, since in the end, it's the local gem version that will be chosen. We can skip this check and as a result, use the faster Compact Index API in this case.

## What is your fix for the problem, implemented in this PR?

Avoid fetching remote gem information for resolution if the gem is locally available.

Fixes part (the most important part) of #6807. 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
