### PR TITLE
Detect existing license update PR

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -572,6 +572,8 @@ task :update_licenses_branch => :update_licenses do
     else
       puts "A license update PR already exists"
     end
+  else
+    puts "Licenses are in sync"
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -561,8 +561,17 @@ task :update_licenses_branch => :update_licenses do
     file, mtime = license_last_update
     date = mtime.strftime("%Y-%m-%d")
     branch_name = "license-list-#{date}"
-    system(*%w[git checkout -b], branch_name, exception: true)
-    system(*%w[git commit -m], "Update SPDX license list as of #{date}", *file, exception: true)
+
+    require "open3"
+    stdout, stderr, status = Open3.capture3(*%w[git ls-remote --heads origin], "refs/heads/#{branch_name}")
+    raise stderr unless status.success?
+
+    if stdout.empty?
+      system(*%w[git checkout -b], branch_name, exception: true)
+      system(*%w[git commit -m], "Update SPDX license list as of #{date}", *file, exception: true)
+    else
+      puts "A license update PR already exists"
+    end
   end
 end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If the weekly license update job runs, but there's already an existing PR that hasn't been merged yet, the job will fail.

That's an expected situation though, so we should let the job finish gracefully here.
 
## What is your fix for the problem, implemented in this PR?

Check if there's a remote branch with the same name before trying to push to it. 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
