### PR TITLE
Give better error when previous installation folder is insecure to remove

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -331,14 +331,6 @@ module Bundler
 
     def rm_rf(path)
       FileUtils.remove_entry_secure(path) if path && File.exist?(path)
-    rescue ArgumentError
-      message = <<EOF
-It is a security vulnerability to allow your home directory to be world-writable, and bundler cannot continue.
-You should probably consider fixing this issue by running `chmod o-w ~` on *nix.
-Please refer to https://ruby-doc.org/stdlib-3.1.2/libdoc/fileutils/rdoc/FileUtils.html#method-c-remove_entry_secure for details.
-EOF
-      File.world_writable?(path) ? Bundler.ui.warn(message) : raise
-      raise PathError, "Please fix the world-writable issue with your #{path} directory"
     end
 
     def settings

--- a/bundler/lib/bundler/errors.rb
+++ b/bundler/lib/bundler/errors.rb
@@ -215,4 +215,19 @@ module Bundler
 
     status_code(36)
   end
+
+  class InsecureInstallPathError < BundlerError
+    def initialize(path)
+      @path = path
+    end
+
+    def message
+      "The installation path is insecure. Bundler cannot continue.\n" \
+      "#{@path} is world-writable (without sticky bit).\n" \
+      "Bundler cannot safely replace gems in world-writeable directories due to potential vulnerabilities.\n" \
+      "Please change the permissions of this directory or choose a different install path."
+    end
+
+    status_code(38)
+  end
 end

--- a/bundler/lib/bundler/installer/gem_installer.rb
+++ b/bundler/lib/bundler/installer/gem_installer.rb
@@ -21,7 +21,7 @@ module Bundler
       raise
     rescue Errno::ENOSPC
       [false, out_of_space_message]
-    rescue Bundler::BundlerError, Gem::InstallError, Bundler::APIResponseInvalidDependenciesError => e
+    rescue Bundler::BundlerError, Gem::InstallError => e
       [false, specific_failure_message(e)]
     end
 

--- a/bundler/lib/bundler/installer/gem_installer.rb
+++ b/bundler/lib/bundler/installer/gem_installer.rb
@@ -17,7 +17,7 @@ module Bundler
       Bundler.ui.debug "#{worker}:  #{spec.name} (#{spec.version}) from #{spec.loaded_from}"
       generate_executable_stubs
       [true, post_install_message]
-    rescue Bundler::InstallHookError, Bundler::SecurityError, Bundler::APIResponseMismatchError
+    rescue Bundler::InstallHookError, Bundler::SecurityError, Bundler::APIResponseMismatchError, Bundler::InsecureInstallPathError
       raise
     rescue Errno::ENOSPC
       [false, out_of_space_message]

--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -124,11 +124,22 @@ module Bundler
     end
 
     def strict_rm_rf(dir)
-      Bundler.rm_rf dir
-    rescue StandardError => e
-      raise unless File.exist?(dir)
+      return unless File.exist?(dir)
 
-      raise DirectoryRemovalError.new(e, "Could not delete previous installation of `#{dir}`")
+      parent = File.dirname(dir)
+      parent_st = File.stat(parent)
+
+      if parent_st.world_writable? && !parent_st.sticky?
+        raise InsecureInstallPathError.new(parent)
+      end
+
+      begin
+        FileUtils.remove_entry_secure(dir)
+      rescue StandardError => e
+        raise unless File.exist?(dir)
+
+        raise DirectoryRemovalError.new(e, "Could not delete previous installation of `#{dir}`")
+      end
     end
   end
 end

--- a/bundler/spec/bundler/bundler_spec.rb
+++ b/bundler/spec/bundler/bundler_spec.rb
@@ -224,24 +224,6 @@ RSpec.describe Bundler do
     end
   end
 
-  describe "#rm_rf" do
-    context "the directory is world writable" do
-      let(:bundler_ui) { Bundler.ui }
-      it "should raise a friendly error" do
-        allow(File).to receive(:exist?).and_return(true)
-        allow(::Bundler::FileUtils).to receive(:remove_entry_secure).and_raise(ArgumentError)
-        allow(File).to receive(:world_writable?).and_return(true)
-        message = <<EOF
-It is a security vulnerability to allow your home directory to be world-writable, and bundler cannot continue.
-You should probably consider fixing this issue by running `chmod o-w ~` on *nix.
-Please refer to https://ruby-doc.org/stdlib-3.1.2/libdoc/fileutils/rdoc/FileUtils.html#method-c-remove_entry_secure for details.
-EOF
-        expect(bundler_ui).to receive(:warn).with(message)
-        expect { Bundler.send(:rm_rf, bundled_app) }.to raise_error(Bundler::PathError)
-      end
-    end
-  end
-
   describe "#mkdir_p" do
     it "creates a folder at the given path" do
       install_gemfile <<-G

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -827,6 +827,36 @@ RSpec.describe "bundle install with gem sources" do
     end
   end
 
