### PR TITLE
Refactor api fetcher logic in Bundler

### DIFF
--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -9,6 +9,7 @@ require "rubygems/request"
 module Bundler
   # Handles all the fetching with the rubygems server
   class Fetcher
+    autoload :Base, File.expand_path("fetcher/base", __dir__)
     autoload :CompactIndex, File.expand_path("fetcher/compact_index", __dir__)
     autoload :Downloader, File.expand_path("fetcher/downloader", __dir__)
     autoload :Dependency, File.expand_path("fetcher/dependency", __dir__)

--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -214,9 +214,7 @@ module Bundler
     end
 
     def fetchers
-      @fetchers ||= available_fetchers
-        .map {|f| f.new(downloader, @remote, uri) }
-        .drop_while { |f| !f.available? }
+      @fetchers ||= available_fetchers.map {|f| f.new(downloader, @remote, uri) }.drop_while {|f| !f.available? }
     end
 
     def fetch_specs(gem_names)

--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -134,18 +134,7 @@ module Bundler
     def specs(gem_names, source)
       index = Bundler::Index.new
 
-      if Bundler::Fetcher.disable_endpoint
-        @use_api = false
-        specs = fetchers.last.specs(gem_names)
-      else
-        specs = []
-        @fetchers = fetchers.drop_while do |f|
-          !f.available? || (f.api_fetcher? && !gem_names) || !specs = f.specs(gem_names)
-        end
-        @use_api = false if fetchers.none?(&:api_fetcher?)
-      end
-
-      specs.each do |name, version, platform, dependencies, metadata|
+      fetch_specs(gem_names).each do |name, version, platform, dependencies, metadata|
         spec = if dependencies
           EndpointSpecification.new(name, version, platform, self, dependencies, metadata)
         else
@@ -158,20 +147,8 @@ module Bundler
 
       index
     rescue CertificateFailureError
-      Bundler.ui.info "" if gem_names && use_api # newline after dots
+      Bundler.ui.info "" if gem_names && api_fetcher? # newline after dots
       raise
-    end
-
-    def use_api
-      return @use_api if defined?(@use_api)
-
-      fetchers.shift until fetchers.first.available?
-
-      @use_api = if remote_uri.scheme == "file" || Bundler::Fetcher.disable_endpoint
-        false
-      else
-        fetchers.first.api_fetcher?
-      end
     end
 
     def user_agent
@@ -209,10 +186,6 @@ module Bundler
       end
     end
 
-    def fetchers
-      @fetchers ||= FETCHERS.map {|f| f.new(downloader, @remote, uri) }
-    end
-
     def http_proxy
       return unless uri = connection.proxy_uri
       uri.to_s
@@ -222,9 +195,38 @@ module Bundler
       "#<#{self.class}:0x#{object_id} uri=#{uri}>"
     end
 
+    def api_fetcher?
+      fetchers.first.api_fetcher?
+    end
+
     private
 
