### PR TITLE
Avoid allocating empty hashes in Index

### DIFF
--- a/bundler/lib/bundler/index.rb
+++ b/bundler/lib/bundler/index.rb
@@ -179,7 +179,8 @@ module Bundler
     end
 
     def specs_by_name(name)
-      @specs[name].values
+      return EMPTY_SEARCH unless specs = @specs.fetch(name, nil)
+      specs.values
     end
 
     EMPTY_SEARCH = [].freeze
@@ -190,11 +191,13 @@ module Bundler
     end
 
     def find_by_spec(spec)
-      @specs[spec.name][spec.full_name]
+      return unless specs = @specs.fetch(spec.name, nil)
+      specs[spec.full_name]
     end
 
     def exist?(spec)
-      @specs[spec.name].key?(spec.full_name)
+      return unless specs = @specs.fetch(spec.name, nil)
+      specs.key?(spec.full_name)
     end
   end
 end


### PR DESCRIPTION
Since the hashes have a default proc that returns a (new) empty hash, we
can avoid allocating those empty hashes when we are only doing lookups.

Test from running `bundle update --bundler` against a rails app I have
lying around:

```
==> memprof.after.txt <==
Total allocated: 9.71 MB (68282 objects)
Total retained:  4.87 MB (33791 objects)

==> memprof.before.txt <==
Total allocated: 10.83 MB (100596 objects)
Total retained:  5.02 MB (34721 objects)
```

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)