### PR TITLE
Improve release scripts

### DIFF
--- a/tool/release.rb
+++ b/tool/release.rb
@@ -279,7 +279,7 @@ class Release
   private
 
   def relevant_unreleased_pull_requests
-    (@bundler.relevant_pull_requests + @rubygems.relevant_pull_requests).sort_by(&:merged_at)
+    (@bundler.relevant_pull_requests + @rubygems.relevant_pull_requests).uniq.sort_by(&:merged_at)
   end
 
   def unreleased_pull_requests

--- a/tool/release.rb
+++ b/tool/release.rb
@@ -221,8 +221,9 @@ class Release
 
   def cherry_pick_pull_requests
     prs = relevant_unreleased_pull_requests
+    raise "No unreleased PRs were found. Make sure to tag them with appropriate labels so that they are selected for backport." unless prs.any?
 
-    if prs.any? && !system("git", "cherry-pick", "-x", "-m", "1", *prs.map(&:merge_commit_sha))
+    unless system("git", "cherry-pick", "-x", "-m", "1", *prs.map(&:merge_commit_sha))
       warn <<~MSG
 
         Opening a new shell to fix the cherry-pick errors manually. You can do the following now:

--- a/tool/release.rb
+++ b/tool/release.rb
@@ -228,7 +228,7 @@ class Release
         Opening a new shell to fix the cherry-pick errors manually. You can do the following now:
 
         * Find the PR that caused the merge conflict.
-        * If you'd like to include that PR in the release, tag it with an appropriate label. Then type `Ctrl-D` and rerun the task so that the PR is cherry-picked before and the conflict is fixed.
+        * If you'd like to include that PR in the release, tag it with an appropriate label. Then type `exit 1` and rerun the task so that the PR is cherry-picked before and the conflict is fixed.
         * If you don't want to include that PR in the release, fix conflicts manually, run `git add . && git cherry-pick --continue` once done, and if it succeeds, run `exit 0` to resume the release preparation.
 
       MSG

--- a/tool/release.rb
+++ b/tool/release.rb
@@ -171,7 +171,7 @@ class Release
       system("git", "push", "origin", @stable_branch, exception: true)
     end
 
-    system("git", "checkout", "-b", @release_branch, @stable_branch, exception: true)
+    create_if_not_exist_and_switch_to_release_branch
 
     begin
       @bundler.set_relevant_pull_requests_from(unreleased_pull_requests)
@@ -226,6 +226,12 @@ class Release
       system("git", "branch", "-D", @release_branch)
       raise
     end
+  end
+
+  def create_if_not_exist_and_switch_to_release_branch
+    system("git", "checkout", @release_branch, exception: true, err: IO::NULL)
+  rescue StandardError
+    system("git", "checkout", "-b", @release_branch, @stable_branch, exception: true)
   end
 
   def cherry_pick_pull_requests

--- a/tool/release.rb
+++ b/tool/release.rb
@@ -223,6 +223,8 @@ class Release
     prs = relevant_unreleased_pull_requests
     raise "No unreleased PRs were found. Make sure to tag them with appropriate labels so that they are selected for backport." unless prs.any?
 
+    puts "The following unreleased prs were found:\n#{prs.map {|pr| "* #{pr.url}" }.join("\n")}"
+
     unless system("git", "cherry-pick", "-x", "-m", "1", *prs.map(&:merge_commit_sha))
       warn <<~MSG
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Try to make generating release PRs easier. I used this branch to generate #6985.

## What is your fix for the problem, implemented in this PR?

To reduce the number of conflicts that need to be manually solved, I made it so you can use an initial branch with some manually added commits. I used this to start with an autocorrect of some rubocop rules that are enforced in the master branch and were generating conflicts. Also to cherry-pick some PRs that were merged using squash or rebase, and that the scripts can't cherry-pick automatically.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
