### PR TITLE
Handle CI configuration on ignore list for Gem::Specification#files

### DIFF
--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -137,10 +137,13 @@ module Bundler
       case config[:ci]
       when "github"
         templates.merge!("github/workflows/main.yml.tt" => ".github/workflows/main.yml")
+        config[:ci_config_path] = ".github "
       when "gitlab"
         templates.merge!("gitlab-ci.yml.tt" => ".gitlab-ci.yml")
+        config[:ci_config_path] = ".gitlab-ci.yml "
       when "circle"
         templates.merge!("circleci/config.yml.tt" => ".circleci/config.yml")
+        config[:ci_config_path] = ".circleci "
       end
 
       if ask_and_set(:mit, "Do you want to license your code permissively under the MIT license?",

--- a/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |f|
       (File.expand_path(f) == __FILE__) ||
-        f.start_with?(*%w[bin/ test/ spec/ features/ .git .circleci appveyor Gemfile])
+        f.start_with?(*%w[bin/ test/ spec/ features/ .git <%= config[:ci_config_path] %>appveyor Gemfile])
     end
   end
   spec.bindir = "exe"

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -960,6 +960,12 @@ RSpec.describe "bundle gem" do
 
         expect(bundled_app("#{gem_name}/.github/workflows/main.yml")).to exist
       end
+
+      it "contained .gitlab-ci.yml into ignore list" do
+        bundle "gem #{gem_name} --ci=github"
+
+        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to include(".git .github appveyor")
+      end
     end
 
     context "--ci set to gitlab" do
@@ -968,6 +974,12 @@ RSpec.describe "bundle gem" do
 
         expect(bundled_app("#{gem_name}/.gitlab-ci.yml")).to exist
       end
+
+      it "contained .gitlab-ci.yml into ignore list" do
+        bundle "gem #{gem_name} --ci=gitlab"
+
+        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to include(".git .gitlab-ci.yml appveyor")
+      end
     end
 
     context "--ci set to circle" do
@@ -975,6 +987,12 @@ RSpec.describe "bundle gem" do
         bundle "gem #{gem_name} --ci=circle"
 
         expect(bundled_app("#{gem_name}/.circleci/config.yml")).to exist
+      end
+
+      it "contained .circleci into ignore list" do
+        bundle "gem #{gem_name} --ci=circle"
+
+        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to include(".git .circleci appveyor")
       end
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Fixes https://github.com/rubygems/rubygems/issues/7087

## What is your fix for the problem, implemented in this PR?

Handle configuration files each CI services.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
