### PR TITLE
Allow installing plugins from path via CLI

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -164,6 +164,7 @@ bundler/lib/bundler/plugin/events.rb
 bundler/lib/bundler/plugin/index.rb
 bundler/lib/bundler/plugin/installer.rb
 bundler/lib/bundler/plugin/installer/git.rb
+bundler/lib/bundler/plugin/installer/path.rb
 bundler/lib/bundler/plugin/installer/rubygems.rb
 bundler/lib/bundler/plugin/source_list.rb
 bundler/lib/bundler/process_lock.rb

--- a/bundler/lib/bundler/cli/plugin.rb
+++ b/bundler/lib/bundler/cli/plugin.rb
@@ -5,7 +5,7 @@ module Bundler
   class CLI::Plugin < Thor
     desc "install PLUGINS", "Install the plugin from the source"
     long_desc <<-D
-      Install plugins either from the rubygems source provided (with --source option) or from a git source provided with --git. If no sources are provided, it uses Gem.sources
+      Install plugins either from the rubygems source provided (with --source option), from a git source provided with --git, or a local path provided with --path. If no sources are provided, it uses Gem.sources
    D
     method_option "source", type: :string, default: nil, banner: "URL of the RubyGems source to fetch the plugin from"
     method_option "version", type: :string, default: nil, banner: "The version of the plugin to fetch"
@@ -13,6 +13,7 @@ module Bundler
     method_option "local_git", type: :string, default: nil, banner: "Path of the local git repo to fetch from (deprecated)"
     method_option "branch", type: :string, default: nil, banner: "The git branch to checkout"
     method_option "ref", type: :string, default: nil, banner: "The git revision to check out"
+    method_option "path", type: :string, default: nil, banner: "Path of a local gem to directly use"
     def install(*plugins)
       Bundler::Plugin.install(plugins, options)
     end

