### PR TITLE
Bypass $LOAD_PATH feature for bundled gems

### DIFF
--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -182,6 +182,9 @@ The following is a list of all configuration keys and their purpose\. You can le
 \fBdeployment\fR (\fBBUNDLE_DEPLOYMENT\fR): Disallow changes to the \fBGemfile\fR\. When the \fBGemfile\fR is changed and the lockfile has not been updated, running Bundler commands will be blocked\.
 .
 .IP "\(bu" 4
+\fBdisable_bundled_gems_load_path\fR (\fBBUNDLE_DISABLE_BUNDLED_GEMS_LOAD_PATH\fR): Stop to add the \fBbundled_gems\fR load paths to \fB$LOAD_PATH\fR under the Bundler environment\.
+.
+.IP "\(bu" 4
 \fBdisable_checksum_validation\fR (\fBBUNDLE_DISABLE_CHECKSUM_VALIDATION\fR): Allow installing gems even if they do not match the checksum provided by RubyGems\.
 .
 .IP "\(bu" 4
@@ -192,9 +195,6 @@ The following is a list of all configuration keys and their purpose\. You can le
 .
 .IP "\(bu" 4
 \fBdisable_local_revision_check\fR (\fBBUNDLE_DISABLE_LOCAL_REVISION_CHECK\fR): Allow Bundler to use a local git override without checking if the revision present in the lockfile is present in the repository\.
-.
-.IP "\(bu" 4
-\fBdisable_bundled_gems_load_path\fR (\fBBUNDLE_DISABLE_BUNDLED_GEMS_LOAD_PATH\fR): Stop to add the \fBbundled_gems\fR load paths to \fB$LOAD_PATH\fR under the Bundler environment\.
 .
 .IP "\(bu" 4
 \fBdisable_shared_gems\fR (\fBBUNDLE_DISABLE_SHARED_GEMS\fR): Stop Bundler from accessing gems installed to RubyGems\' normal location\.

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -194,6 +194,9 @@ The following is a list of all configuration keys and their purpose\. You can le
 \fBdisable_local_revision_check\fR (\fBBUNDLE_DISABLE_LOCAL_REVISION_CHECK\fR): Allow Bundler to use a local git override without checking if the revision present in the lockfile is present in the repository\.
 .
 .IP "\(bu" 4
+\fBdisable_bundled_gems_load_path\fR (\fBBUNDLE_DISABLE_BUNDLED_GEMS_LOAD_PATH\fR): Stop to add the \fBbundled_gems\fR load paths to \fB$LOAD_PATH\fR under the Bundler environment\.
+.
+.IP "\(bu" 4
 \fBdisable_shared_gems\fR (\fBBUNDLE_DISABLE_SHARED_GEMS\fR): Stop Bundler from accessing gems installed to RubyGems\' normal location\.
 .
 .IP "\(bu" 4

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -182,6 +182,9 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
 * `disable_local_revision_check` (`BUNDLE_DISABLE_LOCAL_REVISION_CHECK`):
    Allow Bundler to use a local git override without checking if the revision
    present in the lockfile is present in the repository.
+* `disable_bundled_gems_load_path` (`BUNDLE_DISABLE_BUNDLED_GEMS_LOAD_PATH`):
+   Stop to add the `bundled_gems` load paths to `$LOAD_PATH` under the
+   Bundler environment.
 * `disable_shared_gems` (`BUNDLE_DISABLE_SHARED_GEMS`):
    Stop Bundler from accessing gems installed to RubyGems' normal location.
 * `disable_version_check` (`BUNDLE_DISABLE_VERSION_CHECK`):

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -170,6 +170,9 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
 * `deployment` (`BUNDLE_DEPLOYMENT`):
    Disallow changes to the `Gemfile`. When the `Gemfile` is changed and the
    lockfile has not been updated, running Bundler commands will be blocked.
