### PR TITLE
Don't re-resolve with prereleases if unlocked gem has no prereleases

### DIFF
--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -131,7 +131,7 @@ module Bundler
 
           if base_requirements[name]
             names_to_unlock << name
-          elsif package.ignores_prereleases?
+          elsif package.ignores_prereleases? && @all_specs[name].any? {|s| s.version.prerelease? }
             names_to_allow_prereleases_for << name
           end
 

--- a/bundler/spec/realworld/edgecases_spec.rb
+++ b/bundler/spec/realworld/edgecases_spec.rb
@@ -323,7 +323,7 @@ RSpec.describe "real world edgecases", :realworld => true do
     if Bundler.feature_flag.bundler_3_mode?
       # Conflicts on bundler version, so we count attempts differently
       bundle :lock, :env => { "DEBUG_RESOLVER" => "1" }, :raise_on_error => false
-      expect(out.split("\n").grep(/backtracking to/).count).to eq(16)
+      expect(out.split("\n").grep(/backtracking to/).count).to eq(8)
     else
       bundle :lock, :env => { "DEBUG_RESOLVER" => "1" }
       expect(out).to include("Solution found after 7 attempts")

--- a/bundler/spec/resolver/basic_spec.rb
+++ b/bundler/spec/resolver/basic_spec.rb
@@ -107,6 +107,15 @@ RSpec.describe "Resolving" do
     end.to raise_error(Bundler::SolveFailure)
   end
 
+  it "does not try to re-resolve including prereleases if gems involved don't have prereleases" do
+    @index = a_unresolvable_child_index
+    dep "chef_app_error"
+    expect(Bundler.ui).not_to receive(:debug).with("Retrying resolution...", any_args)
+    expect do
+      resolve
+    end.to raise_error(Bundler::SolveFailure)
+  end
+
   it "raises an exception with the minimal set of conflicting dependencies" do
     @index = build_index do
       %w[0.9 1.0 2.0].each {|v| gem("a", v) }

--- a/bundler/spec/resolver/basic_spec.rb
+++ b/bundler/spec/resolver/basic_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "Resolving" do
   end
 
   it "raises an exception if a child dependency is not resolved" do
-    @index = a_unresovable_child_index
+    @index = a_unresolvable_child_index
     dep "chef_app_error"
     expect do
       resolve

--- a/bundler/spec/support/indexes.rb
+++ b/bundler/spec/support/indexes.rb
@@ -304,7 +304,7 @@ module Spec
       end
     end
 
-    def a_unresovable_child_index
+    def a_unresolvable_child_index
       build_index do
         gem "json", %w[1.8.0]
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I noticed that sometimes when we fail to resolve, we retry resolution claiming that we'll consider pre-releases for the gem that failed to resolve. However, if that gem has no prereleases, it will fail again in the exact same way since the set of gems considered is the same

## What is your fix for the problem, implemented in this PR?

Only do this retry is there are really some extra prerelease gems that we will start considering the second time.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
