### PR TITLE
Add support for generating compact index files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
     - lib/rubygems/resolver/molinillo/**/*
     - lib/rubygems/tsort/**/*
     - lib/rubygems/optparse/**/*
+    - lib/rubygems/indexer/compact_index/**/*
     - bundler/lib/bundler/vendor/**/*
   CacheRootDirectory: tmp/rubocop
   MaxFilesInCache: 5000

--- a/Rakefile
+++ b/Rakefile
@@ -148,6 +148,16 @@ if File.exist?("tool/automatiek.rake")
     lib.license_path = "COPYING"
   end
 
+  desc "Vendor a specific version of compact_index to rubygems"
+  Automatiek::RakeTask.new("compact_index") do |lib|
+    lib.version = "v0.14.0"
+    lib.download = { :github => "https://github.com/rubygems/compact_index" }
+    lib.namespace = "CompactIndex"
+    lib.prefix = "Gem::Indexer"
+    lib.vendor_lib = "lib/rubygems/indexer/compact_index"
+    lib.license_path = "LICENSE.txt"
+  end
+
   desc "Vendor a specific version of pub_grub to bundler"
   Automatiek::RakeTask.new("pub_grub") do |lib|
     lib.version = "main"

--- a/lib/rubygems/commands/generate_index_command.rb
+++ b/lib/rubygems/commands/generate_index_command.rb
@@ -28,8 +28,13 @@ class Gem::Commands::GenerateIndexCommand < Gem::Command
     deprecate_option("--modern", version: "4.0", extra_msg: "Modern indexes (specs, latest_specs, and prerelease_specs) are always generated, so this option is not needed.")
     deprecate_option("--no-modern", version: "4.0", extra_msg: "The `--no-modern` option is currently ignored. Modern indexes (specs, latest_specs, and prerelease_specs) are always generated.")
 
+    add_option "--[no-]compact",
+                "Generate compact index files" do |value, options|
+      options[:build_compact] = value
+    end
+
     add_option "--update",
-               "Update modern indexes with gems added",
+               "Update modern and compact indices with gems added",
                "since the last update" do |value, options|
       options[:update] = value
     end

--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -2,6 +2,7 @@
 
 require_relative "../rubygems"
 require_relative "package"
+require_relative "indexer/compact_index/"
 require "tmpdir"
 
 ##
@@ -14,6 +15,11 @@ class Gem::Indexer
   # Build indexes for RubyGems 1.2.0 and newer when true
 
   attr_accessor :build_modern
+
+  ##
+  # Build compact index files when true
+
+  attr_accessor :build_compact
 
   ##
   # Index install location
@@ -51,6 +57,7 @@ class Gem::Indexer
     options = { :build_modern => true }.merge options
 
     @build_modern = options[:build_modern]
+    @build_compact = options[:build_compact]
 
     @dest_directory = directory
     @directory = Dir.mktmpdir "gem_generate_index"
@@ -90,6 +97,7 @@ class Gem::Indexer
     Gem::Specification._resort! specs
     build_marshal_gemspecs specs
     build_modern_indices specs if @build_modern
+    build_compact_index specs if @build_compact
 
     compress_indices
   end
@@ -181,6 +189,57 @@ class Gem::Indexer
                "#{@latest_specs_index}.gz",
                @prerelease_specs_index,
                "#{@prerelease_specs_index}.gz"]
+  end
+
+  ##
+  # Builds compact index files
+
+  def build_compact_index(specs)
+    gems = compact_index_gems(specs)
+
+    progress = ui.progress_reporter gems.count + 2,
+      "Generating compact index files for #{gems.count} gems",
+      "Complete"
+
+    Gem.time "Generated compact index files" do
+      info_dir = File.join(@directory, "info")
+      FileUtils.mkdir_p info_dir, :mode => 0o700
+
+      gems.each do |gem|
+        info = CompactIndex.info(gem.versions)
+
+        info_checksum = Digest::MD5.hexdigest(info)
+        gem[:versions].last[:info_checksum] = info_checksum
+
+        info_path = File.join(@directory, "info", gem.name)
+        if File.exist?(info_path)
+          raise "info file already exists: #{info_path}"
+        end
+
+        File.open(info_path, "w") do |io|
+          io.write info
+        end
+
+        progress.updated "/info/#{gem.name}"
+      end
+
+      File.open(File.join(@directory, "names"), "w") do |io|
+        io.write CompactIndex.names(gems.map(&:name))
+      end
+      progress.updated "/names"
+
+      CompactIndex::VersionsFile.new(
+        File.join(@directory, "versions")
+      ).create(
+        gems,
+      )
+
+      progress.updated "/versions"
+
+      @files << info_dir << File.join(@directory, "names") << File.join(@directory, "versions")
+
+      progress.done
+    end
   end
 
   def map_gems_to_specs(gems)
