### PR TITLE
Stop bundler eagerly loading all specs with exts

### DIFF
--- a/bundler/lib/bundler/stub_specification.rb
+++ b/bundler/lib/bundler/stub_specification.rb
@@ -16,7 +16,8 @@ module Bundler
       # Stub has no concept of source, which means that extension_dir may be wrong
       # This is the case for git-based gems. So, instead manually assign the extension dir
       return unless source.respond_to?(:extension_dir_name)
-      path = File.join(stub.extensions_dir, source.extension_dir_name)
+      unique_extension_dir = [source.extension_dir_name, File.basename(full_gem_path)].uniq.join("-")
+      path = File.join(stub.extensions_dir, unique_extension_dir)
       stub.extension_dir = File.expand_path(path)
     end
 
@@ -56,7 +57,7 @@ module Bundler
     end
 
     def gem_build_complete_path
-      File.join(extension_dir, "gem.build_complete")
+      stub.gem_build_complete_path
     end
 
     def default_gem?
@@ -108,6 +109,7 @@ module Bundler
         end
 
         rs.source = source
+        rs.base_dir = stub.base_dir
 
         rs
       end

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -728,6 +728,27 @@ end
     R
 
     run <<-R
+      File.open(File.join(Gem.dir, "specifications", "broken-ext.gemspec"), "w") do |f|
+        f.write <<-RUBY
+# -*- encoding: utf-8 -*-
+# stub: broken-ext 1.0.0 ruby lib
+# stub: a.ext\\0b.ext
+
+Gem::Specification.new do |s|
+  s.name = "broken-ext"
+  s.version = "1.0.0"
+  raise "BROKEN GEMSPEC EXT"
+end
+        RUBY
+      end
+      # Need to write the gem.build_complete file,
+      # otherwise the full spec is loaded to check the installed_by_version
+      extensions_dir = Gem.default_ext_dir_for(Gem.dir) || File.join(Gem.dir, "extensions", Gem::Platform.local.to_s, Gem.extension_api_version)
+      Bundler::FileUtils.mkdir_p(File.join(extensions_dir, "broken-ext-1.0.0"))
+      File.open(File.join(extensions_dir, "broken-ext-1.0.0", "gem.build_complete"), "w") {}
+    R
+
+    run <<-R
       puts "WIN"
     R
 


### PR DESCRIPTION
We were setting the wrong `extension_dir` for git specs stubs

Additionally, the call to `self.extension_dir` was loading the remote spec, which was avoidable since the stub had an extension dir (and in fact its #gem_build_complete_path does exactly what we want anyway)

Finally, now set the base_dir when loading the remote_spec from a stub specification, since the git source sets the base dir for stubs based on where the spec _will_ be installed to, and we want to preserve that so the base_dir for the loaded spec & the stub are the same

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Bundler was eagerly loading all gemspecs that had extensions in their stubs

## What is your fix for the problem, implemented in this PR?

Avoid calling methods that force loading the remote spec inside of `#missing_extensions?`

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
