### PR TITLE
Update SPDX list and warn on deprecated identifiers.

### DIFF
--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -371,10 +371,21 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
 
     licenses.each do |license|
       next if Gem::Licenses.match?(license) || license.nil?
+      license_id_deprecated = Gem::Licenses.deprecated_license_id?(license)
+      exception_id_deprecated = Gem::Licenses.deprecated_exception_id?(license)
       suggestions = Gem::Licenses.suggestions(license)
+
+      if license_id_deprecated
+        main_message = "License identifier '#{license}' is deprecated"
+      elsif exception_id_deprecated
+        main_message = "Exception identifier at '#{license}' is deprecated"
+      else
+        main_message = "License identifier '#{license}' is invalid"
+      end
+
       message = <<-WARNING
-license value '#{license}' is invalid.  Use a license identifier from
-http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard license,
+#{main_message}. Use an identifier from
+https://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard license,
 or set it to nil if you don't want to specify a license.
       WARNING
       message += "Did you mean #{suggestions.map {|s| "'#{s}'" }.join(", ")}?\n" unless suggestions.nil?
@@ -382,8 +393,8 @@ or set it to nil if you don't want to specify a license.
     end
 
     warning <<-WARNING if licenses.empty?
-licenses is empty, but is recommended.  Use a license identifier from
-http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard license,
+licenses is empty, but is recommended. Use an license identifier from
+https://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard license,
 or set it to nil if you don't want to specify a license.
     WARNING
   end

--- a/lib/rubygems/util/licenses.rb
+++ b/lib/rubygems/util/licenses.rb
@@ -22,10 +22,8 @@ class Gem::Licenses
     AFL-2.0
     AFL-2.1
     AFL-3.0
-    AGPL-1.0
     AGPL-1.0-only
     AGPL-1.0-or-later
-    AGPL-3.0
     AGPL-3.0-only
     AGPL-3.0-or-later
     AMDPLPA
@@ -58,8 +56,6 @@ class Gem::Licenses
     Artistic-2.0
     BSD-1-Clause
     BSD-2-Clause
-    BSD-2-Clause-FreeBSD
-    BSD-2-Clause-NetBSD
     BSD-2-Clause-Patent
     BSD-2-Clause-Views
     BSD-3-Clause
@@ -219,21 +215,18 @@ class Gem::Licenses
     FreeBSD-DOC
     FreeImage
     GD
-    GFDL-1.1
     GFDL-1.1-invariants-only
     GFDL-1.1-invariants-or-later
     GFDL-1.1-no-invariants-only
     GFDL-1.1-no-invariants-or-later
     GFDL-1.1-only
     GFDL-1.1-or-later
-    GFDL-1.2
     GFDL-1.2-invariants-only
     GFDL-1.2-invariants-or-later
     GFDL-1.2-no-invariants-only
     GFDL-1.2-no-invariants-or-later
     GFDL-1.2-only
     GFDL-1.2-or-later
-    GFDL-1.3
     GFDL-1.3-invariants-only
     GFDL-1.3-invariants-or-later
     GFDL-1.3-no-invariants-only
@@ -242,25 +235,12 @@ class Gem::Licenses
     GFDL-1.3-or-later
     GL2PS
     GLWTPL
-    GPL-1.0
-    GPL-1.0+
     GPL-1.0-only
     GPL-1.0-or-later
-    GPL-2.0
-    GPL-2.0+
     GPL-2.0-only
     GPL-2.0-or-later
-    GPL-2.0-with-GCC-exception
-    GPL-2.0-with-autoconf-exception
-    GPL-2.0-with-bison-exception
-    GPL-2.0-with-classpath-exception
-    GPL-2.0-with-font-exception
-    GPL-3.0
-    GPL-3.0+
     GPL-3.0-only
     GPL-3.0-or-later
-    GPL-3.0-with-GCC-exception
-    GPL-3.0-with-autoconf-exception
     Giftware
     Glide
     Glulxe
@@ -298,16 +278,10 @@ class Gem::Licenses
     Knuth-CTAN
     LAL-1.2
     LAL-1.3
-    LGPL-2.0
-    LGPL-2.0+
     LGPL-2.0-only
     LGPL-2.0-or-later
-    LGPL-2.1
-    LGPL-2.1+
     LGPL-2.1-only
     LGPL-2.1-or-later
-    LGPL-3.0
-    LGPL-3.0+
     LGPL-3.0-only
     LGPL-3.0-or-later
     LGPLLR
@@ -387,7 +361,6 @@ class Gem::Licenses
     Newsletr
     Nokia
     Noweb
-    Nunit
     O-UDA-1.0
     OCCT-PL
     OCLC-2.0
@@ -486,7 +459,6 @@ class Gem::Licenses
     Spencer-86
     Spencer-94
     Spencer-99
-    StandardML-NJ
     SugarCRM-1.1.3
     SunPro
     Symlinks
@@ -539,7 +511,6 @@ class Gem::Licenses
     Zimbra-1.4
     Zlib
     blessing
