### PR TITLE
Show better error when PAT can't authenticate to a private server

### DIFF
--- a/bundler/lib/bundler/fetcher/downloader.rb
+++ b/bundler/lib/bundler/fetcher/downloader.rb
@@ -41,6 +41,8 @@ module Bundler
         when Net::HTTPUnauthorized
           raise BadAuthenticationError, uri.host if uri.userinfo
           raise AuthenticationRequiredError, uri.host
+        when Net::HTTPForbidden
+          raise AuthenticationForbiddenError, uri.host
         when Net::HTTPNotFound
           raise FallbackError, "Net::HTTPNotFound: #{filtered_uri}"
         else

--- a/bundler/lib/bundler/fetcher/index.rb
+++ b/bundler/lib/bundler/fetcher/index.rb
@@ -15,8 +15,7 @@ module Bundler
           raise BadAuthenticationError, remote_uri if remote_uri.userinfo
           raise AuthenticationRequiredError, remote_uri
         when /403/
-          raise BadAuthenticationError, remote_uri if remote_uri.userinfo
-          raise AuthenticationRequiredError, remote_uri
+          raise AuthenticationForbiddenError, remote_uri
         else
           raise HTTPError, "Could not fetch specs from #{display_uri} due to underlying error <#{e.message}>"
         end

--- a/bundler/spec/bundler/fetcher/downloader_spec.rb
+++ b/bundler/spec/bundler/fetcher/downloader_spec.rb
@@ -98,6 +98,16 @@ RSpec.describe Bundler::Fetcher::Downloader do
       end
     end
 
+    context "when the request response is a Net::HTTPForbidden" do
+      let(:http_response) { Net::HTTPForbidden.new("1.1", 403, "Forbidden") }
+      let(:uri) { Bundler::URI("http://user:password@www.uri-to-fetch.com") }
+
+      it "should raise a Bundler::Fetcher::AuthenticationForbiddenError with the uri host" do
+        expect { subject.fetch(uri, options, counter) }.to raise_error(Bundler::Fetcher::AuthenticationForbiddenError,
+          /Access token could not be authenticated for www.uri-to-fetch.com/)
+      end
+    end
+
     context "when the request response is a Net::HTTPNotFound" do
       let(:http_response) { Net::HTTPNotFound.new("1.1", 404, "Not Found") }
 

--- a/bundler/spec/bundler/fetcher/index_spec.rb
+++ b/bundler/spec/bundler/fetcher/index_spec.rb
@@ -63,26 +63,9 @@ RSpec.describe Bundler::Fetcher::Index do
     context "when a 403 response occurs" do
       let(:error_message) { "403" }
 
-      before do
-        allow(remote_uri).to receive(:userinfo).and_return(userinfo)
-      end
-
-      context "and there was userinfo" do
-        let(:userinfo) { double(:userinfo) }
-
-        it "should raise a Bundler::Fetcher::BadAuthenticationError" do
-          expect { subject.specs(gem_names) }.to raise_error(Bundler::Fetcher::BadAuthenticationError,
-            %r{Bad username or password for http://remote-uri.org})
-        end
-      end
-
-      context "and there was no userinfo" do
-        let(:userinfo) { nil }
-
-        it "should raise a Bundler::Fetcher::AuthenticationRequiredError" do
-          expect { subject.specs(gem_names) }.to raise_error(Bundler::Fetcher::AuthenticationRequiredError,
-            %r{Authentication is required for http://remote-uri.org})
-        end
+      it "should raise a Bundler::Fetcher::AuthenticationForbiddenError" do
+        expect { subject.specs(gem_names) }.to raise_error(Bundler::Fetcher::AuthenticationForbiddenError,
+          %r{Access token could not be authenticated for http://remote-uri.org})
       end
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler does not help a lot newbie users trying to configure a private gem server.

## What is your fix for the problem, implemented in this PR?

Hopefully give better error messages.

Before:

```
Fetching gem metadata from https://rubygems.org/........
Fetching source index from https://rubygems.pkg.github.com/my-org/

Bad username or password for https://x-access-token@rubygems.pkg.github.com/my-org/.
Please double-check your credentials and correct them.
```

After:

```
Fetching gem metadata from https://rubygems.org/........
Fetching source index from https://rubygems.pkg.github.com/my-org/

Access token could not be authenticated for https://x-access-token@rubygems.pkg.github.com/my-org/.
Make sure it's valid and has the necessary scopes configured.
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
