### PR TITLE
Fix `rake blog:publish` task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -418,8 +418,8 @@ namespace "blog" do
       digest = OpenSSL::Digest::SHA256.file(file).hexdigest
       basename = File.basename(file)
 
-      checksums << "* #{basename}  \n"
-      checksums << "  #{digest}\n"
+      checksums += "* #{basename}  \n"
+      checksums += "  #{digest}\n"
 
       release_url = URI("https://rubygems.org/#{file.end_with?("gem") ? "gems" : "rubygems"}/#{basename}")
       response = Net::HTTP.get_response(release_url)


### PR DESCRIPTION
Since this file now has `frozen-string-literal: true`, we can't modify string literals.


## What was the end-user or developer problem that led to this PR?

`rake blog:publish` task is failing with:

```
rake aborted!
FrozenError: can't modify frozen String: ""
/path/to/rubygems/Rakefile:360:in `block (3 levels) in <top (required)>'
/path/to/rubygems/Rakefile:356:in `each'
/path/to/rubygems/Rakefile:356:in `block (2 levels) in <top (required)>'
/path/to/rubygems/Rakefile:223:in `block in <top (required)>'
Tasks: TOP => postrelease => blog:publish => blog:update => ../blog.rubygems.org/_posts/2023-08-02-3.4.18-released.md => blog:checksums
```

## What is your fix for the problem, implemented in this PR?

Our Rakefile now has `frozen-string-literal: true`, so make sure to not mutate string literals.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
