### PR TITLE
Refactor lockfile generation and deprecate `Definition#lock` with explicit lockfile

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -200,12 +200,13 @@ module Bundler
     #
     # @param unlock [Hash, Boolean, nil] Gems that have been requested
     #   to be updated or true if all gems should be updated
+    # @param lockfile [Pathname] Path to Gemfile.lock
     # @return [Bundler::Definition]
-    def definition(unlock = nil)
+    def definition(unlock = nil, lockfile = default_lockfile)
       @definition = nil if unlock
       @definition ||= begin
         configure
-        Definition.build(default_gemfile, default_lockfile, unlock)
+        Definition.build(default_gemfile, lockfile, unlock)
       end
     end
 

--- a/bundler/lib/bundler/cli/lock.rb
+++ b/bundler/lib/bundler/cli/lock.rb
@@ -33,8 +33,11 @@ module Bundler
         update = { bundler: bundler }
       end
 
+      file = options[:lockfile]
+      file = file ? Pathname.new(file).expand_path : Bundler.default_lockfile
+
       Bundler.settings.temporary(frozen: false) do
-        definition = Bundler.definition(update)
+        definition = Bundler.definition(update, file)
 
         Bundler::CLI::Common.configure_gem_version_promoter(definition, options) if options[:update]
 
@@ -60,10 +63,8 @@ module Bundler
         if print
           puts definition.to_lock
         else
-          file = options[:lockfile]
-          file = file ? File.expand_path(file) : Bundler.default_lockfile
           puts "Writing lockfile to #{file}"
-          definition.lock(file)
+          definition.lock
         end
       end
 

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -334,7 +334,9 @@ module Bundler
           "Instead, instantiate a new definition passing `#{target_lockfile}`, and call `lock` without a file argument on that definition"
         end
 
-        warn "Passing a file to `Definition#lock` is deprecated. #{suggestion}"
+        msg = "`Definition#lock` was passed a target file argument. #{suggestion}"
+
+        Bundler::SharedHelpers.major_deprecation 2, msg
       end
 
       write_lock(target_lockfile, preserve_unknown_sections)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -320,38 +320,24 @@ module Bundler
       dependencies.map(&:groups).flatten.uniq
     end
 
-    def lock(file, preserve_unknown_sections = false)
-      return if Definition.no_lock
+    def lock(file_or_preserve_unknown_sections = false, preserve_unknown_sections_or_unused = false)
+      if [true, false, nil].include?(file_or_preserve_unknown_sections)
+        target_lockfile = lockfile || Bundler.default_lockfile
+        preserve_unknown_sections = file_or_preserve_unknown_sections
+      else
+        target_lockfile = file_or_preserve_unknown_sections
+        preserve_unknown_sections = preserve_unknown_sections_or_unused
 
-      contents = to_lock
+        suggestion = if target_lockfile == lockfile
+          "To fix this warning, remove it from the `Definition#lock` call."
+        else
+          "Instead, instantiate a new definition passing `#{target_lockfile}`, and call `lock` without a file argument on that definition"
+        end
 
-      # Convert to \r\n if the existing lock has them
-      # i.e., Windows with `git config core.autocrlf=true`
-      contents.gsub!(/\n/, "\r\n") if @lockfile_contents.match?("\r\n")
-
-      if @locked_bundler_version
-        locked_major = @locked_bundler_version.segments.first
-        current_major = bundler_version_to_lock.segments.first
-
-        updating_major = locked_major < current_major
+        warn "Passing a file to `Definition#lock` is deprecated. #{suggestion}"
       end
 
-      preserve_unknown_sections ||= !updating_major && (Bundler.frozen_bundle? || !(unlocking? || @unlocking_bundler))
-
-      if file && File.exist?(file) && lockfiles_equal?(@lockfile_contents, contents, preserve_unknown_sections)
-        return if Bundler.frozen_bundle?
-        SharedHelpers.filesystem_access(file) { FileUtils.touch(file) }
-        return
-      end
-
-      if Bundler.frozen_bundle?
-        Bundler.ui.error "Cannot write a changed lockfile while frozen."
-        return
-      end
-
-      SharedHelpers.filesystem_access(file) do |p|
-        File.open(p, "wb") {|f| f.puts(contents) }
-      end
+      write_lock(target_lockfile, preserve_unknown_sections)
     end
 
     def locked_ruby_version
@@ -518,7 +504,45 @@ module Bundler
     end
 
     def lockfile_exists?
