### PR TITLE
Improve memory usage in Bundler::Settings, and thus improve boot time

### DIFF
--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -340,7 +340,8 @@ module Bundler
     end
 
     def is_bool(name)
-      BOOL_KEYS.include?(name.to_s) || BOOL_KEYS.include?(parent_setting_for(name.to_s))
+      name = name.to_s
+      BOOL_KEYS.include?(name) || BOOL_KEYS.include?(parent_setting_for(name))
     end
 
     def is_string(name)

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -90,8 +90,10 @@ module Bundler
     def initialize(root = nil)
       @root            = root
       @local_config    = load_config(local_config_file)
+
       @env_config      = ENV.to_h
-      @env_config.select! {|key, _value| key.start_with?("BUNDLE_") }
+      @env_config.select! {|key, _value| key.start_with?("BUNDLE_")}
+      @env_config.delete("BUNDLE_")
 
       @global_config   = load_config(global_config_file)
       @temporary       = {}

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -412,6 +412,8 @@ module Bundler
     end
 
     def converted_value(value, key)
+      key = key.to_s
+
       if is_array(key)
         to_array(value)
       elsif value.nil?

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -354,11 +354,7 @@ module Bundler
     def to_bool(value)
       case value
       when String
-        if value.match?(/\A(false|f|no|n|0|)\z/i)
-          false
-        else
-          true
-        end
+        value.match?(/\A(false|f|no|n|0|)\z/i) ? false : true
       when nil, false
         false
       else

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -161,7 +161,7 @@ module Bundler
     def local_overrides
       repos = {}
       all.each do |k|
