### PR TITLE
Use IO.copy_stream when reading, writing

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -268,7 +268,7 @@ class Gem::Package
 
       tar.add_file_simple file, stat.mode, stat.size do |dst_io|
         File.open file, "rb" do |src_io|
-          dst_io.write src_io.read 16_384 until src_io.eof?
+          IO.copy_stream(src_io, dst_io)
         end
       end
     end
@@ -452,7 +452,7 @@ EOM
         end
 
         if entry.file?
-          File.open(destination, "wb") {|out| out.write entry.read }
+          File.open(destination, "wb") {|out| IO.copy_stream(entry, out) }
           FileUtils.chmod file_mode(entry.header.mode), destination
         end
 

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -715,7 +715,7 @@ EOM
 
   if RUBY_ENGINE == "truffleruby"
     def copy_stream(src, dst) # :nodoc:
-      dst.write src.read 16_384 until src.eof?
+      dst.write src.read
     end
   else
     def copy_stream(src, dst) # :nodoc:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Looking at increasing read/write efficiency. I'm not sure if this is actually better, but I believe that's the goal of IO.copy_stream.

## What is your fix for the problem, implemented in this PR?

Use IO.copy_stream when writing gems to files from the gem archive. 

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