-    bzip2-1.0.5
     bzip2-1.0.6
     checkmk
     copyleft-next-0.3.0
@@ -548,7 +519,6 @@ class Gem::Licenses
     diffmark
     dtoa
     dvipdfm
-    eCos-2.0
     eGenix
     etalab-2.0
     gSOAP-1.3b
@@ -566,11 +536,44 @@ class Gem::Licenses
     psutils
     snprintf
     w3m
-    wxWindows
     xinetd
     xlock
     xpp
     zlib-acknowledgement
+  ].freeze
+
+  DEPRECATED_LICENSE_IDENTIFIERS = %w[
+    AGPL-1.0
+    AGPL-3.0
+    BSD-2-Clause-FreeBSD
+    BSD-2-Clause-NetBSD
+    GFDL-1.1
+    GFDL-1.2
+    GFDL-1.3
+    GPL-1.0
+    GPL-1.0+
+    GPL-2.0
+    GPL-2.0+
+    GPL-2.0-with-GCC-exception
+    GPL-2.0-with-autoconf-exception
+    GPL-2.0-with-bison-exception
+    GPL-2.0-with-classpath-exception
+    GPL-2.0-with-font-exception
+    GPL-3.0
+    GPL-3.0+
+    GPL-3.0-with-GCC-exception
+    GPL-3.0-with-autoconf-exception
+    LGPL-2.0
+    LGPL-2.0+
+    LGPL-2.1
+    LGPL-2.1+
+    LGPL-3.0
+    LGPL-3.0+
+    Nunit
+    StandardML-NJ
+    bzip2-1.0.5
+    eCos-2.0
+    wxWindows
   ].freeze
 
   # exception identifiers
@@ -605,7 +608,6 @@ class Gem::Licenses
     LZMA-exception
     Libtool-exception
     Linux-syscall-note
-    Nokia-Qt-exception-1.1
     OCCT-exception-1.0
     OCaml-LGPL-linking-exception
     OpenJDK-assembly-exception-1.0
@@ -633,7 +635,11 @@ class Gem::Licenses
     x11vnc-openssl-exception
   ].freeze
 
