### PR TITLE
Specify -c .rubocop.yml for rake rubocop

### DIFF
--- a/bin/rubocop
+++ b/bin/rubocop
@@ -6,4 +6,6 @@ $LOAD_PATH.unshift(File.expand_path("../bundler/lib", __dir__))
 ENV["BUNDLE_GEMFILE"] = File.expand_path("../tool/bundler/lint_gems.rb", __dir__)
 require "bundler/setup"
 
+ARGV.unshift("--config", ".rubocop.yml")
+
 load Gem.bin_path("rubocop", "rubocop")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This avoids the problem where an existing .rubocop.yml is found in the user's home directory that causes errors or misconfiguration. For example, it was picking up my ~/.rubocop.yml and complaining about Rails cops.

## What is your fix for the problem, implemented in this PR?

Specify the .rubycop.yml config explicitly in the rake task.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
