### PR TITLE
Improve formatting and global source information in `bundle plugin` man page

### DIFF
--- a/bundler/lib/bundler/man/bundle-plugin.1
+++ b/bundler/lib/bundler/man/bundle-plugin.1
@@ -26,36 +26,36 @@ You can install, uninstall, and list plugin(s) with this command to extend funct
 .SS "install"
 Install the given plugin(s)\.
 .
-.IP "\(bu" 4
-\fBbundle plugin install bundler\-graph\fR: Install bundler\-graph gem from RubyGems\.org\. The global source, specified in source in Gemfile is ignored\.
+.TP
+\fBbundle plugin install bundler\-graph\fR
+Install bundler\-graph gem from globally configured sources (defaults to RubyGems\.org)\. The global source, specified in source in Gemfile is ignored\.
 .
-.IP "\(bu" 4
-\fBbundle plugin install bundler\-graph \-\-source https://example\.com\fR: Install bundler\-graph gem from example\.com\. The global source, specified in source in Gemfile is not considered\.
+.TP
+\fBbundle plugin install bundler\-graph \-\-source https://example\.com\fR
+Install bundler\-graph gem from example\.com\. The global source, specified in source in Gemfile is not considered\.
 .
-.IP "\(bu" 4
-\fBbundle plugin install bundler\-graph \-\-version 0\.2\.1\fR: You can specify the version of the gem via \fB\-\-version\fR\.
+.TP
+\fBbundle plugin install bundler\-graph \-\-version 0\.2\.1\fR
+You can specify the version of the gem via \fB\-\-version\fR\.
 .
-.IP "\(bu" 4
-\fBbundle plugin install bundler\-graph \-\-git https://github\.com/rubygems/bundler\-graph\fR: Install bundler\-graph gem from Git repository\. \fB\-\-git\fR can be replaced with \fB\-\-local\-git\fR\. You cannot use both \fB\-\-git\fR and \fB\-\-local\-git\fR\. You can use standard Git URLs like:
+.TP
+\fBbundle plugin install bundler\-graph \-\-git https://github\.com/rubygems/bundler\-graph\fR
+Install bundler\-graph gem from Git repository\. \fB\-\-git\fR can be replaced with \fB\-\-local\-git\fR\. You cannot use both \fB\-\-git\fR and \fB\-\-local\-git\fR\. You can use standard Git URLs like:
 .
-.IP "\(bu" 4
+.IP
 \fBssh://[user@]host\.xz[:port]/path/to/repo\.git\fR
 .
-.IP "\(bu" 4
+.br
 \fBhttp[s]://host\.xz[:port]/path/to/repo\.git\fR
 .
-.IP "\(bu" 4
+.br
 \fB/path/to/repo\fR
 .
-.IP "\(bu" 4
+.br
 \fBfile:///path/to/repo\fR
-.
-.IP "" 0
 .
 .IP
 When you specify \fB\-\-git\fR/\fB\-\-local\-git\fR, you can use \fB\-\-branch\fR or \fB\-\-ref\fR to specify any branch, tag, or commit hash (revision) to use\. When you specify both, only the latter is used\.
-.
-.IP "" 0
 .
 .SS "uninstall"
 Uninstall the plugin(s) specified in PLUGINS\.

--- a/bundler/lib/bundler/man/bundle-plugin.1.ronn
+++ b/bundler/lib/bundler/man/bundle-plugin.1.ronn
@@ -20,7 +20,7 @@ You can install, uninstall, and list plugin(s) with this command to extend funct
 Install the given plugin(s).
 
 * `bundle plugin install bundler-graph`:
-  Install bundler-graph gem from RubyGems.org. The global source, specified in source in Gemfile is ignored.
+  Install bundler-graph gem from globally configured sources (defaults to RubyGems.org). The global source, specified in source in Gemfile is ignored.
 
 * `bundle plugin install bundler-graph --source https://example.com`:
   Install bundler-graph gem from example.com. The global source, specified in source in Gemfile is not considered.
@@ -31,10 +31,10 @@ Install the given plugin(s).
 * `bundle plugin install bundler-graph --git https://github.com/rubygems/bundler-graph`:
   Install bundler-graph gem from Git repository. `--git` can be replaced with `--local-git`. You cannot use both `--git` and `--local-git`. You can use standard Git URLs like:
 
-  * `ssh://[user@]host.xz[:port]/path/to/repo.git`
-  * `http[s]://host.xz[:port]/path/to/repo.git`
-  * `/path/to/repo`
-  * `file:///path/to/repo`
+  `ssh://[user@]host.xz[:port]/path/to/repo.git`<br>
+  `http[s]://host.xz[:port]/path/to/repo.git`<br>
+  `/path/to/repo`<br>
+  `file:///path/to/repo`
 
   When you specify `--git`/`--local-git`, you can use `--branch` or `--ref` to specify any branch, tag, or commit hash (revision) to use. When you specify both, only the latter is used.
 


### PR DESCRIPTION
The formatting was odd, and it hadn't been updated for how the global source is handled.

## What was the end-user or developer problem that led to this PR?

I notice `bundle plugin --help` had odd formatting.

## What is your fix for the problem, implemented in this PR?

Fix the formatting.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
