### PR TITLE
Replace Marshal.load with a fully-checked safe gemspec loader

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -507,6 +507,7 @@ lib/rubygems/s3_uri_signer.rb
 lib/rubygems/safe_marshal.rb
 lib/rubygems/safe_marshal/elements.rb
 lib/rubygems/safe_marshal/reader.rb
+lib/rubygems/safe_marshal/visitors/stream_printer.rb
 lib/rubygems/safe_marshal/visitors/to_ruby.rb
 lib/rubygems/safe_marshal/visitors/visitor.rb
 lib/rubygems/safe_yaml.rb

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -504,6 +504,11 @@ lib/rubygems/resolver/stats.rb
 lib/rubygems/resolver/vendor_set.rb
 lib/rubygems/resolver/vendor_specification.rb
 lib/rubygems/s3_uri_signer.rb
+lib/rubygems/safe_marshal.rb
+lib/rubygems/safe_marshal/elements.rb
+lib/rubygems/safe_marshal/reader.rb
+lib/rubygems/safe_marshal/visitors/to_ruby.rb
+lib/rubygems/safe_marshal/visitors/visitor.rb
 lib/rubygems/safe_yaml.rb
 lib/rubygems/security.rb
 lib/rubygems/security/policies.rb

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -517,7 +517,11 @@ EOF
     def safe_load_marshal(data)
       if Gem.respond_to?(:load_safe_marshal)
         Gem.load_safe_marshal
-        Gem::SafeMarshal.safe_load(data)
+        begin
+          Gem::SafeMarshal.safe_load(data)
+        rescue Gem::SafeMarshal::Reader::Error, Gem::SafeMarshal::Visitors::ToRuby::Error => e
+          raise MarshalError, "#{e.class}: #{e.message}"
+        end
       else
         load_marshal(data, :marshal_proc => SafeMarshal.proc)
       end

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -515,7 +515,12 @@ EOF
     end
 
     def safe_load_marshal(data)
-      load_marshal(data, :marshal_proc => SafeMarshal.proc)
+      if Gem.respond_to?(:load_safe_marshal)
+        Gem.load_safe_marshal
+        Gem::SafeMarshal.safe_load(data)
+      else
+        load_marshal(data, :marshal_proc => SafeMarshal.proc)
+      end
     end
 
     def load_gemspec(file, validate = false)

--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -110,7 +110,7 @@ module Bundler
       spec_file_name = "#{spec.join "-"}.gemspec"
 
       uri = Bundler::URI.parse("#{remote_uri}#{Gem::MARSHAL_SPEC_DIR}#{spec_file_name}.rz")
-      if uri.scheme == "file"
+      spec = if uri.scheme == "file"
         path = Bundler.rubygems.correct_for_windows_path(uri.path)
         Bundler.safe_load_marshal Bundler.rubygems.inflate(Gem.read_binary(path))
       elsif cached_spec_path = gemspec_cached_path(spec_file_name)
@@ -118,6 +118,8 @@ module Bundler
       else
         Bundler.safe_load_marshal Bundler.rubygems.inflate(downloader.fetch(uri).body)
       end
+      raise MarshalError, "is #{spec.inspect}" unless spec.is_a?(Gem::Specification)
+      spec
     rescue MarshalError
       raise HTTPError, "Gemspec #{spec} contained invalid data.\n" \
         "Your network or your gem server is probably having issues right now."

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -483,7 +483,9 @@ module Bundler
       fetcher = gem_remote_fetcher
       fetcher.headers = { "X-Gemfile-Source" => remote.original_uri.to_s } if remote.original_uri
       string = fetcher.fetch_path(path)
-      Bundler.safe_load_marshal(string)
+      specs = Bundler.safe_load_marshal(string)
+      raise MarshalError, "Specs #{name} from #{remote} is expected to be an Array but was unexpected class #{specs.class}" unless specs.is_a?(Array)
+      specs
     rescue Gem::RemoteFetcher::FetchError
       # it's okay for prerelease to fail
       raise unless name == "prerelease_specs"

--- a/bundler/spec/bundler/bundler_spec.rb
+++ b/bundler/spec/bundler/bundler_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Bundler do
     end
 
     it "loads simple structure" do
-      simple_structure = { "name" => [:abc] }
+      simple_structure = { "name" => [:development] }
       data = Marshal.dump(simple_structure)
       expect(Bundler.safe_load_marshal(data)).to eq(simple_structure)
     end

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe "bundle install with install-time dependencies" do
     path = "#{gem_repo2}/#{Gem::MARSHAL_SPEC_DIR}/actionpack-2.3.2.gemspec.rz"
     spec = Marshal.load(Bundler.rubygems.inflate(File.binread(path)))
     spec.dependencies.each do |d|
-      d.instance_variable_set(:@type, :fail)
+      d.instance_variable_set(:@type, "fail")
     end
     File.open(path, "wb") do |f|
       f.write Gem.deflate(Marshal.dump(spec))

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -604,6 +604,16 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     @yaml_loaded = true
   end
 
+  @safe_marshal_loaded = false
+
+  def self.load_safe_marshal
+    return if @safe_marshal_loaded
+
+    require_relative "rubygems/safe_marshal"
+
+    @safe_marshal_loaded = true
+  end
+
   ##
   # The file name and line number of the caller of the caller of this method.
   #

--- a/lib/rubygems/indexer.rb
+++ b/lib/rubygems/indexer.rb
@@ -411,7 +411,8 @@ class Gem::Indexer
   # +dest+.  For a latest index, does not ensure the new file is minimal.
 
   def update_specs_index(index, source, dest)
-    specs_index = Marshal.load Gem.read_binary(source)
+    Gem.load_safe_marshal
+    specs_index = Gem::SafeMarshal.safe_load Gem.read_binary(source)
 
     index.each do |spec|
       platform = spec.original_platform

--- a/lib/rubygems/safe_marshal.rb
+++ b/lib/rubygems/safe_marshal.rb
@@ -38,6 +38,7 @@ module Gem
 
       @_zone
       @cpu
+      @debug_created_info
       @force_ruby_platform
       @marshal_with_utc_coercion
       @name

