### PR TITLE
Add `file` option to `ruby` method in Gemfile

### DIFF
--- a/bundler/lib/bundler/man/gemfile.5
+++ b/bundler/lib/bundler/man/gemfile.5
@@ -85,6 +85,19 @@ ruby "3\.1\.2"
 .
 .IP "" 0
 .
+.P
+If you wish to derive your Ruby version from a version file (ie \.ruby\-version), you can use the \fBfile\fR option instead\.
+.
+.IP "" 4
+.
+.nf
+
+ruby file: "\.ruby\-version"
+.
+.fi
+.
+.IP "" 0
+.
 .SS "ENGINE"
 Each application \fImay\fR specify a Ruby engine\. If an engine is specified, an engine version \fImust\fR also be specified\.
 .

--- a/bundler/lib/bundler/man/gemfile.5.ronn
+++ b/bundler/lib/bundler/man/gemfile.5.ronn
@@ -69,6 +69,11 @@ should be the Ruby version that the engine is compatible with.
 
     ruby "3.1.2"
 
+If you wish to derive your Ruby version from a version file (ie .ruby-version),
+you can use the `file` option instead.
+
+    ruby file: ".ruby-version"
+
 ### ENGINE
 
 Each application _may_ specify a Ruby engine. If an engine is specified, an

--- a/bundler/lib/bundler/ruby_dsl.rb
+++ b/bundler/lib/bundler/ruby_dsl.rb
@@ -5,8 +5,14 @@ module Bundler
     def ruby(*ruby_version)
       options = ruby_version.last.is_a?(Hash) ? ruby_version.pop : {}
       ruby_version.flatten!
+
       raise GemfileError, "Please define :engine_version" if options[:engine] && options[:engine_version].nil?
       raise GemfileError, "Please define :engine" if options[:engine_version] && options[:engine].nil?
+
+      if options[:file]
+        raise GemfileError, "Cannot specify version when using the file option" if ruby_version.any?
+        ruby_version << Bundler.read_file(options[:file]).strip
+      end
 
       if options[:engine] == "ruby" && options[:engine_version] &&
          ruby_version != Array(options[:engine_version])

--- a/bundler/spec/bundler/ruby_dsl_spec.rb
+++ b/bundler/spec/bundler/ruby_dsl_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Bundler::RubyDsl do
 
   let(:dsl) { MockDSL.new }
   let(:ruby_version) { "2.0.0" }
+  let(:ruby_version_arg) { ruby_version }
   let(:version) { "2.0.0" }
   let(:engine) { "jruby" }
   let(:engine_version) { "9000" }
@@ -23,7 +24,10 @@ RSpec.describe Bundler::RubyDsl do
 
   let(:invoke) do
     proc do
-      args = Array(ruby_version) + [options]
+      args = []
+      args << Array(ruby_version_arg) if ruby_version_arg
+      args << options
+
       dsl.ruby(*args)
     end
   end
@@ -89,6 +93,27 @@ RSpec.describe Bundler::RubyDsl do
         let(:ruby_version) { ["~> 2.0.0", "> 2.0.1"] }
         let(:engine_version) { ruby_version }
         it_behaves_like "it stores the ruby version"
+      end
+    end
+
+    context "with a file option" do
+      let(:options) { { :file => "foo" } }
+      let(:version) { "3.2.2" }
+      let(:ruby_version) { "3.2.2" }
+      let(:ruby_version_arg) { nil }
+      let(:engine_version) { version }
+      let(:patchlevel) { nil }
+      let(:engine) { "ruby" }
+      before { allow(Bundler).to receive(:read_file).with("foo").and_return("#{version}\n") }
+
+      it_behaves_like "it stores the ruby version"
+
+      context "and a version" do
+        let(:ruby_version_arg) { "2.0.0" }
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Bundler::GemfileError, "Cannot specify version when using the file option")
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/rubygems/rubygems/issues/6742. Please read the original issue for full context.

You can now do this in your Gemfile:
```
ruby file: '.ruby-version'
```