### PR TITLE
Optimize allocations in Gem::Version

### DIFF
--- a/lib/rubygems/query_utils.rb
+++ b/lib/rubygems/query_utils.rb
@@ -311,8 +311,8 @@ module Gem::QueryUtils
       label = "Installed at"
       specs.each do |s|
         version = s.version.to_s
-        version << ", default" if s.default_gem?
-        entry << "\n" << "    #{label} (#{version}): #{s.base_dir}"
+        default = ", default" if s.default_gem?
+        entry << "\n" << "    #{label} (#{version}#{default}): #{s.base_dir}"
         label = " " * label.length
       end
     end


### PR DESCRIPTION
From running in a random rails app I have locally, here are the changes

1) for `bundle lock --update --bundler` (forcing Bundler to go through
dependency resolution)

```
==> memprof.after.txt <==
Total allocated: 2.98 MB (48307 objects)
Total retained:  1.21 MB (16507 objects)

==> memprof.before.txt <==
Total allocated: 12.62 MB (198506 objects)
Total retained:  1.30 MB (23133 objects)
```

2) for `bin/rails runner true` (essentially only bundler/setup)

```
==> memprof.after.txt <==
Total allocated: 59.50 kB (1017 objects)
Total retained:  25.08 kB (362 objects)

==> memprof.before.txt <==
Total allocated: 561.82 kB (8575 objects)
Total retained:  27.28 kB (513 objects)
```

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)