### PR TITLE
Bump release gems

### DIFF
--- a/tool/bundler/release_gems.rb
+++ b/tool/bundler/release_gems.rb
@@ -2,5 +2,5 @@
 
 source "https://rubygems.org"
 
-gem "octokit", "~> 4.18"
+gem "octokit", "~> 7.0"
 gem "aws-sdk-s3", "~> 1.87"

--- a/tool/bundler/release_gems.rb
+++ b/tool/bundler/release_gems.rb
@@ -3,4 +3,5 @@
 source "https://rubygems.org"
 
 gem "octokit", "~> 7.0"
+gem "faraday-retry", "~> 2.2"
 gem "aws-sdk-s3", "~> 1.87"

--- a/tool/bundler/release_gems.rb.lock
+++ b/tool/bundler/release_gems.rb.lock
@@ -23,6 +23,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
+    faraday-retry (2.2.0)
+      faraday (~> 2.0)
     jmespath (1.6.2)
     octokit (7.0.0)
       faraday (>= 1, < 3)
@@ -47,6 +49,7 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk-s3 (~> 1.87)
+  faraday-retry (~> 2.2)
   octokit (~> 7.0)
 
 BUNDLED WITH

--- a/tool/bundler/release_gems.rb.lock
+++ b/tool/bundler/release_gems.rb.lock
@@ -19,15 +19,15 @@ GEM
       aws-sigv4 (~> 1.4)
     aws-sigv4 (1.5.2)
       aws-eventstream (~> 1, >= 1.0.2)
-    faraday (2.7.6)
+    faraday (2.7.10)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
     jmespath (1.6.2)
-    octokit (4.25.1)
+    octokit (7.0.0)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
-    public_suffix (5.0.1)
+    public_suffix (5.0.3)
     ruby2_keywords (0.0.5)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
@@ -47,7 +47,7 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk-s3 (~> 1.87)
-  octokit (~> 4.18)
+  octokit (~> 7.0)
 
 BUNDLED WITH
    2.5.0.dev


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I get the following warning when releasing:

> To use retry middleware with Faraday v2.0+, install `faraday-retry` gem

## What is your fix for the problem, implemented in this PR?

Implement the suggestion to remove the warning. Since I was at it, also bump octokit. I don't think any of the recent breaking changes affects our usage, but we'll find out if it does.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
