### PR TITLE
Only remove bundler plugin gem when it's inside the cache

### DIFF
--- a/bundler/lib/bundler/plugin.rb
+++ b/bundler/lib/bundler/plugin.rb
@@ -62,7 +62,8 @@ module Bundler
       if names.any?
         names.each do |name|
           if index.installed?(name)
-            Bundler.rm_rf(index.plugin_path(name))
+            path = index.plugin_path(name).to_s
+            Bundler.rm_rf(path) if index.installed_in_plugin_root?(name)
             index.unregister_plugin(name)
             Bundler.ui.info "Uninstalled plugin #{name}"
           else

--- a/bundler/lib/bundler/plugin/index.rb
+++ b/bundler/lib/bundler/plugin/index.rb
@@ -136,6 +136,14 @@ module Bundler
         @hooks[event] || []
       end
 
+      # This plugin is installed inside the .bundle/plugin directory,
+      # and thus is managed solely by Bundler
+      def installed_in_plugin_root?(name)
+        return false unless (path = installed?(name))
+
+        path.start_with?("#{Plugin.root}/")
+      end
+
       private
 
       # Reads the index file from the directory and initializes the instance


### PR DESCRIPTION
Fixes #6953

## What was the end-user or developer problem that led to this PR?

A plugin installed with a local path (i.e. via #6960) would completely remove the external gem when you run `bundle plugin uninstall`.

## What is your fix for the problem, implemented in this PR?

Ensure that any paths are within the plugin root before removing.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
