### PR TITLE
Restore using old way of passing Ruby version to resolver

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -881,7 +881,7 @@ module Bundler
 
     def metadata_dependencies
       @metadata_dependencies ||= [
-        Dependency.new("Ruby\0", Gem.ruby_version),
+        Dependency.new("Ruby\0", Bundler::RubyVersion.system.gem_version),
         Dependency.new("RubyGems\0", Gem::VERSION),
       ]
     end

--- a/bundler/lib/bundler/source/metadata.rb
+++ b/bundler/lib/bundler/source/metadata.rb
@@ -5,7 +5,7 @@ module Bundler
     class Metadata < Source
       def specs
         @specs ||= Index.build do |idx|
-          idx << Gem::Specification.new("Ruby\0", Gem.ruby_version)
+          idx << Gem::Specification.new("Ruby\0", Bundler::RubyVersion.system.gem_version)
           idx << Gem::Specification.new("RubyGems\0", Gem::VERSION) do |s|
             s.required_rubygems_version = Gem::Requirement.default
           end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Don't break [bootboot](https://github.com/Shopify/bootboot) unnecessarily.

I found this while investigating how the changes in #7047 affect bootboot.

## What is your fix for the problem, implemented in this PR?

Restore old code that was changed for no known reason.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