@@ -376,6 +435,10 @@ class Gem::Indexer
                          @prerelease_specs_index)
     end
 
+    Gem.time "Updated compact index files" do
+      files += update_compact_index released, @dest_directory, @directory
+    end if @build_compact
+
     compress_indices
 
     verbose = Gem.configuration.really_verbose
@@ -424,5 +487,86 @@ class Gem::Indexer
     File.open dest, "wb" do |io|
       Marshal.dump specs_index, io
     end
+  end
+
+  ##
+  # Combines specs in +index+ and +source+ then writes out a new
+  # compact index to +dest+.
+
+  def update_compact_index(new_specs, source, dest)
+    files = []
+    source_versions_path = File.join(source, "versions")
+    versions_file = CompactIndex::VersionsFile.new source_versions_path
+
+    gems = compact_index_gems new_specs
+
+    FileUtils.mkdir_p File.join(dest, "info")
+
+    new_names = []
+    gems.each do |gem|
+      existing_info_path = File.join(source, "info", gem.name)
+      if File.exist? existing_info_path
+        info = File.read(existing_info_path) +
+               CompactIndex.info(gem.versions).sub(/\A---\n/, "")
+      else
+        new_names << gem.name
+        info = CompactIndex.info gem.versions
+      end
+
+      info_checksum = Digest::MD5.hexdigest(info)
+      gem[:versions].last[:info_checksum] = info_checksum
+
+      info_path = File.join(dest, "info", gem.name)
+      if File.exist?(info_path)
+        raise "info file already exists: #{info_path}"
+      end
+
+      File.open(info_path, "w") do |io|
+        io.write info
+      end
+      files << info_path
+    end
+
+    versions_path = File.join(dest, "versions")
+    File.open(versions_path, "w") do |io|
+      io.write versions_file.contents(gems)
+    end
+    files << versions_path
+
+    unless new_names.empty?
+      old_names = File.read(File.join(source, "names")).lines(chomp: true)[2..]
+      names_path = File.join(dest, "names")
+
+      names = old_names + new_names
+      names.sort!
+
+      File.open(names_path, "w") do |io|
+        io.write CompactIndex.names(names)
+      end
+
+      files << names_path
+    end
+
+    files
+  end
+
+  def compact_index_gems(specs)
+    versions_by_name = Hash.new {|h, k| h[k] = [] }
+    specs.each do |spec|
+      checksum = spec.loaded_from && Digest::SHA256.file(spec.loaded_from).base64digest!
+      versions_by_name[spec.name] << CompactIndex::GemVersion.new(
+        spec.version.version,
+        spec.platform,
+        checksum,
+        nil, # info_checksum
+        spec.dependencies.map {|d| CompactIndex::Dependency.new(d.name, d.requirement.to_s) },
+        spec.required_ruby_version&.to_s,
+        spec.required_rubygems_version&.to_s
+      )
+    end
+    versions_by_name.map do |name, versions|
+      versions.sort!
+      CompactIndex::Gem.new(name, versions)
+    end.tap(&:sort!)
   end
 end

--- a/lib/rubygems/indexer/compact_index.rb
+++ b/lib/rubygems/indexer/compact_index.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Gem::Indexer
+end
+
+require_relative "compact_index/lib/compact_index"