+* `disable_bundled_gems_load_path` (`BUNDLE_DISABLE_BUNDLED_GEMS_LOAD_PATH`):
+   Stop to add the `bundled_gems` load paths to `$LOAD_PATH` under the
+   Bundler environment.
 * `disable_checksum_validation` (`BUNDLE_DISABLE_CHECKSUM_VALIDATION`):
    Allow installing gems even if they do not match the checksum provided by
    RubyGems.
@@ -182,9 +185,6 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
 * `disable_local_revision_check` (`BUNDLE_DISABLE_LOCAL_REVISION_CHECK`):
    Allow Bundler to use a local git override without checking if the revision
    present in the lockfile is present in the repository.
-* `disable_bundled_gems_load_path` (`BUNDLE_DISABLE_BUNDLED_GEMS_LOAD_PATH`):
-   Stop to add the `bundled_gems` load paths to `$LOAD_PATH` under the
-   Bundler environment.
 * `disable_shared_gems` (`BUNDLE_DISABLE_SHARED_GEMS`):
    Stop Bundler from accessing gems installed to RubyGems' normal location.
 * `disable_version_check` (`BUNDLE_DISABLE_VERSION_CHECK`):

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -19,6 +19,11 @@ require_relative "match_metadata"
 require_relative "force_platform"
 require_relative "match_platform"
 
+begin
+  require "bundled_gems"
+rescue LoadError
+end
+
 # Cherry-pick fixes to `Gem.ruby_version` to be useful for modern Bundler
 # versions and ignore patchlevels
 # (https://github.com/rubygems/rubygems/pull/5472,
@@ -68,18 +73,18 @@ module Gem
     # Returns a Gem::StubSpecification for bundled gems
 
     def self.bundled_stubs
-      require "bundled_gems"
-    rescue LoadError
-      []
-    else
-      Gem.bundled_gems.map do |name, version|
-        if Gem::Specification.respond_to?(:find_by_full_name)
-          Gem::Specification.find_by_full_name("#{name}-#{version}")
-        else
-          Gem::Specification.find_by_name(name)
-        end
-      rescue Gem::MissingSpecError
-      end.compact
+      if Gem.respond_to?(:bundled_stubs)
+        Gem.bundled_gems.map do |name, version|
+          if Gem::Specification.respond_to?(:find_by_full_name)
+            Gem::Specification.find_by_full_name("#{name}-#{version}")
+          else
+            Gem::Specification.find_by_name(name)
+          end
+        rescue Gem::MissingSpecError
+        end.compact
+      else
+        []
+      end
     end
 
     alias_method :rg_extension_dir, :extension_dir

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -69,7 +69,9 @@ module Gem
 
     def self.bundled_stubs
       require "bundled_gems"
-
+    rescue LoadError
+      []
+    else
       Gem.bundled_gems.map do |name, version|
         if Gem::Specification.respond_to?(:find_by_full_name)
           Gem::Specification.find_by_full_name("#{name}-#{version}")
@@ -78,8 +80,6 @@ module Gem
         end
       rescue Gem::MissingSpecError
       end.compact
-    rescue LoadError
-      []
     end
 
     alias_method :rg_extension_dir, :extension_dir

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -64,6 +64,19 @@ module Gem
       full_require_paths
     end
 
+    ##
+    # Returns a Gem::StubSpecification for bundled gems
+
+    def self.bundled_stubs
+      require_relative "../bundled_gems"
+      Gem.bundled_gems.map do |name|
+        Gem::Specification.find_by_name(name)
+      rescue Gem::MissingSpecError
+      end.compact
+    rescue LoadError
+      []
+    end
+
     alias_method :rg_extension_dir, :extension_dir
     def extension_dir
       # following instance variable is already used in original method

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -69,12 +69,16 @@ module Gem
 
     def self.bundled_stubs
       begin
