### PR TITLE
Fix bundle update --redownload

### DIFF
--- a/bundler/lib/bundler/cli/update.rb
+++ b/bundler/lib/bundler/cli/update.rb
@@ -63,6 +63,7 @@ module Bundler
       opts = options.dup
       opts["update"] = true
       opts["local"] = options[:local]
+      opts["force"] = options[:redownload]
 
       Bundler.settings.set_command_option_if_given :jobs, opts["jobs"]
 

--- a/bundler/spec/update/redownload_spec.rb
+++ b/bundler/spec/update/redownload_spec.rb
@@ -30,5 +30,15 @@ RSpec.describe "bundle update" do
       bundle "update rack --no-color --redownload"
       expect(err).not_to include "[DEPRECATED] The `--force` option has been renamed to `--redownload`"
     end
+
+    it "re-installs installed gems" do
+      rack_lib = default_bundle_path("gems/rack-1.0.0/lib/rack.rb")
+      rack_lib.open("w") {|f| f.write("blah blah blah") }
+      bundle :update, :redownload => true
+
+      expect(out).to include "Installing rack 1.0.0"
+      expect(rack_lib.open(&:read)).to eq("RACK = '1.0.0'\n")
+      expect(the_bundle).to include_gems "rack 1.0.0"
+    end
   end
 end


### PR DESCRIPTION

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

`bundle update --redownload`  didn't work

## What is your fix for the problem, implemented in this PR?

Make it work by aliasing `:redownload` to `:force`, just like is done for `bundle install`

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
