### PR TITLE
Gem::Version avoid mutating temporary Array in attempt to fix Windows

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -417,8 +417,10 @@ class Gem::Version
   end
 
   def partition_segments(ver)
-    ver.scan(/\d+|[a-z]+/i).map! do |s|
-      /\A\d/.match?(s) ? s.to_i : -s
-    end.freeze
+    segments = []
+    ver.scan(/\d+|[a-z]+/i) do |s|
+      segments << (/\A\d/.match?(s) ? s.to_i : -s)
+    end
+    segments.freeze
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Windows specs are failing with invalid version string `false.1.pre`. I don't thin this is caused by an actual bug in our code, but some inconsistency in the Windows Ruby 3.2.2 implementation.

Windows is sometimes producing `false.1.3.pre`, with the first segment being the literal `false`, when given the version string `1.1.3.pre`. My guess is that this is caused by a malfunction of map! which was recently introduced into `Gem::Version#_segments` when it is used to modify the temporary Array resulting from of scan (but only on Windows with ruby version 3.2.2).

## What is your fix for the problem, implemented in this PR?

This is an attempt at a harmless alternate version of the same code that I suspect is causing this problem. This allocates the same number Arrays and blocks, but avoids mutating the Array with `map!`, instead adding each element one at a time.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
