### PR TITLE
Only check circular deps when dependency api is available, not on full index sources

### DIFF
--- a/bundler/lib/bundler/fetcher/compact_index.rb
+++ b/bundler/lib/bundler/fetcher/compact_index.rb
@@ -60,10 +60,6 @@ module Bundler
           Bundler.ui.debug("FIPS mode is enabled, bundler can't use the CompactIndex API")
           return nil
         end
-        if fetch_uri.scheme == "file"
-          Bundler.ui.debug("Using a local server, bundler won't use the CompactIndex API")
-          return false
-        end
         # Read info file checksums out of /versions, so we can know if gems are up to date
         compact_index_client.update_and_parse_checksums!
       rescue CompactIndexClient::Updater::MisMatchedChecksumError => e

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -392,7 +392,7 @@ module Bundler
       end
 
       def api_fetchers
-        fetchers.select {|f| f.use_api && f.fetchers.first.api_fetcher? }
+        fetchers.select(&:api_fetcher?)
       end
 
       def remote_specs

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -237,7 +237,7 @@ module Bundler
       end
 
       def spec_names
-        if @allow_remote && dependency_api_available?
+        if dependency_api_available?
           remote_specs.spec_names
         else
           []
@@ -245,7 +245,7 @@ module Bundler
       end
 
       def unmet_deps
-        if @allow_remote && dependency_api_available?
+        if dependency_api_available?
           remote_specs.unmet_dependency_names
         else
           []
@@ -260,7 +260,6 @@ module Bundler
       end
 
       def double_check_for(unmet_dependency_names)
-        return unless @allow_remote
         return unless dependency_api_available?
 
         unmet_dependency_names = unmet_dependency_names.call

--- a/bundler/spec/bundler/fetcher_spec.rb
+++ b/bundler/spec/bundler/fetcher_spec.rb
@@ -189,4 +189,70 @@ RSpec.describe Bundler::Fetcher do
       end
     end
   end
+
+  describe "#specs_with_retry" do
+    let(:downloader)  { double(:downloader) }
+    let(:remote)      { double(:remote, :cache_slug => "slug", :uri => uri, :original_uri => nil, :anonymized_uri => uri) }
+    let(:compact_index) { double(Bundler::Fetcher::CompactIndex, :available? => true, :api_fetcher? => true) }
+    let(:dependency)    { double(Bundler::Fetcher::Dependency, :available? => true, :api_fetcher? => true) }
+    let(:index)         { double(Bundler::Fetcher::Index, :available? => true, :api_fetcher? => false) }
+
+    before do
+      allow(Bundler::Fetcher::CompactIndex).to receive(:new).and_return(compact_index)
+      allow(Bundler::Fetcher::Dependency).to receive(:new).and_return(dependency)
+      allow(Bundler::Fetcher::Index).to receive(:new).and_return(index)
+    end
+
+    it "picks the first fetcher that works" do
+      expect(compact_index).to receive(:specs).with("name").and_return([["name", "1.2.3", "ruby"]])
+      expect(dependency).not_to receive(:specs)
+      expect(index).not_to receive(:specs)
+      fetcher.specs_with_retry("name", double(Bundler::Source::Rubygems))
+    end
+
+    context "when APIs are not available" do
+      before do
+        allow(compact_index).to receive(:available?).and_return(false)
+        allow(dependency).to receive(:available?).and_return(false)
+      end
+
+      it "uses the index" do
+        expect(compact_index).not_to receive(:specs)
+        expect(dependency).not_to receive(:specs)
+        expect(index).to receive(:specs).with("name").and_return([["name", "1.2.3", "ruby"]])
+
+        fetcher.specs_with_retry("name", double(Bundler::Source::Rubygems))
+      end
+    end
+  end
+
+  describe "#api_fetcher?" do
+    let(:downloader)  { double(:downloader) }
+    let(:remote)      { double(:remote, :cache_slug => "slug", :uri => uri, :original_uri => nil, :anonymized_uri => uri) }
+    let(:compact_index) { double(Bundler::Fetcher::CompactIndex, :available? => false, :api_fetcher? => true) }
+    let(:dependency)    { double(Bundler::Fetcher::Dependency, :available? => false, :api_fetcher? => true) }
+    let(:index)         { double(Bundler::Fetcher::Index, :available? => true, :api_fetcher? => false) }
+
+    before do
+      allow(Bundler::Fetcher::CompactIndex).to receive(:new).and_return(compact_index)
+      allow(Bundler::Fetcher::Dependency).to receive(:new).and_return(dependency)
+      allow(Bundler::Fetcher::Index).to receive(:new).and_return(index)
+    end
+
+    context "when an api fetcher is available" do
+      before do
+        allow(compact_index).to receive(:available?).and_return(true)
+      end
+
+      it "is truthy" do
+        expect(fetcher).to be_api_fetcher
+      end
+    end
+
+    context "when only the index fetcher is available" do
+      it "is falsey" do
+        expect(fetcher).not_to be_api_fetcher
+      end
+    end
+  end
 end

--- a/bundler/spec/resolver/basic_spec.rb
+++ b/bundler/spec/resolver/basic_spec.rb
@@ -347,4 +347,27 @@ RSpec.describe "Resolving" do
 
     should_resolve_as %w[rack-3.0.0 standalone_migrations-1.0.13]
   end
+
+  it "does not ignore versions that incorrectly depend on themselves when dependency_api is not available" do
+    @index = build_index do
+      gem "rack", "3.0.0"
+
+      gem "standalone_migrations", "7.1.0" do
+        dep "rack", "~> 2.0"
+      end
+
+      gem "standalone_migrations", "2.0.4" do
+        dep "standalone_migrations", ">= 2.0.5"
+      end
+
+      gem "standalone_migrations", "1.0.13" do
+        dep "rack", ">= 0"
+      end
+    end
+
+    dep "rack", "~> 3.0"
+    dep "standalone_migrations"
+
+    should_resolve_without_dependency_api %w[rack-3.0.0 standalone_migrations-2.0.4]
+  end
 end

--- a/bundler/spec/support/indexes.rb
+++ b/bundler/spec/support/indexes.rb
@@ -14,9 +14,9 @@ module Spec
 
     alias_method :platforms, :platform
 
-    def resolve(args = [])
+    def resolve(args = [], dependency_api_available: true)
       @platforms ||= ["ruby"]
-      default_source = instance_double("Bundler::Source::Rubygems", :specs => @index, :to_s => "locally install gems")
+      default_source = instance_double("Bundler::Source::Rubygems", :specs => @index, :to_s => "locally install gems", :dependency_api_available? => dependency_api_available)
       source_requirements = { :default => default_source }
       base = args[0] || Bundler::SpecSet.new([])
       base.each {|ls| ls.source = default_source }
@@ -37,6 +37,12 @@ module Spec
 
     def should_resolve_as(specs)
       got = resolve
+      got = got.map(&:full_name).sort
+      expect(got).to eq(specs.sort)
+    end
+
+    def should_resolve_without_dependency_api(specs)
+      got = resolve(:dependency_api_available => false)
       got = got.map(&:full_name).sort
       expect(got).to eq(specs.sort)
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This check fixes some edge cases during resolution, but checking it when dependency APIs are not available is too slow.

## What is your fix for the problem, implemented in this PR?

This PR builds on top of #6897 to disable this check.

Fixes #6828.

I tried this manually and it's back to fast but I'd probably add a spec before merging?

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
