### PR TITLE
Don't use full indexes unnecessarily on legacy Gemfiles

### DIFF
--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -399,16 +399,11 @@ module Bundler
         @remote_specs ||= Index.build do |idx|
           index_fetchers = fetchers - api_fetchers
 
-          # gather lists from non-api sites
-          fetch_names(index_fetchers, nil, idx, false)
-
-          # legacy multi-remote sources need special logic to figure out
-          # dependency names and that logic can be very costly if one remote
-          # uses the dependency API but others don't. So use full indexes
-          # consistently in that particular case.
-          allow_api = !multiple_remotes?
-
-          fetch_names(api_fetchers, allow_api && dependency_names, idx, false)
+          if index_fetchers.empty?
+            fetch_names(api_fetchers, dependency_names, idx, false)
+          else
+            fetch_names(fetchers, nil, idx, false)
+          end
         end
       end
 

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -35,6 +35,15 @@ RSpec.describe "bundle install with gems on multiple sources" do
         expect(the_bundle).to include_gems("rack-obama 1.0.0", "rack 1.0.0", :source => "remote1")
       end
 
+      it "does not use the full index unnecessarily", :bundler => "< 3" do
+        bundle :install, :artifice => "compact_index", :verbose => true
+
+        expect(out).to include("https://gem.repo1/versions")
+        expect(out).to include("https://gem.repo3/versions")
+        expect(out).not_to include("https://gem.repo1/quick/Marshal.4.8/")
+        expect(out).not_to include("https://gem.repo3/quick/Marshal.4.8/")
+      end
+
       it "fails", :bundler => "3" do
         bundle :install, :artifice => "compact_index", :raise_on_error => false
         expect(err).to include("Each source after the first must include a block")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

On legacy Gemfiles with multiple remote sources, where all of them support the compact index API, we were still falling back to full indexes, making things slow.

## What is your fix for the problem, implemented in this PR?

My fix to to remove the special case of "multiple remote Gemfile is involved" and change it to "at least one remote that only supports full indexes is involved".

Fixing this also allows to simplifying the code.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
