### PR TITLE
Make rubygems gemspec and Rakefile independent from CWD

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -86,7 +86,7 @@ end
 
 task :default => [:test, :spec]
 
-spec = Gem::Specification.load("rubygems-update.gemspec")
+spec = Gem::Specification.load(File.expand_path("rubygems-update.gemspec", __dir__))
 v = spec.version
 
 require "rdoc/task"
@@ -720,7 +720,7 @@ task :override_version do
 end
 
 namespace :bundler do
-  chdir("bundler") do
+  chdir(File.expand_path("bundler", __dir__)) do
     require_relative "bundler/lib/bundler/gem_tasks"
   end
   require_relative "bundler/spec/support/build_metadata"

--- a/rubygems-update.gemspec
+++ b/rubygems-update.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.metadata = { "source_code_uri" => "https://github.com/rubygems/rubygems" }
   s.licenses = ["Ruby", "MIT"]
 
-  s.files = File.read("Manifest.txt").split
+  s.files = File.read(File.expand_path("Manifest.txt", __dir__)).split
   s.bindir = "exe"
   s.executables = ["update_rubygems"]
   s.require_paths = ["hide_lib_for_update"]
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
     "UPGRADING.md", "POLICIES.md", "CODE_OF_CONDUCT.md",
     "CONTRIBUTING.md",
     "bundler/LICENSE.md", "bundler/README.md",
-    "hide_lib_for_update/note.txt", *Dir["bundler/lib/bundler/man/*.1"]
+    "hide_lib_for_update/note.txt", *Dir["bundler/lib/bundler/man/*.1", :base => __dir__]
   ]
 
   s.required_ruby_version = Gem::Requirement.new(">= 2.6.0")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

While restoring Windows specs running in parallel at #6988, I'm runtime into one spec failure that reads like this:

```
       Invoking `C:/hostedtoolcache/windows/Ruby/3.2.1/x64/bin/ruby.exe -S D:/a/rubygems/rubygems/bundler/tmp/1/gems/base/ruby/3.2.0/bin/rake -e 'load "Rakefile"; puts CLOBBER.inspect'` failed with output:
       ----------------------------------------------------------------------
       rake aborted!
       NoMethodError: undefined method `version' for nil:NilClass
       D:/a/rubygems/rubygems/Rakefile:90:in `<top (required)>'
       (eval):1:in `load'
       (eval):1:in `block in standard_rake_options'
       D:/a/rubygems/rubygems/bundler/tmp/1/gems/base/ruby/3.2.0/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
       (See full trace by running task with --trace)
       ----------------------------------------------------------------------
     # ./spec/support/helpers.rb:202:in `sys_exec'
     # ./spec/runtime/gem_tasks_spec.rb:102:in `block (3 levels) in <top (required)>'
     # ./spec/support/helpers.rb:357:in `block in with_gem_path_as'
     # ./spec/support/helpers.rb:371:in `without_env_side_effects'
     # ./spec/support/helpers.rb:352:in `with_gem_path_as'
     # ./spec/runtime/gem_tasks_spec.rb:101:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:102:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:102:in `block (3 levels) in <top (required)>'
     # ./spec/support/helpers.rb:357:in `block in with_gem_path_as'
     # ./spec/support/helpers.rb:371:in `without_env_side_effects'
     # ./spec/support/helpers.rb:352:in `with_gem_path_as'
     # ./spec/spec_helper.rb:101:in `block (2 levels) in <top (required)>'
     # ./spec/support/rubygems_ext.rb:103:in `load'
     # ./spec/support/rubygems_ext.rb:103:in `gem_load_and_activate'
     # ./spec/support/rubygems_ext.rb:18:in `gem_load'

Finished in 93 minutes 1 second (files took 2.09 seconds to load)
3069 examples, 1 failure, 118 pending

Failed examples:

rspec ./spec/runtime/gem_tasks_spec.rb:100 # require 'bundler/gem_tasks' adds 'pkg' to rake/clean's CLOBBER
```

It seems that for some reason, on Windows, `sys_exec` is not properly switching to the dummy test application folder, and loading the repo root `Rakefile` instead of the dummy `Rakefile` used for this test.

## What is your fix for the problem, implemented in this PR?

This change does not fix the problem. But by making the Rakefile and the rubygems gemspec (loaded from the Rakefile) independent from the CWD, we make the spec not run into this error and still pass.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