+  describe "when gems path is world writable (no sticky bit set)", :permissions do
+    let(:gems_path) { bundled_app("vendor/#{Bundler.ruby_scope}/gems") }
+
+    before do
+      build_repo4 do
+        build_gem "foo", "1.0.0" do |s|
+          s.write "CHANGELOG.md", "foo"
+        end
+      end
+
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo4)}"
+        gem 'foo'
+      G
+    end
+
+    it "should display a proper message to explain the problem" do
+      bundle "config set --local path vendor"
+      bundle :install
+      expect(out).to include("Bundle complete!")
+      expect(err).to be_empty
+
+      FileUtils.chmod(0o777, gems_path)
+
+      bundle "install --redownload", :raise_on_error => false
+
+      expect(err).to include("The installation path is insecure. Bundler cannot continue.")
+    end
+  end
+
   describe "when bundle cache path does not have write access", :permissions do
     let(:cache_path) { bundled_app("vendor/#{Bundler.ruby_scope}/cache") }
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In https://github.com/rubygems/rubygems/issues/6460, user was getting a Bundler error due to the previous gem installation folder having insecure permissions.

However, and even if we've lately improved the message, it's still too verbose and real culprit is a bit hidden.

## What is your fix for the problem, implemented in this PR?

This error is about insecure permissions of the parent install folder for a gem, so it's independent of the particular gem that it's being uninstalled. Hence, even if you're running 8 installation jobs in parallel, the error should be displayed just once.

So my fix is to create a special error class for this that goes straight to the user, instead of being reported once per installation job.

#### Before

```
$ bundle install --force --jobs 2
[DEPRECATED] The `--force` option has been renamed to `--redownload`
Fetching gem metadata from https://rubygems.org/.......
Installing minitest 5.20.0
Installing concurrent-ruby 1.2.2
Installing zeitwerk 2.6.12
Installing public_suffix 5.0.3
Installing did_you_mean 1.6.3
Installing bindata 2.4.15
Installing plist 3.7.0
Installing ruby-macho 4.0.0
Installing sorbet-runtime 0.5.10461
Installing warning 1.3.0
Bundler::DirectoryRemovalError: Could not delete previous installation of `/Users/deivid/Code/playground/world-writable/vendor/bundle/ruby/2.6.0/gems/concurrent-ruby-1.2.2`.
The underlying error was ArgumentError: parent directory is world writable, Bundler::FileUtils#remove_entry_secure does not work; abort:
"/Users/deivid/Code/playground/world-writable/vendor/bundle/ruby/2.6.0/gems/concurrent-ruby-1.2.2" (parent directory mode 40777), with backtrace:
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/vendor/fileutils/lib/fileutils.rb:1387:in `remove_entry_secure'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler.rb:332:in `rm_rf'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/rubygems_gem_installer.rb:111:in `strict_rm_rf'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/rubygems_gem_installer.rb:19:in `install'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/source/rubygems.rb:203:in `install'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/installer/gem_installer.rb:54:in `install'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/installer/parallel_installer.rb:156:in `do_install'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/installer/parallel_installer.rb:147:in `block in worker_pool'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:62:in `apply_func'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:57:in `block in process_queue'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:54:in `loop'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:54:in `process_queue'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:90:in `block (2 levels) in create_threads'

Bundler Error Backtrace:
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/rubygems_gem_installer.rb:115:in `rescue in strict_rm_rf'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/rubygems_gem_installer.rb:110:in `strict_rm_rf'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/rubygems_gem_installer.rb:19:in `install'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/source/rubygems.rb:203:in `install'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/installer/gem_installer.rb:54:in `install'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/installer/parallel_installer.rb:156:in `do_install'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/installer/parallel_installer.rb:147:in `block in worker_pool'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:62:in `apply_func'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:57:in `block in process_queue'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:54:in `loop'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:54:in `process_queue'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:90:in `block (2 levels) in create_threads'

An error occurred while installing concurrent-ruby (1.2.2), and Bundler cannot continue.

In Gemfile:
  activesupport was resolved to 6.1.7.6, which depends on
    i18n was resolved to 1.14.1, which depends on
      concurrent-ruby


