### PR TITLE
Changelogs for RubyGems 3.4.19 and Bundler 2.4.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 3.4.19 / 2023-08-17
+
+## Enhancements:
+
+* Installs bundler 2.4.19 as a default gem.
+
+## Performance:
+
+* Speedup building docs when updating rubygems. Pull request
+  [#6864](https://github.com/rubygems/rubygems/pull/6864) by
+  deivid-rodriguez
+
 # 3.4.18 / 2023-08-02
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 2.4.19 (August 17, 2023)
+
+## Enhancements:
+
+  - Add `file` option to `ruby` method in Gemfile [#6876](https://github.com/rubygems/rubygems/pull/6876)
+  - Show better error when PAT can't authenticate to a private server [#6871](https://github.com/rubygems/rubygems/pull/6871)
+  - Don't fallback to old dependency API when bad credentials are configured [#6869](https://github.com/rubygems/rubygems/pull/6869)
+
+## Bug fixes:
+
+  - Fix git source conservativeness [#6850](https://github.com/rubygems/rubygems/pull/6850)
+
+## Documentation:
+
+  - Clarify that `bundle info` takes a gem name [#6875](https://github.com/rubygems/rubygems/pull/6875)
+
 # 2.4.18 (August 2, 2023)
 
 ## Security:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.4.19 and Bundler 2.4.19 into master.