### PR TITLE
Make the `lock` command not be affected by the `frozen` setting

### DIFF
--- a/bundler/lib/bundler/cli/lock.rb
+++ b/bundler/lib/bundler/cli/lock.rb
@@ -34,7 +34,7 @@ module Bundler
       end
       definition = Bundler.definition(update)
 
-      Bundler::CLI::Common.configure_gem_version_promoter(Bundler.definition, options) if options[:update]
+      Bundler::CLI::Common.configure_gem_version_promoter(definition, options) if options[:update]
 
       options["remove-platform"].each do |platform|
         definition.remove_platform(platform)

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -73,6 +73,12 @@ RSpec.describe "bundle lock" do
     bundle "lock --update"
 
     expect(read_lockfile).to eq(@lockfile)
+
+    lockfile @lockfile.gsub("2.3.2", "2.3.1")
+
+    bundle "lock --update", :env => { "BUNDLE_FROZEN" => "true" }
+
+    expect(read_lockfile).to eq(@lockfile)
   end
 
   it "does not fetch remote specs when using the --local option" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The `lock` command is specifically designed to manage the lockfile, so running it should take precedence over any "frozen" setting.
    
Besides that, "frozen" is not specifically designed as "lockfile cannot be updated" but as "installation of gems should be prevented if gemfile is not in sync with the lockfile".
    
The lock command does not install any gems and preserves the property of the lockfile being in sycn with its gemfile, so I think frozen should not influence it.
    
The current behavior is quite confusing when frozen is set. On an app where rubocop can get lockfile updates
    
    ```
    $ bundle lock --update rubocop
    Writing lockfile to /path/to/Gemfile.lock
    ```
    
Completely silent, it makes you think that it has written the lockfile, but still no updates.
    
In verbose mode, it gives a bit more information, but still confusing and unexpected, and does not change the lockfile:
    
    ```
    $ bundle lock --update rubocop --verbose
    Running `bundle lock --update "rubocop" --verbose` with bundler 2.4.20
    Frozen, using resolution from the lockfile
    Writing lockfile to /path/to/Gemfile.lock
    ```
    
## What is your fix for the problem, implemented in this PR?

With this commit, it updates the lockfile as expected, by ignoring the `frozen` setting during `bundle lock`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
