### PR TITLE
Prevent gem activation in standalone mode

### DIFF
--- a/bundler/lib/bundler/installer/standalone.rb
+++ b/bundler/lib/bundler/installer/standalone.rb
@@ -12,6 +12,7 @@ module Bundler
       end
       File.open File.join(bundler_path, "setup.rb"), "w" do |file|
         file.puts "require 'rbconfig'"
+        file.puts prevent_gem_activation
         file.puts define_path_helpers
         file.puts reverse_rubygems_kernel_mixin
         paths.each do |path|
@@ -60,6 +61,19 @@ module Bundler
     rescue TypeError
       error_message = "#{spec.name} #{spec.version} has an invalid gemspec"
       raise Gem::InvalidSpecificationException.new(error_message)
+    end
+
+    def prevent_gem_activation
+      <<~'END'
+        module Kernel
+          remove_method(:gem) if private_method_defined?(:gem)
+
+          def gem(*)
+          end
+
+          private :gem
+        end
+      END
     end
 
     def define_path_helpers

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -101,6 +101,22 @@ RSpec.shared_examples "bundle install --standalone" do
 
       expect(out).to eq(expected_gems.values.join("\n"))
     end
+
+    it "skips activating gems" do
+      testrb = String.new <<-RUBY
+        $:.unshift File.expand_path("bundle")
+        require "bundler/setup"
+
+        gem "do_not_activate_me"
+      RUBY
+      expected_gems.each do |k, _|
+        testrb << "\nrequire \"#{k}\""
+        testrb << "\nputs #{k.upcase}"
+      end
+      sys_exec %(#{Gem.ruby} -w -e #{testrb.shellescape})
+
+      expect(out).to eq(expected_gems.values.join("\n"))
+    end
   end
 
   describe "with simple gems" do


### PR DESCRIPTION


<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

As discussed in https://github.com/rubygems/rubygems/issues/6273#issuecomment-1449176658

The `gem` method behaves awkwardly in standalone mode. Assuming bundler isn't loaded at all, a call to gem might activate a gem that is not part of the bundle (because it's the gem method defined in lib/rubygems/core_ext/kernel_gem.rb and not
lib/bundler/rubygems_integration.rb). And when running with `--disable-gems`, the gem method won't be defined at all so we'll get a NoMethodError.

Calls to `gem` can appear in dependencies outside an application's control. To work around this at GitHub we defined our own `Kernel#gem` that no-ops.

I agree with https://github.com/rubygems/rubygems/issues/6273#issuecomment-1440755882

> people using standalone mode don't want to activate gems like Kernel.gem

## What is your fix for the problem, implemented in this PR?

This commit redefines `Kernel#gem` in the standalone script to no-op.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
