### PR TITLE
Fix standalone install crashing when using legacy gemfiles with multiple global sources

### DIFF
--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -275,7 +275,9 @@ module Bundler
 
         Bundler.ui.debug "Double checking for #{unmet_dependency_names || "all specs (due to the size of the request)"} in #{self}"
 
-        fetch_names(api_fetchers, unmet_dependency_names, specs, false)
+        fetch_names(api_fetchers, unmet_dependency_names, remote_specs, false)
+
+        specs.use(remote_specs, false)
       end
 
       def dependency_names_to_double_check

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -78,6 +78,33 @@ RSpec.describe "bundle install with gems on multiple sources" do
     end
   end
 
+  context "without source affinity, and a stdlib gem present in one of the sources", :ruby_repo do
+    let(:default_json_version) { ruby "gem 'json'; require 'json'; puts JSON::VERSION" }
+
+    before do
+      build_repo2 do
+        build_gem "json", default_json_version
+      end
+
+      build_repo4 do
+        build_gem "foo" do |s|
+          s.add_dependency "json", default_json_version
+        end
+      end
+
+      gemfile <<-G
+        source "https://gem.repo2"
+        source "https://gem.repo4"
+
+        gem "foo"
+      G
+    end
+
+    it "works in standalone mode", :bundler => "< 3" do
+      bundle "install --standalone", :artifice => "compact_index"
+    end
+  end
+
   context "with source affinity" do
     context "with sources given by a block" do
       before do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If a legacy multi remote Gemfile depends transitively on a default gem, `bundle install --standalone` would crash.

## What is your fix for the problem, implemented in this PR?

If a legacy Gemfile with multiple global sources depends transitively on a default gem, then in standalone mode we'd fail to fetch the proper version from the source that includes it, since we were adding it to `specs` (instead of `remote_specs`), which was already including the default version of the gem, and thus preventing the remote version from "overwriting that" and being added to the index. We should add it to the `remote_specs` index directly instead.

Fixes #6273.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
