### PR TITLE
Raise an error when lockfile is invalid

### DIFF
--- a/bundler/lib/bundler/installer/parallel_installer.rb
+++ b/bundler/lib/bundler/installer/parallel_installer.rb
@@ -108,19 +108,19 @@ module Bundler
       end.reject {|a| a.last.empty? }
       return if unmet_dependencies.empty?
 
-      warning = []
-      warning << "Your lockfile doesn't include a valid resolution."
-      warning << "You can fix this by regenerating your lockfile or manually editing the bad locked gems to a version that satisfies all dependencies."
-      warning << "The unmet dependencies are:"
+      error = []
+      error << "Your lockfile doesn't include a valid resolution."
+      error << "You can fix this by regenerating your lockfile or manually editing the bad locked gems to a version that satisfies all dependencies."
+      error << "The unmet dependencies are:"
 
       unmet_dependencies.each do |spec, unmet_spec_dependencies|
         unmet_spec_dependencies.each do |unmet_spec_dependency|
           found = @specs.find {|s| s.name == unmet_spec_dependency.name && !unmet_spec_dependency.matches_spec?(s.spec) }
-          warning << "* #{unmet_spec_dependency}, dependency of #{spec.full_name}, unsatisfied by #{found.full_name}"
+          error << "* #{unmet_spec_dependency}, dependency of #{spec.full_name}, unsatisfied by #{found.full_name}"
         end
       end
 
-      Bundler.ui.warn(warning.join("\n"))
+      raise Bundler::InstallError, error.join("\n")
     end
 
     private

--- a/bundler/spec/bundler/installer/parallel_installer_spec.rb
+++ b/bundler/spec/bundler/installer/parallel_installer_spec.rb
@@ -19,14 +19,15 @@ RSpec.describe Bundler::ParallelInstaller do
       ].flatten
     end
 
-    it "prints a warning" do
-      expect(Bundler.ui).to receive(:warn).with(<<-W.strip)
+    it "raises an error" do
+      expect do
+        subject.check_for_unmet_dependencies
+      end.to raise_error(Bundler::InstallError, <<-E.strip)
 Your lockfile doesn't include a valid resolution.
 You can fix this by regenerating your lockfile or manually editing the bad locked gems to a version that satisfies all dependencies.
 The unmet dependencies are:
 * diff-lcs (< 1.4), dependency of cucumber-4.1.0, unsatisfied by diff-lcs-1.4.4
-      W
-      subject.check_for_unmet_dependencies
+      E
     end
   end
 
@@ -38,9 +39,10 @@ The unmet dependencies are:
       ].flatten
     end
 
-    it "doesn't print a warning" do
-      expect(Bundler.ui).not_to receive(:warn)
-      subject.check_for_unmet_dependencies
+    it "doesn't raise an error" do
+      expect do
+        subject.check_for_unmet_dependencies
+      end.not_to raise_error
     end
   end
 end

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -237,49 +237,6 @@ RSpec.describe "bundle install from an existing gemspec" do
     expect(the_bundle).to include_gem "foo 1.0"
   end
 
-  it "allows conflicts" do
-    build_lib("foo", :path => tmp.join("foo")) do |s|
-      s.version = "1.0.0"
-      s.add_dependency "bar", "= 1.0.0"
-    end
-    build_gem "deps", :to_bundle => true do |s|
-      s.add_dependency "foo", "= 0.0.1"
-    end
-    build_gem "foo", "0.0.1", :to_bundle => true
-
-    install_gemfile <<-G
-      source "#{file_uri_for(gem_repo2)}"
-      gem "deps"
-      gemspec :path => '#{tmp.join("foo")}', :name => 'foo'
-    G
-
-    expect(the_bundle).to include_gems "foo 1.0.0"
-  end
-
-  it "does not break Gem.finish_resolve with conflicts" do
-    build_lib("foo", :path => tmp.join("foo")) do |s|
-      s.version = "1.0.0"
-      s.add_dependency "bar", "= 1.0.0"
-    end
-    update_repo2 do
-      build_gem "deps" do |s|
-        s.add_dependency "foo", "= 0.0.1"
-      end
-      build_gem "foo", "0.0.1"
-    end
-
-    install_gemfile <<-G
-      source "#{file_uri_for(gem_repo2)}"
-      gem "deps"
-      gemspec :path => '#{tmp.join("foo")}', :name => 'foo'
-    G
-
-    expect(the_bundle).to include_gems "foo 1.0.0"
-
-    run "Gem.finish_resolve; puts 'WIN'"
-    expect(out).to eq("WIN")
-  end
-
   it "handles downgrades" do
     build_lib "omg", "2.0", :path => lib_path("omg")
 


### PR DESCRIPTION
Follow-up to https://github.com/rubygems/rubygems/pull/4459

Instead of printing a warning, raise a handled error to make sure `bundle install` exits with a non-zero status code.

## What was the end-user or developer problem that led to this PR?

An invalid lockfile passed CI when I wish it would have failed.

To add some detail to the linked PR, this can happen relatively easily because Git will happily merge lockfiles, so if one commit changes the top of the lockfile, and another changes the bottom, Git can end up merging those, resulting in an invalid lockfile (in our case it was a commit updating gem to a new version that was limiting the requirements for another dependency, and a commit updating said dependency to the now forbidden version). Once the second commit was merged, the warning was printed, but did not result in CI failing.

A demonstration is available in https://github.com/etiennebarrie/invalid-gemfile.lock.

## What is your fix for the problem, implemented in this PR?

The fix raises a `InstallError` instead of printing a warning, resulting in a non-zero status code.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
