### PR TITLE
Fixup warning feature for bundled gems

### DIFF
--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -244,7 +244,7 @@ module Bundler
       [::Kernel.singleton_class, ::Kernel].each do |kernel_class|
         kernel_class.send(:alias_method, :no_warning_require, :require)
         kernel_class.send(:define_method, :require) do |name|
-          if message = ::Gem::BUNDLED_GEMS.warning?(name)
+          if message = ::Gem::BUNDLED_GEMS.warning?(name, specs: specs)
             warn message, :uplevel => 1
           end
           kernel_class.send(:no_warning_require, name)

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -373,7 +373,7 @@ module Bundler
     def replace_entrypoints(specs)
       specs_by_name = add_default_gems_to(specs)
 
-      if defined?(::Gem::BUNDLED_GEMS::SINCE)
+      if defined?(::Gem::BUNDLED_GEMS)
         replace_require(specs)
       else
         reverse_rubygems_kernel_mixin

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -244,7 +244,7 @@ module Bundler
       [::Kernel.singleton_class, ::Kernel].each do |kernel_class|
         kernel_class.send(:alias_method, :no_warning_require, :require)
         kernel_class.send(:define_method, :require) do |name|
-          if message = ::Gem::BUNDLED_GEMS.warning?(name, specs: specs)
+          if message = ::Gem::BUNDLED_GEMS.warning?(name, specs: specs) # rubocop:disable Style/HashSyntax
             warn message, :uplevel => 1
           end
           kernel_class.send(:no_warning_require, name)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We need to pass Gemfile specs into warnings for the bundled gems.

see https://bugs.ruby-lang.org/issues/19929

## What is your fix for the problem, implemented in this PR?

I refer to `specs` for warnings under the bundler environment.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
