### PR TITLE
Improve require

### DIFF
--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -36,9 +36,7 @@ module Kernel
   def require(path) # :doc:
     return gem_original_require(path) unless Gem.discover_gems_on_require
 
-    begin
-      RUBYGEMS_ACTIVATION_MONITOR.enter
-
+    RUBYGEMS_ACTIVATION_MONITOR.synchronize do
       path = path.to_path if path.respond_to? :to_path
 
       if spec = Gem.find_unresolved_default_spec(path)
@@ -49,13 +47,8 @@ module Kernel
           Gem.suffixes.each do |s|
             $LOAD_PATH[0...load_path_check_index].each do |lp|
               safe_lp = lp.dup.tap(&Gem::UNTAINT)
-              begin
-                if File.symlink? safe_lp # for backward compatibility
-                  next
-                end
-              rescue SecurityError
-                RUBYGEMS_ACTIVATION_MONITOR.exit
-                raise
+              if File.symlink? safe_lp # for backward compatibility
+                next
               end
 
               full_path = File.expand_path(File.join(safe_lp, "#{path}#{s}"))
@@ -69,20 +62,15 @@ module Kernel
           rp
         end
 
-        begin
-          Kernel.send(:gem, spec.name, Gem::Requirement.default_prerelease)
-        rescue StandardError
-          RUBYGEMS_ACTIVATION_MONITOR.exit
-          raise
-        end unless resolved_path
+        Kernel.send(:gem, spec.name, Gem::Requirement.default_prerelease) unless
+          resolved_path
       end
 
       # If there are no unresolved deps, then we can use just try
       # normal require handle loading a gem from the rescue below.
 
       if Gem::Specification.unresolved_deps.empty?
-        RUBYGEMS_ACTIVATION_MONITOR.exit
-        return gem_original_require(path)
+        next
       end
 
       # If +path+ is for a gem that has already been loaded, don't
@@ -92,8 +80,7 @@ module Kernel
       # TODO request access to the C implementation of this to speed up RubyGems
 
       if Gem::Specification.find_active_stub_by_path(path)
-        RUBYGEMS_ACTIVATION_MONITOR.exit
-        return gem_original_require(path)
+        next
       end
 
       # Attempt to find +path+ in any unresolved gems...
@@ -124,7 +111,6 @@ module Kernel
         names = found_specs.map(&:name).uniq
 
         if names.size > 1
-          RUBYGEMS_ACTIVATION_MONITOR.exit
           raise Gem::LoadError, "#{path} found in multiple gems: #{names.join ", "}"
         end
 
@@ -135,26 +121,20 @@ module Kernel
         unless valid
           le = Gem::LoadError.new "unable to find a version of '#{names.first}' to activate"
           le.name = names.first
-          RUBYGEMS_ACTIVATION_MONITOR.exit
           raise le
         end
 
         valid.activate
       end
+    end
 
-      RUBYGEMS_ACTIVATION_MONITOR.exit
+    begin
       gem_original_require(path)
     rescue LoadError => load_error
-      if load_error.path == path
-        RUBYGEMS_ACTIVATION_MONITOR.enter
+      if load_error.path == path &&
+         RUBYGEMS_ACTIVATION_MONITOR.synchronize { Gem.try_activate(path) }
 
-        begin
-          require_again = Gem.try_activate(path)
-        ensure
-          RUBYGEMS_ACTIVATION_MONITOR.exit
-        end
-
-        return gem_original_require(path) if require_again
+        return gem_original_require(path)
       end
 
       raise load_error

--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -44,20 +44,16 @@ module Kernel
         resolved_path = begin
           rp = nil
           load_path_check_index = Gem.load_path_insert_index - Gem.activated_gem_paths
-          Gem.suffixes.each do |s|
-            $LOAD_PATH[0...load_path_check_index].each do |lp|
+          Gem.suffixes.find do |s|
+            $LOAD_PATH[0...load_path_check_index].find do |lp|
               safe_lp = lp.dup.tap(&Gem::UNTAINT)
               if File.symlink? safe_lp # for backward compatibility
                 next
               end
 
               full_path = File.expand_path(File.join(safe_lp, "#{path}#{s}"))
-              if File.file?(full_path)
-                rp = full_path
-                break
-              end
+              rp = full_path if File.file?(full_path)
             end
-            break if rp
           end
           rp
         end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In my experiments extending `Gem.find_unresolved_default_spec` dead locks happened in a few tests, and I suspect this method may exit leaving the monitor locked.

## What is your fix for the problem, implemented in this PR?

Instead `rescue` and `exit` for each time, just surround by `mon_synchronize`, mainly requested gem activation part, and `LoadError` part.

Additionally, the outer loop that iterates until the inner loop find an element can be simplified by using `find` (or `any?`) instead of `each` and `break`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
