### PR TITLE
Restore support for Pathname objects in the replaced require

### DIFF
--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -249,7 +249,7 @@ module Bundler
       [::Kernel.singleton_class, ::Kernel].each do |kernel_class|
         kernel_class.send(:alias_method, :no_warning_require, :require)
         kernel_class.send(:define_method, :require) do |file|
-          name = file.tr("/", "-")
+          name = file.to_s.tr("/", "-")
           if (::Gem::BUNDLED_GEMS.keys - specs.to_a.map(&:name)).include?(name)
             unless $LOADED_FEATURES.any? {|f| f.end_with?("#{name}.rb", "#{name}.#{RbConfig::CONFIG["DLEXT"]}") }
               target_file = begin


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The test suite of Zeitwerk failed yesterday night. There is a [Ruby compatibility test](https://github.com/fxn/zeitwerk/blob/6b388d5e3d8b87a275ff6d2670d7ff77bfd27ba8/test/lib/zeitwerk/test_ruby_compatibility.rb#L303) that checks that required `Pathname` objects end up as strings in `$LOADED_FEATURES`, and raised with

```
NoMethodError: undefined method `tr' for an instance of Pathname
    /Users/runner/.rubies/ruby-head/lib/ruby/3.3.0+0/bundler/rubygems_integration.rb:252
```

Recent edits in `replace_require` invoke `tr` on the argument received by `require`. However, `require` is expected to accept `Pathname` objects too, which do not respond to `tr`.

## What is your fix for the problem, implemented in this PR?

Keep `file` as is, to be able to pass it up via `no_warning_require`, and invoke `to_s` on it when computing the `name` variable.

I did not see where this could be tested, and I am not familiar with this project. The patch does not include a test, but if you could guide me about where it would go I'd be glad to add one.
