### PR TITLE
Run CI on pushes to master again

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -2,7 +2,6 @@ name: bundler
 
 on:
   pull_request:
-  merge_group:
 
   push:
     branches:

--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   merge_group:
 
+  push:
+    branches:
+      - master
+
 concurrency:
   group: ci-${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -2,7 +2,6 @@ name: install-rubygems
 
 on:
   pull_request:
-  merge_group:
 
   push:
     branches:

--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   merge_group:
 
+  push:
+    branches:
+      - master
+
 concurrency:
   group: ci-${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/jruby-bundler.yml
+++ b/.github/workflows/jruby-bundler.yml
@@ -2,7 +2,6 @@ name: jruby-bundler
 
 on:
   pull_request:
-  merge_group:
 
   push:
     branches:

--- a/.github/workflows/jruby-bundler.yml
+++ b/.github/workflows/jruby-bundler.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   merge_group:
 
+  push:
+    branches:
+      - master
+
 concurrency:
   group: ci-${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/legacy-git.yml
+++ b/.github/workflows/legacy-git.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   merge_group:
 
+  push:
+    branches:
+      - master
+
 concurrency:
   group: ci-${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/legacy-git.yml
+++ b/.github/workflows/legacy-git.yml
@@ -2,7 +2,6 @@ name: legacy-git
 
 on:
   pull_request:
-  merge_group:
 
   push:
     branches:

--- a/.github/workflows/realworld-bundler.yml
+++ b/.github/workflows/realworld-bundler.yml
@@ -2,7 +2,6 @@ name: realworld
 
 on:
   pull_request:
-  merge_group:
 
   push:
     branches:

--- a/.github/workflows/realworld-bundler.yml
+++ b/.github/workflows/realworld-bundler.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   merge_group:
 
+  push:
+    branches:
+      - master
+
 concurrency:
   group: ci-${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   merge_group:
 
+  push:
+    branches:
+      - master
+
 concurrency:
   group: ci-${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -2,7 +2,6 @@ name: ruby-core
 
 on:
   pull_request:
-  merge_group:
 
   push:
     branches:

--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   merge_group:
 
+  push:
+    branches:
+      - master
+
 concurrency:
   group: ci-${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -2,7 +2,6 @@ name: rubygems
 
 on:
   pull_request:
-  merge_group:
 
   push:
     branches:

--- a/.github/workflows/spell.yml
+++ b/.github/workflows/spell.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   merge_group:
 
+  push:
+    branches:
+      - master
+
 permissions:
   contents: read
 

--- a/.github/workflows/spell.yml
+++ b/.github/workflows/spell.yml
@@ -2,7 +2,6 @@ name: spell
 
 on:
   pull_request:
-  merge_group:
 
   push:
     branches:

--- a/.github/workflows/system-rubygems-bundler.yml
+++ b/.github/workflows/system-rubygems-bundler.yml
@@ -7,12 +7,6 @@ on:
       - .github/workflows/system-rubygems-bundler.yml
       - .rubocop_bundler.yml
 
-  merge_group:
-    paths:
-      - bundler/**
-      - .github/workflows/system-rubygems-bundler.yml
-      - .rubocop_bundler.yml
-
   push:
     branches:
       - master

--- a/.github/workflows/system-rubygems-bundler.yml
+++ b/.github/workflows/system-rubygems-bundler.yml
@@ -13,6 +13,10 @@ on:
       - .github/workflows/system-rubygems-bundler.yml
       - .rubocop_bundler.yml
 
+  push:
+    branches:
+      - master
+
 concurrency:
   group: ci-${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/truffleruby-bundler.yml
+++ b/.github/workflows/truffleruby-bundler.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   merge_group:
 
+  push:
+    branches:
+      - master
+
 concurrency:
   group: ci-${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/truffleruby-bundler.yml
+++ b/.github/workflows/truffleruby-bundler.yml
@@ -2,7 +2,6 @@ name: truffleruby-bundler
 
 on:
   pull_request:
-  merge_group:
 
   push:
     branches:

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -2,7 +2,6 @@ name: ubuntu-lint
 
 on:
   pull_request:
-  merge_group:
 
   push:
     branches:

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   merge_group:
 
+  push:
+    branches:
+      - master
+
 concurrency:
   group: ci-${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We currently have no easy way to verify if a semantic conflict between two consecutively merged PRs appears.

I think making sure CI is green on pushes to master is reassuring.

## What is your fix for the problem, implemented in this PR?

My fix is to revert https://github.com/rubygems/rubygems/pull/6369, because we ended up disabling the merge queue feature because it didn't quite work for us.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