-        require_relative "../bundled_gems"
+        require "bundled_gems"
+      rescue LoadError
+      end
+
+      if Gem.respond_to?(:bundled_gems)
         Gem.bundled_gems.map do |name|
           Gem::Specification.find_by_name(name)
         rescue Gem::MissingSpecError
         end.compact
-      rescue LoadError
+      else
         []
       end
     end

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -68,23 +68,18 @@ module Gem
     # Returns a Gem::StubSpecification for bundled gems
 
     def self.bundled_stubs
-      begin
-        require "bundled_gems"
-      rescue LoadError
-      end
+      require "bundled_gems"
 
-      if Gem.respond_to?(:bundled_gems)
-        Gem.bundled_gems.map do |name, version|
-          if Gem::Specification.respond_to?(:find_by_full_name)
-            Gem::Specification.find_by_full_name("#{name}-#{version}")
-          else
-            Gem::Specification.find_by_name(name)
-          end
-        rescue Gem::MissingSpecError
-        end.compact
-      else
-        []
-      end
+      Gem.bundled_gems.map do |name, version|
+        if Gem::Specification.respond_to?(:find_by_full_name)
+          Gem::Specification.find_by_full_name("#{name}-#{version}")
+        else
+          Gem::Specification.find_by_name(name)
+        end
+      rescue Gem::MissingSpecError
+      end.compact
+    rescue LoadError
+      []
     end
 
     alias_method :rg_extension_dir, :extension_dir

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -68,13 +68,15 @@ module Gem
     # Returns a Gem::StubSpecification for bundled gems
 
     def self.bundled_stubs
-      require_relative "../bundled_gems"
-      Gem.bundled_gems.map do |name|
-        Gem::Specification.find_by_name(name)
-      rescue Gem::MissingSpecError
-      end.compact
-    rescue LoadError
-      []
+      begin
+        require_relative "../bundled_gems"
+        Gem.bundled_gems.map do |name|
+          Gem::Specification.find_by_name(name)
+        rescue Gem::MissingSpecError
+        end.compact
+      rescue LoadError
+        []
+      end
     end
 
     alias_method :rg_extension_dir, :extension_dir

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -73,7 +73,7 @@ module Gem
     # Returns a Gem::StubSpecification for bundled gems
 
     def self.bundled_stubs
-      if Gem.respond_to?(:bundled_stubs)
+      if Gem.respond_to?(:bundled_gems)
         Gem.bundled_gems.map do |name, version|
           if Gem::Specification.respond_to?(:find_by_full_name)
             Gem::Specification.find_by_full_name("#{name}-#{version}")

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -74,8 +74,12 @@ module Gem
       end
 
       if Gem.respond_to?(:bundled_gems)
-        Gem.bundled_gems.map do |name|
-          Gem::Specification.find_by_name(name)
+        Gem.bundled_gems.map do |name, version|
+          if Gem::Specification.respond_to?(:find_by_full_name)
+            Gem::Specification.find_by_full_name("#{name}-#{version}")
+          else
+            Gem::Specification.find_by_name(name)
+          end
         rescue Gem::MissingSpecError
         end.compact
       else

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -387,7 +387,9 @@ module Bundler
 
     def add_bundled_gems_to(specs_by_name)
       Bundler.rubygems.bundled_stubs.each do |spec|
-        specs_by_name[spec.name] = spec
+        bundled_spec_name = spec.name
+        next if specs_by_name.key?(bundled_spec_name)
+        specs_by_name[bundled_spec_name] = spec
       end
 
       specs_by_name

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -386,16 +386,8 @@ module Bundler
     end
 
     def add_bundled_gems_to(specs_by_name)
-      bundled_gems = %w[
-        rexml
-        rbs
-        debug
-      ]
-
-      bundled_gems.each do |gem_name|
-        spec = Gem::Specification.find_by_name(gem_name)
-        specs_by_name[gem_name] = spec
-      rescue Gem::MissingSpecError
+      Bundler.rubygems.bundled_stubs.each do |spec|
+        specs_by_name[spec.name] = spec
       end
 
       specs_by_name
