### PR TITLE
Deprecate `bundle plugin install --local-git=`

### DIFF
--- a/bundler/lib/bundler/cli/plugin.rb
+++ b/bundler/lib/bundler/cli/plugin.rb
@@ -5,12 +5,12 @@ module Bundler
   class CLI::Plugin < Thor
     desc "install PLUGINS", "Install the plugin from the source"
     long_desc <<-D
-      Install plugins either from the rubygems source provided (with --source option) or from a git source provided with --git (for remote repos) or --local_git (for local repos). If no sources are provided, it uses Gem.sources
+      Install plugins either from the rubygems source provided (with --source option) or from a git source provided with --git. If no sources are provided, it uses Gem.sources
    D
     method_option "source", type: :string, default: nil, banner: "URL of the RubyGems source to fetch the plugin from"
     method_option "version", type: :string, default: nil, banner: "The version of the plugin to fetch"
     method_option "git", type: :string, default: nil, banner: "URL of the git repo to fetch from"
-    method_option "local_git", type: :string, default: nil, banner: "Path of the local git repo to fetch from"
+    method_option "local_git", type: :string, default: nil, banner: "Path of the local git repo to fetch from (deprecated)"
     method_option "branch", type: :string, default: nil, banner: "The git branch to checkout"
     method_option "ref", type: :string, default: nil, banner: "The git revision to check out"
     def install(*plugins)

--- a/bundler/lib/bundler/man/bundle-plugin.1
+++ b/bundler/lib/bundler/man/bundle-plugin.1
@@ -4,7 +4,7 @@
 .SH "NAME"
 \fBbundle\-plugin\fR \- Manage Bundler plugins
 .SH "SYNOPSIS"
-\fBbundle plugin\fR install PLUGINS [\-\-source=\fISOURCE\fR] [\-\-version=\fIversion\fR] [\-\-git|\-\-local_git=\fIgit\-url\fR] [\-\-branch=\fIbranch\fR|\-\-ref=\fIrev\fR]
+\fBbundle plugin\fR install PLUGINS [\-\-source=\fISOURCE\fR] [\-\-version=\fIversion\fR] [\-\-git=\fIgit\-url\fR] [\-\-branch=\fIbranch\fR|\-\-ref=\fIrev\fR]
 .br
 \fBbundle plugin\fR uninstall PLUGINS
 .br
@@ -27,7 +27,7 @@ Install bundler\-graph gem from example\.com\. The global source, specified in s
 You can specify the version of the gem via \fB\-\-version\fR\.
 .TP
 \fBbundle plugin install bundler\-graph \-\-git https://github\.com/rubygems/bundler\-graph\fR
-Install bundler\-graph gem from Git repository\. \fB\-\-git\fR can be replaced with \fB\-\-local\-git\fR\. You cannot use both \fB\-\-git\fR and \fB\-\-local\-git\fR\. You can use standard Git URLs like:
+Install bundler\-graph gem from Git repository\. You can use standard Git URLs like:
 .IP
 \fBssh://[user@]host\.xz[:port]/path/to/repo\.git\fR
 .br
@@ -37,7 +37,7 @@ Install bundler\-graph gem from Git repository\. \fB\-\-git\fR can be replaced w
 .br
 \fBfile:///path/to/repo\fR
 .IP
-When you specify \fB\-\-git\fR/\fB\-\-local\-git\fR, you can use \fB\-\-branch\fR or \fB\-\-ref\fR to specify any branch, tag, or commit hash (revision) to use\. When you specify both, only the latter is used\.
+When you specify \fB\-\-git\fR, you can use \fB\-\-branch\fR or \fB\-\-ref\fR to specify any branch, tag, or commit hash (revision) to use\. When you specify both, only the latter is used\.
 .SS "uninstall"
 Uninstall the plugin(s) specified in PLUGINS\.
 .SS "list"

--- a/bundler/lib/bundler/man/bundle-plugin.1.ronn
+++ b/bundler/lib/bundler/man/bundle-plugin.1.ronn
@@ -4,7 +4,7 @@ bundle-plugin(1) -- Manage Bundler plugins
 ## SYNOPSIS
 
 `bundle plugin` install PLUGINS [--source=<SOURCE>] [--version=<version>]
-                              [--git|--local_git=<git-url>] [--branch=<branch>|--ref=<rev>]<br>
+                              [--git=<git-url>] [--branch=<branch>|--ref=<rev>]<br>
 `bundle plugin` uninstall PLUGINS<br>
 `bundle plugin` list<br>
 `bundle plugin` help [COMMAND]
@@ -29,14 +29,14 @@ Install the given plugin(s).
   You can specify the version of the gem via `--version`.
 
 * `bundle plugin install bundler-graph --git https://github.com/rubygems/bundler-graph`:
