### PR TITLE
Raise an error when adding a gem incompatible with some locked platform

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -452,8 +452,8 @@ module Bundler
       return if current_platform_locked?
 
       raise ProductionError, "Your bundle only supports platforms #{@platforms.map(&:to_s)} " \
-        "but your local platform is #{Bundler.local_platform}. " \
-        "Add the current platform to the lockfile with\n`bundle lock --add-platform #{Bundler.local_platform}` and try again."
+        "but your local platform is #{local_platform}. " \
+        "Add the current platform to the lockfile with\n`bundle lock --add-platform #{local_platform}` and try again."
     end
 
     def add_platform(platform)
@@ -600,7 +600,7 @@ module Bundler
 
     def current_platform_locked?
       @platforms.any? do |bundle_platform|
-        MatchPlatform.platforms_match?(bundle_platform, Bundler.local_platform)
+        MatchPlatform.platforms_match?(bundle_platform, local_platform)
       end
     end
 
@@ -958,7 +958,7 @@ module Bundler
 
     def remove_ruby_from_platforms_if_necessary!(dependencies)
       return if Bundler.frozen_bundle? ||
-                Bundler.local_platform == Gem::Platform::RUBY ||
+                local_platform == Gem::Platform::RUBY ||
                 !platforms.include?(Gem::Platform::RUBY) ||
                 (@new_platform && platforms.last == Gem::Platform::RUBY) ||
                 @path_changes ||

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -295,15 +295,21 @@ module Bundler
                         end
       specs_matching_requirement = filter_matching_specs(specs, package.dependency.requirement)
 
-      if specs_matching_requirement.any?
+      not_found_message = if specs_matching_requirement.any?
         specs = specs_matching_requirement
         matching_part = requirement_label
         platforms = package.platforms
-        platform_label = platforms.size == 1 ? "platform '#{platforms.first}" : "platforms '#{platforms.join("', '")}"
-        requirement_label = "#{requirement_label}' with #{platform_label}"
+
+        if platforms.size == 1
+          "Could not find gem '#{requirement_label}' with platform '#{platforms.first}'"
+        else
+          "Could not find gems matching '#{requirement_label}' valid for all resolution platforms (#{platforms.join(", ")})"
+        end
+      else
+        "Could not find gem '#{requirement_label}'"
       end
 
-      message = String.new("Could not find gem '#{requirement_label}' in #{source}#{cache_message}.\n")
+      message = String.new("#{not_found_message} in #{source}#{cache_message}.\n")
 
       if specs.any?
         message << "\n#{other_specs_matching_message(specs, matching_part)}"

--- a/bundler/lib/bundler/resolver/package.rb
+++ b/bundler/lib/bundler/resolver/package.rb
@@ -21,6 +21,7 @@ module Bundler
         @locked_version = locked_specs[name].first&.version
         @unlock = unlock
         @dependency = dependency || Dependency.new(name, @locked_version)
+        @top_level = !dependency.nil?
         @prerelease = @dependency.prerelease? || @locked_version&.prerelease? || prerelease ? :consider_first : :ignore
       end
 
@@ -30,6 +31,10 @@ module Bundler
 
       def root?
         false
+      end
+
+      def top_level?
+        @top_level
       end
 
       def meta?

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -100,12 +100,12 @@ module Bundler
       end
     end
 
-    def incomplete_ruby_specs?(deps)
+    def incomplete_for_platform?(deps, platform)
       return false if @specs.empty?
 
       @incomplete_specs = []
 
-      self.for(deps, true, [Gem::Platform::RUBY])
+      self.for(deps, true, [platform])
 
       @incomplete_specs.any?
     end

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -416,7 +416,7 @@ RSpec.describe "bundle install with install-time dependencies" do
           end
 
           nice_error = <<~E.strip
-            Could not find gem 'sorbet-static (= 0.5.10554)' with platforms 'arm64-darwin-21', 'aarch64-linux' in rubygems repository #{file_uri_for(gem_repo4)}/ or installed locally.
+            Could not find gems matching 'sorbet-static (= 0.5.10554)' valid for all resolution platforms (arm64-darwin-21, aarch64-linux) in rubygems repository #{file_uri_for(gem_repo4)}/ or installed locally.
 
             The source contains the following gems matching 'sorbet-static (= 0.5.10554)':
               * sorbet-static-0.5.10554-universal-darwin-21


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

While working on #5700, I noticed that when locking multiple platforms, and adding a new dependency to the Gemfile that does not support some of the platforms, we may end up with a successful resolution, and a lockfile that's not really valid.

## What is your fix for the problem, implemented in this PR?

My fix is to prevent this situation at the resolver level, and give a proper error about it.

Since there are existing lockfiles with this bug, which will no longer `bundle update` fine even on platforms where they are valid, I also made sure to detect invalid platforms like these and remove them before re-resolving, so that the lockfile continues to work in the platforms where it was valid.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