-      lockfile && File.exist?(lockfile)
+      file_exists?(lockfile)
+    end
+
+    def file_exists?(file)
+      file && File.exist?(file)
+    end
+
+    def write_lock(file, preserve_unknown_sections)
+      return if Definition.no_lock
+
+      contents = to_lock
+
+      # Convert to \r\n if the existing lock has them
+      # i.e., Windows with `git config core.autocrlf=true`
+      contents.gsub!(/\n/, "\r\n") if @lockfile_contents.match?("\r\n")
+
+      if @locked_bundler_version
+        locked_major = @locked_bundler_version.segments.first
+        current_major = bundler_version_to_lock.segments.first
+
+        updating_major = locked_major < current_major
+      end
+
+      preserve_unknown_sections ||= !updating_major && (Bundler.frozen_bundle? || !(unlocking? || @unlocking_bundler))
+
+      if file_exists?(file) && lockfiles_equal?(@lockfile_contents, contents, preserve_unknown_sections)
+        return if Bundler.frozen_bundle?
+        SharedHelpers.filesystem_access(file) { FileUtils.touch(file) }
+        return
+      end
+
+      if Bundler.frozen_bundle?
+        Bundler.ui.error "Cannot write a changed lockfile while frozen."
+        return
+      end
+
+      SharedHelpers.filesystem_access(file) do |p|
+        File.open(p, "wb") {|f| f.puts(contents) }
+      end
     end
 
     def resolver

--- a/bundler/lib/bundler/injector.rb
+++ b/bundler/lib/bundler/injector.rb
@@ -50,7 +50,7 @@ module Bundler
         append_to(gemfile_path, build_gem_lines(@options[:conservative_versioning])) if @deps.any?
 
         # since we resolved successfully, write out the lockfile
-        @definition.lock(Bundler.default_lockfile)
+        @definition.lock
 
         # invalidate the cached Bundler.definition
         Bundler.reset_paths!

--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -260,8 +260,8 @@ module Bundler
       true
     end
 
-    def lock(opts = {})
-      @definition.lock(Bundler.default_lockfile, opts[:preserve_unknown_sections])
+    def lock
+      @definition.lock(Bundler.default_lockfile)
     end
   end
 end

--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -261,7 +261,7 @@ module Bundler
     end
 
     def lock
-      @definition.lock(Bundler.default_lockfile)
+      @definition.lock
     end
   end
 end

--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -95,7 +95,7 @@ module Bundler
 
     def lock(opts = {})
       return if @definition.no_resolve_needed?
-      @definition.lock(Bundler.default_lockfile, opts[:preserve_unknown_sections])
+      @definition.lock(opts[:preserve_unknown_sections])
     end
 
     alias_method :gems, :specs

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -10,34 +10,34 @@ RSpec.describe Bundler::Definition do
       allow(Bundler).to receive(:ui) { double("UI", info: "", debug: "") }
     end
     context "when it's not possible to write to the file" do
-      subject { Bundler::Definition.new(nil, [], Bundler::SourceList.new, []) }
+      subject { Bundler::Definition.new("Gemfile.lock", [], Bundler::SourceList.new, []) }
 
       it "raises an PermissionError with explanation" do
         allow(File).to receive(:open).and_call_original
         expect(File).to receive(:open).with("Gemfile.lock", "wb").
           and_raise(Errno::EACCES)
-        expect { subject.lock("Gemfile.lock") }.
+        expect { subject.lock }.
           to raise_error(Bundler::PermissionError, /Gemfile\.lock/)
       end
     end
     context "when a temporary resource access issue occurs" do
-      subject { Bundler::Definition.new(nil, [], Bundler::SourceList.new, []) }
+      subject { Bundler::Definition.new("Gemfile.lock", [], Bundler::SourceList.new, []) }
 
       it "raises a TemporaryResourceError with explanation" do
         allow(File).to receive(:open).and_call_original
         expect(File).to receive(:open).with("Gemfile.lock", "wb").
           and_raise(Errno::EAGAIN)
-        expect { subject.lock("Gemfile.lock") }.
+        expect { subject.lock }.
           to raise_error(Bundler::TemporaryResourceError, /temporarily unavailable/)
       end
     end
     context "when Bundler::Definition.no_lock is set to true" do
-      subject { Bundler::Definition.new(nil, [], Bundler::SourceList.new, []) }
+      subject { Bundler::Definition.new("Gemfile.lock", [], Bundler::SourceList.new, []) }
       before { Bundler::Definition.no_lock = true }
       after { Bundler::Definition.no_lock = false }
 
       it "does not create a lock file" do
