### PR TITLE
Allow standalone mode to work on a Windows edge case

### DIFF
--- a/bundler/lib/bundler/installer/standalone.rb
+++ b/bundler/lib/bundler/installer/standalone.rb
@@ -55,11 +55,18 @@ module Bundler
       if spec.source.instance_of?(Source::Path) && spec.source.path.absolute?
         full_path
       else
-        Pathname.new(full_path).relative_path_from(Bundler.root.join(bundler_path)).to_s
+        relative_path_from(Bundler.root.join(bundler_path), :to => full_path) || full_path
       end
     rescue TypeError
       error_message = "#{spec.name} #{spec.version} has an invalid gemspec"
       raise Gem::InvalidSpecificationException.new(error_message)
+    end
+
+    def relative_path_from(source, to:)
+      Pathname.new(to).relative_path_from(source).to_s
+    rescue ArgumentError
+      # on Windows, if source and destination are on different drivers, there's no relative path from one to the other
+      nil
     end
 
     def define_path_helpers


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If a gem is located in a different drive than the Gemfile, standalone mode will fail to generate the `bundler/setup` script, failing with an error like

```
ArgumentError: different prefix: "C:/" and "D:/a/rubygems/rubygems/bundler/tmp/2/bundled_app/bundle/bundler"
  C:/hostedtoolcache/windows/Ruby/3.0.5/x64/lib/ruby/3.0.0/pathname.rb:528:in `relative_path_from'
  D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.4.20/lib/bundler/installer/standalone.rb:58:in `gem_path'
  D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.4.20/lib/bundler/installer/standalone.rb:33:in `block (2 levels) in paths'
  D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.4.20/lib/bundler/installer/standalone.rb:32:in `map'
  D:/a/rubygems/rubygems/bundler/tmp/2/gems/system/gems/bundler-2.4.20/lib/bundler/installer/standalone.rb:32:in `block in paths'
```

## What is your fix for the problem, implemented in this PR?

I'm fixing this by falling back to using a full path in this case.

This was caught by a failing spec, so I'm not adding new specs.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
