### PR TITLE
Resolve ruby version file relative to bundle root

### DIFF
--- a/bundler/lib/bundler/ruby_dsl.rb
+++ b/bundler/lib/bundler/ruby_dsl.rb
@@ -11,7 +11,7 @@ module Bundler
 
       if options[:file]
         raise GemfileError, "Cannot specify version when using the file option" if ruby_version.any?
-        ruby_version << Bundler.read_file(options[:file]).strip
+        ruby_version << Bundler.read_file(Bundler.root.join(options[:file])).strip
       end
 
       if options[:engine] == "ruby" && options[:engine_version] &&

--- a/bundler/spec/bundler/ruby_dsl_spec.rb
+++ b/bundler/spec/bundler/ruby_dsl_spec.rb
@@ -104,7 +104,12 @@ RSpec.describe Bundler::RubyDsl do
       let(:engine_version) { version }
       let(:patchlevel) { nil }
       let(:engine) { "ruby" }
-      before { allow(Bundler).to receive(:read_file).with("foo").and_return("#{version}\n") }
+      let(:project_root) { Pathname.new("/path/to/project") }
+
+      before do
+        allow(Bundler).to receive(:read_file).with(project_root.join("foo")).and_return("#{version}\n")
+        allow(Bundler).to receive(:root).and_return(Pathname.new("/path/to/project"))
+      end
 
       it_behaves_like "it stores the ruby version"
 


### PR DESCRIPTION
This is a follow up to https://github.com/rubygems/rubygems/issues/6876. This change makes it so that the version file is resolved relative to the Bundle root instead of the working directory.

Why is this useful?

If you run a commnad (eg `rails`) from the `app/` directory, your bundle would fail to load.

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Running `rails` from a subdirectory in your project would fail because the version file would be resolved in the working directory...and therefore be not found.

## What is your fix for the problem, implemented in this PR?

Resolve from `Bundle.root`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