-        subject.lock("Gemfile.lock")
+        subject.lock
         expect(File.file?("Gemfile.lock")).to eq false
       end
     end

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -5,17 +5,16 @@ require "bundler/definition"
 RSpec.describe Bundler::Definition do
   describe "#lock" do
     before do
-      allow(Bundler).to receive(:settings) { Bundler::Settings.new(".") }
-      allow(Bundler::SharedHelpers).to receive(:find_gemfile) { Pathname.new("Gemfile") }
+      allow(Bundler::SharedHelpers).to receive(:find_gemfile) { bundled_app_gemfile }
       allow(Bundler).to receive(:ui) { double("UI", info: "", debug: "") }
     end
 
-    subject { Bundler::Definition.new("Gemfile.lock", [], Bundler::SourceList.new, {}) }
+    subject { Bundler::Definition.new(bundled_app_lock, [], Bundler::SourceList.new, {}) }
 
     context "when it's not possible to write to the file" do
       it "raises an PermissionError with explanation" do
         allow(File).to receive(:open).and_call_original
-        expect(File).to receive(:open).with("Gemfile.lock", "wb").
+        expect(File).to receive(:open).with(bundled_app_lock, "wb").
           and_raise(Errno::EACCES)
         expect { subject.lock }.
           to raise_error(Bundler::PermissionError, /Gemfile\.lock/)
@@ -24,7 +23,7 @@ RSpec.describe Bundler::Definition do
     context "when a temporary resource access issue occurs" do
       it "raises a TemporaryResourceError with explanation" do
         allow(File).to receive(:open).and_call_original
-        expect(File).to receive(:open).with("Gemfile.lock", "wb").
+        expect(File).to receive(:open).with(bundled_app_lock, "wb").
           and_raise(Errno::EAGAIN)
         expect { subject.lock }.
           to raise_error(Bundler::TemporaryResourceError, /temporarily unavailable/)

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -9,9 +9,10 @@ RSpec.describe Bundler::Definition do
       allow(Bundler::SharedHelpers).to receive(:find_gemfile) { Pathname.new("Gemfile") }
       allow(Bundler).to receive(:ui) { double("UI", info: "", debug: "") }
     end
-    context "when it's not possible to write to the file" do
-      subject { Bundler::Definition.new("Gemfile.lock", [], Bundler::SourceList.new, []) }
 
+    subject { Bundler::Definition.new("Gemfile.lock", [], Bundler::SourceList.new, []) }
+
+    context "when it's not possible to write to the file" do
       it "raises an PermissionError with explanation" do
         allow(File).to receive(:open).and_call_original
         expect(File).to receive(:open).with("Gemfile.lock", "wb").
@@ -21,8 +22,6 @@ RSpec.describe Bundler::Definition do
       end
     end
     context "when a temporary resource access issue occurs" do
-      subject { Bundler::Definition.new("Gemfile.lock", [], Bundler::SourceList.new, []) }
-
       it "raises a TemporaryResourceError with explanation" do
         allow(File).to receive(:open).and_call_original
         expect(File).to receive(:open).with("Gemfile.lock", "wb").
@@ -32,7 +31,6 @@ RSpec.describe Bundler::Definition do
       end
     end
     context "when Bundler::Definition.no_lock is set to true" do
-      subject { Bundler::Definition.new("Gemfile.lock", [], Bundler::SourceList.new, []) }
       before { Bundler::Definition.no_lock = true }
       after { Bundler::Definition.no_lock = false }
 

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Bundler::Definition do
 
       it "does not create a lock file" do
         subject.lock
-        expect(File.file?("Gemfile.lock")).to eq false
+        expect(bundled_app_lock).not_to be_file
       end
     end
   end

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Bundler::Definition do
       allow(Bundler).to receive(:ui) { double("UI", info: "", debug: "") }
     end
 
-    subject { Bundler::Definition.new("Gemfile.lock", [], Bundler::SourceList.new, []) }
+    subject { Bundler::Definition.new("Gemfile.lock", [], Bundler::SourceList.new, {}) }
 
     context "when it's not possible to write to the file" do
       it "raises an PermissionError with explanation" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

No user problem, but came up with a refactoring that I believe makes the code better and easier to customize.

I think this may help [bootboot](https://github.com/Shopify/bootboot) remove some monkey patches.

## What is your fix for the problem, implemented in this PR?

This PR deprecates passing a file to `Definition#lock`. Instead, it will always lock the lockfile the definition was built for.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
