### PR TITLE
Introduce bundle config set version feature

### DIFF
--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -296,6 +296,9 @@ The following is a list of all configuration keys and their purpose\. You can le
 \fBuser_agent\fR (\fBBUNDLE_USER_AGENT\fR): The custom user agent fragment Bundler includes in API requests\.
 .
 .IP "\(bu" 4
+\fBversion\fR (\fBBUNDLE_VERSION\fR): The version of Bundler to use when running under Bundler environment\. Defaults to \fBlocal\fR\. You can also specify \fBglobal\fR or \fBx\.y\.z\fR\. \fBlocal\fR will use the Bundler version specified in the \fBGemfile\.lock\fR, \fBglobal\fR will use the system version of Bundler, and \fBx\.y\.z\fR will use the specified version of Bundler\.
+.
+.IP "\(bu" 4
 \fBwith\fR (\fBBUNDLE_WITH\fR): A \fB:\fR\-separated list of groups whose gems bundler should install\.
 .
 .IP "\(bu" 4

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -274,6 +274,12 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    and disallow passing no options to `bundle update`.
 * `user_agent` (`BUNDLE_USER_AGENT`):
    The custom user agent fragment Bundler includes in API requests.
+* `version` (`BUNDLE_VERSION`):
+   The version of Bundler to use when running under Bundler environment.
+   Defaults to `local`. You can also specify `global` or `x.y.z`.
+   `local` will use the Bundler version specified in the `Gemfile.lock`,
+   `global` will use the system version of Bundler, and `x.y.z` will use
+   the specified version of Bundler.
 * `with` (`BUNDLE_WITH`):
    A `:`-separated list of groups whose gems bundler should install.
 * `without` (`BUNDLE_WITHOUT`):

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -74,6 +74,7 @@ module Bundler
       shebang
       system_bindir
       trust-policy
+      version
     ].freeze
 
     DEFAULT_CONFIG = {
@@ -83,6 +84,7 @@ module Bundler
       "BUNDLE_REDIRECT" => 5,
       "BUNDLE_RETRY" => 3,
       "BUNDLE_TIMEOUT" => 10,
+      "BUNDLE_VERSION" => "local",
     }.freeze
 
     def initialize(root = nil)

--- a/bundler/spec/runtime/self_management_spec.rb
+++ b/bundler/spec/runtime/self_management_spec.rb
@@ -109,6 +109,9 @@ RSpec.describe "Self management", :rubygems => ">= 3.3.0.dev", :realworld => tru
       bundle "config set --local version #{previous_minor}"
       bundle "install", :artifice => "vcr"
       expect(out).to include("Bundler #{Bundler::VERSION} is running, but your configuration was #{previous_minor}. Installing Bundler #{previous_minor} and restarting using that version.")
+
+      bundle "-v"
+      expect(out).to eq(Bundler::VERSION[0] == "2" ? "Bundler version #{previous_minor}" : previous_minor)
     end
 
     it "does not try to install when using bundle config version global" do

--- a/bundler/spec/runtime/self_management_spec.rb
+++ b/bundler/spec/runtime/self_management_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe "Self management", :rubygems => ">= 3.3.0.dev", :realworld => tru
       "2.3.0"
     end
 
+    let(:current_version) do
+      "2.4.0"
+    end
+
     before do
       build_repo2
 
@@ -104,14 +108,14 @@ RSpec.describe "Self management", :rubygems => ">= 3.3.0.dev", :realworld => tru
     end
 
     it "installs BUNDLE_VERSION version when using bundle config version x.y.z" do
-      lockfile_bundled_with(Bundler::VERSION.gsub(/\.dev/, ""))
+      lockfile_bundled_with(current_version)
 
       bundle "config set --local version #{previous_minor}"
       bundle "install", :artifice => "vcr"
       expect(out).to include("Bundler #{Bundler::VERSION} is running, but your configuration was #{previous_minor}. Installing Bundler #{previous_minor} and restarting using that version.")
 
       bundle "-v"
-      expect(out).to eq(Bundler::VERSION[0] == "2" ? "Bundler version #{previous_minor}" : previous_minor)
+      expect(out).to eq(previous_minor[0] == "2" ? "Bundler version #{previous_minor}" : previous_minor)
     end
 
     it "does not try to install when using bundle config version global" do

--- a/bundler/spec/runtime/self_management_spec.rb
+++ b/bundler/spec/runtime/self_management_spec.rb
@@ -103,6 +103,25 @@ RSpec.describe "Self management", :rubygems => ">= 3.3.0.dev", :realworld => tru
       expect(out).to eq(Bundler::VERSION[0] == "2" ? "Bundler version #{Bundler::VERSION}" : Bundler::VERSION)
     end
 
+    it "installs BUNDLE_VERSION version when using bundle config version x.y.z" do
+      lockfile_bundled_with(Bundler::VERSION.gsub(/\.dev/, ""))
+
+      bundle "config set --local version #{previous_minor}"
+      bundle "install", :artifice => "vcr"
+      expect(out).to include("Bundler #{Bundler::VERSION} is running, but your configuration was #{previous_minor}. Installing Bundler #{previous_minor} and restarting using that version.")
+    end
+
+    it "does not try to install when using bundle config version global" do
+      lockfile_bundled_with(previous_minor)
+
+      bundle "config set version global"
+      bundle "install", :artifice => "vcr"
+      expect(out).not_to match(/restarting using that version/)
+
+      bundle "-v"
+      expect(out).to eq(Bundler::VERSION[0] == "2" ? "Bundler version #{Bundler::VERSION}" : Bundler::VERSION)
+    end
+
     private
 
     def lockfile_bundled_with(version)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Fixes https://github.com/rubygems/rubygems/issues/6613
Ref https://github.com/rubygems/rubygems/pull/6808

## What is your fix for the problem, implemented in this PR?

I introduced `bundle config --local set version global` for disabling to auto-install locked version of Bundler. And I also introduced `bundle config --local set version 2.4.0` for specifying to use version of Bundler.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
