### PR TITLE
Fix GitProxy for branch and ref

### DIFF
--- a/bundler/lib/bundler/cli/info.rb
+++ b/bundler/lib/bundler/cli/info.rb
@@ -33,7 +33,7 @@ module Bundler
     def default_gem_spec(gem_name)
       return unless Gem::Specification.respond_to?(:find_all_by_name)
       gem_spec = Gem::Specification.find_all_by_name(gem_name).last
-      return gem_spec if gem_spec&.default_gem?
+      gem_spec if gem_spec&.default_gem?
     end
 
     def spec_not_found(gem_name)

--- a/bundler/lib/bundler/retry.rb
+++ b/bundler/lib/bundler/retry.rb
@@ -56,7 +56,7 @@ module Bundler
     def keep_trying?
       return true  if current_run.zero?
       return false if last_attempt?
-      return true  if @failed
+      true if @failed
     end
 
     def last_attempt?

--- a/bundler/spec/bundler/source/git/git_proxy_spec.rb
+++ b/bundler/spec/bundler/source/git/git_proxy_spec.rb
@@ -3,34 +3,84 @@
 RSpec.describe Bundler::Source::Git::GitProxy do
   let(:path) { Pathname("path") }
   let(:uri) { "https://github.com/rubygems/rubygems.git" }
-  let(:ref) { "HEAD" }
+  let(:ref) { nil }
+  let(:branch) { nil }
+  let(:tag) { nil }
+  let(:options) { { "ref" => ref, "branch" => branch, "tag" => tag }.compact }
   let(:revision) { nil }
   let(:git_source) { nil }
   let(:clone_result) { double(Process::Status, :success? => true) }
   let(:base_clone_args) { ["clone", "--bare", "--no-hardlinks", "--quiet", "--no-tags", "--depth", "1", "--single-branch"] }
-  subject { described_class.new(path, uri, ref, revision, git_source) }
+  subject(:git_proxy) { described_class.new(path, uri, options, revision, git_source) }
+
+  context "with explicit ref" do
+    context "with branch only" do
+      let(:branch) { "main" }
+      it "sets explicit ref to branch" do
+        expect(git_proxy.explicit_ref).to eq(branch)
+      end
+    end
+
+    context "with ref only" do
+      let(:ref) { "HEAD" }
+      it "sets explicit ref to ref" do
+        expect(git_proxy.explicit_ref).to eq(ref)
+      end
+    end
+
+    context "with tag only" do
+      let(:tag) { "v1.0" }
+      it "sets explicit ref to ref" do
+        expect(git_proxy.explicit_ref).to eq(tag)
+      end
+    end
+
+    context "with tag and branch" do
+      let(:tag) { "v1.0" }
+      let(:branch) { "main" }
+      it "raises error" do
+        expect { git_proxy }.to raise_error(Bundler::Source::Git::AmbiguousGitReference)
+      end
+    end
+
+    context "with tag and ref" do
+      let(:tag) { "v1.0" }
+      let(:ref) { "HEAD" }
+      it "raises error" do
+        expect { git_proxy }.to raise_error(Bundler::Source::Git::AmbiguousGitReference)
+      end
+    end
+
+    context "with branch and ref" do
+      let(:branch) { "main" }
+      let(:ref) { "HEAD" }
+      it "honors ref over branch" do
+        expect(git_proxy.explicit_ref).to eq(ref)
+      end
+    end
+  end
 
   context "with configured credentials" do
     it "adds username and password to URI" do
       Bundler.settings.temporary(uri => "u:p") do
-        allow(subject).to receive(:git_local).with("--version").and_return("git version 2.14.0")
-        expect(subject).to receive(:capture).with([*base_clone_args, "--", "https://u:p@github.com/rubygems/rubygems.git", path.to_s], nil).and_return(["", "", clone_result])
+        allow(git_proxy).to receive(:git_local).with("--version").and_return("git version 2.14.0")
+        expect(git_proxy).to receive(:capture).with([*base_clone_args, "--", "https://u:p@github.com/rubygems/rubygems.git", path.to_s], nil).and_return(["", "", clone_result])
         subject.checkout
       end
     end
 
     it "adds username and password to URI for host" do
       Bundler.settings.temporary("github.com" => "u:p") do
