### PR TITLE
Stop building docs for rubygems-update gem

### DIFF
--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -292,7 +292,7 @@ command to remove old versions.
     args = []
     args << "--silent" if options[:silent]
     args << "--prefix" << Gem.prefix if Gem.prefix
-    args << "--no-document" unless options[:document].include?("rdoc") || options[:document].include?("ri")
+    args << "--no-document"
     args << "--no-format-executable" if options[:no_format_executable]
     args << "--previous-version" << Gem::VERSION if
       options[:system] == true ||

--- a/rubygems-update.gemspec
+++ b/rubygems-update.gemspec
@@ -21,15 +21,6 @@ Gem::Specification.new do |s|
   s.bindir = "exe"
   s.executables = ["update_rubygems"]
   s.require_paths = ["hide_lib_for_update"]
-  s.rdoc_options = ["--main", "README.md", "--title=RubyGems Update Documentation"]
-  s.extra_rdoc_files = [
-    "CHANGELOG.md", "LICENSE.txt", "MAINTAINERS.txt",
-    "MIT.txt", "Manifest.txt", "README.md",
-    "UPGRADING.md", "POLICIES.md", "CODE_OF_CONDUCT.md",
-    "CONTRIBUTING.md", "bundler/CHANGELOG.md",
-    "bundler/LICENSE.md", "bundler/README.md",
-    "hide_lib_for_update/note.txt", *Dir["bundler/man/*.1"]
-  ]
 
   s.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
   s.required_rubygems_version = Gem::Requirement.new(">= 0")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Upgrading RubyGems is painfully slow unless `--no-document` is explicitly set in `.gemrc`. It takes like 30 seconds.

This is just a temporary gem to help upgrading RubyGems. I don't think it makes sense to build docs for it.



## What is your fix for the problem, implemented in this PR?

Most of the time is spent building documentation. We setup a bunch of documentation files to be parsed by rdoc, and that's slow. In particular, two of these files (`CHANGELOG.md` and `bundler/CHANGELOG.md`) are very big and doc is super slow when parsing them.

If we remove those two files from the `extra_rdoc_files` in the `.gemspec` file, things are back to fast, but I went a step further and completely removed building documentation for the ruby gems-update gem, since I don't think it's really useful?

Furthermore, in the future we should probably cleanup after ourselves and remove this gem once we've successfully updated the installation?

Fixes #6860.
 
## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
