### PR TITLE
Don't hide original error in `after(:suite)` hook

### DIFF
--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -114,6 +114,6 @@ RSpec.configure do |config|
   end
 
   config.after :suite do
-    FileUtils.rm_r Spec::Path.pristine_system_gem_path
+    FileUtils.rm_rf Spec::Path.pristine_system_gem_path
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

For some reason, Windows builds are failing quite consistently now. However, it seems that errors are happening before this directory is even created, so removal fails, hiding the original error.

See for example https://github.com/rubygems/rubygems/actions/runs/6536075483/job/17746972318?pr=7070:

```
2 processes for 169 specs, ~ 85 specs per process
FFFFFFFFFFFFFFFFFFFFFFFFF
An error occurred in an `after(:suite)` hook.
Failure/Error: FileUtils.rm_r Spec::Path.pristine_system_gem_path

Errno::ENOENT:
  No such file or directory @ apply2files - D:/a/rubygems/rubygems/bundler/tmp/1/gems/base_system
# C:/hostedtoolcache/windows/Ruby/3.0.6/x64/lib/ruby/3.0.0/fileutils.rb:1466:in `unlink'
# C:/hostedtoolcache/windows/Ruby/3.0.6/x64/lib/ruby/3.0.0/fileutils.rb:1466:in `block in remove_file'
# C:/hostedtoolcache/windows/Ruby/3.0.6/x64/lib/ruby/3.0.0/fileutils.rb:1474:in `platform_support'
# C:/hostedtoolcache/windows/Ruby/3.0.6/x64/lib/ruby/3.0.0/fileutils.rb:1465:in `remove_file'
# C:/hostedtoolcache/windows/Ruby/3.0.6/x64/lib/ruby/3.0.0/fileutils.rb:1454:in `remove'
# C:/hostedtoolcache/windows/Ruby/3.0.6/x64/lib/ruby/3.0.0/fileutils.rb:783:in `block in remove_entry'
# C:/hostedtoolcache/windows/Ruby/3.0.6/x64/lib/ruby/3.0.0/fileutils.rb:1509:in `postorder_traverse'
# C:/hostedtoolcache/windows/Ruby/3.0.6/x64/lib/ruby/3.0.0/fileutils.rb:781:in `remove_entry'
# C:/hostedtoolcache/windows/Ruby/3.0.6/x64/lib/ruby/3.0.0/fileutils.rb:633:in `block in rm_r'
# C:/hostedtoolcache/windows/Ruby/3.0.6/x64/lib/ruby/3.0.0/fileutils.rb:629:in `each'
# C:/hostedtoolcache/windows/Ruby/3.0.6/x64/lib/ruby/3.0.0/fileutils.rb:629:in `rm_r'
# ./spec/spec_helper.rb:117:in `block (2 levels) in <top (required)>'
# C:/hostedtoolcache/windows/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.12.2/lib/rspec/core/example.rb:457:in `instance_exec'
# C:/hostedtoolcache/windows/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.12.2/lib/rspec/core/example.rb:457:in `instance_exec'
# C:/hostedtoolcache/windows/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.12.2/lib/rspec/core/hooks.rb:372:in `run'
# C:/hostedtoolcache/windows/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.12.2/lib/rspec/core/configuration.rb:2157:in `block in run_suite_hooks'
# C:/hostedtoolcache/windows/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.12.2/lib/rspec/core/configuration.rb:2155:in `each'
# C:/hostedtoolcache/windows/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.12.2/lib/rspec/core/configuration.rb:2155:in `run_suite_hooks'
# C:/hostedtoolcache/windows/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.12.2/lib/rspec/core/configuration.rb:2073:in `with_suite_hooks'
# C:/hostedtoolcache/windows/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.12.2/lib/rspec/core/runner.rb:116:in `block in run_specs'
# C:/hostedtoolcache/windows/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.12.2/lib/rspec/core/reporter.rb:74:in `report'
# C:/hostedtoolcache/windows/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.12.2/lib/rspec/core/runner.rb:115:in `run_specs'
# C:/hostedtoolcache/windows/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.12.2/lib/rspec/core/runner.rb:89:in `run'
# C:/hostedtoolcache/windows/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.12.2/lib/rspec/core/runner.rb:71:in `run'
# C:/hostedtoolcache/windows/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.12.2/lib/rspec/core/runner.rb:45:in `invoke'
# C:/hostedtoolcache/windows/Ruby/3.0.6/x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.12.2/exe/rspec:4:in `<top (required)>'
# ./spec/support/rubygems_ext.rb:103:in `load'
# ./spec/support/rubygems_ext.rb:103:in `gem_load_and_activate'
# ./spec/support/rubygems_ext.rb:18:in `gem_load'
# bin/rspec:6:in `<main>'
```

## What is your fix for the problem, implemented in this PR?

Don't let this removal fail due to files not existing.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
