### PR TITLE
Revert set thread configurations inside block in WebAuthn poller and listener

### DIFF
--- a/lib/rubygems/gemcutter_utilities/webauthn_listener.rb
+++ b/lib/rubygems/gemcutter_utilities/webauthn_listener.rb
@@ -34,14 +34,14 @@ module Gem::GemcutterUtilities
 
     def self.listener_thread(host, server)
       thread = Thread.new do
-        Thread.abort_on_exception = true
-        Thread.report_on_exception = false
         Thread.current[:otp] = new(host).wait_for_otp_code(server)
       rescue Gem::WebauthnVerificationError => e
         Thread.current[:error] = e
       ensure
         server.close
       end
+      thread.abort_on_exception = true
+      thread.report_on_exception = false
 
       thread
     end

--- a/lib/rubygems/gemcutter_utilities/webauthn_poller.rb
+++ b/lib/rubygems/gemcutter_utilities/webauthn_poller.rb
@@ -33,12 +33,12 @@ module Gem::GemcutterUtilities
 
     def self.poll_thread(options, host, webauthn_url, credentials)
       thread = Thread.new do
-        Thread.abort_on_exception = true
-        Thread.report_on_exception = false
         Thread.current[:otp] = new(options, host).poll_for_otp(webauthn_url, credentials)
       rescue Gem::WebauthnVerificationError, Timeout::Error => e
         Thread.current[:error] = e
       end
+      thread.abort_on_exception = true
+      thread.report_on_exception = false
 
       thread
     end


### PR DESCRIPTION
This reverts commit 860b145359ec632f816a2e82dc770b3c71ebc06c.

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?
@k0kubun notified me that https://github.com/rubygems/rubygems/pull/6774 caused Ruby CI to fail https://github.com/ruby/ruby/commits/master. This was because I mistakingly configured for all threads and not the specific one ran.

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?
Reverting the commit that caused this.  It was already reverted on ruby/ruby https://github.com/ruby/ruby/commit/bcf823fddbe38e0503805a7ba6ded53c1bc1e19d

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

cc: @deivid-rodriguez 