@@ -569,6 +561,16 @@ module Bundler
     else
       def default_stubs
         Gem::Specification.send(:default_stubs, "*.gemspec")
+      end
+    end
+
+    if Gem::Specification.respond_to?(:bundled_stubs)
+      def bundled_stubs
+        Gem::Specification.bundled_stubs
+      end
+    else
+      def bundled_stubs
+        [] # noop
       end
     end
   end

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -357,6 +357,7 @@ module Bundler
     # of the world.
     def replace_entrypoints(specs)
       specs_by_name = add_default_gems_to(specs)
+      specs_by_name = add_bundled_gems_to(specs_by_name)
 
       replace_gem(specs, specs_by_name)
       stub_rubygems(specs)
@@ -379,6 +380,22 @@ module Bundler
 
         specs << default_spec
         specs_by_name[default_spec_name] = default_spec
+      end
+
+      specs_by_name
+    end
+
+    def add_bundled_gems_to(specs_by_name)
+      bundled_gems = %w[
+        rexml
+        rbs
+        debug
+      ]
+
+      bundled_gems.each do |gem_name|
+        spec = Gem::Specification.find_by_name(gem_name)
+        specs_by_name[gem_name] = spec
+      rescue Gem::MissingSpecError
       end
 
       specs_by_name

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -357,7 +357,6 @@ module Bundler
     # of the world.
     def replace_entrypoints(specs)
       specs_by_name = add_default_gems_to(specs)
-      specs_by_name = add_bundled_gems_to(specs_by_name)
 
       replace_gem(specs, specs_by_name)
       stub_rubygems(specs)
@@ -380,16 +379,6 @@ module Bundler
 
         specs << default_spec
         specs_by_name[default_spec_name] = default_spec
-      end
-
-      specs_by_name
-    end
-
-    def add_bundled_gems_to(specs_by_name)
-      Bundler.rubygems.bundled_stubs.each do |spec|
-        bundled_spec_name = spec.name
-        next if specs_by_name.key?(bundled_spec_name)
-        specs_by_name[bundled_spec_name] = spec
       end
 
       specs_by_name

--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -31,7 +31,7 @@ module Bundler
         spec.load_paths.reject {|path| $LOAD_PATH.include?(path) }
       end.reverse.flatten
 
-      load_paths.concat(bundled_load_paths).uniq!
+      load_paths.concat(bundled_load_paths).uniq! unless Bundler.settings[:disable_bundled_gems_load_path]
 
       Bundler.rubygems.add_to_load_path(load_paths)
 

--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -17,6 +17,7 @@ module Bundler
 
       specs = @definition.specs_for(groups)
 
+      # We need to load gemspecs before bundler's environment
       bundled_load_paths = Bundler.rubygems.bundled_stubs.map(&:load_paths).flatten
 
       SharedHelpers.set_bundle_environment
@@ -30,7 +31,7 @@ module Bundler
         spec.load_paths.reject {|path| $LOAD_PATH.include?(path) }
       end.reverse.flatten
 
-      load_paths = load_paths.concat(bundled_load_paths).uniq
+      load_paths.concat(bundled_load_paths).uniq!
 
       Bundler.rubygems.add_to_load_path(load_paths)
 

--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -17,6 +17,8 @@ module Bundler
 
       specs = @definition.specs_for(groups)
 
+      bundled_load_paths = Bundler.rubygems.bundled_stubs.map(&:load_paths).flatten
+
       SharedHelpers.set_bundle_environment
       Bundler.rubygems.replace_entrypoints(specs)
 
@@ -27,6 +29,8 @@ module Bundler
         Bundler.rubygems.mark_loaded(spec)
         spec.load_paths.reject {|path| $LOAD_PATH.include?(path) }
       end.reverse.flatten
