### PR TITLE
Fix invalid links in documentation.

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -572,7 +572,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
   ##
   # The number of paths in the +$LOAD_PATH+ from activated gems. Used to
-  # prioritize +-I+ and +ENV['RUBYLIB']+ entries during +require+.
+  # prioritize +-I+ and <code>ENV['RUBYLIB']</code> entries during +require+.
 
   def self.activated_gem_paths
     @activated_gem_paths ||= 0

--- a/lib/rubygems/ext/cargo_builder.rb
+++ b/lib/rubygems/ext/cargo_builder.rb
@@ -313,7 +313,7 @@ EOF
     deffile_path
   end
 
-  # We have to basically reimplement RbConfig::CONFIG['SOEXT'] here to support
+  # We have to basically reimplement <code>RbConfig::CONFIG['SOEXT']</code> here to support
   # Ruby < 2.5
   #
   # @see https://github.com/ruby/ruby/blob/c87c027f18c005460746a74c07cd80ee355b16e4/configure.ac#L3185

--- a/lib/rubygems/resolver/api_specification.rb
+++ b/lib/rubygems/resolver/api_specification.rb
@@ -22,7 +22,7 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
   # Creates an APISpecification for the given +set+ from the rubygems.org
   # +api_data+.
   #
-  # See https://guides.rubygems.org/rubygems-org-api/#misc_methods for the
+  # See https://guides.rubygems.org/rubygems-org-api/#misc-methods for the
   # format of the +api_data+.
 
   def initialize(set, api_data)

--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -131,7 +131,7 @@ require_relative "deprecate"
 #
 # == Preventing Version Catastrophe:
 #
-# From: http://blog.zenspider.com/2008/10/rubygems-howto-preventing-cata.html
+# From: https://www.zenspider.com/ruby/2008/10/rubygems-how-to-preventing-catastrophe.html
 #
 # Let's say you're depending on the fnord gem version 2.y.z. If you
 # specify your dependency as ">= 2.0.0" then, you're good, right? What


### PR DESCRIPTION
- wrap ENV variables in `<code>`
- fix rubygems.org link
- fix zenspider.com link

fixes https://github.com/rubygems/rubygems/issues/6986