### PR TITLE
Abort `setup.rb` if Ruby is too old

### DIFF
--- a/setup.rb
+++ b/setup.rb
@@ -7,6 +7,8 @@
 # See LICENSE.txt for permissions.
 #++
 
+abort "RubyGems only supports Ruby 2.6 or higher" if RUBY_VERSION < "2.6.0"
+
 # Make sure rubygems isn't already loaded.
 if ENV["RUBYOPT"] || defined? Gem
   ENV.delete "RUBYOPT"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We don't officially support rubies under Ruby 2.6, however, up until now it was possible to manually download `setup.rb`, and upgrade RubyGems on an older Ruby.

This now finally broke.

## What is your fix for the problem, implemented in this PR?

Officially forbid this script from running on old rubies.

Closes #7010.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
