### PR TITLE
Fix turbo tests Windows monkeypatch

### DIFF
--- a/tool/windows_json_rows_formatter.rb
+++ b/tool/windows_json_rows_formatter.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "turbo_tests/json_rows_formatter"
+
+module TurboTests
+  class WindowsJsonRowsFormatter < JsonRowsFormatter
+    RSpec::Core::Formatters.register(
+      self,
+      :start,
+      :close,
+      :example_failed,
+      :example_passed,
+      :example_pending,
+      :example_group_started,
+      :example_group_finished,
+      :message,
+      :seed
+    )
+
+    private
+
+    def output_row(obj)
+      output.puts ENV["RSPEC_FORMATTER_OUTPUT_ID"] + obj.to_json
+      output.flush
+    end
+  end
+end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We haven't been running Bundler specs on Windows since https://github.com/rubygems/rubygems/pull/6739. That PR introduced a monkeypatch for Windows that made tests take a long time (like now) and still report success. So we did not notice that no specs were actually run.

This can be noticed in the last two lines of the current output:

```
Finished in 93 minutes 10 seconds (files took 0 seconds to load)
0 examples, 0 failures
```

## What is your fix for the problem, implemented in this PR?

My fix is to correct the patch to properly apply our previous solution. We should upstream something but for now I just want the tests running again.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
