### PR TITLE
Add missing platform to tool/bundler/(dev|standard|rubocop)26_gems.rb

### DIFF
--- a/tool/bundler/dev26_gems.rb.lock
+++ b/tool/bundler/dev26_gems.rb.lock
@@ -30,7 +30,12 @@ GEM
     webrick (1.8.1)
 
 PLATFORMS
-  arm64-darwin-21
+  arm64-darwin-22
+  arm64-darwin-23
+  x86_64-darwin-20
+  x86_64-darwin-21
+  x86_64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   parallel (~> 1.19)
@@ -46,4 +51,4 @@ DEPENDENCIES
   webrick (~> 1.6)
 
 BUNDLED WITH
-   2.4.13
+   2.4.20

--- a/tool/bundler/rubocop26_gems.rb.lock
+++ b/tool/bundler/rubocop26_gems.rb.lock
@@ -49,7 +49,12 @@ GEM
     unicode-display_width (2.4.2)
 
 PLATFORMS
+  arm64-darwin-22
   arm64-darwin-23
+  x86_64-darwin-20
+  x86_64-darwin-21
+  x86_64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   minitest
@@ -61,4 +66,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   2.4.13
+   2.4.20

--- a/tool/bundler/standard26_gems.rb.lock
+++ b/tool/bundler/standard26_gems.rb.lock
@@ -65,7 +65,12 @@ GEM
     unicode-display_width (2.4.2)
 
 PLATFORMS
+  arm64-darwin-22
   arm64-darwin-23
+  x86_64-darwin-20
+  x86_64-darwin-21
+  x86_64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   minitest
@@ -78,4 +83,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   2.4.13
+   2.4.20


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Avoid re-resolving gems for new platform on ruby 2.6 CI runs.

## What is your fix for the problem, implemented in this PR?

Add platforms used in CI to the development gemfiles in `tool/bundler` for ruby 26.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