--- a/bundler/lib/bundler/man/bundle-add.1
+++ b/bundler/lib/bundler/man/bundle-add.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-ADD" "1" "February 2024" ""
+.TH "BUNDLE\-ADD" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-add\fR \- Add gem to the Gemfile and run bundle install
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-binstubs.1
+++ b/bundler/lib/bundler/man/bundle-binstubs.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-BINSTUBS" "1" "February 2024" ""
+.TH "BUNDLE\-BINSTUBS" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-binstubs\fR \- Install the binstubs of the listed gems
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-cache.1
+++ b/bundler/lib/bundler/man/bundle-cache.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-CACHE" "1" "February 2024" ""
+.TH "BUNDLE\-CACHE" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-cache\fR \- Package your needed \fB\.gem\fR files into your application
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-check.1
+++ b/bundler/lib/bundler/man/bundle-check.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-CHECK" "1" "February 2024" ""
+.TH "BUNDLE\-CHECK" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-check\fR \- Verifies if dependencies are satisfied by installed gems
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-clean.1
+++ b/bundler/lib/bundler/man/bundle-clean.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-CLEAN" "1" "February 2024" ""
+.TH "BUNDLE\-CLEAN" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-clean\fR \- Cleans up unused gems in your bundler directory
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-CONFIG" "1" "February 2024" ""
+.TH "BUNDLE\-CONFIG" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-config\fR \- Set bundler configuration options
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-console.1
+++ b/bundler/lib/bundler/man/bundle-console.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-CONSOLE" "1" "February 2024" ""
+.TH "BUNDLE\-CONSOLE" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-console\fR \- Deprecated way to open an IRB session with the bundle pre\-loaded
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-doctor.1
+++ b/bundler/lib/bundler/man/bundle-doctor.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-DOCTOR" "1" "February 2024" ""
+.TH "BUNDLE\-DOCTOR" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-doctor\fR \- Checks the bundle for common problems
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-exec.1
+++ b/bundler/lib/bundler/man/bundle-exec.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-EXEC" "1" "February 2024" ""
+.TH "BUNDLE\-EXEC" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-exec\fR \- Execute a command in the context of the bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-gem.1
+++ b/bundler/lib/bundler/man/bundle-gem.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-GEM" "1" "February 2024" ""
+.TH "BUNDLE\-GEM" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-gem\fR \- Generate a project skeleton for creating a rubygem
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-help.1
+++ b/bundler/lib/bundler/man/bundle-help.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-HELP" "1" "February 2024" ""
+.TH "BUNDLE\-HELP" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-help\fR \- Displays detailed help for each subcommand
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-info.1
+++ b/bundler/lib/bundler/man/bundle-info.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-INFO" "1" "February 2024" ""
+.TH "BUNDLE\-INFO" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-info\fR \- Show information for the given gem in your bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-init.1
+++ b/bundler/lib/bundler/man/bundle-init.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-INIT" "1" "February 2024" ""
+.TH "BUNDLE\-INIT" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-init\fR \- Generates a Gemfile into the current working directory
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-inject.1
+++ b/bundler/lib/bundler/man/bundle-inject.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-INJECT" "1" "February 2024" ""
+.TH "BUNDLE\-INJECT" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-inject\fR \- Add named gem(s) with version requirements to Gemfile
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-install.1
+++ b/bundler/lib/bundler/man/bundle-install.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-INSTALL" "1" "February 2024" ""
+.TH "BUNDLE\-INSTALL" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-install\fR \- Install the dependencies specified in your Gemfile
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-list.1
+++ b/bundler/lib/bundler/man/bundle-list.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-LIST" "1" "February 2024" ""
+.TH "BUNDLE\-LIST" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-list\fR \- List all the gems in the bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-lock.1
+++ b/bundler/lib/bundler/man/bundle-lock.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-LOCK" "1" "February 2024" ""
+.TH "BUNDLE\-LOCK" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-lock\fR \- Creates / Updates a lockfile without installing
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-open.1
+++ b/bundler/lib/bundler/man/bundle-open.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-OPEN" "1" "February 2024" ""
+.TH "BUNDLE\-OPEN" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-open\fR \- Opens the source directory for a gem in your bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-outdated.1
+++ b/bundler/lib/bundler/man/bundle-outdated.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-OUTDATED" "1" "February 2024" ""
+.TH "BUNDLE\-OUTDATED" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-outdated\fR \- List installed gems with newer versions available
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-platform.1
+++ b/bundler/lib/bundler/man/bundle-platform.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-PLATFORM" "1" "February 2024" ""
+.TH "BUNDLE\-PLATFORM" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-platform\fR \- Displays platform compatibility information
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-plugin.1
+++ b/bundler/lib/bundler/man/bundle-plugin.1
@@ -1,10 +1,10 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-PLUGIN" "1" "February 2024" ""
+.TH "BUNDLE\-PLUGIN" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-plugin\fR \- Manage Bundler plugins
 .SH "SYNOPSIS"
-\fBbundle plugin\fR install PLUGINS [\-\-source=\fISOURCE\fR] [\-\-version=\fIversion\fR] [\-\-git=\fIgit\-url\fR] [\-\-branch=\fIbranch\fR|\-\-ref=\fIrev\fR]
+\fBbundle plugin\fR install PLUGINS [\-\-source=\fISOURCE\fR] [\-\-version=\fIversion\fR] [\-\-git=\fIgit\-url\fR] [\-\-branch=\fIbranch\fR|\-\-ref=\fIrev\fR] [\-\-path=\fIpath\fR]
 .br
 \fBbundle plugin\fR uninstall PLUGINS
 .br
@@ -37,7 +37,10 @@ Install bundler\-graph gem from Git repository\. You can use standard Git URLs l
 .br
 \fBfile:///path/to/repo\fR
 .IP
-When you specify \fB\-\-git\fR, you can use \fB\-\-branch\fR or \fB\-\-ref\fR to specify any branch, tag, or commit hash (revision) to use\. When you specify both, only the latter is used\.
+When you specify \fB\-\-git\fR, you can use \fB\-\-branch\fR or \fB\-\-ref\fR to specify any branch, tag, or commit hash (revision) to use\.
+.TP
+\fBbundle plugin install bundler\-graph \-\-path \.\./bundler\-graph\fR
+Install bundler\-graph gem from a local path\.
 .SS "uninstall"
 Uninstall the plugin(s) specified in PLUGINS\.
 .SS "list"

