### PR TITLE
Replaced remained local to lockfile

### DIFF
--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -296,7 +296,7 @@ The following is a list of all configuration keys and their purpose\. You can le
 \fBuser_agent\fR (\fBBUNDLE_USER_AGENT\fR): The custom user agent fragment Bundler includes in API requests\.
 .
 .IP "\(bu" 4
-\fBversion\fR (\fBBUNDLE_VERSION\fR): The version of Bundler to use when running under Bundler environment\. Defaults to \fBlocal\fR\. You can also specify \fBsystem\fR or \fBx\.y\.z\fR\. \fBlockfile\fR will use the Bundler version specified in the \fBGemfile\.lock\fR, \fBsystem\fR will use the system version of Bundler, and \fBx\.y\.z\fR will use the specified version of Bundler\.
+\fBversion\fR (\fBBUNDLE_VERSION\fR): The version of Bundler to use when running under Bundler environment\. Defaults to \fBlockfile\fR\. You can also specify \fBsystem\fR or \fBx\.y\.z\fR\. \fBlockfile\fR will use the Bundler version specified in the \fBGemfile\.lock\fR, \fBsystem\fR will use the system version of Bundler, and \fBx\.y\.z\fR will use the specified version of Bundler\.
 .
 .IP "\(bu" 4
 \fBwith\fR (\fBBUNDLE_WITH\fR): A \fB:\fR\-separated list of groups whose gems bundler should install\.

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -276,7 +276,7 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    The custom user agent fragment Bundler includes in API requests.
 * `version` (`BUNDLE_VERSION`):
    The version of Bundler to use when running under Bundler environment.
-   Defaults to `local`. You can also specify `system` or `x.y.z`.
+   Defaults to `lockfile`. You can also specify `system` or `x.y.z`.
    `lockfile` will use the Bundler version specified in the `Gemfile.lock`,
    `system` will use the system version of Bundler, and `x.y.z` will use
    the specified version of Bundler.


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`local` naming still remained at `bundler/lib/bundler/man/bundle-config.1.ronn`.

## What is your fix for the problem, implemented in this PR?

I replaced it to `lockfile`

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