--- a/lib/rubygems/indexer/compact_index/LICENSE.txt
+++ b/lib/rubygems/indexer/compact_index/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 fotanus@gmail.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/lib/rubygems/indexer/compact_index/lib/compact_index.rb
+++ b/lib/rubygems/indexer/compact_index/lib/compact_index.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require_relative "compact_index/gem"
+require_relative "compact_index/gem_version"
+require_relative "compact_index/dependency"
+
+require_relative "compact_index/version"
+require_relative "compact_index/versions_file"
+require_relative "compact_index/ext/date"
+
+module Gem::Indexer::CompactIndex
+  # Formats a list of gem names, to be used on the /names endpoint.
+  # @param gem_names [Array] array with gem names to be formated, in alphabetical order
+  # @return [String] names on the specified format for new index /names endpoint. Example:
+  #   ```ruby
+  #   ---
+  #   rack
+  #   rails
+  #   other-gem
+  #   ```
+  def self.names(gem_names)
+    String.new("---\n") << gem_names.join("\n") << "\n"
+  end
+
+  # Returns the versions file content argumented with some extra gems
+  # @param versions_file [Gem::Indexer::CompactIndex::VersionsFile] which will be used as a base response
+  # @param gems [Array] an optional list of [Gem::Indexer::CompactIndex::Gem] to be appended on the end
+  #   of the base file. Example:
+  #   ```ruby
+  #   [
+  #     Gem::Indexer::CompactIndex::Gem.new("gem1", [
+  #       Gem::Indexer::CompactIndex::GemVersion.new("0.9.8", "ruby", "abc123"),
+  #       Gem::Indexer::CompactIndex::GemVersion.new("0.9.9", "jruby", "abc123"),
+  #     ]),
+  #     Gem::Indexer::CompactIndex::Gem.new("gem2", [
+  #       Gem::Indexer::CompactIndex::GemVersion.new("0.9.8", "ruby", "abc123"),
+  #       Gem::Indexer::CompactIndex::GemVersion.new("0.9.9", "jruby", "abc123"),
+  #     ])
+  #   ]
+  #   ```
+  # @return [String] The formated output. Example:
+  #   ```ruby
+  #   created_at: 2001-01-01T01:01:01-01:01
+  #   ---
+  #   rack 0.1.0,0.1.1,0.1.2,0.2.0,0.2.1,0.3.0,0.4.0,0.4.1,0.5.0,0.5.1,0.5.2,0.5.3 c54e4b7e14861a5d8c225283b75075f4
+  #   rails 0.0.1,0.1.0 00fd5c36764f4ec1e8adf1c9adaada55
+  #   sinatra 0.1.1,0.1.2,0.1.3 46f0a24d291725736216b4b6e7412be6
+  #   ```
+  def self.versions(versions_file, gems = nil, args = {})
+    versions_file.contents(gems, args)
+  end
+
+  # Formats the versions information of a gem, to be display in the `/info/gemname` endpoint.
+  #
+  # @param versions_file [Gem::Indexer::CompactIndex::VersionsFile] which will be used as a base response
+  # @param gems [Array] an optional list of [Gem::Indexer::CompactIndex::Gem] to be appended on the end
+  #   of the base file. Example:
+  #   ```ruby
+  #   [
+  #     Gem::Indexer::CompactIndex::GemVersion.new("1.0.1", "ruby", "abc123", "info123", [
+  #       Gem::Indexer::CompactIndex::Dependency.new("foo", "=1.0.1", "abc123"),
+  #       Gem::Indexer::CompactIndex::Dependency.new("bar", ">1.0, <2.0", "abc123"),
+  #     ])
+  #   ]
+  #   ```
+  #
+  # @return [String] The formated output. Example:
+  #   ```ruby
+  #   --
+  #   1.0.1 requirement:<2.0&>1.0|checksum:abc1
+  #   1.0.2 requirement:<2.0&>1.0,requirement2:=1.1|checksum:abc2,ruby:>1.0,rubygems:>2.0
+  #   ```
+  def self.info(versions)
+    versions.inject("---\n".dup) do |output, version|
+      output << version.to_line << "\n"
+    end
+  end
+end

--- a/lib/rubygems/indexer/compact_index/lib/compact_index/dependency.rb
+++ b/lib/rubygems/indexer/compact_index/lib/compact_index/dependency.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Gem::Indexer::CompactIndex
+  Dependency = Struct.new(:gem, :version, :platform, :checksum) do
+    def version_and_platform
+      if platform.nil? || platform == "ruby"
+        version.dup
+      else
+        "#{version}-#{platform}"
+      end
+    end
+  end
+end

--- a/lib/rubygems/indexer/compact_index/lib/compact_index/ext/date.rb
+++ b/lib/rubygems/indexer/compact_index/lib/compact_index/ext/date.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "date"
+
+# Ruby 1.8.7 makes Time#to_datetime private, but we need it
+unless Time.public_instance_methods.include? :to_datetime
+  class Time
+    public :to_datetime
+  end
+end