--- a/bundler/lib/bundler/man/bundle-plugin.1.ronn
+++ b/bundler/lib/bundler/man/bundle-plugin.1.ronn
@@ -4,7 +4,8 @@ bundle-plugin(1) -- Manage Bundler plugins
 ## SYNOPSIS
 
 `bundle plugin` install PLUGINS [--source=<SOURCE>] [--version=<version>]
-                              [--git=<git-url>] [--branch=<branch>|--ref=<rev>]<br>
+                              [--git=<git-url>] [--branch=<branch>|--ref=<rev>]
+                              [--path=<path>]<br>
 `bundle plugin` uninstall PLUGINS<br>
 `bundle plugin` list<br>
 `bundle plugin` help [COMMAND]
@@ -36,7 +37,10 @@ Install the given plugin(s).
   `/path/to/repo`<br>
   `file:///path/to/repo`
 
-  When you specify `--git`, you can use `--branch` or `--ref` to specify any branch, tag, or commit hash (revision) to use. When you specify both, only the latter is used.
+  When you specify `--git`, you can use `--branch` or `--ref` to specify any branch, tag, or commit hash (revision) to use.
+
+* `bundle plugin install bundler-graph --path ../bundler-graph`:
+  Install bundler-graph gem from a local path.
 
 ### uninstall
 

--- a/bundler/lib/bundler/man/bundle-pristine.1
+++ b/bundler/lib/bundler/man/bundle-pristine.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-PRISTINE" "1" "February 2024" ""
+.TH "BUNDLE\-PRISTINE" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-pristine\fR \- Restores installed gems to their pristine condition
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-remove.1
+++ b/bundler/lib/bundler/man/bundle-remove.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-REMOVE" "1" "February 2024" ""
+.TH "BUNDLE\-REMOVE" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-remove\fR \- Removes gems from the Gemfile
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-show.1
+++ b/bundler/lib/bundler/man/bundle-show.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-SHOW" "1" "February 2024" ""
+.TH "BUNDLE\-SHOW" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-show\fR \- Shows all the gems in your bundle, or the path to a gem
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-update.1
+++ b/bundler/lib/bundler/man/bundle-update.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-UPDATE" "1" "February 2024" ""
+.TH "BUNDLE\-UPDATE" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-update\fR \- Update your gems to the latest available versions
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-version.1
+++ b/bundler/lib/bundler/man/bundle-version.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-VERSION" "1" "February 2024" ""
+.TH "BUNDLE\-VERSION" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-version\fR \- Prints Bundler version information
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-viz.1
+++ b/bundler/lib/bundler/man/bundle-viz.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-VIZ" "1" "February 2024" ""
+.TH "BUNDLE\-VIZ" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\-viz\fR \- Generates a visual dependency graph for your Gemfile
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle.1
+++ b/bundler/lib/bundler/man/bundle.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE" "1" "February 2024" ""
+.TH "BUNDLE" "1" "March 2024" ""
 .SH "NAME"
 \fBbundle\fR \- Ruby Dependency Management
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/gemfile.5
+++ b/bundler/lib/bundler/man/gemfile.5
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "GEMFILE" "5" "February 2024" ""
+.TH "GEMFILE" "5" "March 2024" ""
 .SH "NAME"
 \fBGemfile\fR \- A format for describing gem dependencies for Ruby programs
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/plugin/installer.rb
+++ b/bundler/lib/bundler/plugin/installer.rb
@@ -10,6 +10,7 @@ module Bundler
     class Installer
       autoload :Rubygems, File.expand_path("installer/rubygems", __dir__)
       autoload :Git,      File.expand_path("installer/git", __dir__)
+      autoload :Path, File.expand_path("installer/path", __dir__)
 
       def install(names, options)
         check_sources_consistency!(options)
@@ -18,6 +19,8 @@ module Bundler
 
         if options[:git]
           install_git(names, version, options)
+        elsif options[:path]
+          install_path(names, version, options[:path])
         else
           sources = options[:source] || Gem.sources
           install_rubygems(names, version, sources)
@@ -50,8 +53,8 @@ module Bundler
           options[:git] = options.delete(:local_git)
         end
 
