### PR TITLE
Boundary check in `Gem::StreamUI#choose_from_list`

### DIFF
--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -237,6 +237,7 @@ class Gem::StreamUI
     return nil, nil unless result
 
     result = result.strip.to_i - 1
+    return nil, nil unless (0...list.size) === result
     [list[result], result]
   end
 

--- a/test/rubygems/test_gem_stream_ui.rb
+++ b/test/rubygems/test_gem_stream_ui.rb
@@ -114,6 +114,36 @@ class TestGemStreamUI < Gem::TestCase
     assert_equal "which one?\n 1. foo\n 2. bar\n> ", @out.string
   end
 
+  def test_choose_from_list_0
+    @in.puts "0"
+    @in.rewind
+
+    result = @sui.choose_from_list "which one?", %w[foo bar]
+
+    assert_equal [nil, nil], result
+    assert_equal "which one?\n 1. foo\n 2. bar\n> ", @out.string
+  end
+
+  def test_choose_from_list_over
+    @in.puts "3"
+    @in.rewind
+
+    result = @sui.choose_from_list "which one?", %w[foo bar]
+
+    assert_equal [nil, nil], result
+    assert_equal "which one?\n 1. foo\n 2. bar\n> ", @out.string
+  end
+
+  def test_choose_from_list_negative
+    @in.puts "-1"
+    @in.rewind
+
+    result = @sui.choose_from_list "which one?", %w[foo bar]
+
+    assert_equal [nil, nil], result
+    assert_equal "which one?\n 1. foo\n 2. bar\n> ", @out.string
+  end
+
   def test_progress_reporter_silent_nil
     @cfg.verbose = nil
     reporter = @sui.progress_reporter 10, "hi"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This method returns unexpected value when the input is out-of-bound.
For example, it returns the last element when `0`.

## What is your fix for the problem, implemented in this PR?

Check for the input value.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
