### PR TITLE
Less exceptional user install

### DIFF
--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -136,13 +136,6 @@ You can use `i` command instead of `install`.
     "#{program_name} [options] GEMNAME [GEMNAME ...] -- --build-flags"
   end
 
-  def check_install_dir # :nodoc:
-    if options[:install_dir] && options[:user_install]
-      alert_error "Use --install-dir or --user-install but not both"
-      terminate_interaction 1
-    end
-  end
-
   def check_version # :nodoc:
     if options[:version] != Gem::Requirement.default &&
        get_all_gem_names.size > 1
@@ -162,7 +155,6 @@ You can use `i` command instead of `install`.
 
     ENV.delete "GEM_PATH" if options[:install_dir].nil?
 
-    check_install_dir
     check_version
 
     load_hooks

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -189,12 +189,6 @@ class Gem::Installer
     @package.prog_mode = options[:prog_mode]
     @package.data_mode = options[:data_mode]
 
-    if options[:user_install]
-      @gem_home = Gem.user_dir
-      @bin_dir = Gem.bindir gem_home unless options[:bin_dir]
-      @plugins_dir = Gem.plugindir(gem_home)
-    end
-
     if @gem_home == Gem.user_dir
       # If we get here, then one of the following likely happened:
       # - `--user-install` was specified
@@ -673,21 +667,26 @@ class Gem::Installer
     @env_shebang         = options[:env_shebang]
     @force               = options[:force]
     @install_dir         = options[:install_dir]
-    @gem_home            = options[:install_dir] || Gem.dir
-    @plugins_dir         = Gem.plugindir(@gem_home)
     @ignore_dependencies = options[:ignore_dependencies]
     @format_executable   = options[:format_executable]
     @wrappers            = options[:wrappers]
     @only_install_dir    = options[:only_install_dir]
 
-    # If the user has asked for the gem to be installed in a directory that is
-    # the system gem directory, then use the system bin directory, else create
-    # (or use) a new bin dir under the gem_home.
-    @bin_dir             = options[:bin_dir] || Gem.bindir(gem_home)
+    @bin_dir             = options[:bin_dir]
     @development         = options[:development]
     @build_root          = options[:build_root]
 
     @build_args = options[:build_args]
+
+    @gem_home = @install_dir
+    @gem_home ||= options[:user_install] ? Gem.user_dir : Gem.dir
+
+    # If the user has asked for the gem to be installed in a directory that is
+    # the system gem directory, then use the system bin directory, else create
+    # (or use) a new bin dir under the gem_home.
+    @bin_dir ||= Gem.bindir(@gem_home)
+
+    @plugins_dir = Gem.plugindir(@gem_home)
 
     unless @build_root.nil?
       @bin_dir = File.join(@build_root, @bin_dir.gsub(/^[a-zA-Z]:/, ""))

--- a/test/rubygems/installer_test_case.rb
+++ b/test/rubygems/installer_test_case.rb
@@ -111,7 +111,7 @@ class Gem::InstallerTestCase < Gem::TestCase
 
   def setup_base_installer(force = true)
     @gem = setup_base_gem
-    util_installer @spec, @gemhome, false, force
+    util_installer @spec, @gemhome, force
   end
 
   ##
@@ -163,7 +163,7 @@ class Gem::InstallerTestCase < Gem::TestCase
 
     @user_gem = @user_spec.cache_file
 
-    util_installer @user_spec, Gem.user_dir, :user
+    Gem::Installer.at @user_gem, :user_install => true
   end
 
   ##
@@ -219,13 +219,11 @@ class Gem::InstallerTestCase < Gem::TestCase
   end
 
   ##
-  # Creates an installer for +spec+ that will install into +gem_home+.  If
-  # +user+ is true a user-install will be performed.
+  # Creates an installer for +spec+ that will install into +gem_home+.
 
-  def util_installer(spec, gem_home, user=false, force=true)
+  def util_installer(spec, gem_home, force=true)
     Gem::Installer.at(spec.cache_file,
                        :install_dir => gem_home,
-                       :user_install => user,
                        :force => force)
   end
 

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -436,21 +436,6 @@ ERROR:  Possible alternatives: non_existent_with_hint
     assert_equal expected, output
   end
 
-  def test_execute_conflicting_install_options
-    @cmd.options[:user_install] = true
-    @cmd.options[:install_dir] = "whatever"
-
-    use_ui @ui do
-      assert_raise Gem::MockGemUi::TermError do
-        @cmd.execute
-      end
-    end
-
-    expected = "ERROR:  Use --install-dir or --user-install but not both\n"
-
-    assert_equal expected, @ui.error
-  end
-
   def test_execute_prerelease_skipped_when_no_flag_set
     spec_fetcher do |fetcher|
       fetcher.gem "a", 1

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -995,6 +995,19 @@ end
     assert_equal @tempdir, installer.bin_dir
   end
 
+  def test_install_dir_takes_precedence_to_user_install
+    gemhome2 = "#{@gemhome}2"
+
+    @gem = setup_base_gem
+
+    installer =
+      Gem::Installer.at @gem, :install_dir => gemhome2, :user_install => true
+    installer.install
+
+    assert_path_exist File.join(gemhome2, "gems", @spec.full_name)
+    assert_path_not_exist File.join(Gem.user_dir, "gems", @spec.full_name)
+  end
+
   def test_install
     installer = util_setup_installer
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -821,7 +821,7 @@ gem 'other', version
     File.chmod(0o555, Gem.plugindir)
     system_path = File.join(Gem.plugindir, "a_plugin.rb")
     user_path = File.join(Gem.plugindir(Gem.user_dir), "a_plugin.rb")
-    installer = util_installer spec, Gem.dir, :user
+    installer = Gem::Installer.at spec.cache_file, :user_install => true, :force => true
 
     assert_equal spec, installer.install
 


### PR DESCRIPTION
This is an attempt to make the user install less exceptional. It does several things:

1) It removes the arbitrary limitation that the `--install-dir` and `--user-install` can't be specified at once on command line. This was not the case internally anyway. Now the `--install-dir` simple overrides the `--user-install`.
2) It refactors the code in an attempt to make it more readable. Therefore now if `--build-root` option is specified, it is applied to every possible path, including the user install case. I am not 100% convinced that this really is the right thing, OTOH it should not harm anything, because using `--build-root` is very specific and use it together with `--user-install` would be exceptional

This is an attempt to address some concerns I have risen in #7083