### PR TITLE
BUG_TRIAGE: Refer to CHANGELOG with a full URL for the link in the website to render right

### DIFF
--- a/bundler/doc/contributing/BUG_TRIAGE.md
+++ b/bundler/doc/contributing/BUG_TRIAGE.md
@@ -37,7 +37,7 @@ Everyone is welcome and encouraged to fix any open bug, improve an error message
   3. Commit the code with at least one test covering your changes to a named branch in your fork.
   4. Send us a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) from your bugfix branch.
 
-You do not have to update [CHANGELOG](../../CHANGELOG.md) in your PR. Our release scripts will automatically prepare it from the title of each PR.
+You do not have to update [CHANGELOG](https://github.com/rubygems/rubygems/blob/master/bundler/CHANGELOG.md) in your PR. Our release scripts will automatically prepare it from the title of each PR.
 
 ## Duplicates!
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We are using this in the bundler-site repo, and this would make the link work.

I assume that CHANGELOG.md is not present in bundler-site, so the link becomes a 404.

Fixes https://github.com/rubygems/bundler-site/issues/846

## What is your fix for the problem, implemented in this PR?

Use a full URL.