### PR TITLE
(Further) Improve Bundler::Settings#[] performance and memory usage

### DIFF
--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -102,10 +102,13 @@ module Bundler
     def [](name)
       key = key_for(name)
 
-      values = configs.values
-      values.map! {|config| config[key] }
-      values.compact!
-      value = values.first
+      value = nil
+      configs.each do |_, config|
+        if config[key]
+          value = config[key]
+          break
+        end
+      end
 
       converted_value(value, name)
     end
@@ -316,7 +319,7 @@ module Bundler
     private
 
     def configs
-      {
+      @configs ||= {
         :temporary => @temporary,
         :local => @local_config,
         :env => @env_config,

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -104,10 +104,9 @@ module Bundler
 
       value = nil
       configs.each do |_, config|
-        if config[key]
-          value = config[key]
-          break
-        end
+        value = config[key]
+        next if value.nil?
+        break
       end
 
       converted_value(value, name)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

It's ya boi technicalpickles running [memory_profiler](https://github.com/SamSaffron/memory_profiler) on a large monolith booting Rails again

## What is your fix for the problem, implemented in this PR?

I previously identified and improved this method over in https://github.com/rubygems/rubygems/pull/6884 but while reviewing another memory_profiler profile, I realized another gain we can eek out.

This method keeps comes up in part because `configs` is allocating a new Hash every time. My last change took advantage of that by using `map!` on it. `configs` is called quite often, including in this `[]` method, so there's a benefit to memoizing it.

Back in `[]`, logically we are trying to find the first Hash in `configs` that has a value for the given key. Currently, we end up `map` and `compact` to just get that value.

Instead, we can use a loop over `configs`, and break when we find the value for the key.

## Benchmarks

[Microbenchmarks, comparing implementations](https://gist.github.com/technicalpickles/91933d34dcd47bfc99d6ac0e53fcdb1e) (this PR implements manual_loop w/ memoized configs): 

```
Calculating -------------------------------------
            original   800.000  memsize (   168.000  retained)
                        11.000  objects (     1.000  retained)
                         3.000  strings (     0.000  retained)
         bang_method   392.000  memsize (    72.000  retained)
                         7.000  objects (     1.000  retained)
                         3.000  strings (     1.000  retained)
         with_detect   392.000  memsize (    72.000  retained)
                         7.000  objects (     1.000  retained)
                         3.000  strings (     1.000  retained)
with_detect w/ memoized configs
                       392.000  memsize (    72.000  retained)
                         7.000  objects (     1.000  retained)
                         3.000  strings (     1.000  retained)
         manual_loop   312.000  memsize (    72.000  retained)
                         6.000  objects (     1.000  retained)
                         3.000  strings (     1.000  retained)
manual_loop w/ memoized configs
                       312.000  memsize (    72.000  retained)
                         6.000  objects (     1.000  retained)
                         3.000  strings (     1.000  retained)

Comparison:
         manual_loop:        312 allocated
manual_loop w/ memoized configs:        312 allocated - same
         bang_method:        392 allocated - 1.26x more
         with_detect:        392 allocated - 1.26x more
with_detect w/ memoized configs:        392 allocated - 1.26x more
            original:        800 allocated - 2.56x more
Warming up --------------------------------------
            original    74.589k i/100ms
         bang_method   104.215k i/100ms
         with_detect    99.974k i/100ms
with_detect w/ memoized configs
                       100.748k i/100ms
         manual_loop   104.471k i/100ms
manual_loop w/ memoized configs
                       105.599k i/100ms
Calculating -------------------------------------
            original    753.388k (± 1.7%) i/s -      3.804M in   5.050732s
         bang_method      1.038M (± 1.4%) i/s -      5.211M in   5.022015s
         with_detect      1.003M (± 0.9%) i/s -      5.099M in   5.084331s
with_detect w/ memoized configs
                          1.004M (± 1.0%) i/s -      5.037M in   5.018705s
         manual_loop      1.042M (± 0.8%) i/s -      5.224M in   5.011204s
manual_loop w/ memoized configs
                          1.056M (± 1.2%) i/s -      5.386M in   5.100790s

Comparison:
            original:   753387.7 i/s
manual_loop w/ memoized configs:  1055974.9 i/s - 1.40x  faster
         manual_loop:  1042434.4 i/s - 1.38x  faster
         bang_method:  1037808.1 i/s - 1.38x  faster
with_detect w/ memoized configs:  1003831.7 i/s - 1.33x  faster
         with_detect:  1002897.1 i/s - 1.33x  faster
```

[Hyperfine](https://github.com/sharkdp/hyperfine) running against bundler 2.4.19 vs this branch

```
❯ hyperfine "ruby boot-time-benchmark.rb" "ruby -I/Users/josh.nichols/workspace/rubygems/bundler/lib boot-time-benchmark.rb"
Benchmark 1: ruby boot-time-benchmark.rb
  Time (mean ± σ):      8.902 s ±  0.807 s    [User: 5.142 s, System: 3.117 s]
  Range (min … max):    8.090 s … 10.858 s    10 runs

Benchmark 2: ruby -I/Users/josh.nichols/workspace/rubygems/bundler/lib boot-time-benchmark.rb
  Time (mean ± σ):      8.350 s ±  0.101 s    [User: 5.155 s, System: 3.045 s]
  Range (min … max):    8.233 s …  8.513 s    10 runs

Summary
  ruby -I/Users/josh.nichols/workspace/rubygems/bundler/lib boot-time-benchmark.rb ran
    1.07 ± 0.10 times faster than ruby boot-time-benchmark.rb
```

Colorful version:

<img width="1158" alt="CleanShot 2023-08-28 at 20 55 08@2x" src="https://github.com/rubygems/rubygems/assets/159/7f01f8d3-7a6f-4bb0-a630-82974e51b6c5">




## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