-    FETCHERS = [CompactIndex, Dependency, Index].freeze
+    def available_fetchers
+      if Bundler::Fetcher.disable_endpoint
+        [Index]
+      elsif remote_uri.scheme == "file"
+        Bundler.ui.debug("Using a local server, bundler won't use the CompactIndex API")
+        [Index]
+      else
+        [CompactIndex, Dependency, Index]
+      end
+    end
+
+    def fetchers
+      @fetchers ||= available_fetchers
+        .map {|f| f.new(downloader, @remote, uri) }
+        .drop_while { |f| !f.available? }
+    end
+
+    def fetch_specs(gem_names)
+      fetchers.reject!(&:api_fetcher?) unless gem_names
+      fetchers.reject! do |f|
+        specs = f.specs(gem_names)
+        return specs if specs
+        true
+      end
+      []
+    end
 
     def cis
       env_cis = {

--- a/bundler/lib/bundler/fetcher/compact_index.rb
+++ b/bundler/lib/bundler/fetcher/compact_index.rb
@@ -60,10 +60,6 @@ module Bundler
           Bundler.ui.debug("FIPS mode is enabled, bundler can't use the CompactIndex API")
           return nil
         end
-        if fetch_uri.scheme == "file"
-          Bundler.ui.debug("Using a local server, bundler won't use the CompactIndex API")
-          return false
-        end
         # Read info file checksums out of /versions, so we can know if gems are up to date
         compact_index_client.update_and_parse_checksums!
       rescue CompactIndexClient::Updater::MisMatchedChecksumError => e

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -392,7 +392,7 @@ module Bundler
       end
 
       def api_fetchers
-        fetchers.select {|f| f.use_api && f.fetchers.first.api_fetcher? }
+        fetchers.select(&:api_fetcher?)
       end
 
       def remote_specs

--- a/bundler/spec/bundler/fetcher_spec.rb
+++ b/bundler/spec/bundler/fetcher_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe Bundler::Fetcher do
       fetcher.specs_with_retry("name", double(Bundler::Source::Rubygems))
     end
 
-    context "when no network is available" do
+    context "when APIs are not available" do
       before do
         allow(compact_index).to receive(:available?).and_return(false)
         allow(dependency).to receive(:available?).and_return(false)
@@ -219,7 +219,7 @@ RSpec.describe Bundler::Fetcher do
       it "uses the index" do
         expect(compact_index).not_to receive(:specs)
         expect(dependency).not_to receive(:specs)
-        expect(index).to receive(:specs).with("name").and_return([["name", "1.1.1", "ruby"]])
+        expect(index).to receive(:specs).with("name").and_return([["name", "1.2.3", "ruby"]])
 
         fetcher.specs_with_retry("name", double(Bundler::Source::Rubygems))
       end
@@ -242,7 +242,6 @@ RSpec.describe Bundler::Fetcher do
     context "when an api fetcher is available" do
       before do
         allow(compact_index).to receive(:available?).and_return(true)
-        allow(compact_index).to receive(:specs).with("name").and_return([["name", "1.2.3", "ruby"]])
       end
 
       it "is truthy" do
@@ -251,10 +250,6 @@ RSpec.describe Bundler::Fetcher do
     end
 
     context "when only the index fetcher is available" do
-      before do
-        allow(index).to receive(:specs).with("name").and_return([["name", "1.2.3", "ruby"]])
-      end
-
       it "is falsey" do
         expect(fetcher).not_to be_api_fetcher
       end

--- a/bundler/spec/bundler/fetcher_spec.rb
+++ b/bundler/spec/bundler/fetcher_spec.rb
@@ -192,10 +192,10 @@ RSpec.describe Bundler::Fetcher do
 
   describe "#specs_with_retry" do
     let(:downloader)  { double(:downloader) }
-    let(:remote)      { double(:remote, cache_slug: "slug", uri: uri, original_uri: nil, anonymized_uri: uri) }
-    let(:compact_index) { double(Bundler::Fetcher::CompactIndex, available?: true, api_fetcher?: true) }
-    let(:dependency)    { double(Bundler::Fetcher::Dependency, available?: true, api_fetcher?: true) }
-    let(:index)         { double(Bundler::Fetcher::Index, available?: true, api_fetcher?: false) }
+    let(:remote)      { double(:remote, :cache_slug => "slug", :uri => uri, :original_uri => nil, :anonymized_uri => uri) }
+    let(:compact_index) { double(Bundler::Fetcher::CompactIndex, :available? => true, :api_fetcher? => true) }
+    let(:dependency)    { double(Bundler::Fetcher::Dependency, :available? => true, :api_fetcher? => true) }
+    let(:index)         { double(Bundler::Fetcher::Index, :available? => true, :api_fetcher? => false) }
 
     before do
       allow(Bundler::Fetcher::CompactIndex).to receive(:new).and_return(compact_index)
@@ -227,11 +227,11 @@ RSpec.describe Bundler::Fetcher do
   end
 
   describe "#api_fetcher?" do
-    let(:remote)      { double(:remote, cache_slug: "slug", uri: uri, original_uri: nil, anonymized_uri: uri) }
     let(:downloader)  { double(:downloader) }
-    let(:compact_index) { double(Bundler::Fetcher::CompactIndex, available?: false, api_fetcher?: true) }
-    let(:dependency)    { double(Bundler::Fetcher::Dependency, available?: false, api_fetcher?: true) }
-    let(:index)         { double(Bundler::Fetcher::Index, available?: true, api_fetcher?: false) }
+    let(:remote)      { double(:remote, :cache_slug => "slug", :uri => uri, :original_uri => nil, :anonymized_uri => uri) }
+    let(:compact_index) { double(Bundler::Fetcher::CompactIndex, :available? => false, :api_fetcher? => true) }
+    let(:dependency)    { double(Bundler::Fetcher::Dependency, :available? => false, :api_fetcher? => true) }
+    let(:index)         { double(Bundler::Fetcher::Index, :available? => true, :api_fetcher? => false) }
 
     before do
       allow(Bundler::Fetcher::CompactIndex).to receive(:new).and_return(compact_index)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I started by trying to fix [EDIT TO TRY TO UNLINK RELATED ISSUE] #6828 for both older and newer gem servers by disabling the dependency api for this particular operation. I'm still stumped on how to do this, but this refactor is an improvement.

## What is your fix for the problem, implemented in this PR?

Refactors the api fetcher behavior to be simpler using call order to determine paths that always happen before others (it always eliminates fetchers and determines if API is available before attempting to fetch specs). I think this simplifies the code and is ready to go.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
