### PR TITLE
Fix directory of cargo test app in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: 'weekly'
   - package-ecosystem: 'cargo'
-    directory: '/test/rubygems/test_gem_ext_cargo_builder/custom_name/'
+    directory: '/test/rubygems/test_gem_ext_cargo_builder/custom_name/ext/custom_name_lib'
     schedule:
       interval: 'weekly'
   - package-ecosystem: 'cargo'


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

One Dependabot check is failing because directory was incorrect.

## What is your fix for the problem, implemented in this PR?

Point to the correct directory.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
