### PR TITLE
Fix `bundle lock --minor --update <dep>` edge case

### DIFF
--- a/bundler/lib/bundler/gem_version_promoter.rb
+++ b/bundler/lib/bundler/gem_version_promoter.rb
@@ -101,7 +101,7 @@ module Bundler
           next  1 if b_pre && !a_pre
         end
 
-        if major?
+        if major? || locked_version.nil?
           a <=> b
         elsif either_version_older_than_locked?(a, b, locked_version)
           a <=> b
@@ -117,7 +117,7 @@ module Bundler
     end
 
     def either_version_older_than_locked?(a, b, locked_version)
-      locked_version && (a.version < locked_version || b.version < locked_version)
+      a.version < locked_version || b.version < locked_version
     end
 
     def segments_do_not_match?(a, b, level)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When the latest allowed minor of `dep` adds a new dependency, that new dependency would be incorrectly resolved to the latest minor of the first major version.

## What is your fix for the problem, implemented in this PR?

The `--minor` logic should only be applied for dependencies that are already locked.

Fixes #6952.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
