### PR TITLE
Lazily construct fetcher debug messages

### DIFF
--- a/bundler/lib/bundler/fetcher/base.rb
+++ b/bundler/lib/bundler/fetcher/base.rb
@@ -38,9 +38,9 @@ module Bundler
 
       private
 
-      def log_specs(debug_msg)
+      def log_specs(&block)
         if Bundler.ui.debug?
-          Bundler.ui.debug debug_msg
+          Bundler.ui.debug yield
         else
           Bundler.ui.info ".", false
         end

--- a/bundler/lib/bundler/fetcher/compact_index.rb
+++ b/bundler/lib/bundler/fetcher/compact_index.rb
@@ -35,7 +35,7 @@ module Bundler
         remaining_gems = gem_names.dup
 
         until remaining_gems.empty?
-          log_specs "Looking up gems #{remaining_gems.inspect}"
+          log_specs { "Looking up gems #{remaining_gems.inspect}" }
 
           deps = begin
                    parallel_compact_index_client.dependencies(remaining_gems)

--- a/bundler/lib/bundler/fetcher/dependency.rb
+++ b/bundler/lib/bundler/fetcher/dependency.rb
@@ -24,7 +24,7 @@ module Bundler
       def specs(gem_names, full_dependency_list = [], last_spec_list = [])
         query_list = gem_names.uniq - full_dependency_list
 
-        log_specs "Query List: #{query_list.inspect}"
+        log_specs { "Query List: #{query_list.inspect}" }
 
         return last_spec_list if query_list.empty?
 


### PR DESCRIPTION
Avoids constructing several strings

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)