-        allow(subject).to receive(:git_local).with("--version").and_return("git version 2.14.0")
-        expect(subject).to receive(:capture).with([*base_clone_args, "--", "https://u:p@github.com/rubygems/rubygems.git", path.to_s], nil).and_return(["", "", clone_result])
+        allow(git_proxy).to receive(:git_local).with("--version").and_return("git version 2.14.0")
+        expect(git_proxy).to receive(:capture).with([*base_clone_args, "--", "https://u:p@github.com/rubygems/rubygems.git", path.to_s], nil).and_return(["", "", clone_result])
         subject.checkout
       end
     end
 
     it "does not add username and password to mismatched URI" do
       Bundler.settings.temporary("https://u:p@github.com/rubygems/rubygems-mismatch.git" => "u:p") do
-        allow(subject).to receive(:git_local).with("--version").and_return("git version 2.14.0")
-        expect(subject).to receive(:capture).with([*base_clone_args, "--", uri, path.to_s], nil).and_return(["", "", clone_result])
+        allow(git_proxy).to receive(:git_local).with("--version").and_return("git version 2.14.0")
+        expect(git_proxy).to receive(:capture).with([*base_clone_args, "--", uri, path.to_s], nil).and_return(["", "", clone_result])
         subject.checkout
       end
     end
@@ -38,10 +88,10 @@ RSpec.describe Bundler::Source::Git::GitProxy do
     it "keeps original userinfo" do
       Bundler.settings.temporary("github.com" => "u:p") do
         original = "https://orig:info@github.com/rubygems/rubygems.git"
-        subject = described_class.new(Pathname("path"), original, "HEAD")
-        allow(subject).to receive(:git_local).with("--version").and_return("git version 2.14.0")
-        expect(subject).to receive(:capture).with([*base_clone_args, "--", original, path.to_s], nil).and_return(["", "", clone_result])
-        subject.checkout
+        git_proxy = described_class.new(Pathname("path"), original, options)
+        allow(git_proxy).to receive(:git_local).with("--version").and_return("git version 2.14.0")
+        expect(git_proxy).to receive(:capture).with([*base_clone_args, "--", original, path.to_s], nil).and_return(["", "", clone_result])
+        git_proxy.checkout
       end
     end
   end
@@ -49,46 +99,46 @@ RSpec.describe Bundler::Source::Git::GitProxy do
   describe "#version" do
     context "with a normal version number" do
       before do
-        expect(subject).to receive(:git_local).with("--version").
+        expect(git_proxy).to receive(:git_local).with("--version").
           and_return("git version 1.2.3")
       end
 
       it "returns the git version number" do
-        expect(subject.version).to eq("1.2.3")
+        expect(git_proxy.version).to eq("1.2.3")
       end
 
       it "does not raise an error when passed into Gem::Version.create" do
-        expect { Gem::Version.create subject.version }.not_to raise_error
+        expect { Gem::Version.create git_proxy.version }.not_to raise_error
       end
     end
 
     context "with a OSX version number" do
       before do
-        expect(subject).to receive(:git_local).with("--version").
+        expect(git_proxy).to receive(:git_local).with("--version").
           and_return("git version 1.2.3 (Apple Git-BS)")
       end
 
       it "strips out OSX specific additions in the version string" do
-        expect(subject.version).to eq("1.2.3")
+        expect(git_proxy.version).to eq("1.2.3")
       end
 
       it "does not raise an error when passed into Gem::Version.create" do
-        expect { Gem::Version.create subject.version }.not_to raise_error
+        expect { Gem::Version.create git_proxy.version }.not_to raise_error
       end
     end
 
     context "with a msysgit version number" do
       before do
-        expect(subject).to receive(:git_local).with("--version").
+        expect(git_proxy).to receive(:git_local).with("--version").
           and_return("git version 1.2.3.msysgit.0")
       end
 
       it "strips out msysgit specific additions in the version string" do
-        expect(subject.version).to eq("1.2.3")
+        expect(git_proxy.version).to eq("1.2.3")
       end
 
       it "does not raise an error when passed into Gem::Version.create" do
-        expect { Gem::Version.create subject.version }.not_to raise_error
+        expect { Gem::Version.create git_proxy.version }.not_to raise_error
       end
     end
   end
@@ -96,34 +146,34 @@ RSpec.describe Bundler::Source::Git::GitProxy do
   describe "#full_version" do
     context "with a normal version number" do
       before do
-        expect(subject).to receive(:git_local).with("--version").
+        expect(git_proxy).to receive(:git_local).with("--version").
           and_return("git version 1.2.3")
       end
 
       it "returns the git version number" do