+
+      load_paths = load_paths.concat(bundled_load_paths).uniq
 
       Bundler.rubygems.add_to_load_path(load_paths)
 

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -16,11 +16,11 @@ module Bundler
       clean
       default_install_uses_path
       deployment
+      disable_bundled_gems_load_path
       disable_checksum_validation
       disable_exec_load
       disable_local_branch_check
       disable_local_revision_check
-      disable_bundled_gems_load_path
       disable_shared_gems
       disable_version_check
       force_ruby_platform

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -20,6 +20,7 @@ module Bundler
       disable_exec_load
       disable_local_branch_check
       disable_local_revision_check
+      disable_bundled_gems_load_path
       disable_shared_gems
       disable_version_check
       force_ruby_platform

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -833,6 +833,22 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   ##
+  # Returns a Gem::StubSpecification for bundled gems
+
+  def self.bundled_stubs
+    # TODO
+    bundled_gems = %w[
+      rexml
+      rbs
+      debug
+    ]
+    bundled_gems.map do |name|
+      Gem::Specification.find_by_name(name)
+    rescue Gem::MissingSpecError
+    end.compact
+  end
+
+  ##
   # Returns a Gem::StubSpecification for installed gem named +name+
   # only returns stubs that match Gem.platforms
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -833,19 +833,6 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   ##
-  # Returns a Gem::StubSpecification for bundled gems
-
-  def self.bundled_stubs
-    require_relative "../bundled_gems"
-    Gem.bundled_gems.map do |name|
-      Gem::Specification.find_by_name(name)
-    rescue Gem::MissingSpecError
-    end.compact
-  rescue LoadError
-    []
-  end
-
-  ##
   # Returns a Gem::StubSpecification for installed gem named +name+
   # only returns stubs that match Gem.platforms
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -836,29 +836,13 @@ class Gem::Specification < Gem::BasicSpecification
   # Returns a Gem::StubSpecification for bundled gems
 
   def self.bundled_stubs
-    # for Rails dependencies
-    bundled_gems = %w[
-      base64
-      benchmark
-      delegate
-      drb
-      forwardable
-      ipaddr
-      irb
-      mutex_m
-      ostruct
-      rdoc
-      singleton
-      tsort
-      weakref
-      bigdecimal
-      date
-      racc
-    ]
-    bundled_gems.map do |name|
+    require_relative "../bundled_gems"
+    Gem.bundled_gems.map do |name|
       Gem::Specification.find_by_name(name)
     rescue Gem::MissingSpecError
     end.compact
+  rescue LoadError
+    []
   end
 
   ##

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -836,11 +836,24 @@ class Gem::Specification < Gem::BasicSpecification
   # Returns a Gem::StubSpecification for bundled gems
 
   def self.bundled_stubs
-    # TODO
+    # for Rails dependencies
     bundled_gems = %w[
-      rexml
-      rbs
-      debug
+      base64
+      benchmark
+      delegate
+      drb
+      forwardable
+      ipaddr
+      irb
+      mutex_m
+      ostruct
+      rdoc
+      singleton
+      tsort
+      weakref
+      bigdecimal
+      date
+      racc
     ]
     bundled_gems.map do |name|
       Gem::Specification.find_by_name(name)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This is PoC and WIP status for https://bugs.ruby-lang.org/issues/19351 and https://github.com/ruby/ruby/pull/7436

I would like to promote current default gems to bundled gems in `ruby/ruby` repository. After that, the users need to add bundled gems like `csv`, `nkf` and others into `Gemfile` on their application.

The Ruby core team want to reduce additional work with bundled gems from users.

## What is your fix for the problem, implemented in this PR?

I introduce bypass feature under the Bundler environment. The users can load bundled gems like `csv` without `gem 'csv'` on Gemfile. Additionally, I will warn notice message when user loaded  `csv` library without Gemfile.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
