### PR TITLE
Use the dedicated method to convert file path

### DIFF
--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -245,7 +245,8 @@ module Bundler
       [::Kernel.singleton_class, ::Kernel].each do |kernel_class|
         kernel_class.send(:alias_method, :no_warning_require, :require)
         kernel_class.send(:define_method, :require) do |file|
-          name = file.to_s.tr("/", "-")
+          file = File.path(file)
+          name = file.tr("/", "-")
           if (::Gem::BUNDLED_GEMS::SINCE.keys - specs.to_a.map(&:name)).include?(name)
             unless $LOADED_FEATURES.any? {|f| f.end_with?("#{name}.rb", "#{name}.#{RbConfig::CONFIG["DLEXT"]}") }
               target_file = begin

--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -37,8 +37,7 @@ module Kernel
     return gem_original_require(path) unless Gem.discover_gems_on_require
 
     RUBYGEMS_ACTIVATION_MONITOR.synchronize do
-      path = path.to_path if path.respond_to? :to_path
-      path = String.try_convert(path) || path
+      path = File.path(path)
 
       if spec = Gem.find_unresolved_default_spec(path)
         # Ensure -I beats a default gem


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The dedicated method `File.path` to deal with pathname-like objects has been provided since ruby 1.9.0.

## What is your fix for the problem, implemented in this PR?

Call `File.path`.
Also adds a test for rubygems/rubygems#6837.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
