### PR TITLE
Add Bundler::Plugin.loaded? helper

### DIFF
--- a/bundler/lib/bundler/plugin.rb
+++ b/bundler/lib/bundler/plugin.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "set"
-
 require_relative "plugin/api"
 
 module Bundler
@@ -27,7 +25,7 @@ module Bundler
       @sources = {}
       @commands = {}
       @hooks_by_event = Hash.new {|h, k| h[k] = [] }
-      @loaded_plugin_names = Set.new
+      @loaded_plugin_names = []
     end
 
     reset!

--- a/bundler/lib/bundler/plugin.rb
+++ b/bundler/lib/bundler/plugin.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "set"
+
 require_relative "plugin/api"
 
 module Bundler
@@ -25,7 +27,7 @@ module Bundler
       @sources = {}
       @commands = {}
       @hooks_by_event = Hash.new {|h, k| h[k] = [] }
-      @loaded_plugin_names = []
+      @loaded_plugin_names = Set.new
     end
 
     reset!
@@ -227,7 +229,7 @@ module Bundler
       plugins = index.hook_plugins(event)
       return unless plugins.any?
 
-      (plugins - @loaded_plugin_names).each {|name| load_plugin(name) }
+      plugins.each {|name| load_plugin(name) }
 
       @hooks_by_event[event].each {|blk| blk.call(*args, &arg_blk) }
     end
@@ -237,6 +239,11 @@ module Bundler
     # @return [String, nil] installed path
     def installed?(plugin)
       Index.new.installed?(plugin)
+    end
+
+    # @return [true, false] whether the plugin is loaded
+    def loaded?(plugin)
+      @loaded_plugin_names.include?(plugin)
     end
 
     # Post installation processing and registering with index
@@ -329,6 +336,7 @@ module Bundler
     # @param [String] name of the plugin
     def load_plugin(name)
       return unless name && !name.empty?
+      return if loaded?(name)
 
       # Need to ensure before this that plugin root where the rest of gems
       # are installed to be on load path to support plugin deps. Currently not


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I have a bundler plugin that adds to the bundler DSL. Right now users of the plugin must do something like `return unless defined?(...)` to see if the plugin has loaded. A simpler, more direct helper was desired.

## What is your fix for the problem, implemented in this PR?

Add a Plugin.loaded? helper. Use it internally, also making Plugin.load_plugin idempotent (many plugins I've looked at have a tendency to call that method directly, and use a `unless defined?(...)` guard.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
