### PR TITLE
Rename BUNDLE_VERSION variables

### DIFF
--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -296,7 +296,7 @@ The following is a list of all configuration keys and their purpose\. You can le
 \fBuser_agent\fR (\fBBUNDLE_USER_AGENT\fR): The custom user agent fragment Bundler includes in API requests\.
 .
 .IP "\(bu" 4
-\fBversion\fR (\fBBUNDLE_VERSION\fR): The version of Bundler to use when running under Bundler environment\. Defaults to \fBlocal\fR\. You can also specify \fBglobal\fR or \fBx\.y\.z\fR\. \fBlocal\fR will use the Bundler version specified in the \fBGemfile\.lock\fR, \fBglobal\fR will use the system version of Bundler, and \fBx\.y\.z\fR will use the specified version of Bundler\.
+\fBversion\fR (\fBBUNDLE_VERSION\fR): The version of Bundler to use when running under Bundler environment\. Defaults to \fBlocal\fR\. You can also specify \fBsystem\fR or \fBx\.y\.z\fR\. \fBlockfile\fR will use the Bundler version specified in the \fBGemfile\.lock\fR, \fBsystem\fR will use the system version of Bundler, and \fBx\.y\.z\fR will use the specified version of Bundler\.
 .
 .IP "\(bu" 4
 \fBwith\fR (\fBBUNDLE_WITH\fR): A \fB:\fR\-separated list of groups whose gems bundler should install\.

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -276,9 +276,9 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    The custom user agent fragment Bundler includes in API requests.
 * `version` (`BUNDLE_VERSION`):
    The version of Bundler to use when running under Bundler environment.
-   Defaults to `local`. You can also specify `global` or `x.y.z`.
-   `local` will use the Bundler version specified in the `Gemfile.lock`,
-   `global` will use the system version of Bundler, and `x.y.z` will use
+   Defaults to `local`. You can also specify `system` or `x.y.z`.
+   `lockfile` will use the Bundler version specified in the `Gemfile.lock`,
+   `system` will use the system version of Bundler, and `x.y.z` will use
    the specified version of Bundler.
 * `with` (`BUNDLE_WITH`):
    A `:`-separated list of groups whose gems bundler should install.

--- a/bundler/lib/bundler/self_manager.rb
+++ b/bundler/lib/bundler/self_manager.rb
@@ -86,7 +86,7 @@ module Bundler
         released?(lockfile_version) &&
         !running?(lockfile_version) &&
         !updating? &&
-        Bundler.settings[:version] != "global"
+        Bundler.settings[:version] != "system"
     end
 
     def autoswitching_applies?
@@ -177,7 +177,7 @@ module Bundler
       # BUNDLE_VERSION=x.y.z
       @restart_version = Gem::Version.new(Bundler.settings[:version])
     rescue ArgumentError
-      # BUNDLE_VERSION=local
+      # BUNDLE_VERSION=lockfile
       @restart_version = lockfile_version
     end
   end

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -84,7 +84,7 @@ module Bundler
       "BUNDLE_REDIRECT" => 5,
       "BUNDLE_RETRY" => 3,
       "BUNDLE_TIMEOUT" => 10,
-      "BUNDLE_VERSION" => "local",
+      "BUNDLE_VERSION" => "lockfile",
     }.freeze
 
     def initialize(root = nil)

--- a/bundler/spec/runtime/self_management_spec.rb
+++ b/bundler/spec/runtime/self_management_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe "Self management", :rubygems => ">= 3.3.0.dev", :realworld => tru
     it "does not try to install when using bundle config version global" do
       lockfile_bundled_with(previous_minor)
 
-      bundle "config set version global"
+      bundle "config set version system"
       bundle "install", :artifice => "vcr"
       expect(out).not_to match(/restarting using that version/)
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We discussed configuration variable about https://github.com/rubygems/rubygems/pull/6817#issuecomment-1633772200

## What is your fix for the problem, implemented in this PR?

I renamed `local` to `lockfile` and `global` to `system`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
