### PR TITLE
Support Ruby's preview version format (Ex: 3.3.0-preview2) in Gemfile

### DIFF
--- a/bundler/lib/bundler/ruby_version.rb
+++ b/bundler/lib/bundler/ruby_version.rb
@@ -23,7 +23,7 @@ module Bundler
       #   specified must match the version.
 
       @versions = Array(versions).map do |v|
-        op, v = Gem::Requirement.parse(v)
+        op, v = Gem::Requirement.parse(normalize_version(v))
         op == "=" ? v.to_s : "#{op} #{v}"
       end
 
@@ -111,6 +111,13 @@ module Bundler
     end
 
     private
+
+    # Ruby's official preview version format uses a `-`: Example: 3.3.0-preview2
+    # However, RubyGems recognizes preview version format with a `.`: Example: 3.3.0.preview2
+    # Returns version string after replacing `-` with `.`
+    def normalize_version(version)
+      version.tr("-", ".")
+    end
 
     def matches?(requirements, version)
       # Handles RUBY_PATCHLEVEL of -1 for instances like ruby-head

--- a/bundler/spec/bundler/ruby_dsl_spec.rb
+++ b/bundler/spec/bundler/ruby_dsl_spec.rb
@@ -65,6 +65,15 @@ RSpec.describe Bundler::RubyDsl do
       it_behaves_like "it stores the ruby version"
     end
 
+    context "with a preview version" do
+      let(:ruby_version) { "3.3.0-preview2" }
+
+      it "stores the version" do
+        expect(subject.versions).to eq(Array("3.3.0.preview2"))
+        expect(subject.gem_version.version).to eq("3.3.0.preview2")
+      end
+    end
+
     context "with two requirements in the same string" do
       let(:ruby_version) { ">= 2.0.0, < 3.0" }
       it "raises an error" do


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

Fixes https://github.com/rubygems/rubygems/issues/7013

Support Ruby's preview versions in Gemfile.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Replaced '-' with '.' before passing to `Gem::Requirement.parse` to support preview version format (Ex: 3.3.0-preview2) in Gemfile.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
