### PR TITLE
Fix force_ruby_platform: when the lockfile only locks the ruby platform

### DIFF
--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -202,6 +202,7 @@ module Bundler
       specs_for_name = lookup[dep.name]
       target_platform = dep.force_ruby_platform ? Gem::Platform::RUBY : (platform || Bundler.local_platform)
       matching_specs = GemHelpers.select_best_platform_match(specs_for_name, target_platform)
+      matching_specs.each {|s| s.force_ruby_platform = true } if dep.force_ruby_platform
       matching_specs.map!(&:materialize_for_installation).compact! if platform.nil?
       matching_specs
     end

--- a/bundler/spec/install/gemfile/force_ruby_platform_spec.rb
+++ b/bundler/spec/install/gemfile/force_ruby_platform_spec.rb
@@ -114,5 +114,48 @@ RSpec.describe "bundle install with force_ruby_platform DSL option", :jruby do
       expect(the_bundle).to include_gems "depends_on_platform_specific 1.0.0 RUBY"
       expect(the_bundle).to include_gems "platform_specific 1.0.0 #{Bundler.local_platform}"
     end
+
+    it "uses ruby variants for the explicit transitive dependency with a lockile that has only ruby platform" do
+      lockfile <<-L
+        GEM
+          remote: #{file_uri_for(gem_repo4)}
+          specs:
+            dep_level_2 (1.0)
+              depends_on_platform_specific
+            depends_on_platform_specific (1.0)
+              platform_specific
+            platform_specific (1.0)
+
+        PLATFORMS
+          ruby
+
+        DEPENDENCIES
+          dep_level_2
+          platform_specific
+
+        BUNDLED WITH
+            #{Bundler::VERSION}
+      L
+
+      install_gemfile <<-G, :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }, :artifice => "compact_index", :verbose => true
+        source "#{file_uri_for(gem_repo4)}"
+
+        gem "platform_specific"
+        gem "depends_on_platform_specific"
+      G
+
+      expect(the_bundle).to include_gems "depends_on_platform_specific 1.0.0 #{Bundler.local_platform}"
+      expect(the_bundle).to include_gems "platform_specific 1.0.0 #{Bundler.local_platform}"
+
+      install_gemfile <<-G, :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }, :artifice => "compact_index"
+        source "#{file_uri_for(gem_repo4)}"
+
+        gem "platform_specific", :force_ruby_platform => true
+        gem "depends_on_platform_specific"
+      G
+
+      expect(the_bundle).to include_gems "depends_on_platform_specific 1.0.0 #{Bundler.local_platform}"
+      expect(the_bundle).to include_gems "platform_specific 1.0.0 RUBY"
+    end
   end
 end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

I was unable to force ruby platform for google-protobuf in the rubygems.org bundle

## What is your fix for the problem, implemented in this PR?

Respect `force_ruby_platform:` when materializing by transferring it over to the lazy spec from the gemfile dep

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
