### PR TITLE
Add universal-java-19 to CI test setup Gemfile locks

### DIFF
--- a/tool/bundler/dev_gems.rb.lock
+++ b/tool/bundler/dev_gems.rb.lock
@@ -44,6 +44,7 @@ PLATFORMS
   java
   universal-java-11
   universal-java-18
+  universal-java-19
   x64-mingw-ucrt
   x64-mingw32
   x86_64-darwin-20

--- a/tool/bundler/rubocop_gems.rb.lock
+++ b/tool/bundler/rubocop_gems.rb.lock
@@ -58,6 +58,7 @@ PLATFORMS
   arm64-darwin-23
   universal-java-11
   universal-java-18
+  universal-java-19
   x64-mingw-ucrt
   x86_64-darwin-19
   x86_64-darwin-20

--- a/tool/bundler/standard_gems.rb.lock
+++ b/tool/bundler/standard_gems.rb.lock
@@ -74,6 +74,7 @@ PLATFORMS
   arm64-darwin-23
   universal-java-11
   universal-java-18
+  universal-java-19
   x64-mingw-ucrt
   x86_64-darwin-19
   x86_64-darwin-20

--- a/tool/bundler/test_gems.rb.lock
+++ b/tool/bundler/test_gems.rb.lock
@@ -26,6 +26,7 @@ PLATFORMS
   ruby
   universal-java-11
   universal-java-18
+  universal-java-19
   x64-mingw-ucrt
   x64-mingw32
   x86_64-darwin-20


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I noticed `Found changes from the lockfile, re-resolving dependencies because you added a new platform to your gemfile` during the Prepare dependencies CI step on jruby windows.


## What is your fix for the problem, implemented in this PR?

Try adding the platform to see if it removes the extra re-resolve.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
