### PR TITLE
Raise exception on unexpected EOF in marshal

### DIFF
--- a/lib/rubygems/safe_marshal/reader.rb
+++ b/lib/rubygems/safe_marshal/reader.rb
@@ -17,6 +17,9 @@ module Gem
       class NotImplementedError < Error
       end
 
+      class EOFError < Error
+      end
+
       def initialize(io)
         @io = io
       end
@@ -64,6 +67,8 @@ module Gem
           read_byte | (read_byte << 8) | -0x10000
         when 0xFF
           read_byte | -0x100
+        when nil
+          raise EOFError, "Unexpected EOF"
         else
           signed = (b ^ 128) - 128
           if b >= 128
@@ -102,6 +107,8 @@ module Gem
         when 47 then read_regexp # ?/
         when 83 then read_struct # ?S
         when 67 then read_user_class # ?C
+        when nil
+          raise EOFError, "Unexpected EOF"
         else
           raise Error, "Unknown marshal type discriminator #{type.chr.inspect} (#{type})"
         end

--- a/test/rubygems/test_gem_safe_marshal.rb
+++ b/test/rubygems/test_gem_safe_marshal.rb
@@ -310,6 +310,23 @@ class TestGemSafeMarshal < Gem::TestCase
     assert_equal e.message, "Attempting to set unpermitted ivar \"@foobar\" on object of class Hash @ root.[18].ivar_0"
   end
 
+  def test_unexpected_eof
+    e = assert_raise(Gem::SafeMarshal::Reader::EOFError) do
+      Gem::SafeMarshal.safe_load("\x04\x08")
+    end
+    assert_equal e.message, "Unexpected EOF"
+
+    e = assert_raise(Gem::SafeMarshal::Reader::EOFError) do
+      Gem::SafeMarshal.safe_load("\x04\x08[")
+    end
+    assert_equal e.message, "Unexpected EOF"
+
+    e = assert_raise(Gem::SafeMarshal::Reader::EOFError) do
+      Gem::SafeMarshal.safe_load("\x04\x08[\x06")
+    end
+    assert_equal e.message, "Unexpected EOF"
+  end
+
   def assert_safe_load_marshal(dumped, additional_methods: [], permitted_ivars: nil, equality: true, marshal_dump_equality: true)
     loaded = Marshal.load(dumped)
     safe_loaded =


### PR DESCRIPTION
Instead of NoMethodError being raised by accidentally trying to use nil
