### PR TITLE
Fix Incorrect Dates on some Gem::Specification

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1126,8 +1126,8 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
     specified_epoch = ENV["SOURCE_DATE_EPOCH"]
 
-    # If it's empty or just whitespace, treat it like it wasn't set at all.
-    specified_epoch = nil if !specified_epoch.nil? && specified_epoch.strip.empty?
+    # If it's empty, just whitespace, or a unique placeholder, treat it like it wasn't set at all.
+    specified_epoch = nil if !specified_epoch.nil? && (specified_epoch.strip.empty? || specified_epoch === "315532800")
 
     epoch = specified_epoch || @default_source_date_epoch
 

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -154,7 +154,6 @@ class TestGemPackage < Gem::Package::TarTestCase
     refute_equal Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc, package.build_time
   end
 
-
   def test_add_files
     spec = Gem::Specification.new
     spec.files = %w[lib/code.rb lib/empty]

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -140,6 +140,21 @@ class TestGemPackage < Gem::Package::TarTestCase
     ENV["SOURCE_DATE_EPOCH"] = epoch
   end
 
+  def test_build_time_ignores_invalid_source_date_epoch
+    ENV["SOURCE_DATE_EPOCH"] = "315532800"
+
+    spec = Gem::Specification.new "build", "1"
+    spec.summary = "build"
+    spec.authors = "build"
+    spec.files = ["lib/code.rb"]
+    spec.rubygems_version = Gem::Version.new "0"
+
+    package = Gem::Package.new spec.file_name
+
+    refute_equal Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc, package.build_time
+  end
+
+
   def test_add_files
     spec = Gem::Specification.new
     spec.files = %w[lib/code.rb lib/empty]


### PR DESCRIPTION
Hey there! 👋 

Thanks for taking a bit of time to read this PR. I took a look at the code of conduct, and contribution guidelines and I believe everything here should be in line!

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Issue number #6815 regarding incorrect dates on GemSpecs, with recent Puma versions appearing to be built in 1980. 
Another discussion happened on the Puma gem [here](https://github.com/puma/puma/discussions/3197). 

A [thread in the puma discussion showed that](https://github.com/puma/puma/discussions/3197#discussioncomment-6569250) behind the scenes, using Nix as a system config / package manager sets a default `SOURCE_DATE_EPOCH` environment variable to encourage build stability. It's a noticeable, and unique value, for [reasons related to other Nix dependencies](https://github.com/NixOS/nixpkgs/blob/78faafa6e6684acd1ec9770161a85d3b83caf7c5/pkgs/stdenv/generic/setup.sh#L403).


In spirit of the proposal in #2290 for reproducible builds, and attending to backwards-compatible considerations from [this comment](https://github.com/rubygems/rubygems/pull/3088#issuecomment-580949568) in #3088 to avoid changing the `SOURCE_DATE_EPOCH` variable, I've put a barebones conditional check forward.



## What is your fix for the problem, implemented in this PR?

This PR adds to the check for an existing `SOURCE_DATE_EPOCH`; if nothing is set, or it's an empty string, `Gem` will now explicitly ignore this specific default date.

I wanted to get something concrete to start a discussion on, but I think this exact implementation could be a problematic fix for gem versions that have been built with the Nix default. By explicitly ignoring those invalid dates, doing a rebuild of any gems based on that default date will result in a non-equivalent build. 

It _may_ be preferable to put a hard stop to any gems that defaulted to that date, in which case perhaps I didn't go far enough in this PR. If we would like to catch and remediate any of these mistaken dates perhaps we want to go as far as raising an error if a gem author tries to do a rebuild explicitly on that nix date.

Given that `rubygems` handles the build date automatically, it felt relevant to me that a fix for this type of build error happen at this layer. I think there could be some room to discuss moving from defaulting to the "current date", to check the git history for the date of the most recent revision on the branch as a reasonable default for builds. Thank you to  @penguincoder for the discussion, and suggesting using git refs, which aligns with other OSS approaches to consistent builds with epoch times.  

If the `rubygems` team is open to a git-based approach to `SOURCE_DATE_EPOCH`, I'd be pleased to open a standalone discussion and attempt an implementation. I left that approach out of this PR, as it felt like closing the gap felt like the pertinent first step, but I'm open to feedback! 😁 


<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes

Noting here I had an error running the whole suite locally, with a failure on checking the manifest was up to date, but running the update manifest rake task didn't change anything 😄 Not sure if I made a mistake somewhere, but I can investigate a bit further if needed!

- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