-        expect(subject.full_version).to eq("1.2.3")
+        expect(git_proxy.full_version).to eq("1.2.3")
       end
     end
 
     context "with a OSX version number" do
       before do
-        expect(subject).to receive(:git_local).with("--version").
+        expect(git_proxy).to receive(:git_local).with("--version").
           and_return("git version 1.2.3 (Apple Git-BS)")
       end
 
       it "does not strip out OSX specific additions in the version string" do
-        expect(subject.full_version).to eq("1.2.3 (Apple Git-BS)")
+        expect(git_proxy.full_version).to eq("1.2.3 (Apple Git-BS)")
       end
     end
 
     context "with a msysgit version number" do
       before do
-        expect(subject).to receive(:git_local).with("--version").
+        expect(git_proxy).to receive(:git_local).with("--version").
           and_return("git version 1.2.3.msysgit.0")
       end
 
       it "does not strip out msysgit specific additions in the version string" do
-        expect(subject.full_version).to eq("1.2.3.msysgit.0")
+        expect(git_proxy.full_version).to eq("1.2.3.msysgit.0")
       end
     end
   end

--- a/bundler/spec/commands/add_spec.rb
+++ b/bundler/spec/commands/add_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "bundle add" do
     it "adds multiple version constraints when specified" do
       requirements = ["< 3.0", "> 1.0"]
       bundle "add 'foo' --version='#{requirements.join(", ")}'"
