### PR TITLE
Handled unknown gems in bundled gems warning

### DIFF
--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -253,21 +253,23 @@ module Bundler
                             rescue GemfileNotFound
                               "inline Gemfile"
                             end
-              be = ::Gem::BUNDLED_GEMS::SINCE[name] > RUBY_VERSION ? "will be" : "is"
-              message = "#{name} #{be} not part of the default gems since Ruby #{::Gem::BUNDLED_GEMS::SINCE[name]}." \
-              " Add #{name} to your #{target_file}."
-              location = caller_locations(1,1)[0]&.path
-              if File.file?(location) && !location.start_with?(Gem::BUNDLED_GEMS::LIBDIR)
-                caller_gem = nil
-                Gem.path.each do |path|
-                  if location =~ %r{#{path}/gems/([\w\-\.]+)}
-                    caller_gem = $1
-                    break
+              if ::Gem::BUNDLED_GEMS::SINCE[name]
+                be = ::Gem::BUNDLED_GEMS::SINCE[name] > RUBY_VERSION ? "will be" : "is"
+                message = "#{name} #{be} not part of the default gems since Ruby #{::Gem::BUNDLED_GEMS::SINCE[name]}." \
+                " Add #{name} to your #{target_file}."
+                location = caller_locations(1,1)[0]&.path
+                if File.file?(location) && !location.start_with?(Gem::BUNDLED_GEMS::LIBDIR)
+                  caller_gem = nil
+                  Gem.path.each do |path|
+                    if location =~ %r{#{path}/gems/([\w\-\.]+)}
+                      caller_gem = $1
+                      break
+                    end
                   end
+                  message += " Also contact author of #{caller_gem} to add #{name} into its gemspec."
                 end
-                message += " Also contact author of #{caller_gem} to add #{name} into its gemspec."
+                warn message, :uplevel => 1
               end
-              warn message, :uplevel => 1
             end
           end
           kernel_class.send(:no_warning_require, file)


### PR DESCRIPTION
We have this code that started failing on 3.3.0-dev recently:

```
irb(main):002> require File.join(RbConfig::CONFIG["rubylibdir"], "observer.rb")
/opt/rubies/3.3.0-dev-09-29/lib/ruby/3.3.0+0/bundled_gems.rb:86:in `<': comparison of String with nil failed (ArgumentError)

    end + " which #{RUBY_VERSION < SINCE[gem] ? "will be" : "is"} not part of the default gems since Ruby #{SINCE[gem]}"
                                   ^^^^^^^^^^
	from /opt/rubies/3.3.0-dev-09-29/lib/ruby/3.3.0+0/bundled_gems.rb:86:in `warning?'
	from /opt/rubies/3.3.0-dev-09-29/lib/ruby/3.3.0+0/bundled_gems.rb:92:in `block in <module:BUNDLED_GEMS>'
	from <internal:/opt/rubies/3.3.0-dev-09-29/lib/ruby/3.3.0+0/rubygems/core_ext/kernel_require.rb>:42:in `block in require'
	from <internal:/opt/rubies/3.3.0-dev-09-29/lib/ruby/3.3.0+0/rubygems/core_ext/kernel_require.rb>:39:in `synchronize'
	from <internal:/opt/rubies/3.3.0-dev-09-29/lib/ruby/3.3.0+0/rubygems/core_ext/kernel_require.rb>:39:in `require'
	from (irb):2:in `<main>'
	from <internal:kernel>:187:in `loop'
	from /opt/rubies/3.3.0-dev-09-29/lib/ruby/gems/3.3.0+0/gems/irb-1.8.1/exe/irb:9:in `<top (required)>'
	from /Users/byroot/.gem/ruby/3.3.0/bin/irb:25:in `load'
	from /Users/byroot/.gem/ruby/3.3.0/bin/irb:25:in `<main>'
```

cc @hsbt 