### PR TITLE
Don't delete the release version from pre-release string more than once

### DIFF
--- a/bundler/lib/bundler/injector.rb
+++ b/bundler/lib/bundler/injector.rb
@@ -86,7 +86,7 @@ module Bundler
       segments = version.segments
       seg_end_index = version >= Gem::Version.new("1.0") ? 1 : 2
 
-      prerelease_suffix = version.to_s.gsub(version.release.to_s, "") if version.prerelease?
+      prerelease_suffix = version.to_s.delete_prefix(version.release.to_s) if version.prerelease?
       "#{version_prefix}#{segments[0..seg_end_index].join(".")}#{prerelease_suffix}"
     end
 

--- a/bundler/spec/commands/add_spec.rb
+++ b/bundler/spec/commands/add_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "bundle add" do
       build_gem "bar", "0.12.3"
       build_gem "cat", "0.12.3.pre"
       build_gem "dog", "1.1.3.pre"
+      build_gem "lemur", "3.1.1.pre.2023.1.1"
     end
 
     build_git "foo", "2.0"
@@ -50,6 +51,13 @@ RSpec.describe "bundle add" do
       bundle "add 'dog'"
       expect(bundled_app_gemfile.read).to match(/gem "dog", "~> 1.1.pre"/)
       expect(the_bundle).to include_gems "dog 1.1.3.pre"
+    end
+
+    it "version requirement becomes ~> major.minor.pre.tail when resolved version has a very long tail pre version" do
+      bundle "add 'lemur'"
+      # the trailing pre purposely matches the release version to ensure that subbing the release doesn't change the pre.version"
+      expect(bundled_app_gemfile.read).to match(/gem "lemur", "~> 3.1.pre.2023.1.1"/)
+      expect(the_bundle).to include_gems "lemur 3.1.1.pre.2023.1.1"
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Small fix to Bundler to avoid deleting the gem version twice. (Extracted from other PRs so we can merge this).

## What is your fix for the problem, implemented in this PR?

Use delete_prefix and add a test.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
