### PR TITLE
Small follow up to automatic generation of license update PRs

### DIFF
--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -36,7 +36,7 @@ jobs:
           rake update_licenses_branch
           git diff --no-ext-diff --ignore-submodules --quiet "${BASE##*/}" -- || {
             git push origin
-            gh pr create --base "${BASE##*/}" --fill
+            gh pr create --base "${BASE##*/}" --fill --label "rubygems:enhancement"
           }
         env:
           BASE: ${{ github.ref }}

--- a/Rakefile
+++ b/Rakefile
@@ -562,7 +562,7 @@ task :update_licenses_branch => :update_licenses do
     date = mtime.strftime("%Y-%m-%d")
     branch_name = "license-list-#{date}"
     system(*%w[git checkout -b], branch_name, exception: true)
-    system(*%w[git commit -m], "[License] Update SPDX license list #{date}", *file, exception: true)
+    system(*%w[git commit -m], "Update SPDX license list as of #{date}", *file, exception: true)
   end
 end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Not really a problem. Just wanted to tweak #6868 so that it generates more ready to ship PRs.
 
## What is your fix for the problem, implemented in this PR?

Auto-label PRs and small tweak in commit message.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
