### PR TITLE
Fix `bundle install` when older revisions of git source

### DIFF
--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -130,7 +130,8 @@ module Bundler
             end
           end
 
-          git "fetch", "--force", "--quiet", *extra_fetch_args, :dir => destination if @commit_ref
+          ref = @commit_ref || (full_sha_revision? && @revision)
+          git "fetch", "--force", "--quiet", *extra_fetch_args(ref), :dir => destination if ref
 
           git "reset", "--hard", @revision, :dir => destination
 
@@ -248,6 +249,10 @@ module Bundler
 
         def pinned_to_full_sha?
           ref =~ /\A\h{40}\z/
+        end
+
+        def full_sha_revision?
+          @revision.match?(/\A\h{40}\z/)
         end
 
         def git_null(*command, dir: nil)
@@ -411,9 +416,9 @@ module Bundler
           ["--depth", depth.to_s]
         end
 
-        def extra_fetch_args
+        def extra_fetch_args(ref)
           extra_args = [path.to_s, *depth_args]
-          extra_args.push(@commit_ref)
+          extra_args.push(ref)
           extra_args
         end
 

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -130,7 +130,7 @@ module Bundler
             end
           end
 
-          ref = @commit_ref || (full_sha_revision? && @revision)
+          ref = @commit_ref || (locked_to_full_sha? && @revision)
           git "fetch", "--force", "--quiet", *extra_fetch_args(ref), :dir => destination if ref
 
           git "reset", "--hard", @revision, :dir => destination
@@ -248,11 +248,15 @@ module Bundler
         end
 
         def pinned_to_full_sha?
-          ref =~ /\A\h{40}\z/
+          full_sha_revision?(ref)
         end
 
-        def full_sha_revision?
-          @revision.match?(/\A\h{40}\z/)
+        def locked_to_full_sha?
+          full_sha_revision?(@revision)
+        end
+
+        def full_sha_revision?(ref)
+          ref&.match?(/\A\h{40}\z/)
         end
 
         def git_null(*command, dir: nil)


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?
Fixes #6929.

`bundle install` may fail if an old revision is specified for a gem of git source.
At that time, the following error occurs.

```
Git error: command `git reset --hard 41982d4703e4a89eaeaa1c90ae4982ff574e48eb` in directory
/tmp/path/to/app/vendor/bundle/ruby/3.1.0/bundler/gems/foo-41982d4703e4 has failed.
fatal: Could not parse object '41982d4703e4a89eaeaa1c90ae4982ff574e48eb'.
```

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

This implementation is to execute `fetch` after copying to the installation directory. Because the target commit may exist in the repository in cache, but not in the destination repository.

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