-        if (options.keys & [:source, :git]).length > 1
-          raise InvalidOption, "Only one of --source, or --git may be specified"
+        if (options.keys & [:source, :git, :path]).length > 1
+          raise InvalidOption, "Only one of --source, --git, or --path may be specified"
         end
 
         if (options.key?(:branch) || options.key?(:ref)) && !options.key?(:git)
@@ -64,10 +67,19 @@ module Bundler
       end
 
       def install_git(names, version, options)
-        uri = options.delete(:git)
-        options["uri"] = uri
+        source_list = SourceList.new
+        source = source_list.add_git_source({ "uri" => options[:git],
+                                              "branch" => options[:branch],
+                                              "ref" => options[:ref] })
 
-        install_all_sources(names, version, options, options[:source])
+        install_all_sources(names, version, source_list, source)
+      end
+
+      def install_path(names, version, path)
+        source_list = SourceList.new
+        source = source_list.add_path_source({ "path" => path })
+
+        install_all_sources(names, version, source_list, source)
       end
 
       # Installs the plugin from rubygems source and returns the path where the
@@ -79,16 +91,15 @@ module Bundler
       #
       # @return [Hash] map of names to the specs of plugins installed
       def install_rubygems(names, version, sources)
-        install_all_sources(names, version, nil, sources)
-      end
-
-      def install_all_sources(names, version, git_source_options, rubygems_source)
         source_list = SourceList.new
 
-        source_list.add_git_source(git_source_options) if git_source_options
-        Array(rubygems_source).each {|remote| source_list.add_global_rubygems_remote(remote) } if rubygems_source
+        Array(sources).each {|remote| source_list.add_global_rubygems_remote(remote) }
 
-        deps = names.map {|name| Dependency.new name, version }
+        install_all_sources(names, version, source_list)
+      end
+
+      def install_all_sources(names, version, source_list, source = nil)
+        deps = names.map {|name| Dependency.new(name, version, { "source" => source }) }
 
         Bundler.configure_gem_home_and_path(Plugin.root)
 

--- a/bundler/lib/bundler/plugin/installer/path.rb
+++ b/bundler/lib/bundler/plugin/installer/path.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Bundler
+  module Plugin
+    class Installer
+      class Path < Bundler::Source::Path
+        def root
+          Plugin.root
+        end
+
+        def generate_bin(spec, disable_extensions = false)
+          # Need to find a way without code duplication
+          # For now, we can ignore this
+        end
+      end
+    end
+  end
+end

--- a/bundler/lib/bundler/plugin/source_list.rb
+++ b/bundler/lib/bundler/plugin/source_list.rb
@@ -9,16 +9,16 @@ module Bundler
         add_source_to_list Plugin::Installer::Git.new(options), git_sources
       end
 
+      def add_path_source(options = {})
+        add_source_to_list Plugin::Installer::Path.new(options), path_sources
+      end
+
       def add_rubygems_source(options = {})
         add_source_to_list Plugin::Installer::Rubygems.new(options), @rubygems_sources
       end
 
       def all_sources
         path_sources + git_sources + rubygems_sources + [metadata_source]
-      end
-
-      def default_source
-        git_sources.first || global_rubygems_source
       end
 
       private

--- a/bundler/spec/plugins/install_spec.rb
+++ b/bundler/spec/plugins/install_spec.rb
@@ -212,6 +212,16 @@ RSpec.describe "bundler plugin install" do
     end
   end
 
+  it "installs from a path source" do
+    build_lib "path_plugin" do |s|
+      s.write "plugins.rb"
+    end
+    bundle "plugin install path_plugin --path #{lib_path("path_plugin-1.0")}"
+
+    expect(out).to include("Installed plugin path_plugin")
+    plugin_should_be_installed("path_plugin")
+  end
+
   context "Gemfile eval" do
     before do
       allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)


### PR DESCRIPTION
Refs #3319

## What was the end-user or developer problem that led to this PR?

You can install a local plugin gem in the Gemfile via `plugin 'plugin', path: '../plugin'`, but you cannot do the analogous `bundle plugin install plugin --path=../plugin` from the CLI.

## What is your fix for the problem, implemented in this PR?

Refactor how sources are passed to the plugin installer, support the path source, remove duplicate code for git sources, and update docs.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