-        repos[$'] = self[k] if k.start_with?("local.")
+        repos[k.delete_prefix("local.")] = self[k] if k.start_with?("local.")
       end
       repos
     end

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -351,7 +351,13 @@ module Bundler
 
     def to_bool(value)
       case value
-      when nil, /\A(false|f|no|n|0|)\z/i, false
+      when String
+        if value.match?(/\A(false|f|no|n|0|)\z/i)
+          false
+        else
+          true
+        end
+      when nil, false
         false
       else
         true

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -148,9 +148,14 @@ module Bundler
     def all
       keys = @temporary.keys.union(@global_config.keys, @local_config.keys, @env_config.keys)
 
-      keys.map do |key|
-        key.sub(/^BUNDLE_/, "").gsub(/___/, "-").gsub(/__/, ".").downcase
-      end.sort
+      keys.map! do |key|
+        key = key.delete_prefix("BUNDLE_")
+        key.gsub!("___", "-")
+        key.gsub!("__", ".")
+        key.downcase!
+        key
+      end.sort!
+      keys
     end
 
     def local_overrides

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -99,7 +99,11 @@ module Bundler
 
     def [](name)
       key = key_for(name)
-      value = configs.values.map {|config| config[key] }.compact.first
+
+      values = configs.values
+      values.map! {|config| config[key] }
+      values.compact!
+      value = values.first
 
       converted_value(value, name)
     end

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -512,8 +512,11 @@ module Bundler
 
     def self.key_for(key)
       key = normalize_uri(key).to_s if key.is_a?(String) && key.start_with?("http", "mirror.http")
-      key = key.to_s.gsub(".", "__").gsub("-", "___").upcase
-      "BUNDLE_#{key}"
+      key = key.to_s.gsub(".", "__")
+      key.gsub!("-", "___")
+      key.upcase!
+
+      key.prepend("BUNDLE_")
     end
 
     # TODO: duplicates Rubygems#normalize_uri

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -92,7 +92,7 @@ module Bundler
       @local_config    = load_config(local_config_file)
 
       @env_config      = ENV.to_h
-      @env_config.select! {|key, _value| key.start_with?("BUNDLE_")}
+      @env_config.select! {|key, _value| key.start_with?("BUNDLE_") }
       @env_config.delete("BUNDLE_")
 
       @global_config   = load_config(global_config_file)

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -345,7 +345,8 @@ module Bundler
     end
 
     def is_string(name)
-      STRING_KEYS.include?(name.to_s) || name.to_s.start_with?("local.") || name.to_s.start_with?("mirror.") || name.to_s.start_with?("build.")
+      name = name.to_s
+      STRING_KEYS.include?(name) || name.start_with?("local.") || name.start_with?("mirror.") || name.start_with?("build.")
     end
 
     def to_bool(value)

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -161,7 +161,7 @@ module Bundler
     def local_overrides
       repos = {}
       all.each do |k|
-        repos[$'] = self[k] if k =~ /^local\./
+        repos[$'] = self[k] if k.start_with?("local.")
       end
       repos
     end

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -90,7 +90,9 @@ module Bundler
     def initialize(root = nil)
       @root            = root
       @local_config    = load_config(local_config_file)
-      @env_config      = ENV.to_h.select {|key, _value| key =~ /\ABUNDLE_.+/ }
+      @env_config      = ENV.to_h
+      @env_config.select! {|key, _value| key.start_with?("BUNDLE_") }
+
       @global_config   = load_config(global_config_file)
       @temporary       = {}
     end

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -146,7 +146,7 @@ module Bundler
     end
 
     def all
-      keys = @temporary.keys | @global_config.keys | @local_config.keys | @env_config.keys
+      keys = @temporary.keys.union(@global_config.keys, @local_config.keys, @env_config.keys)
 
       keys.map do |key|
         key.sub(/^BUNDLE_/, "").gsub(/___/, "-").gsub(/__/, ".").downcase


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

I was running [memory_profiler](https://github.com/SamSaffron/memory_profiler) on our Rails app boot-time, and saw some opportunities.

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

I used this code to scope memory allocations in our rails app to just bundler:

```ruby
require 'memory_profiler'

MemoryProfiler.report(allow_files: 'bundler/settings.rb') do
  require_relative 'config/environment'
end.pretty_print
```

And then compared it with these changes by adding adding calling it with `ruby -Ipath/to/checkout/rubygems/bundler/lib`.

### Memory

Before:

```
Total allocated: 4883872 bytes (65211 objects)
Total retained:  22644 bytes (226 objects)


allocated memory by file
-----------------------------------
   4883872  /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.18/lib/bundler/settings.rb

allocated objects by file
-----------------------------------
     28606  /Users/josh.nichols/workspace/rubygems/bundler/lib/bundler/settings.rb

retained memory by file
-----------------------------------
     21333  /Users/josh.nichols/workspace/rubygems/bundler/lib/bundler/settings.rb

retained objects by file
-----------------------------------
       226  /Users/josh.nichols/workspace/rubygems/bundler/lib/bundler/settings.rb
```

After:

```
Total allocated: 2326771 bytes (28606 objects)
Total retained:  20207 bytes (221 objects)

allocated memory by file
-----------------------------------
   2326771  /Users/josh.nichols/workspace/rubygems/bundler/lib/bundler/settings.rb

allocated objects by file
-----------------------------------
     28606  /Users/josh.nichols/workspace/rubygems/bundler/lib/bundler/settings.rb


retained memory by file
-----------------------------------
     20207  /Users/josh.nichols/workspace/rubygems/bundler/lib/bundler/settings.rb

retained objects by file
-----------------------------------
       221  /Users/josh.nichols/workspace/rubygems/bundler/lib/bundler/settings.rb
```

### Runtime

For runtime, I with the same file above, but without the memory_profiling:

```ruby
require_relative 'config/environment'
```

I used [hyperfine](https://github.com/sharkdp/hyperfine) to compare before/after: `hyperfine "ruby boot-time-benchmark.rb" "ruby -I/Users/josh.nichols/workspace/rubygems/bundler/lib boot-time-benchmark.rb"`:


![CleanShot 2023-08-16 at 15 25 27](https://github.com/rubygems/rubygems/assets/159/75665059-c75a-4416-aa2b-0366a44705c7)

### Summary

This reduces the amount of memory allocated during Rails startup in our app by 52%, from 4_883_872 bytes to 2_326_771 bytes.

It also reduces startup time by 6%, from 8.807s to 8.256s.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
