### PR TITLE
Specify -c .rubocop.yml for bin/rubocop (performance)

### DIFF
--- a/bin/rubocop
+++ b/bin/rubocop
@@ -6,4 +6,7 @@ $LOAD_PATH.unshift(File.expand_path("../bundler/lib", __dir__))
 ENV["BUNDLE_GEMFILE"] = File.expand_path("../tool/bundler/lint_gems.rb", __dir__)
 require "bundler/setup"
 
+# explicit rubocop config increases performance slightly while avoiding config confusion.
+ARGV.unshift("--config", ".rubocop.yml")
+
 load Gem.bin_path("rubocop", "rubocop")


### PR DESCRIPTION
Speeds up rubocop by 13% based on hyperfine, presumably because it doesn't need to look for the right config file.

## What was the end-user or developer problem that led to this PR?

Another attempt at #6913 which addresses this as a performance improvement, in addition to a temporary big fix.

Hyperfine shows a 13% improvement over the identical command and environment without `-c .rubocop.yml`.

## What is your fix for the problem, implemented in this PR?

Explicit .rubocop.yml config

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
