### PR TITLE
Remove PR not yet backported from changelog

### DIFF
--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -21,7 +21,6 @@
 
   - Lazily construct fetcher debug messages [#6973](https://github.com/rubygems/rubygems/pull/6973)
   - Avoid allocating empty hashes in Index [#6962](https://github.com/rubygems/rubygems/pull/6962)
-  - Stop allocating the same settings keys repeatedly [#6963](https://github.com/rubygems/rubygems/pull/6963)
   - Improve `Bundler::Index` efficiency by removing unnecessary creation and dups [#6931](https://github.com/rubygems/rubygems/pull/6931)
   - (Further) Improve Bundler::Settings#[] performance and memory usage [#6923](https://github.com/rubygems/rubygems/pull/6923)
   - Don't use full indexes unnecessarily on legacy Gemfiles [#6916](https://github.com/rubygems/rubygems/pull/6916)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This PR did not make it to the 2.4.20 release.

## What is your fix for the problem, implemented in this PR?

Remove from changelog.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
