### PR TITLE
Don't fallback to old dependency API when bad credentials are configured

### DIFF
--- a/bundler/lib/bundler/fetcher/compact_index.rb
+++ b/bundler/lib/bundler/fetcher/compact_index.rb
@@ -15,7 +15,7 @@ module Bundler
           method.bind(self).call(*args, &blk)
         rescue NetworkDownError, CompactIndexClient::Updater::MisMatchedChecksumError => e
           raise HTTPError, e.message
-        rescue AuthenticationRequiredError
+        rescue AuthenticationRequiredError, BadAuthenticationError
           # Fail since we got a 401 from the server.
           raise
         rescue HTTPError => e

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -683,6 +683,15 @@ The checksum of /versions does not match the checksum provided by the server! So
         bundle :install, :artifice => "compact_index_strict_basic_authentication", :raise_on_error => false
         expect(err).to include("Bad username or password")
       end
+
+      it "does not fallback to old dependency API if bad authentication is provided" do
+        bundle "config set #{source_hostname} #{user}:wrong"
+
+        bundle :install, :artifice => "compact_index_strict_basic_authentication", :raise_on_error => false, :verbose => true
+        expect(err).to include("Bad username or password")
+        expect(out).to include("HTTP 401 Unauthorized http://user@localgemserver.test/versions")
+        expect(out).not_to include("HTTP 401 Unauthorized http://user@localgemserver.test/api/v1/dependencies")
+      end
     end
 
     describe "with no password" do

--- a/bundler/spec/support/artifice/compact_index_strict_basic_authentication.rb
+++ b/bundler/spec/support/artifice/compact_index_strict_basic_authentication.rb
@@ -10,7 +10,7 @@ class CompactIndexStrictBasicAuthentication < CompactIndexAPI
 
     # Only accepts password == "password"
     unless env["HTTP_AUTHORIZATION"] == "Basic dXNlcjpwYXNz"
-      halt 403, "Authentication failed"
+      halt 401, "Authentication failed"
     end
   end
 end

--- a/bundler/spec/support/artifice/endpoint_strict_basic_authentication.rb
+++ b/bundler/spec/support/artifice/endpoint_strict_basic_authentication.rb
@@ -10,7 +10,7 @@ class EndpointStrictBasicAuthentication < Endpoint
 
     # Only accepts password == "password"
     unless env["HTTP_AUTHORIZATION"] == "Basic dXNlcjpwYXNz"
-      halt 403, "Authentication failed"
+      halt 401, "Authentication failed"
     end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If the user has bad credentials setup, falling back is not going to fix the issue.

## What is your fix for the problem, implemented in this PR?

Shortcircuit the situation like we do for missing credentials.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
