### PR TITLE
Fixed false positive SymlinkError in symbolic link directory

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -413,6 +413,8 @@ EOM
   # extracted.
 
   def extract_tar_gz(io, destination_dir, pattern = "*") # :nodoc:
+    real_destination_dir = File.realpath(destination_dir)
+
     directories = []
     symlinks = []
 
@@ -428,7 +430,7 @@ EOM
           real_destination = link_target.start_with?("/") ? link_target : File.expand_path(link_target, File.dirname(destination))
 
           raise Gem::Package::SymlinkError.new(full_name, real_destination, destination_dir) unless
-            normalize_path(real_destination).start_with? normalize_path(destination_dir + "/")
+            normalize_path(real_destination).start_with? normalize_path(real_destination_dir + "/")
 
           symlinks << [full_name, link_target, destination, real_destination]
         end

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -413,7 +413,7 @@ EOM
   # extracted.
 
   def extract_tar_gz(io, destination_dir, pattern = "*") # :nodoc:
-    real_destination_dir = File.realpath(destination_dir)
+    destination_dir = File.realpath(destination_dir)
 
     directories = []
     symlinks = []
@@ -430,7 +430,7 @@ EOM
           real_destination = link_target.start_with?("/") ? link_target : File.expand_path(link_target, File.dirname(destination))
 
           raise Gem::Package::SymlinkError.new(full_name, real_destination, destination_dir) unless
-            normalize_path(real_destination).start_with? normalize_path(real_destination_dir + "/")
+            normalize_path(real_destination).start_with? normalize_path(destination_dir + "/")
 
           symlinks << [full_name, link_target, destination, real_destination]
         end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->
False positive SymlinkError is detected when all of the following conditions are met.
- Symlink is included in the gem.
- Symlink is included in the installation location of the gem.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

The code that verifies that the symlink points to a location in the gem is changed.

The `real_destination` is a realpath, whereas the `destination_dir` is the path containing the symlink.
Changed to compare after converting both to realpath.

Below is the previous corresponding code.
https://github.com/rubygems/rubygems/blob/fa06cbff5fd5b61de6afdb454367bf38a01b0993/lib/rubygems/package.rb#L424-L434

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
