### PR TITLE
Add `ruby_version_file` to Gemfile DSL

### DIFF
--- a/bundler/lib/bundler/ruby_dsl.rb
+++ b/bundler/lib/bundler/ruby_dsl.rb
@@ -21,6 +21,10 @@ module Bundler
       @ruby_version = RubyVersion.new(ruby_version, options[:patchlevel], options[:engine], options[:engine_version])
     end
 
+    def ruby_version_file
+      File.read(".ruby-version").chomp
+    end
+
     # Support the various file formats found in .ruby-version files.
     #
     #     3.2.2


### PR DESCRIPTION
Add `ruby_version_file` to Gemfile DSL so we can do this:

```
ruby ruby_version_file
```

Instead of

```
ruby File.read(".ruby-version").chomp
```

## Motivation

There's too many places where a Ruby version is specified. Many projects and libraries like rbenv and rvm use the `.ruby-version` file. This change reads that file and sets the ruby version in a Gemfile.

## Discussion points

There's probably a better way to do this, but this will at least get a conversation going about it.