### PR TITLE
Reduce allocations for stub specifications

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -133,9 +133,9 @@ class Gem::BasicSpecification
 
   def full_name
     if platform == Gem::Platform::RUBY || platform.nil?
-      "#{name}-#{version}".dup.tap(&Gem::UNTAINT)
+      (+"#{name}-#{version}").tap(&Gem::UNTAINT)
     else
-      "#{name}-#{version}-#{platform}".dup.tap(&Gem::UNTAINT)
+      (+"#{name}-#{version}-#{platform}").tap(&Gem::UNTAINT)
     end
   end
 


### PR DESCRIPTION
This helps with memory usage during application boot time

```
==> memprof.after.txt <==
Total allocated: 1.43 MB (18852 objects)
Total retained:  421.12 kB (4352 objects)

==> memprof.before.txt <==
Total allocated: 2.43 MB (28355 objects)
Total retained:  469.69 kB (5425 objects)
```

See https://bugs.ruby-lang.org/issues/19890 about the readline
allocations

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)