Bundler::DirectoryRemovalError: Could not delete previous installation of `/Users/deivid/Code/playground/world-writable/vendor/bundle/ruby/2.6.0/gems/minitest-5.20.0`.
The underlying error was ArgumentError: parent directory is world writable, Bundler::FileUtils#remove_entry_secure does not work; abort:
"/Users/deivid/Code/playground/world-writable/vendor/bundle/ruby/2.6.0/gems/minitest-5.20.0" (parent directory mode 40777), with backtrace:
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/vendor/fileutils/lib/fileutils.rb:1387:in `remove_entry_secure'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler.rb:332:in `rm_rf'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/rubygems_gem_installer.rb:111:in `strict_rm_rf'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/rubygems_gem_installer.rb:19:in `install'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/source/rubygems.rb:203:in `install'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/installer/gem_installer.rb:54:in `install'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/installer/parallel_installer.rb:156:in `do_install'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/installer/parallel_installer.rb:147:in `block in worker_pool'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:62:in `apply_func'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:57:in `block in process_queue'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:54:in `loop'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:54:in `process_queue'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:90:in `block (2 levels) in create_threads'

Bundler Error Backtrace:
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/rubygems_gem_installer.rb:115:in `rescue in strict_rm_rf'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/rubygems_gem_installer.rb:110:in `strict_rm_rf'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/rubygems_gem_installer.rb:19:in `install'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/source/rubygems.rb:203:in `install'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/installer/gem_installer.rb:54:in `install'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/installer/parallel_installer.rb:156:in `do_install'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/installer/parallel_installer.rb:147:in `block in worker_pool'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:62:in `apply_func'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:57:in `block in process_queue'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:54:in `loop'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:54:in `process_queue'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:90:in `block (2 levels) in create_threads'

An error occurred while installing minitest (5.20.0), and Bundler cannot continue.

In Gemfile:
  activesupport was resolved to 6.1.7.6, which depends on
    minitest


Bundler::DirectoryRemovalError: Could not delete previous installation of `/Users/deivid/Code/playground/world-writable/vendor/bundle/ruby/2.6.0/gems/zeitwerk-2.6.12`.
The underlying error was ArgumentError: parent directory is world writable, Bundler::FileUtils#remove_entry_secure does not work; abort:
"/Users/deivid/Code/playground/world-writable/vendor/bundle/ruby/2.6.0/gems/zeitwerk-2.6.12" (parent directory mode 40777), with backtrace:
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/vendor/fileutils/lib/fileutils.rb:1387:in `remove_entry_secure'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler.rb:332:in `rm_rf'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/rubygems_gem_installer.rb:111:in `strict_rm_rf'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/rubygems_gem_installer.rb:19:in `install'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/source/rubygems.rb:203:in `install'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/installer/gem_installer.rb:54:in `install'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/installer/parallel_installer.rb:156:in `do_install'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/installer/parallel_installer.rb:147:in `block in worker_pool'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:62:in `apply_func'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:57:in `block in process_queue'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:54:in `loop'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:54:in `process_queue'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:90:in `block (2 levels) in create_threads'

Bundler Error Backtrace:
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/rubygems_gem_installer.rb:115:in `rescue in strict_rm_rf'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/rubygems_gem_installer.rb:110:in `strict_rm_rf'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/rubygems_gem_installer.rb:19:in `install'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/source/rubygems.rb:203:in `install'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/installer/gem_installer.rb:54:in `install'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/installer/parallel_installer.rb:156:in `do_install'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/installer/parallel_installer.rb:147:in `block in worker_pool'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:62:in `apply_func'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:57:in `block in process_queue'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:54:in `loop'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:54:in `process_queue'
  /Users/deivid/.asdf/installs/ruby/2.6.10/lib/ruby/site_ruby/2.6.0/bundler/worker.rb:90:in `block (2 levels) in create_threads'

An error occurred while installing zeitwerk (2.6.12), and Bundler cannot continue.

In Gemfile:
  activesupport was resolved to 6.1.7.6, which depends on
    zeitwerk
```

#### After

```
$ bundle install --force --jobs 2
[DEPRECATED] The `--force` option has been renamed to `--redownload`
Fetching gem metadata from https://rubygems.org/.......
Installing minitest 5.20.0
Installing concurrent-ruby 1.2.2
Installing zeitwerk 2.6.12
Installing public_suffix 5.0.3
Installing bindata 2.4.15
Installing did_you_mean 1.6.3
Installing plist 3.7.0
Installing ruby-macho 4.0.0
Installing sorbet-runtime 0.5.10461
Installing warning 1.3.0
Your installation path /Users/deivid/Code/playground/world-writable/vendor/bundle/ruby/2.6.0/gems has insecure permissions (it's both world-writable and does not have the sticky bit set), so Bundler can't
reinstall any gems into it since it needs to remove previous installations which is insecure.
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
