### PR TITLE
Update Magnus version in Rust extension gem template

### DIFF
--- a/bundler/lib/bundler/templates/newgem/ext/newgem/Cargo.toml.tt
+++ b/bundler/lib/bundler/templates/newgem/ext/newgem/Cargo.toml.tt
@@ -12,4 +12,4 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-magnus = { version = "0.4" }
+magnus = { version = "0.6" }

--- a/bundler/lib/bundler/templates/newgem/ext/newgem/src/lib.rs.tt
+++ b/bundler/lib/bundler/templates/newgem/ext/newgem/src/lib.rs.tt
@@ -1,12 +1,12 @@
-use magnus::{define_module, function, prelude::*, Error};
+use magnus::{function, prelude::*, Error, Ruby};
 
 fn hello(subject: String) -> String {
-    format!("Hello from Rust, {}!", subject)
+    format!("Hello from Rust, {subject}!")
 }
 
 #[magnus::init]
-fn init() -> Result<(), Error> {
-    let module = <%= config[:constant_array].map {|c| "define_module(#{c.dump})?"}.join(".") %>;
+fn init(ruby: &Ruby) -> Result<(), Error> {
+    let module = ruby.<%= config[:constant_array].map {|c| "define_module(#{c.dump})?"}.join(".") %>;
     module.define_singleton_method("hello", function!(hello, 1))?;
     Ok(())
 }


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

[Magnus](https://github.com/matsadler/magnus), the Ruby bindings library used in the template for a Rust extension gem has released a newer version. It would be helpful if the generated gem skeleton used the latest version.

## What is your fix for the problem, implemented in this PR?

The version number has been updated in the template `Cargo.toml`, and a few changes have been made to `lib.rs.tt` to account for API changes.

As the newer version of Magnus requires a Rust version that will support inline variables in format strings (e.g. `format!("{foo}")` instead of `format!("{}", foo)`) I've made that change too.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
