### PR TITLE
Index#first_result last_result empty? any? to short circuit queries

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -560,7 +560,7 @@ module Bundler
         incomplete_specs = still_incomplete_specs
       end
 
-      bundler = sources.metadata_source.specs.search(["bundler", Bundler.gem_version]).last
+      bundler = sources.metadata_source.specs.last_result(["bundler", Bundler.gem_version])
       specs["bundler"] = bundler
 
       specs
@@ -583,7 +583,7 @@ module Bundler
         local_source = original_source.dup
         local_source.local_only!
 
-        new_source_requirements[name] = if local_source.specs.search(name).any?
+        new_source_requirements[name] = if local_source.specs.any?(name)
           local_source
         else
           original_source
@@ -906,7 +906,7 @@ module Bundler
 
     def verify_changed_sources!
       @specs_that_changed_sources.each do |s|
-        if s.source.specs.search(s.name).empty?
+        if s.source.specs.empty?(s.name)
           raise GemNotFound, "Could not find gem '#{s.name}' in #{s.source}"
         end
       end

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -222,7 +222,7 @@ module Bundler
       def cached_built_in_gem(spec)
         cached_path = cached_path(spec)
         if cached_path.nil?
-          remote_spec = remote_specs.search(spec).first
+          remote_spec = remote_specs.first_result(spec)
           if remote_spec
             cached_path = fetch_gem(remote_spec)
           else

--- a/bundler/spec/bundler/index_spec.rb
+++ b/bundler/spec/bundler/index_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Bundler::Index do
     end
     let(:specs) { [spec] }
 
-    describe "#search_by_spec" do
+    describe "#search" do
       it "finds the spec when a nil platform is specified" do
         expect(subject.search(spec)).to eq([spec])
       end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Index#search constructs arrays of all results before returning. Sometimes the return value is reduced to `search(query).empty?` which wastes the time constructing the results.

## What is your fix for the problem, implemented in this PR?

Add specialized methods for queries that only need to know empty/any or fetch the first or last result.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
