### PR TITLE
Fix git source conservativeness

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -832,9 +832,9 @@ module Bundler
         if s.source.instance_of?(Source::Path) || s.source.instance_of?(Source::Gemspec)
           new_specs = begin
             s.source.specs
-          rescue PathError, GitError
+          rescue PathError
             # if we won't need the source (according to the lockfile),
-            # don't error if the path/git source isn't available
+            # don't error if the path source isn't available
             next if specs.
                     for(requested_dependencies, false).
                     none? {|locked_spec| locked_spec.source == s.source }

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -819,6 +819,7 @@ module Bundler
 
           @specs_that_changed_sources << s if gemfile_source != lockfile_source
           deps << dep if !dep.source || lockfile_source.include?(dep.source)
+          @unlock[:gems] << name if lockfile_source.include?(dep.source) && lockfile_source != gemfile_source
 
           # Replace the locked dependency's source with the equivalent source from the Gemfile
           s.source = gemfile_source

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -811,18 +811,18 @@ module Bundler
 
       specs.each do |s|
         dep = @dependencies.find {|d| s.satisfies?(d) }
+        lockfile_source = s.source
 
         # Replace the locked dependency's source with the equivalent source from the Gemfile
         s.source = if dep
           gemfile_source = dep.source || sources.default_source
-          lockfile_source = s.source
 
           @specs_that_changed_sources << s if gemfile_source != lockfile_source
           deps << dep if !dep.source || lockfile_source.include?(dep.source)
 
           gemfile_source
         else
-          sources.get_with_fallback(s.source)
+          sources.get_with_fallback(lockfile_source)
         end
 
         next if @unlock[:sources].include?(s.source.name)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -813,16 +813,17 @@ module Bundler
         dep = @dependencies.find {|d| s.satisfies?(d) }
         lockfile_source = s.source
 
-        # Replace the locked dependency's source with the equivalent source from the Gemfile
-        s.source = if dep
+        if dep
           gemfile_source = dep.source || default_source
 
           @specs_that_changed_sources << s if gemfile_source != lockfile_source
           deps << dep if !dep.source || lockfile_source.include?(dep.source)
 
-          gemfile_source
+          # Replace the locked dependency's source with the equivalent source from the Gemfile
+          s.source = gemfile_source
         else
-          sources.get_with_fallback(lockfile_source)
+          # Replace the locked dependency's source with the default source, if the locked source is no longer in the Gemfile
+          s.source = default_source unless sources.get(lockfile_source)
         end
 
         next if @unlock[:sources].include?(s.source.name)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -810,6 +810,7 @@ module Bundler
       @specs_that_changed_sources = []
 
       specs.each do |s|
+        name = s.name
         dep = @dependencies.find {|d| s.satisfies?(d) }
         lockfile_source = s.source
 
@@ -848,11 +849,11 @@ module Bundler
           else
             # If the spec is no longer in the path source, unlock it. This
             # commonly happens if the version changed in the gemspec
-            @unlock[:gems] << s.name
+            @unlock[:gems] << name
           end
         end
 
-        if dep.nil? && requested_dependencies.find {|d| s.name == d.name }
+        if dep.nil? && requested_dependencies.find {|d| name == d.name }
           @unlock[:gems] << s.name
         else
           converged << s

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -390,8 +390,8 @@ module Bundler
       both_sources.each do |name, (dep, lock_dep)|
         next if dep.nil? || lock_dep.nil?
 
-        gemfile_source = dep.source || sources.default_source
-        lock_source = lock_dep.source || sources.default_source
+        gemfile_source = dep.source || default_source
+        lock_source = lock_dep.source || default_source
         next if lock_source.include?(gemfile_source)
 
         gemfile_source_name = dep.source ? gemfile_source.to_gemfile : "no specified source"
@@ -815,7 +815,7 @@ module Bundler
 
         # Replace the locked dependency's source with the equivalent source from the Gemfile
         s.source = if dep
-          gemfile_source = dep.source || sources.default_source
+          gemfile_source = dep.source || default_source
 
           @specs_that_changed_sources << s if gemfile_source != lockfile_source
           deps << dep if !dep.source || lockfile_source.include?(dep.source)
@@ -875,7 +875,7 @@ module Bundler
       source_requirements = if precompute_source_requirements_for_indirect_dependencies?
         all_requirements = source_map.all_requirements
         all_requirements = pin_locally_available_names(all_requirements) if @prefer_local
-        { :default => sources.default_source }.merge(all_requirements)
+        { :default => default_source }.merge(all_requirements)
       else
         { :default => Source::RubygemsAggregate.new(sources, source_map) }.merge(source_map.direct_requirements)
       end
@@ -884,7 +884,7 @@ module Bundler
         source_requirements[dep.name] = sources.metadata_source
       end
 
-      default_bundler_source = source_requirements["bundler"] || sources.default_source
+      default_bundler_source = source_requirements["bundler"] || default_source
 
       if @unlocking_bundler
         default_bundler_source.add_dependency_names("bundler")
@@ -895,6 +895,10 @@ module Bundler
 
       verify_changed_sources!
       source_requirements
+    end
+
+    def default_source
+      sources.default_source
     end
 
     def verify_changed_sources!

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -811,14 +811,14 @@ module Bundler
 
       specs.each do |s|
         dep = @dependencies.find {|d| s.satisfies?(d) }
