### PR TITLE
Fix regression when installing native extensions on universal rubies

### DIFF
--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -338,7 +338,7 @@ module Gem
   end
 
   # On universal Rubies, resolve the "universal" arch to the real CPU arch, without changing the extension directory.
-  class Specification
+  class BasicSpecification
     if /^universal\.(?<arch>.*?)-/ =~ (CROSS_COMPILING || RUBY_PLATFORM)
       local_platform = Platform.local
       if local_platform.cpu == "universal"

--- a/bundler/spec/bundler/specifications/foo.gemspec
+++ b/bundler/spec/bundler/specifications/foo.gemspec
@@ -1,0 +1,13 @@
+# rubocop:disable Style/FrozenStringLiteralComment
+# stub: foo 1.0.0 ruby lib
+
+# The first line would be '# -*- encoding: utf-8 -*-' in a real stub gemspec
+
+Gem::Specification.new do |s|
+  s.name = "foo"
+  s.version = "1.0.0"
+  s.loaded_from = __FILE__
+  s.extensions = "ext/foo"
+  s.required_ruby_version = ">= 2.6.0"
+end
+# rubocop:enable Style/FrozenStringLiteralComment

--- a/bundler/spec/bundler/stub_specification_spec.rb
+++ b/bundler/spec/bundler/stub_specification_spec.rb
@@ -19,6 +19,17 @@ RSpec.describe Bundler::StubSpecification do
     end
   end
 
+  describe "#gem_build_complete_path" do
+    it "StubSpecification should have equal gem_build_complete_path as Specification" do
+      spec_path = File.join(File.dirname(__FILE__), "specifications", "foo.gemspec")
+      spec = Gem::Specification.load(spec_path)
+      gem_stub = Gem::StubSpecification.new(spec_path, File.dirname(__FILE__),"","")
+
+      stub = described_class.from_stub(gem_stub)
+      expect(stub.gem_build_complete_path).to eq spec.gem_build_complete_path
+    end
+  end
+
   describe "#manually_installed?" do
     it "returns true if installed_by_version is nil or 0" do
       stub = described_class.from_stub(with_bundler_stub_spec)


### PR DESCRIPTION
Since #6945 the extension dir changed to Gem::BasicSpecification's implementation, we didn't hook that in rubygems_ext.rb. So for universal rubies, we ended up using the universal platform name when installing, but arch replaced platform name when checking. This lead to native extensions can never be correctly installed on universal rubies.

Hook Gem::BasicSpecifications so the behavior is consistent on installing and checking.

## What was the end-user or developer problem that led to this PR?
For universal rubies, the change from #6945 to def gem_build_complete_path is incorrect. Previously, extension_dir is invoked on the Bundler::StubSpecification, which is a child class of Specification. After the change to stub.gem_build_complete_path, @Stub is actually an instance of Gem::StubSpecification, thus gem_build_complete_path is from Gem::BasicSpecification.

The problem arise when in bundler, we replace the 'universal' part of Gem::Platform with the arch. But we still use the universal name for Gem::Specification, this is defined in 'rubygems_ext.rb'. Now the stub is using extension_dir defined in Gem::BasicSpecification, so the 'universal' part ended up being swapped by arch.

So, we install native extensions to 'extensions/universal-darwin-22/', but finding them in 'extensions/x86_64-darwin-22/'. Leading to native extension gems can never be installed on universal ruby.

## What is your fix for the problem, implemented in this PR?
Hook Gem::BasicSpecifications so the behavior is consistent on installing and checking.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
