### PR TITLE
fix pre-commit hook failing rubocop on non-ruby files

### DIFF
--- a/.githooks/pre-commit-rubocop
+++ b/.githooks/pre-commit-rubocop
@@ -5,7 +5,7 @@ length=${#files}
 
 # Run rubocop hook only when analyzable files are present
 if [[ $length -ne 0 ]]; then
-  ./bin/rubocop $files
+  ./bin/rubocop --only-recognized-file-types $files
 else
   echo "No files to analyze"
 fi


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If you changed a man page, it was force-feeding that to rubocop when committing, and it would fail every line as unparseable.

## What is your fix for the problem, implemented in this PR?

Add the rubocop flag that tells it to apply file-type filters to the list of files passed on the command line.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