-        deps << dep if dep && (!dep.source || s.source.include?(dep.source))
 
         # Replace the locked dependency's source with the equivalent source from the Gemfile
-        s.source = if dep&.source
-          gemfile_source = dep.source
+        s.source = if dep
+          gemfile_source = dep.source || sources.default_source
           lockfile_source = s.source
 
           @specs_that_changed_sources << s if gemfile_source != lockfile_source
+          deps << dep if !dep.source || lockfile_source.include?(dep.source)
 
           gemfile_source
         else

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -805,15 +805,13 @@ module Bundler
 
     def converge_specs(specs)
       converged = []
-
-      deps = @dependencies.select do |dep|
-        specs[dep].any? {|s| s.satisfies?(dep) && (!dep.source || s.source.include?(dep.source)) }
-      end
+      deps = []
 
       @specs_that_changed_sources = []
 
       specs.each do |s|
         dep = @dependencies.find {|d| s.satisfies?(d) }
+        deps << dep if dep && (!dep.source || s.source.include?(dep.source))
 
         # Replace the locked dependency's source with the equivalent source from the Gemfile
         s.source = if dep&.source

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -67,6 +67,13 @@ module Bundler
 
       alias_method :==, :eql?
 
+      def include?(other)
+        other.is_a?(Git) && uri == other.uri &&
+          name == other.name &&
+          glob == other.glob &&
+          submodules == other.submodules
+      end
+
       def to_s
         begin
           at = humanized_ref || current_branch

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -101,10 +101,6 @@ module Bundler
       source_list_for(source).find {|s| equivalent_source?(source, s) }
     end
 
-    def get_with_fallback(source)
-      get(source) || default_source
-    end
-
     def lock_sources
       lock_other_sources + lock_rubygems_sources
     end

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -540,6 +540,92 @@ RSpec.describe "the lockfile format" do
     G
   end
 
+  it "is conservative with dependencies of git gems" do
+    build_repo4 do
+      build_gem "orm_adapter", "0.4.1"
+      build_gem "orm_adapter", "0.5.0"
+    end
+
+    FileUtils.mkdir_p lib_path("ckeditor/lib")
+
+    @remote = build_git("ckeditor_remote", :bare => true)
+
+    build_git "ckeditor", :path => lib_path("ckeditor") do |s|
+      s.write "lib/ckeditor.rb", "CKEDITOR = '4.0.7'"
+      s.version = "4.0.7"
+      s.add_dependency "orm_adapter"
+    end
+
+    update_git "ckeditor", :path => lib_path("ckeditor"), :remote => file_uri_for(@remote.path)
+    update_git "ckeditor", :path => lib_path("ckeditor"), :tag => "v4.0.7"
+    old_git = update_git "ckeditor", :path => lib_path("ckeditor"), :push => "v4.0.7"
+
+    update_git "ckeditor", :path => lib_path("ckeditor"), :gemspec => true do |s|
+      s.write "lib/ckeditor.rb", "CKEDITOR = '4.0.8'"
+      s.version = "4.0.8"
+      s.add_dependency "orm_adapter"
+    end
+    update_git "ckeditor", :path => lib_path("ckeditor"), :tag => "v4.0.8"
+
+    new_git = update_git "ckeditor", :path => lib_path("ckeditor"), :push => "v4.0.8"
+
+    gemfile <<-G
+      source "#{file_uri_for(gem_repo4)}"
+      gem "ckeditor", :git => "#{@remote.path}", :tag => "v4.0.8"
+    G
+
+    lockfile <<~L
+      GIT
+        remote: #{@remote.path}
+        revision: #{old_git.ref_for("v4.0.7")}
+        tag: v4.0.7
+        specs:
+          ckeditor (4.0.7)
+            orm_adapter
+
+      GEM
+        remote: #{file_uri_for(gem_repo4)}/
+        specs:
+          orm_adapter (0.4.1)
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        ckeditor!
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    bundle "lock"
+
+    # Bumps the git gem, but keeps its dependency locked
+    expect(lockfile).to eq <<~L
+      GIT
+        remote: #{@remote.path}
+        revision: #{new_git.ref_for("v4.0.8")}
+        tag: v4.0.8
+        specs:
+          ckeditor (4.0.8)
+            orm_adapter
+
+      GEM
+        remote: #{file_uri_for(gem_repo4)}/
+        specs:
+          orm_adapter (0.4.1)
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        ckeditor!
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+  end
+
   it "serializes pinned path sources to the lockfile" do
     build_lib "foo"
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Git sources are not always conservative.

If you edit an attribute of a git source in the Gemfile (like its tag), but don't change the source itself (it's URL), then Bundler should behave consistently for dependencies of that source: it should re-resolve direct dependencies to satisfy the new change git source, but keep transitive dependencies already in the lockfile as much as possible.

## What is your fix for the problem, implemented in this PR?

The fix is to allow Bundler to make the distinction between:

* A git source was completely changed to a different source. We want full unlock here.
* A git source is still the same, but the Gemfile is now pointing to a different reference. We want conservative subdependencies here.

This distinction is implemented by 9a0e0dfd5b528d1df8b1eb389a1b5b2b3f884a9d. The other commits are just minor refactorings while trying to figure things out.

Fixes #6816.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