--- a/lib/rubygems/indexer/compact_index/lib/compact_index/gem.rb
+++ b/lib/rubygems/indexer/compact_index/lib/compact_index/gem.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Gem::Indexer::CompactIndex
+  Gem = Struct.new(:name, :versions) do
+    def <=>(other)
+      name <=> other.name
+    end
+  end
+end

--- a/lib/rubygems/indexer/compact_index/lib/compact_index/gem_version.rb
+++ b/lib/rubygems/indexer/compact_index/lib/compact_index/gem_version.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Gem::Indexer::CompactIndex
+  # rubocop:disable Metrics/BlockLength
+  GemVersion = Struct.new(:number, :platform, :checksum, :info_checksum,
+    :dependencies, :ruby_version, :rubygems_version) do
+    def number_and_platform
+      if platform.nil? || platform == "ruby"
+        number.dup
+      else
+        "#{number}-#{platform}"
+      end
+    end
+
+    def <=>(other)
+      number_comp = number <=> other.number
+
+      if number_comp.zero?
+        [number, platform].compact <=> [other.number, other.platform].compact
+      else
+        number_comp
+      end
+    end
+
+    def to_line
+      line = number_and_platform.dup << " " << deps_line << "|checksum:#{checksum}"
+      line << ",ruby:#{ruby_version_line}" if ruby_version && ruby_version != ">= 0"
+      line << ",rubygems:#{rubygems_version_line}" if rubygems_version && rubygems_version != ">= 0"
+      line
+    end
+
+  private
+
+    def ruby_version_line
+      join_multiple(ruby_version)
+    end
+
+    def rubygems_version_line
+      join_multiple(rubygems_version)
+    end
+
+    def deps_line
+      return "" if dependencies.nil?
+      dependencies.map do |d|
+        [d[:gem], join_multiple(d.version_and_platform)].join(":")
+      end.join(",")
+    end
+
+    def join_multiple(requirements)
+      requirements.split(", ").sort.join("&")
+    end
+  end
+end

--- a/lib/rubygems/indexer/compact_index/lib/compact_index/version.rb
+++ b/lib/rubygems/indexer/compact_index/lib/compact_index/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Gem::Indexer::CompactIndex
+  VERSION = "0.14.0".freeze
+end

--- a/lib/rubygems/indexer/compact_index/lib/compact_index/versions_file.rb
+++ b/lib/rubygems/indexer/compact_index/lib/compact_index/versions_file.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "time"
+require "date"
+require "digest"
+
+module Gem::Indexer::CompactIndex
+  class VersionsFile
+    def initialize(file = nil)
+      @path = file || "/versions.list"
+    end
+
+    def contents(gems = nil, args = {})
+      gems = calculate_info_checksums(gems) if args.delete(:calculate_info_checksums) { false }
+
+      raise ArgumentError, "Unknown options: #{args.keys.join(", ")}" unless args.empty?
+
+      File.read(@path).tap do |out|
+        out << gem_lines(gems) if gems
+      end
+    end
+
+    def updated_at
+      created_at_header(@path) || Time.at(0).to_datetime
+    end
+
+    def create(gems, ts = Time.now.iso8601)
+      gems.sort!
+
+      File.open(@path, "w") do |io|
+        io.write "created_at: #{ts}\n---\n"
+        io.write gem_lines(gems)
+      end
+    end
+
+  private
+
+    def gem_lines(gems)
+      gems.reduce("".dup) do |lines, gem|
+        version_numbers = gem.versions.map(&:number_and_platform).join(",")
+        lines << gem.name <<
+          " ".freeze << version_numbers <<
+          " #{gem.versions.last.info_checksum}\n"
+      end
+    end
+
+    def calculate_info_checksums(gems)
+      gems.each do |gem|
+        info_checksum = Digest::MD5.hexdigest(Gem::Indexer::CompactIndex.info(gem[:versions]))
+        gem[:versions].last[:info_checksum] = info_checksum
+      end
+    end
+
+    def created_at_header(path)
+      return unless File.exist? path
+
+      File.open(path) do |file|
+        file.each_line do |line|
+          line.match(/created_at: (.*)\n|---\n/) do |match|
+            return match[1] && DateTime.parse(match[1])
+          end
+        end
+      end
+
+      nil
+    end
+  end
+end

--- a/test/rubygems/test_gem_indexer.rb
+++ b/test/rubygems/test_gem_indexer.rb
@@ -7,6 +7,8 @@ class TestGemIndexer < Gem::TestCase
   def setup
     super
 
