### PR TITLE
Escape the target string to be checked

### DIFF
--- a/bundler/spec/quality_spec.rb
+++ b/bundler/spec/quality_spec.rb
@@ -41,11 +41,9 @@ RSpec.describe "The library itself" do
   end
 
   def check_for_straneous_quotes(filename)
-    return if File.expand_path(filename) == __FILE__
-
     failing_lines = []
     each_line(filename) do |line, number|
-      failing_lines << number + 1 if /’/.match?(line)
+      failing_lines << number + 1 if /\u{2019}/.match?(line)
     end
 
     return if failing_lines.empty?


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Comparing file paths as strings may not work well for some reasons, symlink, relative `__FILE__`, etc.

## What is your fix for the problem, implemented in this PR?


Some alternatives are possible: comparing with `File.realpath`, or with `File.identical?`, it should be most robust to escape the target string contained within this file itself.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
