### PR TITLE
Set thread configurations in the thread-local manner

### DIFF
--- a/lib/rubygems/gemcutter_utilities/webauthn_listener.rb
+++ b/lib/rubygems/gemcutter_utilities/webauthn_listener.rb
@@ -33,17 +33,16 @@ module Gem::GemcutterUtilities
     end
 
     def self.listener_thread(host, server)
-      thread = Thread.new do
-        Thread.current[:otp] = new(host).wait_for_otp_code(server)
+      Thread.new do
+        thread = Thread.current
+        thread.abort_on_exception = true
+        thread.report_on_exception = false
+        thread[:otp] = new(host).wait_for_otp_code(server)
       rescue Gem::WebauthnVerificationError => e
-        Thread.current[:error] = e
+        thread[:error] = e
       ensure
         server.close
       end
-      thread.abort_on_exception = true
-      thread.report_on_exception = false
-
-      thread
     end
 
     def wait_for_otp_code(server)

--- a/lib/rubygems/gemcutter_utilities/webauthn_listener.rb
+++ b/lib/rubygems/gemcutter_utilities/webauthn_listener.rb
@@ -34,14 +34,14 @@ module Gem::GemcutterUtilities
 
     def self.listener_thread(host, server)
       thread = Thread.new do
-        Thread.abort_on_exception = true
-        Thread.report_on_exception = false
         Thread.current[:otp] = new(host).wait_for_otp_code(server)
       rescue Gem::WebauthnVerificationError => e
         Thread.current[:error] = e
       ensure
         server.close
       end
+      thread.abort_on_exception = true
+      thread.report_on_exception = false
 
       thread
     end

--- a/lib/rubygems/gemcutter_utilities/webauthn_poller.rb
+++ b/lib/rubygems/gemcutter_utilities/webauthn_poller.rb
@@ -33,12 +33,12 @@ module Gem::GemcutterUtilities
 
     def self.poll_thread(options, host, webauthn_url, credentials)
       thread = Thread.new do
-        Thread.abort_on_exception = true
-        Thread.report_on_exception = false
         Thread.current[:otp] = new(options, host).poll_for_otp(webauthn_url, credentials)
       rescue Gem::WebauthnVerificationError, Timeout::Error => e
         Thread.current[:error] = e
       end
+      thread.abort_on_exception = true
+      thread.report_on_exception = false
 
       thread
     end

--- a/lib/rubygems/gemcutter_utilities/webauthn_poller.rb
+++ b/lib/rubygems/gemcutter_utilities/webauthn_poller.rb
@@ -32,15 +32,14 @@ module Gem::GemcutterUtilities
     end
 
     def self.poll_thread(options, host, webauthn_url, credentials)
-      thread = Thread.new do
-        Thread.current[:otp] = new(options, host).poll_for_otp(webauthn_url, credentials)
+      Thread.new do
+        thread = Thread.current
+        thread.abort_on_exception = true
+        thread.report_on_exception = false
+        thread[:otp] = new(options, host).poll_for_otp(webauthn_url, credentials)
       rescue Gem::WebauthnVerificationError, Timeout::Error => e
-        Thread.current[:error] = e
+        thread[:error] = e
       end
-      thread.abort_on_exception = true
-      thread.report_on_exception = false
-
-      thread
     end
 
     def poll_for_otp(webauthn_url, credentials)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Global thread configuration affects others tests.

## What is your fix for the problem, implemented in this PR?

Set thread configurations in the thread-local manner.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