-  Install bundler-graph gem from Git repository. `--git` can be replaced with `--local-git`. You cannot use both `--git` and `--local-git`. You can use standard Git URLs like:
+  Install bundler-graph gem from Git repository. You can use standard Git URLs like:
 
   `ssh://[user@]host.xz[:port]/path/to/repo.git`<br>
   `http[s]://host.xz[:port]/path/to/repo.git`<br>
   `/path/to/repo`<br>
   `file:///path/to/repo`
 
-  When you specify `--git`/`--local-git`, you can use `--branch` or `--ref` to specify any branch, tag, or commit hash (revision) to use. When you specify both, only the latter is used.
+  When you specify `--git`, you can use `--branch` or `--ref` to specify any branch, tag, or commit hash (revision) to use. When you specify both, only the latter is used.
 
 ### uninstall
 

--- a/bundler/lib/bundler/plugin/installer.rb
+++ b/bundler/lib/bundler/plugin/installer.rb
@@ -18,8 +18,6 @@ module Bundler
 
         if options[:git]
           install_git(names, version, options)
-        elsif options[:local_git]
-          install_local_git(names, version, options)
         else
           sources = options[:source] || Gem.sources
           install_rubygems(names, version, sources)
@@ -45,17 +43,15 @@ module Bundler
         if options.key?(:git) && options.key?(:local_git)
           raise InvalidOption, "Remote and local plugin git sources can't be both specified"
         end
+        # back-compat; local_git is an alias for git
+        if options.key?(:local_git)
+          Bundler::SharedHelpers.major_deprecation(2, "--local_git is deprecated, use --git")
+          options[:git] = options.delete(:local_git)
+        end
       end
 
       def install_git(names, version, options)
         uri = options.delete(:git)
-        options["uri"] = uri
-
-        install_all_sources(names, version, options, options[:source])
-      end
-
-      def install_local_git(names, version, options)
-        uri = options.delete(:local_git)
         options["uri"] = uri
 
         install_all_sources(names, version, options, options[:source])

--- a/bundler/spec/bundler/plugin/installer_spec.rb
+++ b/bundler/spec/bundler/plugin/installer_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe Bundler::Plugin::Installer do
       end
 
       it "returns the installed spec after installing local git plugins" do
-        allow(installer).to receive(:install_local_git).
+        allow(installer).to receive(:install_git).
           and_return("new-plugin" => spec)
 
-        expect(installer.install(["new-plugin"], local_git: "/phony/path/repo")).
+        expect(installer.install(["new-plugin"], git: "/phony/path/repo")).
           to eq("new-plugin" => spec)
       end
 
@@ -80,7 +80,7 @@ RSpec.describe Bundler::Plugin::Installer do
         end
 
         let(:result) do
-          installer.install(["ga-plugin"], local_git: lib_path("ga-plugin").to_s)
+          installer.install(["ga-plugin"], git: lib_path("ga-plugin").to_s)
         end
 
         it "returns the installed spec after installing" do

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -601,6 +601,23 @@ RSpec.describe "major deprecations" do
     pending "fails with a helpful message", bundler: "3"
   end
 
+  context "bundle plugin install --local_git" do
+    before do
+      build_git "foo" do |s|
+        s.write "plugins.rb"
+      end
+    end
+
+    it "prints a deprecation warning", bundler: "< 3" do
+      bundle "plugin install foo --local_git #{lib_path("foo-1.0")}"
+
+      expect(out).to include("Installed plugin foo")
+      expect(deprecations).to include "--local_git is deprecated, use --git"
+    end
+
+    pending "fails with a helpful message", bundler: "3"
+  end
+
   describe "deprecating rubocop", :readline do
     context "bundle gem --rubocop" do
       before do

--- a/bundler/spec/plugins/install_spec.rb
+++ b/bundler/spec/plugins/install_spec.rb
@@ -196,14 +196,14 @@ RSpec.describe "bundler plugin install" do
         s.write "plugins.rb"
       end
 
-      bundle "plugin install foo --local_git #{lib_path("foo-1.0")}"
+      bundle "plugin install foo --git #{lib_path("foo-1.0")}"
 
       expect(out).to include("Installed plugin foo")
       plugin_should_be_installed("foo")
     end
 
-    it "raises an error when both git and local git sources are specified" do
-      bundle "plugin install foo --local_git /phony/path/project --git git@gitphony.com:/repo/project", raise_on_error: false
+    it "raises an error when both git and local git sources are specified", bundler: "< 3" do
+      bundle "plugin install foo --git /phony/path/project --local_git git@gitphony.com:/repo/project", raise_on_error: false
 
       expect(exitstatus).not_to eq(0)
       expect(err).to eq("Remote and local plugin git sources can't be both specified")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Adding the --path param, I noticed --git and --local-git have identical implementations.

## What is your fix for the problem, implemented in this PR?

Keep --local-git as an undocumented alias for --git. Use the same actual implementation now. No functionality change.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
