### PR TITLE
Gemfile `ruby file:` supports `ruby-3.2.2` but not `3.2.2@gemset`

### DIFF
--- a/bundler/lib/bundler/ruby_dsl.rb
+++ b/bundler/lib/bundler/ruby_dsl.rb
@@ -10,13 +10,8 @@ module Bundler
       raise GemfileError, "Please define :engine" if options[:engine_version] && options[:engine].nil?
 
       if options[:file]
-        raise GemfileError, "Cannot specify version when using the file option" if ruby_version.any?
-        file_content = Bundler.read_file(Bundler.root.join(options[:file]))
-        if /^ruby\s+(.*)$/.match(file_content) # match .tool-versions files
-          ruby_version << $1.split("#", 2).first.strip # remove trailing comment
-        else
-          ruby_version << file_content.strip
-        end
+        raise GemfileError, "Do not pass version argument when using :file option" unless ruby_version.empty?
+        ruby_version << normalize_ruby_file(options[:file])
       end
 
       if options[:engine] == "ruby" && options[:engine_version] &&
@@ -24,6 +19,27 @@ module Bundler
         raise GemfileEvalError, "ruby_version must match the :engine_version for MRI"
       end
       @ruby_version = RubyVersion.new(ruby_version, options[:patchlevel], options[:engine], options[:engine_version])
+    end
+
+    # Support the various file formats found in .ruby-version files.
+    #
+    #     3.2.2
+    #     ruby-3.2.2
+    #
+    # Also supports .tool-versions files for asdf. Lines not starting with "ruby" are ignored.
+    #
+    #     ruby 2.5.1 # comment is ignored
+    #     ruby   2.5.1# close comment and extra spaces doesn't confuse
+    #
+    # Intentionally does not support `3.2.1@gemset` since rvm recommends using .ruby-gemset instead
+    def normalize_ruby_file(filename)
+      file_content = Bundler.read_file(Bundler.root.join(filename))
+      # match "ruby-3.2.2" or "ruby   3.2.2" capturing version string up to the first space or comment
+      if /^ruby(-|\s+)([^\s#]+)/.match(file_content)
+        $2
+      else
+        file_content.strip
+      end
     end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Follow up comments in issue #6876 brought up missing support in `.ruby-version`.

## What is your fix for the problem, implemented in this PR?

- Increase test coverage to explicitly test what is and is not supported.
- Add support for `ruby-3.2.2` with the `ruby-` prefix, which is common and easy to support.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
