### PR TITLE
Fix typos detected by codespell

### DIFF
--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -2181,7 +2181,7 @@ Changes
 
   - retry gem downloads ([#4846](https://github.com/rubygems/bundler/issues/4846), @jkeiser)
   - improve the CompactIndex to handle capitalized legacy gems ([#4867](https://github.com/rubygems/bundler/issues/4867), @segiddins)
-  - re-use persistent HTTP connections for CompactIndex (@NickLaMuro)
+  - reuse persistent HTTP connections for CompactIndex (@NickLaMuro)
   - respect `required_ruby_version` when Gemfile contains `ruby` version (@indirect)
   - allow `rake release` to sign git tags ([#4743](https://github.com/rubygems/bundler/issues/4743), @eagletmt)
   - set process titles when using `#load` during `exec` (@yob)
@@ -3377,7 +3377,7 @@ Changes
   - `gem` option --test can generate rspec stubs (@MafcoCinco)
   - `gem` option --test can generate minitest stubs (@kcurtin)
   - `gem` command generates MIT license (@BrentWheeldon)
-  - gem rake task 'release' resuses existing tags (@shtirlic)
+  - gem rake task 'release' reuses existing tags (@shtirlic)
 
 ## Bug fixes:
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Codespell raised errors in an unrelated PR.

## What is your fix for the problem, implemented in this PR?

Fix the typos.

We should probably try codespell not to suddenly raise these errors. My guess is that they happen because the underlying dictionaries are updated when the base actions image is updated, and we can't really control that at the moment.

Not sure if there's an easy fix, so I'm just fixing the typos as they appear.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
