### PR TITLE
Handle empty array at built-in YAML serializer

### DIFF
--- a/bundler/lib/bundler/yaml_serializer.rb
+++ b/bundler/lib/bundler/yaml_serializer.rb
@@ -17,7 +17,11 @@ module Bundler
         if v.is_a?(Hash)
           yaml << dump_hash(v).gsub(/^(?!$)/, "  ") # indent all non-empty lines
         elsif v.is_a?(Array) # Expected to be array of strings
-          yaml << "\n- " << v.map {|s| s.to_s.gsub(/\s+/, " ").inspect }.join("\n- ") << "\n"
+          if v.empty?
+            yaml << " []\n"
+          else
+            yaml << "\n- " << v.map {|s| s.to_s.gsub(/\s+/, " ").inspect }.join("\n- ") << "\n"
+          end
         else
           yaml << " " << v.to_s.gsub(/\s+/, " ").inspect << "\n"
         end
@@ -63,6 +67,7 @@ module Bundler
             last_empty_key = key
             last_hash = stack[depth]
           else
+            val = [] if val == "[]" # empty array
             stack[depth][key] = val
           end
         elsif match = ARRAY_REGEX.match(line)

--- a/bundler/spec/bundler/yaml_serializer_spec.rb
+++ b/bundler/spec/bundler/yaml_serializer_spec.rb
@@ -57,6 +57,19 @@ RSpec.describe Bundler::YAMLSerializer do
 
       expect(serializer.dump(hash)).to eq(expected)
     end
+
+    it "handles empty array" do
+      hash = {
+        "empty_array" => [],
+      }
+
+      expected = <<~YAML
+        ---
+        empty_array: []
+      YAML
+
+      expect(serializer.dump(hash)).to eq(expected)
+    end
   end
 
   describe "#load" do
@@ -144,6 +157,19 @@ RSpec.describe Bundler::YAMLSerializer do
             "oh so silly",
           ],
         },
+      }
+
+      expect(serializer.load(yaml)).to eq(hash)
+    end
+
+    it "handles empty array" do
+      yaml = <<~YAML
+        ---
+        empty_array: []
+      YAML
+
+      hash = {
+        "empty_array" => [],
       }
 
       expect(serializer.load(yaml)).to eq(hash)

--- a/lib/rubygems/yaml_serializer.rb
+++ b/lib/rubygems/yaml_serializer.rb
@@ -17,7 +17,11 @@ module Gem
         if v.is_a?(Hash)
           yaml << dump_hash(v).gsub(/^(?!$)/, "  ") # indent all non-empty lines
         elsif v.is_a?(Array) # Expected to be array of strings
-          yaml << "\n- " << v.map {|s| s.to_s.gsub(/\s+/, " ").inspect }.join("\n- ") << "\n"
+          if v.empty?
+            yaml << " []\n"
+          else
+            yaml << "\n- " << v.map {|s| s.to_s.gsub(/\s+/, " ").inspect }.join("\n- ") << "\n"
+          end
         else
           yaml << " " << v.to_s.gsub(/\s+/, " ").inspect << "\n"
         end
@@ -63,6 +67,7 @@ module Gem
             last_empty_key = key
             last_hash = stack[depth]
           else
+            val = [] if val == "[]" # empty array
             stack[depth][key] = val
           end
         elsif match = ARRAY_REGEX.match(line)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Fixes https://github.com/rubygems/rubygems/issues/7098

## What is your fix for the problem, implemented in this PR?

I added simple condition for empty array. But I'm not sure this is the best approach for fixing this issue.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
