### PR TITLE
Speedup building docs when updating rubygems

### DIFF
--- a/rubygems-update.gemspec
+++ b/rubygems-update.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
     "UPGRADING.md", "POLICIES.md", "CODE_OF_CONDUCT.md",
     "CONTRIBUTING.md", "bundler/CHANGELOG.md",
     "bundler/LICENSE.md", "bundler/README.md",
-    "hide_lib_for_update/note.txt", *Dir["bundler/man/*.1"]
+    "hide_lib_for_update/note.txt", *Dir["bundler/lib/bundler/man/*.1"]
   ]
 
   s.required_ruby_version = Gem::Requirement.new(">= 2.6.0")

--- a/rubygems-update.gemspec
+++ b/rubygems-update.gemspec
@@ -23,10 +23,10 @@ Gem::Specification.new do |s|
   s.require_paths = ["hide_lib_for_update"]
   s.rdoc_options = ["--main", "README.md", "--title=RubyGems Update Documentation"]
   s.extra_rdoc_files = [
-    "CHANGELOG.md", "LICENSE.txt", "MAINTAINERS.txt",
+    "LICENSE.txt", "MAINTAINERS.txt",
     "MIT.txt", "Manifest.txt", "README.md",
     "UPGRADING.md", "POLICIES.md", "CODE_OF_CONDUCT.md",
-    "CONTRIBUTING.md", "bundler/CHANGELOG.md",
+    "CONTRIBUTING.md",
     "bundler/LICENSE.md", "bundler/README.md",
     "hide_lib_for_update/note.txt", *Dir["bundler/lib/bundler/man/*.1"]
   ]


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Updating Rubygems is really slow by default.

## What is your fix for the problem, implemented in this PR?

The problem is that the default is to build documentation, and that we have two files (`CHANGELOG.md` and `bundler/CHANGELOG.md`) that RDoc takes forever to parse.

The fix is to remove these files from the list of files to be built by RDoc.

#### Before

```
$ gem install rubygems-update-3.5.0.dev.gem
Successfully installed rubygems-update-3.5.0.dev
Parsing documentation for rubygems-update-3.5.0.dev
Installing ri documentation for rubygems-update-3.5.0.dev
Done installing documentation for rubygems-update after 27 seconds
1 gem installed
```

#### After

```
$ gem install rubygems-update-3.5.0.dev.gem
Successfully installed rubygems-update-3.5.0.dev
Parsing documentation for rubygems-update-3.5.0.dev
Installing ri documentation for rubygems-update-3.5.0.dev
Done installing documentation for rubygems-update after 0 seconds
1 gem installed
```

Fixes #6860.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
