### PR TITLE
Lock Rails version installed in our Windows CI

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -123,7 +123,7 @@ jobs:
         run: bundle init && bundle add fileutils --git https://github.com/ruby/fileutils
         shell: bash
       - name: Generate a Rails application
-        run: gem install rails && rails new foo ${{ matrix.ruby.rails-args }}
+        run: gem install rails --version 7.0.8 && rails new foo ${{ matrix.ruby.rails-args }}
         shell: bash
 
     timeout-minutes: 20


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Broken CI after Rails 7.1 release.

## What is your fix for the problem, implemented in this PR?

The point of this realworld test was that the `bundle install` commands run by `rails new` succeed. I don't think the Rails version matters much, and Rails 7.1 does not work with JRuby.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
