### PR TITLE
Avoid regexp match on every call to `Gem::Platform.local`

### DIFF
--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -13,9 +13,11 @@ class Gem::Platform
   attr_accessor :cpu, :os, :version
 
   def self.local
-    arch = RbConfig::CONFIG["arch"]
-    arch = "#{arch}_60" if /mswin(?:32|64)$/.match?(arch)
-    @local ||= new(arch)
+    @local ||= begin
+      arch = RbConfig::CONFIG["arch"]
+      arch = "#{arch}_60" if /mswin(?:32|64)$/.match?(arch)
+      new(arch)
+    end
   end
 
   def self.match(platform)


### PR DESCRIPTION
The result of `arch` would be ignored if `@local` is set, so wrap all
the logic in `@local ||=` to short-circuit everything
