### PR TITLE
Update GitHub organization of Standard Ruby

### DIFF
--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -348,7 +348,7 @@ module Bundler
         Bundler.ui.confirm "Do you want to add a code linter and formatter to your gem? " \
           "Supported Linters:\n" \
           "* RuboCop:       https://rubocop.org\n" \
-          "* Standard:      https://github.com/testdouble/standard\n" \
+          "* Standard:      https://github.com/standardrb/standard\n" \
           "\n"
         Bundler.ui.info hint_text("linter")
 

--- a/bundler/lib/bundler/templates/newgem/standard.yml.tt
+++ b/bundler/lib/bundler/templates/newgem/standard.yml.tt
@@ -1,3 +1,3 @@
 # For available configuration options, see:
-#   https://github.com/testdouble/standard
+#   https://github.com/standardrb/standard
 ruby_version: <%= ::Gem::Version.new(config[:required_ruby_version]).segments[0..1].join(".") %>


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The old URL https://github.com/testdouble/standard is mentioned.

## What is your fix for the problem, implemented in this PR?

This PR updates to the new URL https://github.com/standardrb/standard.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
