### PR TITLE
Reuse Gem::RemoteFetcher instance in bundler

### DIFF
--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -521,8 +521,7 @@ module Bundler
 
     def gem_remote_fetcher
       require "rubygems/remote_fetcher"
-      proxy = Gem.configuration[:http_proxy]
-      Gem::RemoteFetcher.new(proxy)
+      Gem::RemoteFetcher.fetcher
     end
 
     def build(spec, skip_validation = false)


### PR DESCRIPTION
Closes https://github.com/rubygems/rubygems/issues/7076

Bundler will now use the same (shared) remote fetcher instance that
RubyGems uses.

This will allow installs to use a shared connection pool, which
represents a significant performance improvement on a clean install.
