### PR TITLE
Gem::NameTuple equality ignores Gem::Platform or String variation

### DIFF
--- a/lib/rubygems/name_tuple.rb
+++ b/lib/rubygems/name_tuple.rb
@@ -6,14 +6,12 @@
 # wrap the data returned from the indexes.
 
 class Gem::NameTuple
-  def initialize(name, version, platform="ruby")
+  def initialize(name, version, platform=Gem::Platform::RUBY)
     @name = name
     @version = version
 
-    unless platform.is_a? Gem::Platform
-      platform = "ruby" if !platform || platform.empty?
-    end
-
+    platform &&= platform.to_s
+    platform = Gem::Platform::RUBY if !platform || platform.empty?
     @platform = platform
   end
 
@@ -49,7 +47,7 @@ class Gem::NameTuple
 
   def full_name
     case @platform
-    when nil, "ruby", ""
+    when nil, "", Gem::Platform::RUBY
       "#{@name}-#{@version}"
     else
       "#{@name}-#{@version}-#{@platform}"

--- a/test/rubygems/test_gem_name_tuple.rb
+++ b/test/rubygems/test_gem_name_tuple.rb
@@ -19,14 +19,31 @@ class TestGemNameTuple < Gem::TestCase
   end
 
   def test_platform_normalization
-    n = Gem::NameTuple.new "a", Gem::Version.new(0), "ruby"
-    assert_equal "ruby", n.platform
+    a = Gem::NameTuple.new "a", Gem::Version.new(0), "ruby"
+    b = Gem::NameTuple.new "a", Gem::Version.new(0), Gem::Platform::RUBY
+    assert_equal a, b
+    assert_equal a.hash, b.hash
 
-    n = Gem::NameTuple.new "a", Gem::Version.new(0), nil
-    assert_equal "ruby", n.platform
+    a = Gem::NameTuple.new "a", Gem::Version.new(0), nil
+    b = Gem::NameTuple.new "a", Gem::Version.new(0), Gem::Platform.new("ruby")
+    assert_equal a, b
+    assert_equal a.hash, b.hash
 
-    n = Gem::NameTuple.new "a", Gem::Version.new(0), ""
-    assert_equal "ruby", n.platform
+    a = Gem::NameTuple.new "a", Gem::Version.new(0), ""
+    b = Gem::NameTuple.new "a", Gem::Version.new(0), Gem::Platform.new("ruby")
+    assert_equal a, b
+    assert_equal a.hash, b.hash
+
+    a = Gem::NameTuple.new "a", Gem::Version.new(0), "universal-darwin-23"
+    b = Gem::NameTuple.new "a", Gem::Version.new(0), Gem::Platform.new("universal-darwin-23")
+    assert_equal a, b
+    assert_equal a.hash, b.hash
+
+    # Gem::Platform does normalization so that these are equal (note the missing dash before 21)
+    a = Gem::NameTuple.new "a", Gem::Version.new(0), "universal-darwin-21"
+    b = Gem::NameTuple.new "a", Gem::Version.new(0), Gem::Platform.new("universal-darwin21")
+    assert_equal a, b
+    assert_equal a.hash, b.hash
   end
 
   def test_spec_name


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When implementing bundler checksums (#6374), I needed `NameTuple` to be equivalent whether the platform came from a `String` or a `Gem::Platform`.

## What is your fix for the problem, implemented in this PR?

My fix is based on the assumption that `NameTuple` is only for generating names. It's not intended to hold the `Gem::Platform` unaltered so that it can be used later.

This should be safe because:
* I can't find any calls to `NameTuple#platform` in the code. It's only used in the tests I modified here.
* Existing platforms could be either `String` or `Gem::Platform` object so all callers will already handle either case.
* I'm naturally optimistic.

Despite the fix, I will need to patch over this in Bundler for the foreseeable future. Is there anything you can think of to improve that situation?

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
