### PR TITLE
Confirm verification warnings

### DIFF
--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -955,11 +955,15 @@ class TestGemPackage < Gem::Package::TarTestCase
 
     package = Gem::Package.new "corrupt.gem"
 
-    e = assert_raise Gem::Package::FormatError do
-      package.verify
+    e = nil
+    out_err = capture_output do
+      e = assert_raise Gem::Package::FormatError do
+        package.verify
+      end
     end
 
     assert_match(/(EOFError|end of file reached) in corrupt.gem/i, e.message)
+    assert_equal(["", "Exception while verifying corrupt.gem\n"], out_err)
   end
 
   def test_verify_corrupt_tar_checksums_entry
@@ -987,11 +991,15 @@ class TestGemPackage < Gem::Package::TarTestCase
 
     package = Gem::Package.new "corrupt.gem"
 
-    e = assert_raise Gem::Package::FormatError do
-      package.verify
+    e = nil
+    out_err = capture_output do
+      e = assert_raise Gem::Package::FormatError do
+        package.verify
+      end
     end
 
     assert_match(/(EOFError|end of file reached) in corrupt.gem/i, e.message)
+    assert_equal(["", "Exception while verifying corrupt.gem\n"], out_err)
   end
 
   def test_corrupt_data_tar_gz


### PR DESCRIPTION
Fix up https://github.com/rubygems/rubygems/pull/6882

# What was the end-user or developer problem that led to this PR?

Warnings get mixed up in the test output.

## What is your fix for the problem, implemented in this PR?

Capture and confirm the warnings, as well as `TestGemPackage#test_verify_entry`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
