### PR TITLE
Reduce allocations when installing gems with bundler

### DIFF
--- a/bundler/spec/bundler/installer/spec_installation_spec.rb
+++ b/bundler/spec/bundler/installer/spec_installation_spec.rb
@@ -47,7 +47,8 @@ RSpec.describe Bundler::ParallelInstaller::SpecInstallation do
         all_specs = dependencies + [instance_double("SpecInstallation", :spec => "gamma", :name => "gamma", :installed? => false, :all_dependencies => [], :type => :production)]
         spec = described_class.new(dep)
         allow(spec).to receive(:all_dependencies).and_return(dependencies)
-        expect(spec.dependencies_installed?(all_specs)).to be_truthy
+        installed_specs = all_specs.select(&:installed?).map {|s| [s.name, true] }.to_h
+        expect(spec.dependencies_installed?(installed_specs)).to be_truthy
       end
     end
 
@@ -59,7 +60,8 @@ RSpec.describe Bundler::ParallelInstaller::SpecInstallation do
         all_specs = dependencies + [instance_double("SpecInstallation", :spec => "gamma", :name => "gamma", :installed? => false, :all_dependencies => [], :type => :production)]
         spec = described_class.new(dep)
         allow(spec).to receive(:all_dependencies).and_return(dependencies)
-        expect(spec.dependencies_installed?(all_specs)).to be_falsey
+        installed_specs = all_specs.select(&:installed?).map {|s| [s.name, true] }.to_h
+        expect(spec.dependencies_installed?(installed_specs)).to be_falsey
       end
     end
   end


### PR DESCRIPTION
```
==> memprof.after.txt <==
Total allocated: 1.13 MB (2352 objects)
Total retained:  10.08 kB (78 objects)

==> memprof.before.txt <==
Total allocated: 46.27 MB (38439 objects)
Total retained:  9.94 kB (75 objects)
```

Yes, we were allocating 45MB of arrays in `dependencies_installed?`,
it was accidentally cubic.

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)