### PR TITLE
Fix NoMethodError when choosing a too big number from `gem uni` list

### DIFF
--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -133,7 +133,7 @@ class Gem::Uninstaller
 
       if index == list.size
         remove_all list
-      elsif index >= 0 && index < list.size
+      elsif index && index >= 0 && index < list.size
         uninstall_gem list[index]
       else
         say "Error: must enter a number [1-#{list.size + 1}]"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Executing `gem uni somegem` and choosing a very big number that is not in the list (e.g. choosing `5` from the `gem uni rails` list where having only 2 rails version being installed) causes the following error:

```
ERROR:  While executing gem ... (NoMethodError)
    undefined method `>=' for nil

      elsif index >= 0 && index < list.size
```

This happens since abacb0cb34cdd3eaa141f1f24c52b6a524dfe095 by @nobu where `choose_from_list` has been changed to return `nil` index when an out-of-bound number was chosen (it used to simply return the chosen index regardless of the list size), and so this error can be reproduced on either rubygems v3.4.18, v3.4.19, and 3.5.0.dev as of today.

## What is your fix for the problem, implemented in this PR?

Just added a `nil` check before using the index value in Uninstaller#uninstall.

I skipped adding a reproduction test for this case because I couldn't find a good place to write such an integrated combination test of the ui and the command while unit test for each of them exist independently.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)