### PR TITLE
Stop allocating the same settings keys repeatedly

### DIFF
--- a/bundler/lib/bundler/yaml_serializer.rb
+++ b/bundler/lib/bundler/yaml_serializer.rb
@@ -54,8 +54,8 @@ module Bundler
       str.split(/\r?\n/).each do |line|
         if match = HASH_REGEX.match(line)
           indent, key, quote, val = match.captures
-          key = convert_to_backward_compatible_key(key)
-          depth = indent.scan(/  /).length
+          convert_to_backward_compatible_key!(key)
+          depth = indent.size / 2
           if quote.empty? && val.empty?
             new_hash = {}
             stack[depth][key] = new_hash
@@ -76,14 +76,13 @@ module Bundler
     end
 
     # for settings' keys
-    def convert_to_backward_compatible_key(key)
-      key = "#{key}/" if key =~ /https?:/i && key !~ %r{/\Z}
-      key = key.gsub(".", "__") if key.include?(".")
-      key
+    def convert_to_backward_compatible_key!(key)
+      key << "/" if /https?:/i.match?(key) && !%r{/\Z}.match?(key)
+      key.gsub!(".", "__")
     end
 
     class << self
-      private :dump_hash, :convert_to_backward_compatible_key
+      private :dump_hash, :convert_to_backward_compatible_key!
     end
   end
 end

--- a/lib/rubygems/yaml_serializer.rb
+++ b/lib/rubygems/yaml_serializer.rb
@@ -54,8 +54,8 @@ module Gem
       str.split(/\r?\n/).each do |line|
         if match = HASH_REGEX.match(line)
           indent, key, quote, val = match.captures
-          key = convert_to_backward_compatible_key(key)
-          depth = indent.scan(/  /).length
+          convert_to_backward_compatible_key!(key)
+          depth = indent.size / 2
           if quote.empty? && val.empty?
             new_hash = {}
             stack[depth][key] = new_hash
@@ -76,14 +76,13 @@ module Gem
     end
 
     # for settings' keys
-    def convert_to_backward_compatible_key(key)
-      key = "#{key}/" if key =~ /https?:/i && key !~ %r{/\Z}
-      key = key.gsub(".", "__") if key.include?(".")
-      key
+    def convert_to_backward_compatible_key!(key)
+      key << "/" if /https?:/i.match?(key) && !%r{/\Z}.match?(key)
+      key.gsub!(".", "__")
     end
 
     class << self
-      private :dump_hash, :convert_to_backward_compatible_key
+      private :dump_hash, :convert_to_backward_compatible_key!
     end
   end
 end


### PR DESCRIPTION
Running `bundle update --bundler` on a rails app locally:

```
==> memprof.after.txt <==
Total allocated: 301.90 kB (3794 objects)
Total retained:  73.24 kB (698 objects)

==> memprof.before.txt <==
Total allocated: 14.47 MB (196378 objects)
Total retained:  25.93 kB (202 objects)
```

So for a slight increase in retained memory (all keys are now retained),
we go from about 200k allocations in the settings file to under 4k

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)