--- a/lib/rubygems/safe_marshal.rb
+++ b/lib/rubygems/safe_marshal.rb
@@ -42,7 +42,7 @@ module Gem
     private_constant :PERMITTED_SYMBOLS
 
     PERMITTED_IVARS = {
-      "String" => %w[E @taguri @debug_created_info],
+      "String" => %w[E encoding @taguri @debug_created_info],
       "Time" => %w[
         offset zone nano_num nano_den submicro
         @_zone @marshal_with_utc_coercion

--- a/lib/rubygems/safe_marshal.rb
+++ b/lib/rubygems/safe_marshal.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require_relative "safe_marshal/reader"
+require_relative "safe_marshal/visitors/to_ruby"
+
+module Gem
+  ###
+  # This module is used for safely loading Marshal specs from a gem.  The
+  # `safe_load` method defined on this module is specifically designed for
+  # loading Gem specifications.
+
+  module SafeMarshal
+    PERMITTED_CLASSES = %w[
+      Time
+      Date
+
+      Gem::Dependency
+      Gem::NameTuple
+      Gem::Platform
+      Gem::Requirement
+      Gem::Specification
+      Gem::Version
+      Gem::Version::Requirement
+
+      YAML::Syck::DefaultKey
+      YAML::PrivateType
+    ].freeze
+    private_constant :PERMITTED_CLASSES
+
+    PERMITTED_SYMBOLS = %w[
+      E
+
+      offset
+      zone
+      nano_num
+      nano_den
+      submicro
+
+      @_zone
+      @cpu
+      @force_ruby_platform
+      @marshal_with_utc_coercion
+      @name
+      @os
+      @platform
+      @prerelease
+      @requirement
+      @taguri
+      @type
+      @type_id
+      @value
+      @version
+      @version_requirement
+      @version_requirements
+
+      development
+      runtime
+    ].freeze
+    private_constant :PERMITTED_SYMBOLS
+
+    def self.safe_load(input)
+      load(input, permitted_classes: PERMITTED_CLASSES, permitted_symbols: PERMITTED_SYMBOLS)
+    end
+
+    def self.load(input, permitted_classes: [::Symbol], permitted_symbols: [])
+      root = Reader.new(StringIO.new(input, "r")).read!
+
+      Visitors::ToRuby.new(permitted_classes: permitted_classes, permitted_symbols: permitted_symbols).visit(root)
+    end
+  end
+end

--- a/lib/rubygems/safe_marshal.rb
+++ b/lib/rubygems/safe_marshal.rb
@@ -11,8 +11,9 @@ module Gem
 
   module SafeMarshal
     PERMITTED_CLASSES = %w[
-      Time
       Date
+      Time
+      Rational
 
       Gem::Dependency
       Gem::NameTuple
@@ -28,45 +29,39 @@ module Gem
     private_constant :PERMITTED_CLASSES
 
     PERMITTED_SYMBOLS = %w[
-      E
-
-      offset
-      zone
-      nano_num
-      nano_den
-      submicro
-
-      @_zone
-      @cpu
-      @debug_created_info
-      @force_ruby_platform
-      @marshal_with_utc_coercion
-      @name
-      @os
-      @platform
-      @prerelease
-      @requirement
-      @taguri
-      @type
-      @type_id
-      @value
-      @version
-      @version_requirement
-      @version_requirements
-
       development
       runtime
     ].freeze
     private_constant :PERMITTED_SYMBOLS
 
+    PERMITTED_IVARS = {
+      "String" => %w[E @taguri @debug_created_info],
+      "Time" => %w[
+        offset zone nano_num nano_den submicro
+        @_zone @marshal_with_utc_coercion
+      ],
+      "Gem::Dependency" => %w[
+        @name @requirement @prerelease @version_requirement @version_requirements @type
+        @force_ruby_platform
+      ],
+      "Gem::NameTuple" => %w[@name @version @platform],
+      "Gem::Platform" => %w[@os @cpu @version],
+      "Psych::PrivateType" => %w[@value @type_id],
+    }.freeze
+    private_constant :PERMITTED_IVARS
+
     def self.safe_load(input)
-      load(input, permitted_classes: PERMITTED_CLASSES, permitted_symbols: PERMITTED_SYMBOLS)
+      load(input, permitted_classes: PERMITTED_CLASSES, permitted_symbols: PERMITTED_SYMBOLS, permitted_ivars: PERMITTED_IVARS)
     end
 
-    def self.load(input, permitted_classes: [::Symbol], permitted_symbols: [])
+    def self.load(input, permitted_classes: [::Symbol], permitted_symbols: [], permitted_ivars: {})
       root = Reader.new(StringIO.new(input, "r")).read!
 
-      Visitors::ToRuby.new(permitted_classes: permitted_classes, permitted_symbols: permitted_symbols).visit(root)
+      Visitors::ToRuby.new(
+        permitted_classes: permitted_classes,
+        permitted_symbols: permitted_symbols,
+        permitted_ivars: permitted_ivars,
+      ).visit(root)
     end
   end
 end

--- a/lib/rubygems/safe_marshal.rb
+++ b/lib/rubygems/safe_marshal.rb
@@ -62,7 +62,7 @@ module Gem
     end
 
     def self.load(input, permitted_classes: [::Symbol], permitted_symbols: [], permitted_ivars: {})
-      root = Reader.new(StringIO.new(input, "r")).read!
+      root = Reader.new(StringIO.new(input, "r").binmode).read!
 
       Visitors::ToRuby.new(
         permitted_classes: permitted_classes,

--- a/lib/rubygems/safe_marshal.rb
+++ b/lib/rubygems/safe_marshal.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "stringio"
+
 require_relative "safe_marshal/reader"
 require_relative "safe_marshal/visitors/to_ruby"
 
@@ -31,6 +33,11 @@ module Gem
     PERMITTED_SYMBOLS = %w[
       development
       runtime
+
+      name
+      number
+      platform
+      dependencies
     ].freeze
     private_constant :PERMITTED_SYMBOLS
 

--- a/lib/rubygems/safe_marshal/elements.rb
+++ b/lib/rubygems/safe_marshal/elements.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+module Gem
+  module SafeMarshal
+    module Elements
+      class Element
+      end
+
+      class Symbol < Element
+        def initialize(name:)
+          @name = name
+        end
+        attr_reader :name
+      end
+
+      class UserDefined < Element
+        def initialize(name:, binary_string:)
+          @name = name
+          @binary_string = binary_string
+        end
+
+        attr_reader :name, :binary_string
+      end
+
+      class UserMarshal < Element
+        def initialize(name:, data:)
+          @name = name
+          @data = data
+        end
+
+        attr_reader :name, :data
+      end
+
+      class String < Element
+        def initialize(str:)
+          @str = str
+        end
+
+        attr_reader :str
+      end
+
+      class Hash < Element
+        def initialize(pairs:)
+          @pairs = pairs
+        end
+
+        attr_reader :pairs
+      end
+
+      class HashWithDefaultValue < Hash
+        def initialize(default:, **kwargs)
+          super(**kwargs)
+          @default = default
+        end
+
+        attr_reader :default
+      end
+
+      class Array < Element
+        def initialize(elements:)
+          @elements = elements
+        end
+
+        attr_reader :elements
+      end
+
+      class Integer < Element
+        def initialize(int:)
+          @int = int
+        end
+
+        attr_reader :int
+      end
+
+      class True < Element
+        def initialize
+        end
+        TRUE = new.freeze
+      end
+
+      class False < Element
+        def initialize
+        end
+
+        FALSE = new.freeze
+      end
+
+      class WithIvars < Element
+        def initialize(object:,ivars:)
+          @object = object
+          @ivars = ivars
+        end
+
+        attr_reader :object, :ivars
+      end
+
+      class Object < Element
+        def initialize(name:)
+          @name = name
+        end
+        attr_reader :name
+      end
+
+      class Nil < Element
+        NIL = new.freeze
+      end
+
+      class ObjectLink < Element
+        def initialize(offset:)
+          @offset = offset
+        end
+        attr_reader :offset
+      end
+
+      class SymbolLink < Element
+        def initialize(offset:)
+          @offset = offset
+        end
+        attr_reader :offset
+      end
+
+      class Float < Element
+        def initialize(string:)
+          @string = string
+        end
+        attr_reader :string
+      end
+
+      class Bignum < Element # rubocop:disable Lint/UnifiedInteger
+        def initialize(sign:, data:)
+          @sign = sign
+          @data = data
+        end
+        attr_reader :sign, :data
+      end
+    end
+  end
+end

--- a/lib/rubygems/safe_marshal/reader.rb
+++ b/lib/rubygems/safe_marshal/reader.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+require_relative "elements"
+
+module Gem
+  module SafeMarshal
+    class Reader
+      class UnconsumedBytesError < StandardError
+      end
+
+      def initialize(io)
+        @io = io
+      end
+
+      def read!
+        read_header
+        root = read_element
+        raise UnconsumedBytesError unless @io.eof?
+        root
+      end
+
+      private
+
+      MARSHAL_VERSION = [Marshal::MAJOR_VERSION, Marshal::MINOR_VERSION].map(&:chr).join.freeze
+      private_constant :MARSHAL_VERSION
+
+      def read_header
+        v = @io.read(2)
+        raise "Unsupported marshal version #{v.inspect}, expected #{MARSHAL_VERSION.inspect}" unless v == MARSHAL_VERSION
+      end
+
+      def read_byte
+        @io.getbyte
+      end
+
+      def read_integer
+        b = read_byte
+
+        case b
+        when 0x00
+          0
+        when 0x01
+          @io.read(1).unpack1("C")
+        when 0x02
+          @io.read(2).unpack1("S<")
+        when 0x03
+          (@io.read(3) + "\0").unpack1("L<")
+        when 0x04
+          @io.read(4).unpack1("L<")
+        when 0xFC
+          @io.read(4).unpack1("L<") | -0x100000000
+        when 0xFD
+          (@io.read(3) + "\0").unpack1("L<") | -0x1000000
+        when 0xFE
+          @io.read(2).unpack1("s<") | -0x10000
+        when 0xFF
+          read_byte | -0x100
+        else
+          signed = (b ^ 128) - 128
+          if b >= 128
+            signed + 5
+          else
+            signed - 5
+          end
+        end
+      end
+
+      def read_element
+        type = read_byte
+        case type
+        when 34 then read_string # ?"
+        when 48 then read_nil # ?0
+        when 58 then read_symbol # ?:
+        when 59 then read_symbol_link # ?;
+        when 64 then read_object_link # ?@
+        when 70 then read_false # ?F
+        when 73 then read_object_with_ivars # ?I
+        when 84 then read_true # ?T
+        when 85 then read_user_marshal # ?U
+        when 91 then read_array # ?[
+        when 102 then read_float # ?f
+        when 105 then Elements::Integer.new int: read_integer # ?i
+        when 108 then read_bignum
+        when 111 then read_object # ?o
+        when 117 then read_user_defined # ?u
+        when 123 then read_hash # ?{
+        when 125 then read_hash_with_default_value # ?}
+        when "e".ord then read_extended_object
+        when "c".ord then read_class
+        when "m".ord then read_module
+        when "M".ord then read_class_or_module
+        when "d".ord then read_data
+        when "/".ord then read_regexp
+        when "S".ord then read_struct
+        when "C".ord then read_user_class
+        else
+          raise "Unsupported marshal type discriminator #{type.chr.inspect} (#{type})"
+        end
+      end
+
+      def read_symbol
+        Elements::Symbol.new name: @io.read(read_integer)
+      end
+
+      def read_string
+        Elements::String.new(str: @io.read(read_integer))
+      end
+
+      def read_true
+        Elements::True::TRUE
+      end
+
+      def read_false
+        Elements::False::FALSE
+      end
+
+      def read_user_defined
+        Elements::UserDefined.new(name: read_element, binary_string: @io.read(read_integer))
+      end
+
+      def read_array
+        Elements::Array.new(elements: Array.new(read_integer) do |_i|
+                                        read_element
+                                      end)
+      end
+
+      def read_object_with_ivars
+        Elements::WithIvars.new(object: read_element, ivars:
+          Array.new(read_integer) do
+            [read_element, read_element]
+          end)
+      end
+
+      def read_symbol_link
+        Elements::SymbolLink.new offset: read_integer
+      end
+
+      def read_user_marshal
+        Elements::UserMarshal.new(name: read_element, data: read_element)
+      end
+
+      def read_object_link
+        Elements::ObjectLink.new(offset: read_integer)
+      end
+
+      def read_hash
+        pairs = Array.new(read_integer) do
+          [read_element, read_element]
+        end
+        Elements::Hash.new(pairs: pairs)
+      end
+
+      def read_hash_with_default_value
+        pairs = Array.new(read_integer) do
+          [read_element, read_element]
+        end
+        Elements::HashWithDefaultValue.new(pairs: pairs, default: read_element)
+      end
+
+      def read_object
+        Elements::WithIvars.new(
+          object: Elements::Object.new(name: read_element),
+          ivars: Array.new(read_integer) do
+            [read_element, read_element]
+          end
+        )
+      end
+
+      def read_nil
+        Elements::Nil::NIL
+      end
+
+      def read_float
+        Elements::Float.new string: @io.read(read_integer)
+      end
+
+      def read_bignum
+        Elements::Bignum.new(sign: read_byte, data: @io.read(read_integer * 2))
+      end
+    end
+  end
+end

--- a/lib/rubygems/safe_marshal/visitors/stream_printer.rb
+++ b/lib/rubygems/safe_marshal/visitors/stream_printer.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative "visitor"
+
+module Gem::SafeMarshal
+  module Visitors
+    class StreamPrinter < Visitor
+      def initialize(io, indent: "")
+        @io = io
+        @indent = indent
+        @level = 0
+      end
+
+      def visit(target)
+        @io.write("#{@indent * @level}#{target.class}")
+        target.instance_variables.each do |ivar|
+          value = target.instance_variable_get(ivar)
+          next if Elements::Element === value || Array === value
+          @io.write(" #{ivar}=#{value.inspect}")
+        end
+        @io.write("\n")
+        begin
+          @level += 1
+          super
+        ensure
+          @level -= 1
+        end
+      end
+    end
+  end
+end

--- a/lib/rubygems/safe_marshal/visitors/to_ruby.rb
+++ b/lib/rubygems/safe_marshal/visitors/to_ruby.rb
@@ -305,7 +305,10 @@ module Gem::SafeMarshal
         raise MethodCallError, "Unable to call #{method.inspect} on #{receiver.inspect}, perhaps it is a class using marshal compat, which is not visible in ruby? #{e}"
       end
 
-      class UnpermittedSymbolError < StandardError
+      class Error < StandardError
+      end
+
+      class UnpermittedSymbolError < Error
         def initialize(symbol:, stack:)
           @symbol = symbol
           @stack = stack
@@ -313,7 +316,7 @@ module Gem::SafeMarshal
         end
       end
 
-      class UnpermittedIvarError < StandardError
+      class UnpermittedIvarError < Error
         def initialize(symbol:, klass:, stack:)
           @symbol = symbol
           @klass = klass
@@ -322,7 +325,7 @@ module Gem::SafeMarshal
         end
       end
 
-      class UnpermittedClassError < StandardError
+      class UnpermittedClassError < Error
         def initialize(name:, stack:)
           @name = name
           @stack = stack
@@ -330,10 +333,10 @@ module Gem::SafeMarshal
         end
       end
 
-      class FormatError < StandardError
+      class FormatError < Error
       end
 
-      class MethodCallError < StandardError
+      class MethodCallError < Error
       end
     end
   end

--- a/lib/rubygems/safe_marshal/visitors/to_ruby.rb
+++ b/lib/rubygems/safe_marshal/visitors/to_ruby.rb
@@ -76,7 +76,7 @@ module Gem::SafeMarshal
               end
               true
             end
-            object = object.localtime offset if offset
+
             if (nano_den || nano_num) && !(nano_den && nano_num)
               raise FormatError, "Must have all of nano_den, nano_num for Time #{e.pretty_inspect}"
             elsif nano_den && nano_num
@@ -86,10 +86,15 @@ module Gem::SafeMarshal
 
               object = Time.at(object.to_r, nano, :nanosecond)
             end
+
             if zone
               require "time"
+              zone = "+0000" if zone == "UTC" && offset == 0
               Time.send(:force_zone!, object, zone, offset)
+            elsif offset
+              object = object.localtime offset
             end
+
             @objects[object_offset] = object
           end
         when Elements::String

--- a/lib/rubygems/safe_marshal/visitors/to_ruby.rb
+++ b/lib/rubygems/safe_marshal/visitors/to_ruby.rb
@@ -1,0 +1,266 @@
+# frozen_string_literal: true
+
+require_relative "visitor"
+
+module Gem::SafeMarshal
+  module Visitors
+    class ToRuby < Visitor
+      def initialize(permitted_classes:, permitted_symbols:)
+        @permitted_classes = permitted_classes
+        @permitted_symbols = permitted_symbols | permitted_classes | ["E"]
+
+        @objects = []
+        @symbols = []
+        @class_cache = {}
+
+        @stack = ["root"]
+      end
+
+      def inspect # :nodoc:
+        format("#<%s permitted_classes: %p permitted_symbols: %p>", self.class, @permitted_classes, @permitted_symbols)
+      end
+
+      def visit(target)
+        depth = @stack.size
+        super
+      ensure
+        @stack.slice!(depth.pred..)
+      end
+
+      private
+
+      def visit_Gem_SafeMarshal_Elements_Array(a)
+        register_object([]).replace(a.elements.each_with_index.map do |e, i|
+          @stack << "[#{i}]"
+          visit(e)
+        end)
+      end
+
+      def visit_Gem_SafeMarshal_Elements_Symbol(s)
+        resolve_symbol(s.name)
+      end
+
+      def map_ivars(ivars)
+        ivars.map.with_index do |(k, v), i|
+          @stack << "ivar #{i}"
+          k = visit(k)
+          @stack << k
+          next k, visit(v)
+        end
+      end
+
+      def visit_Gem_SafeMarshal_Elements_WithIvars(e)
+        idx = 0
+        object_offset = @objects.size
+        @stack << "object"
+        object = visit(e.object)
+        ivars = map_ivars(e.ivars)
+
+        case e.object
+        when Elements::UserDefined
+          if object.class == ::Time
+            offset = zone = nano_num = nano_den = nil
+            ivars.reject! do |k, v|
+              case k
+              when :offset
+                offset = v
+              when :zone
+                zone = v
+              when :nano_num
+                nano_num = v
+              when :nano_den
+                nano_den = v
+              when :submicro
+              else
+                next false
+              end
+              true
+            end
+            object = object.localtime offset if offset
+            if (nano_den || nano_num) && !(nano_den && nano_num)
+              raise FormatError, "Must have all of nano_den, nano_num for Time #{e.pretty_inspect}"
+            elsif nano_den && nano_num
+              nano = Rational(nano_num, nano_den)
+              nsec, subnano = nano.divmod(1)
+              nano  = nsec + subnano
+
+              object = Time.at(object.to_r, nano, :nanosecond)
+            end
+            if zone
+              require "time"
+              Time.send(:force_zone!, object, zone, offset)
+            end
+            @objects[object_offset] = object
+          end
+        when Elements::String
+          enc = nil
+
+          ivars.each do |k, v|
+            case k
+            when :E
+              case v
+              when TrueClass
+                enc = "UTF-8"
+              when FalseClass
+                enc = "US-ASCII"
+              end
+            else
+              break
+            end
+            idx += 1
+          end
+
+          object.replace ::String.new(object, encoding: enc)
+        end
+
+        ivars[idx..].each do |k, v|
+          object.instance_variable_set k, v
+        end
+        object
+      end
+
+      def visit_Gem_SafeMarshal_Elements_Hash(o)
+        hash = register_object({})
+
+        o.pairs.each_with_index do |(k, v), i|
+          @stack << i
+          k = visit(k)
+          @stack << k
+          hash[k] = visit(v)
+        end
+
+        hash
+      end
+
+      def visit_Gem_SafeMarshal_Elements_HashWithDefaultValue(o)
+        hash = visit_Gem_SafeMarshal_Elements_Hash(o)
+        @stack << :default
+        hash.default = visit(o.default)
+        hash
+      end
+
+      def visit_Gem_SafeMarshal_Elements_Object(o)
+        register_object(resolve_class(o.name).allocate)
+      end
+
+      def visit_Gem_SafeMarshal_Elements_ObjectLink(o)
+        @objects[o.offset]
+      end
+
+      def visit_Gem_SafeMarshal_Elements_SymbolLink(o)
+        @symbols[o.offset]
+      end
+
+      def visit_Gem_SafeMarshal_Elements_UserDefined(o)
+        register_object(resolve_class(o.name).send(:_load, o.binary_string))
+      end
+
+      def visit_Gem_SafeMarshal_Elements_UserMarshal(o)
+        register_object(resolve_class(o.name).allocate).tap do |object|
+          @stack << :data
+          object.marshal_load visit(o.data)
+        end
+      end
+
+      def visit_Gem_SafeMarshal_Elements_Integer(i)
+        i.int
+      end
+
+      def visit_Gem_SafeMarshal_Elements_Nil(_)
+        nil
+      end
+
+      def visit_Gem_SafeMarshal_Elements_True(_)
+        true
+      end
+
+      def visit_Gem_SafeMarshal_Elements_False(_)
+        false
+      end
+
+      def visit_Gem_SafeMarshal_Elements_String(s)
+        register_object(s.str)
+      end
+
+      def visit_Gem_SafeMarshal_Elements_Float(f)
+        case f.string
+        when "inf"
+          ::Float::INFINITY
+        when "-inf"
+          -::Float::INFINITY
+        when "nan"
+          ::Float::NAN
+        else
+          f.string.to_f
+        end
+      end
+
+      def visit_Gem_SafeMarshal_Elements_Bignum(b)
+        result = 0
+        b.data.each_byte.with_index do |byte, exp|
+          result += (byte * 2**(exp * 8))
+        end
+
+        case b.sign
+        when 43 # ?+
+          result
+        when 45 # ?-
+          -result
+        else
+          raise FormatError, "Unexpected sign for Bignum #{b.sign.chr.inspect} (#{b.sign})"
+        end
+      end
+
+      def resolve_class(n)
+        @class_cache[n] ||= begin
+          name = nil
+          case n
+          when Elements::Symbol, Elements::SymbolLink
+            @stack << "class name"
+            name = visit(n)
+          else
+            raise FormatError, "Class names must be Symbol or SymbolLink"
+          end
+          to_s = name.to_s
+          raise UnpermittedClassError.new(name: name, stack: @stack.dup) unless @permitted_classes.include?(to_s)
+          begin
+            ::Object.const_get(to_s)
+          rescue NameError
+            raise ArgumentError, "Undefined class #{to_s.inspect}"
+          end
+        end
+      end
+
+      def resolve_symbol(name)
+        raise UnpermittedSymbolError.new(symbol: name, stack: @stack.dup) unless @permitted_symbols.include?(name)
+        sym = name.to_sym
+        @symbols << sym
+        sym
+      end
+
+      def register_object(o)
+        @objects << o
+        o
+      end
+
+      class UnpermittedSymbolError < StandardError
+        def initialize(symbol:, stack:)
+          @symbol = symbol
+          @stack = stack
+          super "Attempting to load unpermitted symbol #{symbol.inspect} @ #{stack.join "."}"
+        end
+      end
+
+      class UnpermittedClassError < StandardError
+        def initialize(name:, stack:)
+          @name = name
+          @stack = stack
+          super "Attempting to load unpermitted class #{name.inspect} @ #{stack.join "."}"
+        end
+      end
+
+      class FormatError < StandardError
+      end
+    end
+  end
+end

--- a/lib/rubygems/safe_marshal/visitors/to_ruby.rb
+++ b/lib/rubygems/safe_marshal/visitors/to_ruby.rb
@@ -258,7 +258,7 @@ module Gem::SafeMarshal
       end
 
       COMPAT_CLASSES = {}.tap do |h|
-        h[Rational] = RationalCompat if RUBY_VERSION >= "3"
+        h[Rational] = RationalCompat
       end.freeze
       private_constant :COMPAT_CLASSES
 

--- a/lib/rubygems/safe_marshal/visitors/visitor.rb
+++ b/lib/rubygems/safe_marshal/visitors/visitor.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Gem::SafeMarshal::Visitors
+  class Visitor
+    def visit(target)
+      send DISPATCH.fetch(target.class), target
+    end
+
+    private
+
+    DISPATCH = Gem::SafeMarshal::Elements.constants.each_with_object({}) do |c, h|
+      next if c == :Element
+
+      klass = Gem::SafeMarshal::Elements.const_get(c)
+      h[klass] = :"visit_#{klass.name.gsub("::", "_")}"
+      h.default = :visit_unknown_element
+    end.compare_by_identity.freeze
+    private_constant :DISPATCH
+
+    def visit_unknown_element(e)
+      raise ArgumentError, "Attempting to visit unknown element #{e.inspect}"
+    end
+
+    def visit_Gem_SafeMarshal_Elements_Array(target)
+      target.elements.each {|e| visit(e) }
+    end
+
+    def visit_Gem_SafeMarshal_Elements_Bignum(target); end
+    def visit_Gem_SafeMarshal_Elements_False(target); end
+    def visit_Gem_SafeMarshal_Elements_Float(target); end
+
+    def visit_Gem_SafeMarshal_Elements_Hash(target)
+      target.pairs.each do |k, v|
+        visit(k)
+        visit(v)
+      end
+    end
+
+    def visit_Gem_SafeMarshal_Elements_HashWithDefaultValue(target)
+      visit_Gem_SafeMarshal_Elements_Hash(target)
+      visit(target.default)
+    end
+
+    def visit_Gem_SafeMarshal_Elements_Integer(target); end
+    def visit_Gem_SafeMarshal_Elements_Nil(target); end
+
+    def visit_Gem_SafeMarshal_Elements_Object(target)
+      visit(target.name)
+    end
+
+    def visit_Gem_SafeMarshal_Elements_ObjectLink(target); end
+    def visit_Gem_SafeMarshal_Elements_String(target); end
+    def visit_Gem_SafeMarshal_Elements_Symbol(target); end
+    def visit_Gem_SafeMarshal_Elements_SymbolLink(target); end
+    def visit_Gem_SafeMarshal_Elements_True(target); end
+
+    def visit_Gem_SafeMarshal_Elements_UserDefined(target)
+      visit(target.name)
+    end
+
+    def visit_Gem_SafeMarshal_Elements_UserMarshal(target)
+      visit(target.name)
+      visit(target.data)
+    end
+
+    def visit_Gem_SafeMarshal_Elements_WithIvars(target)
+      visit(target.object)
+      target.ivars.each do |k, v|
+        visit(k)
+        visit(v)
+      end
+    end
+  end
+end

--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -135,8 +135,9 @@ class Gem::Source
 
     if File.exist? local_spec
       spec = Gem.read_binary local_spec
+      Gem.load_safe_marshal
       spec = begin
-               Marshal.load(spec)
+               Gem::SafeMarshal.safe_load(spec)
              rescue StandardError
                nil
              end
@@ -157,8 +158,9 @@ class Gem::Source
       end
     end
 
+    Gem.load_safe_marshal
     # TODO: Investigate setting Gem::Specification#loaded_from to a URI
-    Marshal.load spec
+    Gem::SafeMarshal.safe_load spec
   end
 
   ##
@@ -188,8 +190,9 @@ class Gem::Source
 
     spec_dump = fetcher.cache_update_path spec_path, local_file, update_cache?
 
+    Gem.load_safe_marshal
     begin
-      Gem::NameTuple.from_list Marshal.load(spec_dump)
+      Gem::NameTuple.from_list Gem::SafeMarshal.safe_load(spec_dump)
     rescue ArgumentError
       if update_cache? && !retried
         FileUtils.rm local_file

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1300,12 +1300,13 @@ class Gem::Specification < Gem::BasicSpecification
 
   def self._load(str)
     Gem.load_yaml
+    Gem.load_safe_marshal
 
     yaml_set = false
     retry_count = 0
 
     array = begin
-      Marshal.load str
+      Gem::SafeMarshal.safe_load str
     rescue ArgumentError => e
       # Avoid an infinite retry loop when the argument error has nothing to do
       # with the classes not being defined.

--- a/test/rubygems/test_gem_safe_marshal.rb
+++ b/test/rubygems/test_gem_safe_marshal.rb
@@ -6,6 +6,120 @@ require "date"
 require "rubygems/safe_marshal"
 
 class TestGemSafeMarshal < Gem::TestCase
+  define_method("test_safe_load_marshal Date #<Date: 1994-12-09 ((2449696j,0s,0n),+0s,2299161j)>") { assert_safe_load_marshal "\x04\bU:\tDate[\vi\x00i\x03 a%i\x00i\x00i\x00f\f2299161" }
+  define_method("test_safe_load_marshal Float 0.0") { assert_safe_load_marshal "\x04\bf\x060" }
+  define_method("test_safe_load_marshal Float -0.0") { assert_safe_load_marshal "\x04\bf\a-0" }
+  define_method("test_safe_load_marshal Float Infinity") { assert_safe_load_marshal "\x04\bf\binf" }
+  define_method("test_safe_load_marshal Float -Infinity") { assert_safe_load_marshal "\x04\bf\t-inf" }
+  define_method("test_safe_load_marshal Float NaN") { assert_safe_load_marshal "\x04\bf\bnan", equality: false }
+  define_method("test_safe_load_marshal Float 1.1") { assert_safe_load_marshal "\x04\bf\b1.1" }
+  define_method("test_safe_load_marshal Float -1.1") { assert_safe_load_marshal "\x04\bf\t-1.1" }
+  define_method("test_safe_load_marshal Float 30000000.0") { assert_safe_load_marshal "\x04\bf\b3e7" }
+  define_method("test_safe_load_marshal Float -30000000.0") { assert_safe_load_marshal "\x04\bf\t-3e7" }
+  define_method("test_safe_load_marshal Gem::Version #<Gem::Version \"1.abc\">") { assert_safe_load_marshal "\x04\bU:\x11Gem::Version[\x06I\"\n1.abc\x06:\x06ET" }
+  define_method("test_safe_load_marshal Hash {}") { assert_safe_load_marshal "\x04\b}\x00[\x00" }
+  define_method("test_safe_load_marshal Hash {:runtime=>:development}") { assert_safe_load_marshal "\x04\bI{\x06:\fruntime:\x10development\x06:\n@type[\x00", permitted_ivars: { "Hash" => %w[@type] } }
+  define_method("test_safe_load_marshal Integer -1") { assert_safe_load_marshal "\x04\bi\xFA" }
+  define_method("test_safe_load_marshal Integer -1048575") { assert_safe_load_marshal "\x04\bi\xFD\x01\x00\xF0" }
+  define_method("test_safe_load_marshal Integer -122") { assert_safe_load_marshal "\x04\bi\x81" }
+  define_method("test_safe_load_marshal Integer -123") { assert_safe_load_marshal "\x04\bi\x80" }
+  define_method("test_safe_load_marshal Integer -124") { assert_safe_load_marshal "\x04\bi\xFF\x84" }
+  define_method("test_safe_load_marshal Integer -127") { assert_safe_load_marshal "\x04\bi\xFF\x81" }
+  define_method("test_safe_load_marshal Integer -128") { assert_safe_load_marshal "\x04\bi\xFF\x80" }
+  define_method("test_safe_load_marshal Integer -2") { assert_safe_load_marshal "\x04\bi\xF9" }
+  define_method("test_safe_load_marshal Integer -255") { assert_safe_load_marshal "\x04\bi\xFF\x01" }
+  define_method("test_safe_load_marshal Integer -256") { assert_safe_load_marshal "\x04\bi\xFF\x00" }
+  define_method("test_safe_load_marshal Integer -257") { assert_safe_load_marshal "\x04\bi\xFE\xFF\xFE" }
+  define_method("test_safe_load_marshal Integer -268435455") { assert_safe_load_marshal "\x04\bi\xFC\x01\x00\x00\xF0" }
+  define_method("test_safe_load_marshal Integer -268435456") { assert_safe_load_marshal "\x04\bi\xFC\x00\x00\x00\xF0" }
+  define_method("test_safe_load_marshal Integer -3") { assert_safe_load_marshal "\x04\bi\xF8" }
+  define_method("test_safe_load_marshal Integer -4") { assert_safe_load_marshal "\x04\bi\xF7" }
+  define_method("test_safe_load_marshal Integer -4294967295") { assert_safe_load_marshal "\x04\bl-\a\xFF\xFF\xFF\xFF" }
+  define_method("test_safe_load_marshal Integer -4294967296") { assert_safe_load_marshal "\x04\bl-\b\x00\x00\x00\x00\x01\x00" }
+  define_method("test_safe_load_marshal Integer -5") { assert_safe_load_marshal "\x04\bi\xF6" }
+  define_method("test_safe_load_marshal Integer -6") { assert_safe_load_marshal "\x04\bi\xF5" }
+  define_method("test_safe_load_marshal Integer -65535") { assert_safe_load_marshal "\x04\bi\xFE\x01\x00" }
+  define_method("test_safe_load_marshal Integer -65536") { assert_safe_load_marshal "\x04\bi\xFE\x00\x00" }
+  define_method("test_safe_load_marshal Integer -9223372036854775807") { assert_safe_load_marshal "\x04\bl-\t\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F" }
+  define_method("test_safe_load_marshal Integer -9223372036854775808") { assert_safe_load_marshal "\x04\bl-\t\x00\x00\x00\x00\x00\x00\x00\x80" }
+  define_method("test_safe_load_marshal Integer 0") { assert_safe_load_marshal "\x04\bi\x00" }
+  define_method("test_safe_load_marshal Integer 1") { assert_safe_load_marshal "\x04\bi\x06" }
+  define_method("test_safe_load_marshal Integer 1048574") { assert_safe_load_marshal "\x04\bi\x03\xFE\xFF\x0F" }
+  define_method("test_safe_load_marshal Integer 1048575") { assert_safe_load_marshal "\x04\bi\x03\xFF\xFF\x0F" }
+  define_method("test_safe_load_marshal Integer 1048576") { assert_safe_load_marshal "\x04\bi\x03\x00\x00\x10" }
+  define_method("test_safe_load_marshal Integer 121") { assert_safe_load_marshal "\x04\bi~" }
+  define_method("test_safe_load_marshal Integer 122") { assert_safe_load_marshal "\x04\bi\x7F" }
+  define_method("test_safe_load_marshal Integer 123") { assert_safe_load_marshal "\x04\bi\x01{" }
+  define_method("test_safe_load_marshal Integer 124") { assert_safe_load_marshal "\x04\bi\x01|" }
+  define_method("test_safe_load_marshal Integer 125") { assert_safe_load_marshal "\x04\bi\x01}" }
+  define_method("test_safe_load_marshal Integer 126") { assert_safe_load_marshal "\x04\bi\x01~" }
+  define_method("test_safe_load_marshal Integer 127") { assert_safe_load_marshal "\x04\bi\x01\x7F" }
+  define_method("test_safe_load_marshal Integer 128") { assert_safe_load_marshal "\x04\bi\x01\x80" }
+  define_method("test_safe_load_marshal Integer 129") { assert_safe_load_marshal "\x04\bi\x01\x81" }
+  define_method("test_safe_load_marshal Integer 2") { assert_safe_load_marshal "\x04\bi\a" }
+  define_method("test_safe_load_marshal Integer 254") { assert_safe_load_marshal "\x04\bi\x01\xFE" }
+  define_method("test_safe_load_marshal Integer 255") { assert_safe_load_marshal "\x04\bi\x01\xFF" }
+  define_method("test_safe_load_marshal Integer 256") { assert_safe_load_marshal "\x04\bi\x02\x00\x01" }
+  define_method("test_safe_load_marshal Integer 257") { assert_safe_load_marshal "\x04\bi\x02\x01\x01" }
+  define_method("test_safe_load_marshal Integer 258") { assert_safe_load_marshal "\x04\bi\x02\x02\x01" }
+  define_method("test_safe_load_marshal Integer 268435454") { assert_safe_load_marshal "\x04\bi\x04\xFE\xFF\xFF\x0F" }
+  define_method("test_safe_load_marshal Integer 268435455") { assert_safe_load_marshal "\x04\bi\x04\xFF\xFF\xFF\x0F" }
+  define_method("test_safe_load_marshal Integer 268435456") { assert_safe_load_marshal "\x04\bi\x04\x00\x00\x00\x10" }
+  define_method("test_safe_load_marshal Integer 268435457") { assert_safe_load_marshal "\x04\bi\x04\x01\x00\x00\x10" }
+  define_method("test_safe_load_marshal Integer 3") { assert_safe_load_marshal "\x04\bi\b" }
+  define_method("test_safe_load_marshal Integer 4") { assert_safe_load_marshal "\x04\bi\t" }
+  define_method("test_safe_load_marshal Integer 4294967294") { assert_safe_load_marshal "\x04\bl+\a\xFE\xFF\xFF\xFF" }
+  define_method("test_safe_load_marshal Integer 4294967295") { assert_safe_load_marshal "\x04\bl+\a\xFF\xFF\xFF\xFF" }
+  define_method("test_safe_load_marshal Integer 4294967296") { assert_safe_load_marshal "\x04\bl+\b\x00\x00\x00\x00\x01\x00" }
+  define_method("test_safe_load_marshal Integer 4294967297") { assert_safe_load_marshal "\x04\bl+\b\x01\x00\x00\x00\x01\x00" }
+  define_method("test_safe_load_marshal Integer 5") { assert_safe_load_marshal "\x04\bi\n" }
+  define_method("test_safe_load_marshal Integer 6") { assert_safe_load_marshal "\x04\bi\v" }
+  define_method("test_safe_load_marshal Integer 65534") { assert_safe_load_marshal "\x04\bi\x02\xFE\xFF" }
+  define_method("test_safe_load_marshal Integer 65535") { assert_safe_load_marshal "\x04\bi\x02\xFF\xFF" }
+  define_method("test_safe_load_marshal Integer 65536") { assert_safe_load_marshal "\x04\bi\x03\x00\x00\x01" }
+  define_method("test_safe_load_marshal Integer 65537") { assert_safe_load_marshal "\x04\bi\x03\x01\x00\x01" }
+  define_method("test_safe_load_marshal Integer 7") { assert_safe_load_marshal "\x04\bi\f" }
+  define_method("test_safe_load_marshal Integer 9223372036854775806") { assert_safe_load_marshal "\x04\bl+\t\xFE\xFF\xFF\xFF\xFF\xFF\xFF\x7F" }
+  define_method("test_safe_load_marshal Integer 9223372036854775807") { assert_safe_load_marshal "\x04\bl+\t\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x7F" }
+  define_method("test_safe_load_marshal Integer 9223372036854775808") { assert_safe_load_marshal "\x04\bl+\t\x00\x00\x00\x00\x00\x00\x00\x80" }
+  define_method("test_safe_load_marshal Integer 9223372036854775809") { assert_safe_load_marshal "\x04\bl+\t\x01\x00\x00\x00\x00\x00\x00\x80" }
+  define_method("test_safe_load_marshal Rational (1/3)") { assert_safe_load_marshal "\x04\bU:\rRational[\ai\x06i\b" }
+  define_method("test_safe_load_marshal Array [[...]]") { assert_safe_load_marshal "\x04\b[\x06@\x00" }
+  define_method("test_safe_load_marshal String \"hello\" ivar") { assert_safe_load_marshal "\x04\bI\"\nhello\a:\x06ET:\n@type@\x00", additional_methods: [:instance_variables], permitted_ivars: { "String" => %w[@type E] } }
+  define_method("test_safe_load_marshal Array [\"hello\", [\"hello\"], \"hello\", [\"hello\"]]") { assert_safe_load_marshal "\x04\b[\tI\"\nhello\x06:\x06ET[\x06@\x06@\x06@\a" }
+  define_method("test_safe_load_marshal Array [\"hello\", \"hello\"]") { assert_safe_load_marshal "\x04\b[\aI\"\nhello\x06:\x06ET@\x06" }
+  define_method("test_safe_load_marshal Array [:development, :development]") { assert_safe_load_marshal "\x04\b[\a:\x10development;\x00" }
+  define_method("test_safe_load_marshal String \"abc\" ascii") { assert_safe_load_marshal "\x04\bI\"\babc\x06:\x06EF", additional_methods: [:encoding] }
+  define_method("test_safe_load_marshal Array [\"abc\", \"abc\"] ascii") { assert_safe_load_marshal "\x04\b[\aI\"\babc\x06:\x06EF@\x06", additional_methods: [->(x) { x.map(&:encoding) }] }
+  define_method("test_safe_load_marshal String \"abc\" utf8") { assert_safe_load_marshal "\x04\bI\"\babc\x06:\x06ET", additional_methods: [:encoding] }
+  define_method("test_safe_load_marshal Array [\"abc\", \"abc\"] utf8") { assert_safe_load_marshal "\x04\b[\aI\"\babc\x06:\x06ET@\x06", additional_methods: [->(x) { x.map(&:encoding) }] }
+  define_method("test_safe_load_marshal String \"abc\" Windows-1256") { assert_safe_load_marshal "\x04\bI\"\babc\x06:\rencoding\"\x11Windows-1256", additional_methods: [:encoding] }
+  define_method("test_safe_load_marshal Array [\"abc\", \"abc\"] Windows-1256") { assert_safe_load_marshal "\x04\b[\aI\"\babc\x06:\rencoding\"\x11Windows-1256@\x06", additional_methods: [->(x) { x.map(&:encoding) }] }
+  define_method("test_safe_load_marshal String \"abc\" binary") { assert_safe_load_marshal "\x04\b\"\babc", additional_methods: [:encoding] }
+  define_method("test_safe_load_marshal Array [\"abc\", \"abc\"] binary") { assert_safe_load_marshal "\x04\b[\a\"\babc@\x06", additional_methods: [->(x) { x.map(&:encoding) }] }
+  define_method("test_safe_load_marshal String \"\\x61\\x62\\x63\" utf32") { assert_safe_load_marshal "\x04\bI\"\babc\x06:\rencoding\"\vUTF-32", additional_methods: [:encoding] }
+  define_method("test_safe_load_marshal Array [\"\\x61\\x62\\x63\", \"\\x61\\x62\\x63\"] utf32") { assert_safe_load_marshal "\x04\b[\aI\"\babc\x06:\rencoding\"\vUTF-32@\x06", additional_methods: [->(x) { x.map(&:encoding) }] }
+  define_method("test_safe_load_marshal String \"abc\" ivar") { assert_safe_load_marshal "\x04\bI\"\babc\a:\x06ET:\n@typeI\"\ttype\x06;\x00T", permitted_ivars: { "String" => %w[@type E] } }
+  define_method("test_safe_load_marshal String \"\"") { assert_safe_load_marshal "\x04\bI\"\babc\x06:\x06ET" }
+  define_method("test_safe_load_marshal Time 2000-12-31 20:07:59 -1152") { assert_safe_load_marshal "\x04\bIu:\tTime\r'@\x19\x80\x00\x00\xB0\xEF\a:\voffseti\xFE Y:\tzone0", additional_methods: [:ctime, :to_f, :to_r, :to_i, :zone, :subsec, :instance_variables, :dst?, :to_a] }
+  define_method("test_safe_load_marshal Time 2000-12-31 23:59:59 -0800") { assert_safe_load_marshal "\x04\bIu:\tTime\r'@\x19\x80\x00\x00\xB0\xEF\a:\voffseti\xFE\x80\x8F:\tzoneI\"\bPST\x06:\x06EF", additional_methods: [:ctime, :to_f, :to_r, :to_i, :zone, :subsec, :instance_variables, :dst?, :to_a] }
+  define_method("test_safe_load_marshal Time 2000-12-31 23:59:59 2254051613498933/2251799813685248000000000 -0800") { assert_safe_load_marshal "\x04\bIu:\tTime\r'@\x19\x80\x00\x00\xB0\xEF\n:\rnano_numl+\t5^\xBAI\f\x02\b\x00:\rnano_denl+\t\x00\x00\x00\x00\x00\x00\b\x00:\rsubmicro\"\a\x00\x10:\voffseti\xFE\x80\x8F:\tzoneI\"\bPST\x06:\x06EF", additional_methods: [:ctime, :to_f, :to_r, :to_i, :zone, :subsec, :instance_variables, :dst?, :to_a] }
+  define_method("test_safe_load_marshal Time 2000-12-31 23:59:59 2476979795053773/2251799813685248000 -0800") { assert_safe_load_marshal "\x04\bIu:\tTime\r'@\x19\x80L\x04\xB0\xEF\t:\rnano_numi\x025\f:\rnano_denl+\b\x00\x00\x00\x00\x00 :\voffseti\xFE\x80\x8F:\tzoneI\"\bPST\x06:\x06EF", additional_methods: [:ctime, :to_f, :to_r, :to_i, :zone, :subsec, :instance_variables, :dst?, :to_a] }
+  define_method("test_safe_load_marshal Time 2000-12-31 23:59:59 2476979795053773/2251799813685248000000 -0800") { assert_safe_load_marshal "\x04\bIu:\tTime\r'@\x19\x80\x01\x00\xB0\xEF\n:\rnano_numl+\t\x19\x00\x00\x00\x00\x00d\x00:\rnano_denl+\t\x00\x00\x00\x00\x00\x00\x01\x00:\rsubmicro\"\x06\x10:\voffseti\xFE\x80\x8F:\tzoneI\"\bPST\x06:\x06EF", additional_methods: [:ctime, :to_f, :to_r, :to_i, :zone, :subsec, :instance_variables, :dst?, :to_a] }
+  define_method("test_safe_load_marshal Time 2000-12-31 23:59:59 2476979795053773/2251799813685248000000000 -0800") { assert_safe_load_marshal "\x04\bIu:\tTime\r'@\x19\x80\x00\x00\xB0\xEF\n:\rnano_numl+\t\xCD\xCC\xCC\xCC\xCC\xCC\b\x00:\rnano_denl+\t\x00\x00\x00\x00\x00\x00\b\x00:\rsubmicro\"\a\x00\x10:\voffseti\xFE\x80\x8F:\tzoneI\"\bPST\x06:\x06EF", additional_methods: [:ctime, :to_f, :to_r, :to_i, :zone, :subsec, :instance_variables, :dst?, :to_a] }
+  define_method("test_safe_load_marshal Time 2000-12-31 23:59:59 450364466336677/450359962737049600000000 -0800") { assert_safe_load_marshal "\x04\bIu:\tTime\r'@\x19\x80\x00\x00\xB0\xEF\n:\rnano_numl+\t9b->\x05\x00\b\x00:\rnano_denl+\t\x00\x00\x00\x00\x00\x00\b\x00:\rsubmicro\"\a\x00\x10:\voffseti\xFE\x80\x8F:\tzoneI\"\bPST\x06:\x06EF", additional_methods: [:ctime, :to_f, :to_r, :to_i, :zone, :subsec, :instance_variables, :dst?, :to_a] }
+  define_method("test_safe_load_marshal Time 2000-12-31 23:59:59 4548635623644201/4503599627370496000 -0800") { assert_safe_load_marshal "\x04\bIu:\tTime\r'@\x19\x80\xF2\x03\xB0\xEF\t:\rnano_numi\x02q\x02:\rnano_denl+\b\x00\x00\x00\x00\x00@:\voffseti\xFE\x80\x8F:\tzoneI\"\bPST\x06:\x06EF", additional_methods: [:ctime, :to_f, :to_r, :to_i, :zone, :subsec, :instance_variables, :dst?, :to_a] }
+  define_method("test_safe_load_marshal Time 2000-12-31 23:59:59 4548635623644201/4503599627370496000000 -0800") { assert_safe_load_marshal "\x04\bIu:\tTime\r'@\x19\x80\x01\x00\xB0\xEF\n:\rnano_numl+\t\x05\x00\x00\x00\x00\x00\x14\x00:\rnano_denl+\t\x00\x00\x00\x00\x00\x00\x02\x00:\rsubmicro\"\x06\x01:\voffseti\xFE\x80\x8F:\tzoneI\"\bPST\x06:\x06EF", additional_methods: [:ctime, :to_f, :to_r, :to_i, :zone, :subsec, :instance_variables, :dst?, :to_a] }
+  define_method("test_safe_load_marshal Time 2000-12-31 23:59:59 4548635623644201/4503599627370496000000000 -0800") { assert_safe_load_marshal "\x04\bIu:\tTime\r'@\x19\x80\x00\x00\xB0\xEF\n:\rnano_numl+\t)\\\x8F\xC2\xF5(\x10\x00:\rnano_denl+\t\x00\x00\x00\x00\x00\x00\x10\x00:\rsubmicro\"\a\x00\x10:\voffseti\xFE\x80\x8F:\tzoneI\"\bPST\x06:\x06EF", additional_methods: [:ctime, :to_f, :to_r, :to_i, :zone, :subsec, :instance_variables, :dst?, :to_a] }
+  define_method("test_safe_load_marshal Time 2000-12-31 23:59:59.000000001 -0800") { assert_safe_load_marshal "\x04\bIu:\tTime\r'@\x19\x80\x00\x00\xB0\xEF\n:\rnano_numi\x06:\rnano_deni\x06:\rsubmicro\"\a\x00\x10:\voffseti\xFE\x80\x8F:\tzoneI\"\bPST\x06:\x06EF", additional_methods: [:ctime, :to_f, :to_r, :to_i, :zone, :subsec, :instance_variables, :dst?, :to_a] }
+  define_method("test_safe_load_marshal Time 2000-12-31 23:59:59.000001 -0800") { assert_safe_load_marshal "\x04\bIu:\tTime\r'@\x19\x80\x01\x00\xB0\xEF\a:\voffseti\xFE\x80\x8F:\tzoneI\"\bPST\x06:\x06EF", additional_methods: [:ctime, :to_f, :to_r, :to_i, :zone, :subsec, :instance_variables, :dst?, :to_a] }
+  define_method("test_safe_load_marshal Time 2000-12-31 23:59:59.001 -0800") { assert_safe_load_marshal "\x04\bIu:\tTime\r'@\x19\x80\xE8\x03\xB0\xEF\a:\voffseti\xFE\x80\x8F:\tzoneI\"\bPST\x06:\x06EF", additional_methods: [:ctime, :to_f, :to_r, :to_i, :zone, :subsec, :instance_variables, :dst?, :to_a] }
+  define_method("test_safe_load_marshal Time 2001-01-01 07:59:59 +0000") { assert_safe_load_marshal "\x04\bIu:\tTime\r'@\x19\x80\x00\x00\xB0\xEF\a:\voffseti\x00:\tzone0", additional_methods: [:ctime, :to_f, :to_r, :to_i, :zone, :subsec, :instance_variables, :dst?, :to_a] }
+  define_method("test_safe_load_marshal Time 2001-01-01 07:59:59 UTC") { assert_safe_load_marshal "\x04\bIu:\tTime\r'@\x19\xC0\x00\x00\xB0\xEF\x06:\tzoneI\"\bUTC\x06:\x06EF", additional_methods: [:ctime, :to_f, :to_r, :to_i, :zone, :subsec, :instance_variables, :dst?, :to_a] }
+  define_method("test_safe_load_marshal Time 2001-01-01 11:59:59 +0400") { assert_safe_load_marshal "\x04\bIu:\tTime\r'@\x19\x80\x00\x00\xB0\xEF\a:\voffseti\x02@8:\tzone0", additional_methods: [:ctime, :to_f, :to_r, :to_i, :zone, :subsec, :instance_variables, :dst?, :to_a] }
+  define_method("test_safe_load_marshal Time 2023-08-24 10:10:39.09565 -0700") { assert_safe_load_marshal "\x04\bIu:\tTime\r\x11\xDF\x1E\x80\xA2uq*\a:\voffseti\xFE\x90\x9D:\tzoneI\"\bPDT\x06:\x06EF" }
+  define_method("test_safe_load_marshal Time 2023-08-24 10:10:39.098453 -0700") { assert_safe_load_marshal "\x04\bIu:\tTime\r\x11\xDF\x1E\x80\x95\x80q*\b:\n@typeI\"\fruntime\x06:\x06ET:\voffseti\xFE\x90\x9D:\tzoneI\"\bPDT\x06;\aF", permitted_ivars: { "Time" => %w[@type offset zone], "String" => %w[E @debug_created_info] }, marshal_dump_equality: (RUBY_ENGINE != "truffleruby" || RUBY_ENGINE_VERSION >= "23") }
+
   def test_repeated_symbol
     assert_safe_load_as [:development, :development]
   end
@@ -60,7 +174,7 @@ class TestGemSafeMarshal < Gem::TestCase
     pend "Marshal.load of Time with ivars is broken on jruby, see https://github.com/jruby/jruby/issues/7902" if RUBY_ENGINE == "jruby"
 
     with_const(Gem::SafeMarshal, :PERMITTED_IVARS, { "Time" => %w[@type offset zone nano_num nano_den submicro], "String" => %w[E @debug_created_info] }) do
-      assert_safe_load_as Time.new.tap {|t| t.instance_variable_set :@type, "runtime" }
+      assert_safe_load_as Time.new.tap {|t| t.instance_variable_set :@type, "runtime" }, marshal_dump_equality: (RUBY_ENGINE != "truffleruby" || RUBY_ENGINE_VERSION >= "23")
     end
   end
 
@@ -168,19 +282,24 @@ class TestGemSafeMarshal < Gem::TestCase
     assert_equal e.message, "Attempting to load unpermitted symbol \"rspec\" @ root.[9].[0].@name"
   end
 
-  def assert_safe_load_as(x, additional_methods: [])
-    dumped = Marshal.dump(x)
+  def assert_safe_load_marshal(dumped, additional_methods: [], permitted_ivars: nil, equality: true, marshal_dump_equality: true)
     loaded = Marshal.load(dumped)
-    safe_loaded = Gem::SafeMarshal.safe_load(dumped)
+    safe_loaded =
+      if permitted_ivars
+        with_const(Gem::SafeMarshal, :PERMITTED_IVARS, permitted_ivars) do
+          Gem::SafeMarshal.safe_load(dumped)
+        end
+      else
+        Gem::SafeMarshal.safe_load(dumped)
+      end
 
     # NaN != NaN, for example
-    if x == x # rubocop:disable Lint/BinaryOperatorWithIdenticalOperands
-      assert_equal x, safe_loaded, "should load #{dumped.inspect}"
+    if equality
       assert_equal loaded, safe_loaded, "should equal what Marshal.load returns"
     end
 
-    assert_equal x.to_s, safe_loaded.to_s, "should have equal to_s"
-    assert_equal x.inspect, safe_loaded.inspect, "should have equal inspect"
+    assert_equal loaded.to_s, safe_loaded.to_s, "should have equal to_s"
+    assert_equal loaded.inspect, safe_loaded.inspect, "should have equal inspect"
     additional_methods.each do |m|
       if m.is_a?(Proc)
         call = m
@@ -190,7 +309,15 @@ class TestGemSafeMarshal < Gem::TestCase
 
       assert_equal call[loaded], call[safe_loaded], "should have equal #{m}"
     end
-    assert_equal Marshal.dump(loaded), Marshal.dump(safe_loaded), "should Marshal.dump the same"
+    if marshal_dump_equality
+      assert_equal Marshal.dump(loaded).dump, Marshal.dump(safe_loaded).dump, "should Marshal.dump the same"
+    end
+  end
+
+  def assert_safe_load_as(x, **kwargs)
+    dumped = Marshal.dump(x)
+    equality = x == x # rubocop:disable Lint/BinaryOperatorWithIdenticalOperands
+    assert_safe_load_marshal(dumped, equality: equality, **kwargs)
   end
 
   def with_const(mod, name, new_value, &block)

--- a/test/rubygems/test_gem_safe_marshal.rb
+++ b/test/rubygems/test_gem_safe_marshal.rb
@@ -39,19 +39,20 @@ class TestGemSafeMarshal < Gem::TestCase
   end
 
   def test_string_with_ivar
-    assert_safe_load_as String.new("abc").tap { _1.instance_variable_set :@type, "type" }
+    assert_safe_load_as String.new("abc").tap {|s| s.instance_variable_set :@type, "type" }
   end
 
   def test_time_with_ivar
-    assert_safe_load_as Time.new.tap { _1.instance_variable_set :@type, "type" }
+    assert_safe_load_as Time.new.tap {|t| t.instance_variable_set :@type, "type" }
   end
 
   secs = Time.new(2000, 12, 31, 23, 59, 59).to_i
   [
-    Time.new,
-    Time.now(in: "+04:00"),
-    Time.now(in: "-11:52"),
-    Time.at(secs, in: "UTC"),
+    Time.at(secs),
+    Time.at(secs, in: "+04:00"),
+    Time.at(secs, in: "-11:52"),
+    Time.at(secs, in: "+00:00"),
+    Time.at(secs, in: "-00:00"),
     Time.at(secs, 1, :millisecond),
     Time.at(secs, 1.1, :millisecond),
     Time.at(secs, 1.01, :millisecond),
@@ -78,7 +79,7 @@ class TestGemSafeMarshal < Gem::TestCase
   end
 
   def test_hash_with_ivar
-    assert_safe_load_as({ runtime: :development }.tap { _1.instance_variable_set :@type, "null" })
+    assert_safe_load_as({ runtime: :development }.tap {|h| h.instance_variable_set :@type, "null" })
   end
 
   def test_hash_with_default_value
@@ -115,7 +116,7 @@ class TestGemSafeMarshal < Gem::TestCase
         s.name = "hi"
         s.version = "1.2.3"
 
-        s.dependencies << Gem::Dependency.new("rspec", Gem::Requirement.new([">= 1.2.3"]), :runtime).tap { _1.instance_variable_set(:@name, :rspec) }
+        s.dependencies << Gem::Dependency.new("rspec", Gem::Requirement.new([">= 1.2.3"]), :runtime).tap {|d| d.instance_variable_set(:@name, :rspec) }
       end
       Gem::SafeMarshal.safe_load(Marshal.dump(spec))
     end

--- a/test/rubygems/test_gem_safe_marshal.rb
+++ b/test/rubygems/test_gem_safe_marshal.rb
@@ -77,7 +77,10 @@ class TestGemSafeMarshal < Gem::TestCase
     Time.at(secs, 1.00001, :nanosecond),
   ].each_with_index do |t, i|
     define_method("test_time_#{i} #{t.inspect}") do
-      assert_safe_load_as t, additional_methods: [:ctime, :to_f, :to_r, :to_i, :zone, :subsec, :instance_variables, :dst?, :to_a]
+      pend "Marshal.load of Time with custom zone is broken before Truffleruby 23" if t.zone.nil? && RUBY_ENGINE == "truffleruby" && RUBY_ENGINE_VERSION < "23"
+
+      additional_methods = [:ctime, :to_f, :to_r, :to_i, :zone, :subsec, :instance_variables, :dst?, :to_a]
+      assert_safe_load_as t, additional_methods: additional_methods
     end
   end
 

--- a/test/rubygems/test_gem_safe_marshal.rb
+++ b/test/rubygems/test_gem_safe_marshal.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require_relative "helper"
+
+require "date"
+require "rubygems/safe_marshal"
+
+class TestGemSafeMarshal < Gem::TestCase
+  def test_repeated_symbol
+    assert_safe_load_as [:development, :development]
+  end
+
+  def test_repeated_string
+    s = "hello"
+    a = [s]
+    assert_safe_load_as [s, a, s, a]
+    assert_safe_load_as [s, s]
+  end
+
+  def test_recursive_string
+    s = String.new("hello")
+    s.instance_variable_set(:@type, s)
+    assert_safe_load_as s, additional_methods: [:instance_variables]
+  end
+
+  def test_recursive_array
+    a = []
+    a << a
+    assert_safe_load_as a
+  end
+
+  def test_time_loads
+    assert_safe_load_as Time.new
+  end
+
+  def test_time_with_zone_loads
+    assert_safe_load_as Time.now(in: "+04:00")
+  end
+
+  def test_string_with_encoding
+    assert_safe_load_as String.new("abc", encoding: "US-ASCII")
+    assert_safe_load_as String.new("abc", encoding: "UTF-8")
+  end
+
+  def test_string_with_ivar
+    assert_safe_load_as String.new("abc").tap { _1.instance_variable_set :@type, "type" }
+  end
+
+  def test_time_with_ivar
+    assert_safe_load_as Time.new.tap { _1.instance_variable_set :@type, "type" }
+  end
+
+  secs = Time.new(2000, 12, 31, 23, 59, 59).to_i
+  [
+    Time.at(secs, 1, :millisecond),
+    Time.at(secs, 1.1, :millisecond),
+    Time.at(secs, 1.01, :millisecond),
+    Time.at(secs, 1, :microsecond),
+    Time.at(secs, 1.1, :microsecond),
+    Time.at(secs, 1.01, :microsecond),
+    Time.at(secs, 1, :nanosecond),
+    Time.at(secs, 1.1, :nanosecond),
+    Time.at(secs, 1.01, :nanosecond),
+    Time.at(secs, 1.001, :nanosecond),
+    Time.at(secs, 1.00001, :nanosecond),
+    Time.at(secs, 1.00001, :nanosecond).tap {|t| t.instance_variable_set :@type, "type" },
+  ].each_with_index do |t, i|
+    define_method("test_time_#{i} #{t.inspect}") do
+      assert_safe_load_as t, additional_methods: [:ctime, :to_f, :to_r, :to_i, :zone, :subsec, :instance_variables, :to_a]
+    end
+  end
+
+  def test_floats
+    [0.0, Float::INFINITY, Float::NAN, 1.1, 3e7].each do |f|
+      assert_safe_load_as f
+      assert_safe_load_as(-f)
+    end
+  end
+
+  def test_hash_with_ivar
+    assert_safe_load_as({ runtime: :development }.tap { _1.instance_variable_set :@type, "null" })
+  end
+
+  def test_hash_with_default_value
+    assert_safe_load_as Hash.new([])
+  end
+
+  def test_frozen_object
+    assert_safe_load_as Gem::Version.new("1.abc").freeze
+  end
+
+  def test_date
+    assert_safe_load_as Date.new
+  end
+
+  [
+    0, 1, 2, 3, 4, 5, 6, 122, 123, 124, 127, 128, 255, 256, 257,
+    2**16, 2**16 - 1, 2**20 - 1,
+    2**28, 2**28 - 1,
+    2**32, 2**32 - 1,
+    2**63, 2**63 - 1
+  ].
+  each do |i|
+    define_method("test_int_ #{i}") do
+      assert_safe_load_as i
+      assert_safe_load_as(-i)
+      assert_safe_load_as(i + 1)
+      assert_safe_load_as(i - 1)
+    end
+  end
+
+  def test_gem_spec_disallowed_symbol
+    e = assert_raise(Gem::SafeMarshal::Visitors::ToRuby::UnpermittedSymbolError) do
+      spec = Gem::Specification.new do |s|
+        s.name = "hi"
+        s.version = "1.2.3"
+
+        s.dependencies << Gem::Dependency.new("rspec", Gem::Requirement.new([">= 1.2.3"]), :runtime).tap { _1.instance_variable_set(:@name, :rspec) }
+      end
+      Gem::SafeMarshal.safe_load(Marshal.dump(spec))
+    end
+
+    assert_equal e.message, "Attempting to load unpermitted symbol \"rspec\" @ root.[9].[0].@name"
+  end
+
+  def assert_safe_load_as(x, additional_methods: [])
+    dumped = Marshal.dump(x)
+    loaded = Marshal.load(dumped)
+    safe_loaded = Gem::SafeMarshal.safe_load(dumped)
+
+    # NaN != NaN, for example
+    if x == x # rubocop:disable Lint/BinaryOperatorWithIdenticalOperands
+      # assert_equal x, safe_loaded, "should load #{dumped.inspect}"
+      assert_equal loaded, safe_loaded, "should equal what Marshal.load returns"
+    end
+
+    assert_equal x.to_s, safe_loaded.to_s, "should have equal to_s"
+    assert_equal x.inspect, safe_loaded.inspect, "should have equal inspect"
+    additional_methods.each do |m|
+      assert_equal loaded.send(m), safe_loaded.send(m), "should have equal #{m}"
+    end
+    assert_equal Marshal.dump(loaded), Marshal.dump(safe_loaded), "should Marshal.dump the same"
+  end
+end

--- a/test/rubygems/test_gem_safe_marshal.rb
+++ b/test/rubygems/test_gem_safe_marshal.rb
@@ -84,10 +84,12 @@ class TestGemSafeMarshal < Gem::TestCase
     Time.at(secs, 1.00001, :nanosecond),
     Time.at(secs, 1.00001, :nanosecond),
   ].tap do |times|
-    times.concat [
-      Time.at(secs, in: "UTC"),
-      Time.at(secs, in: "Z"),
-    ] unless RUBY_ENGINE == "truffleruby" && RUBY_ENGINE_VERSION < "23"
+    unless RUBY_ENGINE == "truffleruby" && RUBY_ENGINE_VERSION < "23" || RUBY_VERSION < "2.7"
+      times.concat [
+        Time.at(secs, in: "UTC"),
+        Time.at(secs, in: "Z"),
+      ]
+    end
   end.each_with_index do |t, i|
     define_method("test_time_#{i} #{t.inspect}") do
       pend "Marshal.load of Time with custom zone is broken before Truffleruby 23" if t.zone.nil? && RUBY_ENGINE == "truffleruby" && RUBY_ENGINE_VERSION < "23"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Ruby has historically had many security issues while loading serialized YAML or Marshal data, with the worst outcome being remote code execution. RubyGems and Bundler both load gemspecs from gem source URLs provided by users. To prevent exploits by malicious gem servers against developer machines installing gems, we need to load only a safe subset of Ruby classes and objects.

Previously, we implemented `YAML.safe_load` to prevent exploits by malicious gem servers via crafted YAML files. Until now, we have not been able to provide the same defenses for marshaled gemspecs due to the lack of a `Marshal.safe_load`.

This PR implements `Marshal.safe_load`, a loader for marshaled data that excludes unknown objects and classes. The loader prevents exploits by malicious gem servers, or crafted marshaled data provided to RubyGems or Bundler.

## What is your fix for the problem, implemented in this PR?

Implement a new reader / AST visitor for Marshal documents, following https://rubyreferences.github.io/rubyref/builtin/marshal.html and using the `Psych` `ToRuby` visitor for inspiration.

As a followup, will conditionally use the new module in Bundler

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