+    ENV["SOURCE_DATE_EPOCH"] = "123456789"
+
     util_make_gems
 
     @d2_0 = util_spec "d", "2.0" do |s|
@@ -29,11 +31,12 @@ class TestGemIndexer < Gem::TestCase
     FileUtils.mkdir_p gems
     FileUtils.mv Dir[File.join(@gemhome, "cache", "*.gem")], gems
 
-    @indexer = Gem::Indexer.new(@indexerdir)
+    @indexer = Gem::Indexer.new(@indexerdir, build_compact: true)
   end
 
   def teardown
     FileUtils.rm_rf(@indexer.directory)
+    ENV["SOURCE_DATE_EPOCH"] = nil
   ensure
     super
   end
@@ -99,6 +102,55 @@ class TestGemIndexer < Gem::TestCase
                 ["x",      Gem::Version.new("1"),   "ruby"]]
 
     assert_equal expected, latest_specs, "latest_specs"
+
+    compact_index_names_path = File.join(@indexer.directory,
+                                         "names")
+    assert_equal <<~NAMES_FILE, File.read(compact_index_names_path)
+      ---
+      a
+      a_evil
+      b
+      c
+      d
+      dep_x
+      pl
+      x
+    NAMES_FILE
+
+    compact_index_versions_path = File.join(@indexer.directory,
+                                            "versions")
+    versions_file = Gem::Indexer::CompactIndex::VersionsFile.new compact_index_versions_path
+    expected_versions_file = <<~VERSIONS_FILE
+      created_at: #{versions_file.updated_at}
+      ---
+      a 1,2,3.a f8082c9f1c8f8763b0a453158d0faa9d
+      a_evil 9 16ff5d412806a913849fe40bd877c939
+      b 2 c1933af94f22b87fab588fe1432cd2d3
+      c 1.2 dcd813bfba50f09b2cfebeefb2fc30b0
+      d 2.0,2.0.a,2.0.b 059cf6d52d2b1e15b94f1484f10cb323
+      dep_x 1 13c49185545056c0006fb24c3977eac7
+      pl 1-x86-linux 3eb334d3f36632021a814317ece7ee18
+      x 1 c4a44a459ab4663ca968f6941b0290bc
+    VERSIONS_FILE
+    assert_equal expected_versions_file, File.read(compact_index_versions_path)
+    assert_versions_file_info_checksums @indexer.directory
+
+    assert_equal <<~INFO_FILE, File.read(File.join(@indexer.directory, "info", "a"))
+      ---
+      1 |checksum:lVcAlAtGlKED7gyvQwT7uGcynbte0YniUqEzlTSZsC0=
+      2 |checksum:2ioGHwKtDif2ILuqx7jUHmvkKEOBmZaFLtdy3zi1VyU=
+      3.a |checksum:jn/beBfFJBAC0E66bdonwMuZuoB100R2kTMZVAXII6A=,rubygems:> 1.3.1
+    INFO_FILE
+
+    assert_equal <<~INFO_FILE, File.read(File.join(@indexer.directory, "info", "dep_x"))
+      ---
+      1 x:>= 1|checksum:hUh/oIpcREk1WEHd+N/wZoVsPcPtFzKBG+ACj0i1y9w=
+    INFO_FILE
+
+    assert_equal <<~INFO_FILE, File.read(File.join(@indexer.directory, "info", "pl"))
+      ---
+      1-x86-linux |checksum:1lbLFgr+P4Xk3XZsflVMNQBL6avnbov+fckUbgay3B8=
+    INFO_FILE
   end
 
   def test_generate_index
@@ -322,8 +374,14 @@ class TestGemIndexer < Gem::TestCase
     quickdir = File.join @indexerdir, "quick"
     marshal_quickdir = File.join quickdir, "Marshal.#{@marshal_version}"
 
+    infodir = File.join @indexerdir, "info"
+
     assert_directory_exists quickdir
     assert_directory_exists marshal_quickdir
+
+    compact_index_versions_path = File.join(@indexerdir,
+      "versions")
+    versions_file_created_at = Gem::Indexer::CompactIndex::VersionsFile.new(compact_index_versions_path).updated_at
 
     @d2_1 = util_spec "d", "2.1"
     util_build_gem @d2_1
