### PR TITLE
Ruby version resolvers

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -64,6 +64,7 @@ module Bundler
   autoload :Retry,                  File.expand_path("bundler/retry", __dir__)
   autoload :RubyDsl,                File.expand_path("bundler/ruby_dsl", __dir__)
   autoload :RubyVersion,            File.expand_path("bundler/ruby_version", __dir__)
+  autoload :RubyVersionResolvers,   File.expand_path("bundler/ruby_version_resolvers", __dir__)
   autoload :Runtime,                File.expand_path("bundler/runtime", __dir__)
   autoload :SelfManager,            File.expand_path("bundler/self_manager", __dir__)
   autoload :Settings,               File.expand_path("bundler/settings", __dir__)

--- a/bundler/lib/bundler/ruby_dsl.rb
+++ b/bundler/lib/bundler/ruby_dsl.rb
@@ -10,8 +10,14 @@ module Bundler
       raise GemfileError, "Please define :engine" if options[:engine_version] && options[:engine].nil?
 
       if options[:file]
-        raise GemfileError, "Cannot specify version when using the file option" if ruby_version.any?
+        raise GemfileError, "Ruby version already specified: #{ruby_version}" if ruby_version.any?
         ruby_version << Bundler.read_file(Bundler.root.join(options[:file])).strip
+      elsif options[:from]
+        raise GemfileError, "Ruby version already specified: #{ruby_version}" if ruby_version.any?
+        ruby_version << RubyVersionResolvers.resolvers[options[:from]]&.call
+        if ruby_version.empty?
+          raise GemfileError, "Unable to determine Ruby version from '#{options[:from]}'"
+        end
       end
 
       if options[:engine] == "ruby" && options[:engine_version] &&

--- a/bundler/lib/bundler/ruby_version_resolvers.rb
+++ b/bundler/lib/bundler/ruby_version_resolvers.rb
@@ -1,0 +1,17 @@
+module Bundler
+  class RubyVersionResolvers
+    @resolvers = {
+      ruby_version: -> {
+        Bundler.read_file(Bundler.root.join(".ruby-version")).strip
+      },
+      tool_versions: -> {
+        contents = Bundler.read_file(Bundler.root.join(".tool-versions"))
+        contents[/^ruby\s+(\w+)/, 1]
+      }
+    }
+
+    class << self
+      attr_reader :resolvers
+    end
+  end
+end


### PR DESCRIPTION
Introduce the concept of Ruby version resolvers. This is just a proof of concept. I haven't run this code nor written tests. It's just for discussion.

The idea is that Bundler can now support known Ruby version managers. The API is like so:

`Gemfile`
```ruby
ruby from: :ruby_version
# or
ruby from: :tool_versions
# or
ruby from: :rvmrc
```

FWIW, I'm not a fan of this...I think the entire ecosystem should agree on one way, and I think it's `.ruby-version`.