### PR TITLE
Fix `bundler/setup` unintendedly writing to the filesystem

### DIFF
--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -69,19 +69,7 @@ module Bundler
 
       def to_s
         begin
-          at = if local?
-            path
-          elsif user_ref = options["ref"]
-            if /\A[a-z0-9]{4,}\z/i.match?(ref)
-              shortref_for_display(user_ref)
-            else
-              user_ref
-            end
-          elsif ref
-            ref
-          else
-            current_branch
-          end
+          at = humanized_ref || current_branch
 
           rev = "at #{at}@#{shortref_for_display(revision)}"
         rescue GitError
@@ -89,6 +77,10 @@ module Bundler
         end
 
         uri_with_specifiers([rev, glob_for_display])
+      end
+
+      def identifier
+        uri_with_specifiers([humanized_ref, cached_revision, glob_for_display])
       end
 
       def uri_with_specifiers(specifiers)
@@ -255,6 +247,20 @@ module Bundler
       end
 
       private
+
+      def humanized_ref
+        if local?
+          path
+        elsif user_ref = options["ref"]
+          if /\A[a-z0-9]{4,}\z/i.match?(ref)
+            shortref_for_display(user_ref)
+          else
+            user_ref
+          end
+        elsif ref
+          ref
+        end
+      end
 
       def serialize_gemspecs_in(destination)
         destination = destination.expand_path(Bundler.root) if destination.relative?

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe "bundle install with git sources" do
       expect(Dir["#{default_bundle_path}/cache/bundler/git/foo-1.0-*"]).to have_attributes :size => 1
     end
 
+    it "does not write to cache on bundler/setup" do
+      cache_path = default_bundle_path.join("cache")
+      FileUtils.rm_rf(cache_path)
+      ruby "require 'bundler/setup'"
+      expect(cache_path).not_to exist
+    end
+
     it "caches the git repo globally and properly uses the cached repo on the next invocation" do
       simulate_new_machine
       bundle "config set global_gem_cache true"

--- a/bundler/spec/install/git_spec.rb
+++ b/bundler/spec/install/git_spec.rb
@@ -147,8 +147,6 @@ RSpec.describe "bundle install" do
            #{Bundler::VERSION}
       L
 
-      original_lockfile = lockfile
-
       # If GH#6743 is present, the first `bundle install` will change the
       # lockfile, by flipping the order (`other` would be moved to the top).
       #


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

After #6786, `bundler/setup` would write to the filesystem when dealing with git sources.

## What is your fix for the problem, implemented in this PR?

When sorting and comparing git Gemfile vs lockfile sources during `bundler/setup` to figure out whether we need to re-resolve or not, we would try to find the default branch if nothing more specific was specified in the Gemfile.
    
If the git cache has been deleted though, that would fail.

The error would still be swallowed (and the branch would simply not be displayed), but trying to clone would still generate the side effect of creating the parent folder for the clone.
    
That could affect non-writable systems that don't expect `bundler/setup` to write to the filesystem at all.
    
To fix this, override `Bundler::Source::Git#identifier` to use exclusively static information, so it does not even try to clone the repo nor generate any side effects.

This is essentially a rework of the [original attempt](https://github.com/rubygems/rubygems/pull/6782) to fix #6743, but without the problems discussed in that PR.

Fixes #6813.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