@@ -333,10 +391,15 @@ class TestGemIndexer < Gem::TestCase
     util_build_gem @d2_1_a
     @d2_1_a_tuple = [@d2_1_a.name, @d2_1_a.version, @d2_1_a.original_platform]
 
+    @e1 = util_spec "e", "1"
+    util_build_gem @e1
+    @e1_tuple = [@e1.name, @e1.version, @e1.original_platform]
+
     gems = File.join @indexerdir, "gems"
 
     FileUtils.mv @d2_1.cache_file, gems
     FileUtils.mv @d2_1_a.cache_file, gems
+    FileUtils.mv @e1.cache_file, gems
 
     with_system_gems do
       use_ui @ui do
@@ -365,6 +428,50 @@ class TestGemIndexer < Gem::TestCase
       refute_includes pre_specs_index, @d2_1_tuple
 
       refute_directory_exists @indexer.directory
+
+      assert_indexed infodir, "e"
+
+      assert_equal <<~NAMES_FILE, File.read(File.join(@indexerdir, "names"))
+        ---
+        a_evil
+        b
+        c
+        d
+        dep_x
+        e
+        pl
+        x
+      NAMES_FILE
+
+      assert_equal <<~INFO_FILE, File.read(File.join(infodir, "e"))
+        ---
+        1 |checksum:vLrEGbrFWFIBquicosX+yieL3f9Y8LSm5HjXf3Aci6o=
+      INFO_FILE
+
+      assert_equal <<~INFO_FILE, File.read(File.join(infodir, "d"))
+        ---
+        2.0 |checksum:67B/mnOYPQdPVg8ANHBoUI8C8n/0teIGWI9VcmfwfTk=
+        2.0.a |checksum:mBOKSlZSpMeb3Knw1CSNrb6OeKcCFXXOwYOaSDxxWzg=,rubygems:> 1.3.1
+        2.0.b |checksum:ufqDWxulKkwxj+D6Oa3VRKnS7Goa18IQFj1BmFnMVXc=,rubygems:> 1.3.1
+        2.1 |checksum:9esoQjUb03MGN4XbMl1rMjSOe8eYq+0uHPxqRzcnYZY=
+      INFO_FILE
+
+      assert_equal <<~VERSIONS_FILE, File.read(File.join(@indexerdir, "versions"))
+        created_at: #{versions_file_created_at}
+        ---
+        a 1,2,3.a f8082c9f1c8f8763b0a453158d0faa9d
+        a_evil 9 16ff5d412806a913849fe40bd877c939
+        b 2 c1933af94f22b87fab588fe1432cd2d3
+        c 1.2 dcd813bfba50f09b2cfebeefb2fc30b0
+        d 2.0,2.0.a,2.0.b 059cf6d52d2b1e15b94f1484f10cb323
+        dep_x 1 13c49185545056c0006fb24c3977eac7
+        pl 1-x86-linux 3eb334d3f36632021a814317ece7ee18
+        x 1 c4a44a459ab4663ca968f6941b0290bc
+        d 2.1 6b3c63264fc0018b2fe6f8d4df2de647
+        e 1 31fbe8118d89e939f2ff6790c6ccf716
+      VERSIONS_FILE
+
+      assert_versions_file_info_checksums(@indexerdir)
     end
   end
 
@@ -376,5 +483,18 @@ class TestGemIndexer < Gem::TestCase
   def refute_indexed(dir, name)
     file = File.join dir, name
     refute File.exist?(file), "#{file} exists"
+  end
+
+  def assert_versions_file_info_checksums(dir)
+    info_dir = File.join(dir, "info")
+    assert_indexed dir, "versions"
+    File.read(File.join(dir, "versions")).lines[2..].each_with_object({}) do |line, checksums|
+      name, sum = line.split(" ").values_at(0, 2)
+      checksums[name] = sum
+    end.each do |name, checksum|
+      assert_indexed info_dir, name
+      actual = Digest::MD5.hexdigest(File.read(File.join(dir, "info", name)))
+      assert_equal checksum, actual, "Expected versions file checksum for #{name} (#{checksum}) to match info checksum on disk"
+    end
   end
 end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Fixes https://github.com/rubygems/rubygems/issues/6674

`gem generate_index` did not output compact index files, making those self-hosted indexes slower to install gems from than necessary

## What is your fix for the problem, implemented in this PR?

Added compact index file generation, behind a `--compact` CLI flag

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
