### PR TITLE
Make error message about out of sync man pages more actionable

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -708,7 +708,7 @@ namespace :man do
     task :check => [:check_ronn, :set_current_date, :build] do
       Spec::Rubygems.check_source_control_changes(
         :success_message => "Man pages are in sync",
-        :error_message => "Man pages are out of sync. Above you can see the list of files that got modified or generated from rebuilding them. Please review and commit the results."
+        :error_message => "Man pages are out of sync. Please run `rake man:build` and commit the results."
       )
     end
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When a contributor updates a `.ronn` documentation file but forgets to regenerate the man page from it, we error in CI but fail to provide instructions to fix the error.

## What is your fix for the problem, implemented in this PR?

Give a more actionable error message.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
