### PR TITLE
Unify LockfileParser loading of SPECS section

### DIFF
--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -110,21 +110,9 @@ module Bundler
     def parse_source(line)
       case line
       when SPECS
-        case @type
-        when PATH
-          @current_source = TYPES[@type].from_lock(@opts)
-          @sources << @current_source
-        when GIT
-          @current_source = TYPES[@type].from_lock(@opts)
-          @sources << @current_source
-        when GEM
-          @opts["remotes"] = Array(@opts.delete("remote")).reverse
-          @current_source = TYPES[@type].from_lock(@opts)
-          @sources << @current_source
-        when PLUGIN
-          @current_source = Plugin.source_from_lock(@opts)
-          @sources << @current_source
-        end
+        return unless TYPES.key?(@type)
+        @current_source = TYPES[@type].from_lock(@opts)
+        @sources << @current_source
       when OPTIONS
         value = $2
         value = true if value == "true"

--- a/bundler/lib/bundler/plugin.rb
+++ b/bundler/lib/bundler/plugin.rb
@@ -197,7 +197,7 @@ module Bundler
     # @param [Hash] The options that are present in the lock file
     # @return [API::Source] the instance of the class that handles the source
     #                       type passed in locked_opts
-    def source_from_lock(locked_opts)
+    def from_lock(locked_opts)
       src = source(locked_opts["type"])
 
       src.new(locked_opts.merge("uri" => locked_opts["remote"]))

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -88,6 +88,7 @@ module Bundler
       end
 
       def self.from_lock(options)
+        options["remotes"] = Array(options.delete("remote")).reverse
         new(options)
       end
 

--- a/bundler/spec/bundler/plugin_spec.rb
+++ b/bundler/spec/bundler/plugin_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe Bundler::Plugin do
     end
   end
 
-  describe "#source_from_lock" do
+  describe "#from_lock" do
     it "returns instance of registered class initialized with locked opts" do
       opts = { "type" => "l_source", "remote" => "xyz", "other" => "random" }
       allow(index).to receive(:source_plugin).with("l_source") { "plugin_name" }
@@ -236,7 +236,7 @@ RSpec.describe Bundler::Plugin do
 
       expect(SClass).to receive(:new).
         with(hash_including("type" => "l_source", "uri" => "xyz", "other" => "random")) { s_instance }
-      expect(subject.source_from_lock(opts)).to be(s_instance)
+      expect(subject.from_lock(opts)).to be(s_instance)
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Tiny refactor that was begging to be made.

## What is your fix for the problem, implemented in this PR?

This was almost following a very common refactoring pattern, so I just took the last step.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
