### PR TITLE
Speed up `gem install <gem-that-does-not-exist>`

### DIFF
--- a/lib/rubygems/resolver/best_set.rb
+++ b/lib/rubygems/resolver/best_set.rb
@@ -30,9 +30,13 @@ class Gem::Resolver::BestSet < Gem::Resolver::ComposedSet
 
     super
   rescue Gem::RemoteFetcher::FetchError => e
-    replace_failed_api_set e
+    if e.message.include?("Not Found 404")
+      []
+    else
+      replace_failed_api_set e
 
-    retry
+      retry
+    end
   end
 
   def prefetch(reqs) # :nodoc:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When target gem does not exist, `gem install` is very slow.

## What is your fix for the problem, implemented in this PR?

My fix is to skip the full index resolve in this case, since we know it will fail already from the compact index result.

#### Before:

```
$ time ruby -I lib exe/gem install --debug --verbose pony-gem
NOTE:  Debugging mode prints all exceptions even when rescued
HEAD https://index.rubygems.org/
200 OK
GET https://index.rubygems.org/info/pony-gem
404 Not Found
Exception `Gem::RemoteFetcher::FetchError' at /home/deivid/code/rubygems/rubygems/lib/rubygems/remote_fetcher.rb:237 - bad response Not Found 404 (https://index.rubygems.org/info/pony-gem)
GET https://index.rubygems.org/prerelease_specs.4.8.gz
200 OK
GET https://index.rubygems.org/specs.4.8.gz
200 OK
Exception `Gem::UnsatisfiableDependencyError' at /home/deivid/code/rubygems/rubygems/lib/rubygems/resolver/installer_set.rb:83 - Unable to resolve dependency: user requested 'pony-gem (>= 0)'
ERROR:  Could not find a valid gem 'pony-gem' (>= 0) in any repository
GET https://rubygems.org/latest_specs.4.8.gz
304 Not Modified
ERROR:  Possible alternatives: donsgem, moneygem, poc_gem, pokegem, pry-gem, tinygem

real	0m30,753s
user	0m26,480s
sys	0m0,633s
```

#### After

```
$ time ruby -I lib exe/gem install --debug --verbose pony-gem
NOTE:  Debugging mode prints all exceptions even when rescued
HEAD https://index.rubygems.org/
200 OK
GET https://index.rubygems.org/info/pony-gem
404 Not Found
Exception `Gem::RemoteFetcher::FetchError' at /home/deivid/code/rubygems/rubygems/lib/rubygems/remote_fetcher.rb:237 - bad response Not Found 404 (https://index.rubygems.org/info/pony-gem)
Exception `Gem::UnsatisfiableDependencyError' at /home/deivid/code/rubygems/rubygems/lib/rubygems/resolver/installer_set.rb:83 - Unable to resolve dependency: user requested 'pony-gem (>= 0)'
ERROR:  Could not find a valid gem 'pony-gem' (>= 0) in any repository
GET https://rubygems.org/latest_specs.4.8.gz
304 Not Modified
ERROR:  Possible alternatives: donsgem, moneygem, poc_gem, pokegem, pry-gem, tinygem

real	0m5,709s
user	0m4,909s
sys	0m0,149s
```

Fixes #6821.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
