### PR TITLE
Fix incorrect release task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -727,6 +727,8 @@ namespace :bundler do
   task :build => ["bundler:build_metadata"] do
     Rake::Task["bundler:build_metadata:clean"].tap(&:reenable).invoke
   end
+
+  desc "Push to rubygems.org"
   task "bundler:release:rubygem_push" => ["bundler:release:setup", "man:check", "bundler:build_metadata", "bundler:release:github"]
 
   desc "Generates the changelog for a specific target version"

--- a/Rakefile
+++ b/Rakefile
@@ -729,7 +729,7 @@ namespace :bundler do
   end
 
   desc "Push to rubygems.org"
-  task "bundler:release:rubygem_push" => ["bundler:release:setup", "man:check", "bundler:build_metadata", "bundler:release:github"]
+  task "release:rubygem_push" => ["bundler:release:setup", "man:check", "bundler:build_metadata", "bundler:release:github"]
 
   desc "Generates the changelog for a specific target version"
   task :generate_changelog, [:version] do |_t, opts|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I have backported repository layout changes to the stable branch. That means release tasks are now setup differently.

I will update the new release tasks once I successfully release once, but for now I detected a bug where several release prerequisites were not being run due to a incorrect extra namespacing.

## What is your fix for the problem, implemented in this PR?

Remove the extra namespacing.

I have not yet checked that this works, since I have not yet release, but I added a description for the task and while before when listing the tasks I got (note the double namespace for bundler:bundler:release:rubygem_push)

```
$ rake -T bundler:
rake bundler:build                         # Build bundler-2.5.0.dev.gem into the pkg directory
rake bundler:build:checksum                # Generate SHA512 checksum if bundler-2.5.0.dev.gem into the checksums directory
rake bundler:bundler:release:rubygem_push  # Push to rubygems.org
rake bundler:clean                         # Remove any temporary products
rake bundler:clobber                       # Remove any generated files
rake bundler:generate_changelog[version]   # Generates the changelog for a specific target version
rake bundler:install                       # Build and install bundler-2.5.0.dev.gem into system gems
rake bundler:install:local                 # Build and install bundler-2.5.0.dev.gem into system gems without network access
rake bundler:release[remote]               # Create tag v2.5.0.dev and build and push bundler-2.5.0.dev.gem to rubygems.org
rake bundler:release:github                # Push the release to GitHub releases
rake bundler:release:setup                 # Install gems needed for releasing
```

Now I get

```
$ rake -T bundler:
rake bundler:build                        # Build bundler-2.5.0.dev.gem into the pkg directory
rake bundler:build:checksum               # Generate SHA512 checksum if bundler-2.5.0.dev.gem into the checksums directory
rake bundler:clean                        # Remove any temporary products
rake bundler:clobber                      # Remove any generated files
rake bundler:generate_changelog[version]  # Generates the changelog for a specific target version
rake bundler:install                      # Build and install bundler-2.5.0.dev.gem into system gems
rake bundler:install:local                # Build and install bundler-2.5.0.dev.gem into system gems without network access
rake bundler:release[remote]              # Create tag v2.5.0.dev and build and push bundler-2.5.0.dev.gem to rubygems.org
rake bundler:release:github               # Push the release to GitHub releases
rake bundler:release:rubygem_push         # Push to rubygems.org
rake bundler:release:setup                # Install gems needed for releasing
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
