### PR TITLE
Clear `YAML` constant if it was undefined previously

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1301,6 +1301,8 @@ class Gem::Specification < Gem::BasicSpecification
   def self._load(str)
     Gem.load_yaml
 
+    yaml_set = false
+
     array = begin
       Marshal.load str
     rescue ArgumentError => e
@@ -1313,7 +1315,10 @@ class Gem::Specification < Gem::BasicSpecification
       message = e.message
       raise unless message.include?("YAML::")
 
-      Object.const_set "YAML", Psych unless Object.const_defined?(:YAML)
+      unless Object.const_defined?(:YAML)
+        Object.const_set "YAML", Psych
+        yaml_set = true
+      end
 
       if message.include?("YAML::Syck::")
         YAML.const_set "Syck", YAML unless YAML.const_defined?(:Syck)
@@ -1324,6 +1329,8 @@ class Gem::Specification < Gem::BasicSpecification
       end
 
       retry
+    ensure
+      Object.__send__(:remove_const, "YAML") if yaml_set
     end
 
     spec = Gem::Specification.new

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1071,19 +1071,27 @@ dependencies: []
   end
 
   def test_handles_private_null_type
+    yaml_defined = Object.const_defined?("YAML")
+
     path = File.expand_path "data/pry-0.4.7.gemspec.rz", __dir__
 
     data = Marshal.load Gem::Util.inflate(Gem.read_binary(path))
 
     assert_instance_of Gem::Specification, data
+
+    assert_equal(yaml_defined, Object.const_defined?("YAML"))
   end
 
   def test_handles_dependencies_with_syck_requirements_bug
+    yaml_defined = Object.const_defined?("YAML")
+
     path = File.expand_path "data/excon-0.7.7.gemspec.rz", __dir__
 
     data = Marshal.load Gem::Util.inflate(Gem.read_binary(path))
 
     assert_instance_of Gem::Specification, data
+
+    assert_equal(yaml_defined, Object.const_defined?("YAML"))
   end
 
   def test_initialize


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes, depending on test order, YAML redefinition warning is shown during ruby's tests, for instance [here].

> ```
> /home/runner/work/ruby/ruby/src/lib/yaml.rb:20: warning: already initialized constant YAML
> /home/runner/work/ruby/ruby/src/lib/rubygems/specification.rb:1316: warning: previous definition of YAML was here
> ```

[here]: https://github.com/ruby/ruby/actions/runs/5595968323/jobs/10232417604#step:9:99

## What is your fix for the problem, implemented in this PR?

The cause is while un-marshaling old `Gem::Specification` `Gem::Specification._load` adds `YAML` related constants.
This PR removes `YAML` if it was not defined and added in this method.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
