### PR TITLE
Use Kernel.singleton_class

### DIFF
--- a/bundler/lib/bundler/installer/standalone.rb
+++ b/bundler/lib/bundler/installer/standalone.rb
@@ -87,8 +87,7 @@ module Bundler
       if Gem.respond_to?(:discover_gems_on_require=)
         Gem.discover_gems_on_require = false
       else
-        kernel = (class << ::Kernel; self; end)
-        [kernel, ::Kernel].each do |k|
+        [::Kernel.singleton_class, ::Kernel].each do |k|
           if k.private_method_defined?(:gem_original_require)
             private_require = k.private_method_defined?(:require)
             k.send(:remove_method, :require)

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -230,8 +230,7 @@ module Bundler
       if Gem.respond_to?(:discover_gems_on_require=)
         Gem.discover_gems_on_require = false
       else
-        kernel = (class << ::Kernel; self; end)
-        [kernel, ::Kernel].each do |k|
+        [::Kernel.singleton_class, ::Kernel].each do |k|
           if k.private_method_defined?(:gem_original_require)
             redefine_method(k, :require, k.instance_method(:gem_original_require))
           end
@@ -271,8 +270,7 @@ module Bundler
     def replace_gem(specs, specs_by_name)
       executables = nil
 
-      kernel = (class << ::Kernel; self; end)
-      [kernel, ::Kernel].each do |kernel_class|
+      [::Kernel.singleton_class, ::Kernel].each do |kernel_class|
         redefine_method(kernel_class, :gem) do |dep, *reqs|
           if executables&.include?(File.basename(caller.first.split(":").first))
             break


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`class << ::Kernel; self; end` is `Kernel.singleton_class` today.

There is no reason why we keep compatible code for old Ruby.

## What is your fix for the problem, implemented in this PR?

I replaced it.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
