### PR TITLE
Remove usage of Dir.chdir that only execute a subprocess

### DIFF
--- a/bundler/lib/bundler/build_metadata.rb
+++ b/bundler/lib/bundler/build_metadata.rb
@@ -29,7 +29,7 @@ module Bundler
       # commit instance variable then we can't determine its commits SHA.
       git_dir = File.expand_path("../../../.git", __dir__)
       if File.directory?(git_dir)
-        return @git_commit_sha = Dir.chdir(git_dir) { `git rev-parse --short HEAD`.strip.freeze }
+        return @git_commit_sha = IO.popen(%w[git rev-parse --short HEAD], { :chdir => git_dir }, &:read).strip.freeze
       end
 
       @git_commit_sha ||= "unknown"

--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -233,9 +233,7 @@ module Bundler
       end
 
       if use_git
-        Dir.chdir(target) do
-          `git add .`
-        end
+        IO.popen(%w[git add .], { :chdir => target }, &:read)
       end
 
       # Open gemspec in editor

--- a/bundler/lib/bundler/cli/open.rb
+++ b/bundler/lib/bundler/cli/open.rb
@@ -18,13 +18,11 @@ module Bundler
         Bundler.ui.info "Unable to open #{name} because it's a default gem, so the directory it would normally be installed to does not exist."
       else
         root_path = spec.full_gem_path
-        Dir.chdir(root_path) do
-          require "shellwords"
-          command = Shellwords.split(editor) << File.join([root_path, path].compact)
-          Bundler.with_original_env do
-            system(*command)
-          end || Bundler.ui.info("Could not run '#{command.join(" ")}'")
-        end
+        require "shellwords"
+        command = Shellwords.split(editor) << File.join([root_path, path].compact)
+        Bundler.with_original_env do
+          system(*command, { :chdir => root_path })
+        end || Bundler.ui.info("Could not run '#{command.join(" ")}'")
       end
     end
   end

--- a/lib/rubygems/commands/open_command.rb
+++ b/lib/rubygems/commands/open_command.rb
@@ -70,9 +70,7 @@ class Gem::Commands::OpenCommand < Gem::Command
   end
 
   def open_editor(path)
-    Dir.chdir(path) do
-      system(*@editor.split(/\s+/) + [path])
-    end
+    system(*@editor.split(/\s+/) + [path], { :chdir => path })
   end
 
   def spec_for(name)


### PR DESCRIPTION
Preferring instead to spawn the subprocess in the correct directory

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

I noticed some usages of un-mutexed `Dir.chdir` calls

## What is your fix for the problem, implemented in this PR?

Use `chdir:` when spawning subprocesses

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
