### PR TITLE
Merge warning feature for rubygems

### DIFF
--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 require "rubygems" unless defined?(Gem)
-begin
-  require "bundled_gems" unless defined?(Gem::BUNDLED_GEMS)
-rescue LoadError
-end
 
 module Bundler
   class RubygemsIntegration
@@ -250,14 +246,14 @@ module Bundler
         kernel_class.send(:alias_method, :no_warning_require, :require)
         kernel_class.send(:define_method, :require) do |file|
           name = file.to_s.tr("/", "-")
-          if (::Gem::BUNDLED_GEMS.keys - specs.to_a.map(&:name)).include?(name)
+          if (::Gem::BUNDLED_GEMS::SINCE.keys - specs.to_a.map(&:name)).include?(name)
             unless $LOADED_FEATURES.any? {|f| f.end_with?("#{name}.rb", "#{name}.#{RbConfig::CONFIG["DLEXT"]}") }
               target_file = begin
                               Bundler.default_gemfile.basename
                             rescue GemfileNotFound
                               "inline Gemfile"
                             end
-              warn "#{name} is not part of the default gems since Ruby #{::Gem::BUNDLED_GEMS[file]}." \
+              warn "#{name} is not part of the default gems since Ruby #{::Gem::BUNDLED_GEMS::SINCE[file]}." \
               " Add it to your #{target_file}."
             end
           end
@@ -388,7 +384,7 @@ module Bundler
     def replace_entrypoints(specs)
       specs_by_name = add_default_gems_to(specs)
 
-      if defined?(::Gem::BUNDLED_GEMS)
+      if defined?(::Gem::BUNDLED_GEMS::SINCE)
         replace_require(specs)
       else
         reverse_rubygems_kernel_mixin

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1567,9 +1567,9 @@ end
     G
 
     ruby <<-R
-      module Gem
-        remove_const :BUNDLED_GEMS if defined?(BUNDLED_GEMS)
-        BUNDLED_GEMS = { "csv" => "1.0.0" }
+      Gem.send(:remove_const, :BUNDLED_GEMS) if defined?(Gem::BUNDLED_GEMS)
+      module Gem::BUNDLED_GEMS
+        SINCE = { "csv" => "1.0.0" }
       end
       require 'bundler/setup'
       require 'csv'
@@ -1589,9 +1589,9 @@ end
     G
 
     ruby <<-R
-      module Gem
-        remove_const :BUNDLED_GEMS if defined?(BUNDLED_GEMS)
-        BUNDLED_GEMS = { "csv" => "1.0.0" }
+      Gem.send(:remove_const, :BUNDLED_GEMS) if defined?(Gem::BUNDLED_GEMS)
+      module Gem::BUNDLED_GEMS
+        SINCE = { "csv" => "1.0.0" }
       end
       require 'csv'
       require 'bundler/setup'
@@ -1612,9 +1612,9 @@ end
     G
 
     ruby <<-R
-      module Gem
-        remove_const :BUNDLED_GEMS if defined?(BUNDLED_GEMS)
-        BUNDLED_GEMS = { "csv" => "1.0.0" }
+      Gem.send(:remove_const, :BUNDLED_GEMS) if defined?(Gem::BUNDLED_GEMS)
+      module Gem::BUNDLED_GEMS
+        SINCE = { "csv" => "1.0.0" }
       end
       require 'bundler/setup'
       require 'csv'
@@ -1637,9 +1637,9 @@ end
     G
 
     ruby <<-R
-      module Gem
-        remove_const :BUNDLED_GEMS if defined?(BUNDLED_GEMS)
-        BUNDLED_GEMS = { "csv" => "1.0.0", "net-imap" => "0.0.1" }
+      Gem.send(:remove_const, :BUNDLED_GEMS) if defined?(Gem::BUNDLED_GEMS)
+      module Gem::BUNDLED_GEMS
+        SINCE = { "csv" => "1.0.0", "net-imap" => "0.0.1" }
       end
       require 'bundler/setup'
       begin

--- a/lib/rubygems/core_ext/kernel_require.rb
+++ b/lib/rubygems/core_ext/kernel_require.rb
@@ -38,6 +38,7 @@ module Kernel
 
     RUBYGEMS_ACTIVATION_MONITOR.synchronize do
       path = path.to_path if path.respond_to? :to_path
+      path = String.try_convert(path) || path
 
       if spec = Gem.find_unresolved_default_spec(path)
         # Ensure -I beats a default gem


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

@nobu implemented warnings feature like https://github.com/rubygems/rubygems/pull/6831 for rubygems.

## What is your fix for the problem, implemented in this PR?

Merge https://github.com/ruby/ruby/pull/8126 commits for rubygems repository.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
