### PR TITLE
Support ruby file: ".tool-versions" in Gemfile

### DIFF
--- a/bundler/lib/bundler/man/gemfile.5
+++ b/bundler/lib/bundler/man/gemfile.5
@@ -98,6 +98,17 @@ ruby file: "\.ruby\-version"
 .
 .IP "" 0
 .
+.P
+The version file should conform to any of the following formats:
+.
+.IP "\(bu" 4
+\fB3\.1\.2\fR (\.ruby\-version)
+.
+.IP "\(bu" 4
+\fBruby 3\.1\.2\fR (\.tool\-versions, read: https://asdf\-vm\.com/manage/configuration\.html#tool\-versions)
+.
+.IP "" 0
+.
 .SS "ENGINE"
 Each application \fImay\fR specify a Ruby engine\. If an engine is specified, an engine version \fImust\fR also be specified\.
 .

--- a/bundler/lib/bundler/man/gemfile.5.ronn
+++ b/bundler/lib/bundler/man/gemfile.5.ronn
@@ -74,6 +74,11 @@ you can use the `file` option instead.
 
     ruby file: ".ruby-version"
 
+The version file should conform to any of the following formats:
+
+  - `3.1.2` (.ruby-version)
+  - `ruby 3.1.2` (.tool-versions, read: https://asdf-vm.com/manage/configuration.html#tool-versions)
+
 ### ENGINE
 
 Each application _may_ specify a Ruby engine. If an engine is specified, an

--- a/bundler/lib/bundler/ruby_dsl.rb
+++ b/bundler/lib/bundler/ruby_dsl.rb
@@ -12,7 +12,7 @@ module Bundler
       if options[:file]
         raise GemfileError, "Cannot specify version when using the file option" if ruby_version.any?
         file_content = Bundler.read_file(Bundler.root.join(options[:file]))
-        matched_ruby_version = /^ruby\s(.*)$/.match(file_content)
+        matched_ruby_version = /^ruby\s+([\d.]+)(?:\s*#\s*.*)?$/.match(file_content)
         # if a line in the file begins with "ruby" use that else use the whole file
         ruby_version << matched_ruby_version.present? ? matched_ruby_version[1].strip : file_content.strip
       end

--- a/bundler/lib/bundler/ruby_dsl.rb
+++ b/bundler/lib/bundler/ruby_dsl.rb
@@ -11,7 +11,10 @@ module Bundler
 
       if options[:file]
         raise GemfileError, "Cannot specify version when using the file option" if ruby_version.any?
-        ruby_version << Bundler.read_file(Bundler.root.join(options[:file])).strip
+        file_content = Bundler.read_file(Bundler.root.join(options[:file]))
+        matched_ruby_version = /^ruby\s(.*)$/.match(file_content)
+        # if a line in the file begins with "ruby" use that else use the whole file
+        ruby_version << matched_ruby_version.present? ? matched_ruby_version[1].strip : file_content.strip
       end
 
       if options[:engine] == "ruby" && options[:engine_version] &&

--- a/bundler/lib/bundler/ruby_dsl.rb
+++ b/bundler/lib/bundler/ruby_dsl.rb
@@ -14,7 +14,7 @@ module Bundler
         file_content = Bundler.read_file(Bundler.root.join(options[:file]))
         matched_ruby_version = /^ruby\s+([\d.]+)(?:\s*#\s*.*)?$/.match(file_content)
         # if a line in the file begins with "ruby" use that else use the whole file
-        ruby_version << matched_ruby_version.present? ? matched_ruby_version[1].strip : file_content.strip
+        ruby_version << matched_ruby_version ? matched_ruby_version[1].strip : file_content.strip
       end
 
       if options[:engine] == "ruby" && options[:engine_version] &&

--- a/bundler/lib/bundler/ruby_dsl.rb
+++ b/bundler/lib/bundler/ruby_dsl.rb
@@ -12,9 +12,11 @@ module Bundler
       if options[:file]
         raise GemfileError, "Cannot specify version when using the file option" if ruby_version.any?
         file_content = Bundler.read_file(Bundler.root.join(options[:file]))
-        matched_ruby_version = /^ruby\s+([\d.]+)(?:\s*#\s*.*)?$/.match(file_content)
-        # if a line in the file begins with "ruby" use that else use the whole file
-        ruby_version << matched_ruby_version ? matched_ruby_version[1].strip : file_content.strip
+        if /^ruby\s+(.*)$/.match(file_content) # match .tool-versions files
+          ruby_version << $1.split("#", 2).first.strip # remove trailing comment
+        else
+          ruby_version << file_content.strip
+        end
       end
 
       if options[:engine] == "ruby" && options[:engine_version] &&

--- a/bundler/spec/bundler/ruby_dsl_spec.rb
+++ b/bundler/spec/bundler/ruby_dsl_spec.rb
@@ -121,5 +121,31 @@ RSpec.describe Bundler::RubyDsl do
         end
       end
     end
+
+    context "with a (.tool-versions) file option" do
+      let(:options) { { :file => "foo" } }
+      let(:version) { "3.2.2" }
+      let(:ruby_version) { "3.2.2" }
+      let(:ruby_version_arg) { nil }
+      let(:engine_version) { version }
+      let(:patchlevel) { nil }
+      let(:engine) { "ruby" }
+      let(:project_root) { Pathname.new("/path/to/project") }
+
+      before do
+        allow(Bundler).to receive(:read_file).with(project_root.join("foo")).and_return("nodejs 18.16.0\nruby #{version}\npnpm 8.6.12\n")
+        allow(Bundler).to receive(:root).and_return(Pathname.new("/path/to/project"))
+      end
+
+      it_behaves_like "it stores the ruby version"
+
+      context "and a version" do
+        let(:ruby_version_arg) { "2.0.0" }
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Bundler::GemfileError, "Cannot specify version when using the file option")
+        end
+      end
+    end
   end
 end

--- a/bundler/spec/bundler/ruby_dsl_spec.rb
+++ b/bundler/spec/bundler/ruby_dsl_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Bundler::RubyDsl do
       let(:project_root) { Pathname.new("/path/to/project") }
 
       before do
-        allow(Bundler).to receive(:read_file).with(project_root.join("foo")).and_return("nodejs 18.16.0\nruby #{version}\npnpm 8.6.12\n")
+        allow(Bundler).to receive(:read_file).with(project_root.join("foo")).and_return("nodejs 18.16.0\nruby #{version} # This is a comment\npnpm 8.6.12\n")
         allow(Bundler).to receive(:root).and_return(Pathname.new("/path/to/project"))
       end
 


### PR DESCRIPTION
Add support for .tool-versions via simple detect a line begins with "ruby"

## What was the end-user or developer problem that led to this PR?

Not supporting ASDF .tool-versions

## What is your fix for the problem, implemented in this PR?

Discussed more in the relevant issue: https://github.com/rubygems/rubygems/issues/6895
