### PR TITLE
Ignore non-tar format `.gem` files during search

### DIFF
--- a/lib/rubygems/package/tar_reader.rb
+++ b/lib/rubygems/package/tar_reader.rb
@@ -52,7 +52,14 @@ class Gem::Package::TarReader
     return enum_for __method__ unless block_given?
 
     until @io.eof? do
-      header = Gem::Package::TarHeader.from @io
+      begin
+        header = Gem::Package::TarHeader.from @io
+      rescue ArgumentError => e
+        # Specialize only exceptions from Gem::Package::TarHeader.strict_oct
+        raise e unless e.message.match?(/ is not an octal string$/)
+        raise Gem::Package::TarInvalidError, e.message
+      end
+
       return if header.empty?
       entry = Gem::Package::TarReader::Entry.new header, @io
       yield entry

--- a/lib/rubygems/source/local.rb
+++ b/lib/rubygems/source/local.rb
@@ -40,10 +40,11 @@ class Gem::Source::Local < Gem::Source
 
       Dir["*.gem"].each do |file|
         pkg = Gem::Package.new(file)
+        spec = pkg.spec
       rescue SystemCallError, Gem::Package::FormatError
         # ignore
       else
-        tup = pkg.spec.name_tuple
+        tup = spec.name_tuple
         @specs[tup] = [File.expand_path(file), pkg]
 
         case type

--- a/test/rubygems/test_gem_package_tar_reader.rb
+++ b/test/rubygems/test_gem_package_tar_reader.rb
@@ -25,6 +25,21 @@ class TestGemPackageTarReader < Gem::Package::TarTestCase
     io.close!
   end
 
+  def test_each_with_not_a_tar
+    text = "Hello, world!!?\n" * 256 # 4 KiB
+    io = TempIO.new text
+
+    Gem::Package::TarReader.new io do |tar|
+      assert_raise Gem::Package::TarInvalidError do
+        tar.each do
+          flunk "TarInvalidError was expected to occur, but an entry was found"
+        end
+      end
+    end
+  ensure
+    io.close!
+  end
+
   def test_rewind
     content = ("a".."z").to_a.join(" ")
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`rake install` fails with an error if there is a non-tar format `.gem` file in the current working directory.
Also, `rake update` fails with the same error.

The first time I encountered the problem was in the clone directory of https://github.com/mruby/mgem-list.git.

ref. #7049

## What is your fix for the problem, implemented in this PR?

The problematic `.gem` file, while in tar format, is simply ignored.
Therefore, the solution to this problem is to ignore it as well.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

Fix #7049

Thanks to @martinemde for their assistance in resolving the issue.
