### PR TITLE
Include gemspec in ExtensionTask for native gem tasks

### DIFF
--- a/bundler/lib/bundler/templates/newgem/Rakefile.tt
+++ b/bundler/lib/bundler/templates/newgem/Rakefile.tt
@@ -46,7 +46,9 @@ require "rb_sys/extensiontask"
 
 task build: :compile
 
-RbSys::ExtensionTask.new(<%= config[:name].inspect %>) do |ext|
+GEMSPEC = Gem::Specification.load("<%= config[:underscored_name] %>.gemspec")
+
+RbSys::ExtensionTask.new(<%= config[:name].inspect %>, GEMSPEC) do |ext|
   ext.lib_dir = "lib/<%= config[:namespaced_path] %>"
 end
 <% else -%>
@@ -54,7 +56,9 @@ require "rake/extensiontask"
 
 task build: :compile
 
-Rake::ExtensionTask.new("<%= config[:underscored_name] %>") do |ext|
+GEMSPEC = Gem::Specification.load("<%= config[:underscored_name] %>.gemspec")
+
+Rake::ExtensionTask.new("<%= config[:underscored_name] %>", GEMSPEC) do |ext|
   ext.lib_dir = "lib/<%= config[:namespaced_path] %>"
 end
 <% end -%>

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -1427,7 +1427,9 @@ RSpec.describe "bundle gem" do
 
           task build: :compile
 
-          Rake::ExtensionTask.new("#{gem_name}") do |ext|
+          GEMSPEC = Gem::Specification.load("#{gem_name}.gemspec")
+
+          Rake::ExtensionTask.new("#{gem_name}", GEMSPEC) do |ext|
             ext.lib_dir = "lib/#{gem_name}"
           end
 
@@ -1485,7 +1487,9 @@ RSpec.describe "bundle gem" do
 
           task build: :compile
 
-          RbSys::ExtensionTask.new("#{gem_name}") do |ext|
+          GEMSPEC = Gem::Specification.load("#{gem_name}.gemspec")
+
+          RbSys::ExtensionTask.new("#{gem_name}", GEMSPEC) do |ext|
             ext.lib_dir = "lib/#{gem_name}"
           end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Original issue stated in https://github.com/oxidize-rb/rb-sys/issues/249.

New gems created with `--ext=rust` do not include the native build tasks from `rake-compiler`.

## What is your fix for the problem, implemented in this PR?

Pass the gemspec into the second argument to `RbSys::ExtensionTask` so the native gem tasks are available for Rake. Users can now run `bundle exec rake native gem` after generating a new Rust extension.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