-      expect(bundled_app_gemfile.read).to match(/gem "foo", #{Gem::Requirement.new(requirements).as_list.map(&:dump).join(', ')}/)
+      expect(bundled_app_gemfile.read).to match(/gem "foo", #{Gem::Requirement.new(requirements).as_list.map(&:dump).join(", ")}/)
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end

--- a/bundler/spec/commands/open_spec.rb
+++ b/bundler/spec/commands/open_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe "bundle open" do
         input.puts "2"
       end
 
-      expect(out).to match(%r{bundler_editor #{default_bundle_path('gems', 'activerecord-2.3.2')}/CHANGELOG\.md\z})
+      expect(out).to match(%r{bundler_editor #{default_bundle_path("gems", "activerecord-2.3.2")}/CHANGELOG\.md\z})
     end
 
     it "opens deep subpath of the selected matching gem", :readline do
@@ -113,7 +113,7 @@ RSpec.describe "bundle open" do
         input.puts "2"
       end
 
-      expect(out).to match(%r{bundler_editor #{default_bundle_path('gems', 'activerecord-2.3.2')}/lib/activerecord/version\.rb\z})
+      expect(out).to match(%r{bundler_editor #{default_bundle_path("gems", "activerecord-2.3.2")}/lib/activerecord/version\.rb\z})
     end
 
     it "select the gem from many match gems", :readline do
@@ -122,7 +122,7 @@ RSpec.describe "bundle open" do
         input.puts "2"
       end
 
-      expect(out).to match(/bundler_editor #{default_bundle_path('gems', 'activerecord-2.3.2')}\z/)
+      expect(out).to match(/bundler_editor #{default_bundle_path("gems", "activerecord-2.3.2")}\z/)
     end
 
     it "allows selecting exit from many match gems", :readline do

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "bundle install from an existing gemspec" do
       source "#{file_uri_for(gem_repo2)}"
       gemspec :path => '#{tmp.join("foo")}'
     G
-    expect(err).to match(/There are no gemspecs at #{tmp.join('foo')}/)
+    expect(err).to match(/There are no gemspecs at #{tmp.join("foo")}/)
   end
 
   it "should raise if there are too many gemspecs available" do
@@ -97,7 +97,7 @@ RSpec.describe "bundle install from an existing gemspec" do
       source "#{file_uri_for(gem_repo2)}"
       gemspec :path => '#{tmp.join("foo")}'
     G
-    expect(err).to match(/There are multiple gemspecs at #{tmp.join('foo')}/)
+    expect(err).to match(/There are multiple gemspecs at #{tmp.join("foo")}/)
   end
 
   it "should pick a specific gemspec" do

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -572,7 +572,7 @@ RSpec.describe "bundle install with git sources" do
 
       bundle %(config set local.rack #{lib_path("local-rack")})
       bundle :install, :raise_on_error => false
-      expect(err).to match(/Cannot use local override for rack-0.8 because #{Regexp.escape(lib_path('local-rack').to_s)} does not exist/)
+      expect(err).to match(/Cannot use local override for rack-0.8 because #{Regexp.escape(lib_path("local-rack").to_s)} does not exist/)
 
       solution = "config unset local.rack"
       expect(err).to match(/Run `bundle #{solution}` to remove the local override/)
@@ -594,7 +594,7 @@ RSpec.describe "bundle install with git sources" do
 
       bundle %(config set local.rack #{lib_path("local-rack")})
       bundle :install, :raise_on_error => false
-      expect(err).to match(/Cannot use local override for rack-0.8 at #{Regexp.escape(lib_path('local-rack').to_s)} because :branch is not specified in Gemfile/)
+      expect(err).to match(/Cannot use local override for rack-0.8 at #{Regexp.escape(lib_path("local-rack").to_s)} because :branch is not specified in Gemfile/)
 
       solution = "config unset local.rack"
       expect(err).to match(/Specify a branch or run `bundle #{solution}` to remove the local override/)

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -411,7 +411,7 @@ RSpec.describe "Bundler.setup" do
 
     it "provides a useful exception when the git repo is not checked out yet" do
       run "1", :raise_on_error => false
-      expect(err).to match(/the git source #{lib_path('rack-1.0.0')} is not yet checked out. Please run `bundle install`/i)
+      expect(err).to match(/the git source #{lib_path("rack-1.0.0")} is not yet checked out. Please run `bundle install`/i)
     end
 
     it "does not hit the git binary if the lockfile is available and up to date" do
@@ -498,7 +498,7 @@ RSpec.describe "Bundler.setup" do
 
       FileUtils.rm_rf(lib_path("local-rack"))
       run "require 'rack'", :raise_on_error => false
-      expect(err).to match(/Cannot use local override for rack-0.8 because #{Regexp.escape(lib_path('local-rack').to_s)} does not exist/)
+      expect(err).to match(/Cannot use local override for rack-0.8 because #{Regexp.escape(lib_path("local-rack").to_s)} does not exist/)
     end
 
     it "explodes if branch is not given on runtime" do

--- a/tool/bundler/dev_gems.rb.lock
+++ b/tool/bundler/dev_gems.rb.lock
@@ -48,6 +48,8 @@ PLATFORMS
   x64-mingw-ucrt
   x64-mingw32
   x86_64-darwin-20
+  x86_64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/tool/bundler/release_gems.rb.lock
+++ b/tool/bundler/release_gems.rb.lock
@@ -45,6 +45,7 @@ PLATFORMS
   universal-java-18
   x86_64-darwin-20
   x86_64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/tool/bundler/rubocop_gems.rb.lock
+++ b/tool/bundler/rubocop_gems.rb.lock
@@ -63,6 +63,7 @@ PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/tool/bundler/standard_gems.rb.lock
+++ b/tool/bundler/standard_gems.rb.lock
@@ -79,6 +79,7 @@ PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Fixes https://github.com/rubygems/rubygems/issues/6951 to honor `ref` > `branch`.  This in turn fixes `bundle outdated` for Gemfiles with dependencies specifying both `branch` and `ref`.

Also:
- Raises an error when `ref` or `branch` are specified with `tag`, as that's an ambiguous state.
- Improves spec for GitProxy

## What was the end-user or developer problem that led to this PR?

1. When specifying both `branch` and `ref` on a git source, some bundler commands break (e.g. `bundle outdated` see #6951)
2. If it were to work, `branch` had higher precedence than `ref`, which is incorrect.
3. `tag` was in between `branch` and `ref` in precedence, which doesn't make any sense, and in fact, `tag` should never be specified with `branch` or `ref`, as it creates an ambiguous reference that has until now been arbitrarily decided by the code in bundler (should it be the tag, or the branch/ref?).
4. Last commit is strictly RuboCop lint fixes, which, if undesired as unrelated, I'm happy to pop off of this PR to keep it focused.
5. First commit just synchronizes the platforms for latest MacOS/Darwin across some lockfiles.

## What is your fix for the problem, implemented in this PR?

This implementation raises an error, and I expect it can affect users who unwittingly specified ambiguous references in their Gemfile, but for whom `bundle` commands currently work.  As such this might be considered a breaking change, but it is also definitely a bugfix.  In many cases this would only affect users for whom the bundle / git commands are already broken, such as the case in #6951.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