-  REGEXP = /
+  DEPRECATED_EXCEPTION_IDENTIFIERS = %w[
+    Nokia-Qt-exception-1.1
+  ].freeze
+
+  VALID_REGEXP = /
     \A
     (?:
       #{Regexp.union(LICENSE_IDENTIFIERS)}
@@ -645,8 +651,32 @@ class Gem::Licenses
     \Z
   /ox.freeze
 
+  DEPRECATED_LICENSE_REGEXP = /
+    \A
+    #{Regexp.union(DEPRECATED_LICENSE_IDENTIFIERS)}
+    \+?
+    (?:\s WITH \s .+?)?
+    \Z
+  /ox.freeze
+
+  DEPRECATED_EXCEPTION_REGEXP = /
+    \A
+    .+?
+    \+?
+    (?:\s WITH \s #{Regexp.union(DEPRECATED_EXCEPTION_IDENTIFIERS)})
+    \Z
+  /ox.freeze
+
   def self.match?(license)
-    REGEXP.match?(license)
+    VALID_REGEXP.match?(license)
+  end
+
+  def self.deprecated_license_id?(license)
+    DEPRECATED_LICENSE_REGEXP.match?(license)
+  end
+
+  def self.deprecated_exception_id?(license)
+    DEPRECATED_EXCEPTION_REGEXP.match?(license)
   end
 
   def self.suggestions(license)

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -26,7 +26,7 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     end
 
     @gem = util_spec "some_gem" do |s|
-      s.license = "AGPL-3.0"
+      s.license = "AGPL-3.0-only"
       s.files = ["README.md"]
     end
 
@@ -198,8 +198,8 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     end
 
     error = @ui.error.split "\n"
-    assert_equal "WARNING:  licenses is empty, but is recommended.  Use a license identifier from", error.shift
-    assert_equal "http://spdx.org/licenses or 'Nonstandard' for a nonstandard license,", error.shift
+    assert_equal "WARNING:  licenses is empty, but is recommended. Use an license identifier from", error.shift
+    assert_equal "https://spdx.org/licenses or 'Nonstandard' for a nonstandard license,", error.shift
     assert_equal "or set it to nil if you don't want to specify a license.", error.shift
     assert_equal "WARNING:  See https://guides.rubygems.org/specification-reference/ for help", error.shift
     assert_equal [], error

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3104,8 +3104,8 @@ Please report a bug if this causes problems.
     end
 
     assert_match <<-WARNING, @ui.error
-WARNING:  licenses is empty, but is recommended.  Use a license identifier from
-http://spdx.org/licenses or 'Nonstandard' for a nonstandard license,
+WARNING:  licenses is empty, but is recommended. Use an license identifier from
+https://spdx.org/licenses or 'Nonstandard' for a nonstandard license,
 or set it to nil if you don't want to specify a license.
     WARNING
   end
@@ -3156,8 +3156,8 @@ or set it to nil if you don't want to specify a license.
     end
 
     assert_match <<-WARNING, @ui.error
-WARNING:  license value 'BSD' is invalid.  Use a license identifier from
-http://spdx.org/licenses or 'Nonstandard' for a nonstandard license,
+WARNING:  License identifier 'BSD' is invalid. Use an identifier from
+https://spdx.org/licenses or 'Nonstandard' for a nonstandard license,
 or set it to nil if you don't want to specify a license.
     WARNING
   end
@@ -3173,7 +3173,7 @@ or set it to nil if you don't want to specify a license.
     assert_empty @ui.error
   end
 
-  def test_validate_license_values_plus
+  def test_validate_deprecated_license_values_plus
     util_setup_validate
 
     use_ui @ui do
@@ -3181,7 +3181,11 @@ or set it to nil if you don't want to specify a license.
       @a1.validate
     end
 
-    assert_empty @ui.error
+    assert_match <<-WARNING, @ui.error
+WARNING:  License identifier 'GPL-2.0+' is deprecated. Use an identifier from
+https://spdx.org/licenses or 'Nonstandard' for a nonstandard license,
+or set it to nil if you don't want to specify a license.
+    WARNING
   end
 
   def test_validate_license_values_or_later
@@ -3199,7 +3203,7 @@ or set it to nil if you don't want to specify a license.
     util_setup_validate
 
     use_ui @ui do
-      @a1.licenses = ["GPL-2.0+ WITH Autoconf-exception-2.0"]
+      @a1.licenses = ["GPL-2.0-or-later WITH Autoconf-exception-2.0"]
       @a1.validate
     end
 
@@ -3215,13 +3219,13 @@ or set it to nil if you don't want to specify a license.
     end
 
     assert_match <<-WARNING, @ui.error
-WARNING:  license value 'GPL-2.0+ FOO' is invalid.  Use a license identifier from
-http://spdx.org/licenses or 'Nonstandard' for a nonstandard license,
+WARNING:  License identifier 'GPL-2.0+ FOO' is invalid. Use an identifier from
+https://spdx.org/licenses or 'Nonstandard' for a nonstandard license,
 or set it to nil if you don't want to specify a license.
     WARNING
     assert_match <<-WARNING, @ui.error
-WARNING:  license value 'GPL-2.0 FOO' is invalid.  Use a license identifier from
-http://spdx.org/licenses or 'Nonstandard' for a nonstandard license,
+WARNING:  License identifier 'GPL-2.0+ FOO' is invalid. Use an identifier from
+https://spdx.org/licenses or 'Nonstandard' for a nonstandard license,
 or set it to nil if you don't want to specify a license.
     WARNING
   end
@@ -3230,13 +3234,28 @@ or set it to nil if you don't want to specify a license.
     util_setup_validate
 
     use_ui @ui do
-      @a1.licenses = ["GPL-2.0+ WITH Autocofn-exception-2.0"]
+      @a1.licenses = ["GPL-2.0-only WITH Autocofn-exception-2.0"]
       @a1.validate
     end
 
     assert_match <<-WARNING, @ui.error
-WARNING:  license value 'GPL-2.0+ WITH Autocofn-exception-2.0' is invalid.  Use a license identifier from
-http://spdx.org/licenses or 'Nonstandard' for a nonstandard license,
+WARNING:  License identifier 'GPL-2.0-only WITH Autocofn-exception-2.0' is invalid. Use an identifier from
+https://spdx.org/licenses or 'Nonstandard' for a nonstandard license,
+or set it to nil if you don't want to specify a license.
+    WARNING
+  end
+
+  def test_validate_license_with_deprecated_exception
+    util_setup_validate
+
+    use_ui @ui do
+      @a1.licenses = ["GPL-2.0-only WITH Nokia-Qt-exception-1.1"]
+      @a1.validate
+    end
+
+    assert_match <<-WARNING, @ui.error
+WARNING:  Exception identifier at 'GPL-2.0-only WITH Nokia-Qt-exception-1.1' is deprecated. Use an identifier from
+https://spdx.org/licenses or 'Nonstandard' for a nonstandard license,
 or set it to nil if you don't want to specify a license.
     WARNING
   end
@@ -3250,8 +3269,8 @@ or set it to nil if you don't want to specify a license.
     end
 
     assert_match <<-WARNING, @ui.error
-WARNING:  license value 'ruby' is invalid.  Use a license identifier from
-http://spdx.org/licenses or 'Nonstandard' for a nonstandard license,
+WARNING:  License identifier 'ruby' is invalid. Use an identifier from
+https://spdx.org/licenses or 'Nonstandard' for a nonstandard license,
 or set it to nil if you don't want to specify a license.
 Did you mean 'Ruby'?
     WARNING


### PR DESCRIPTION
- updates SPDX list
- split licence identifiers list into valid and deprecated ones
- provide detailed message of SPDX identifier validity (invalid or deprecated identifier or exception part)
- update SPDX link to https

closes https://github.com/rubygems/rubygems/issues/2153, https://github.com/rubygems/rubygems/pull/2259

/cc @voxik 