### PR TITLE
Set file path when eval-ing local specification in EndpointSpecification

### DIFF
--- a/bundler/lib/bundler/endpoint_specification.rb
+++ b/bundler/lib/bundler/endpoint_specification.rb
@@ -94,7 +94,7 @@ module Bundler
 
     def _local_specification
       return unless @loaded_from && File.exist?(local_specification_path)
-      eval(File.read(local_specification_path)).tap do |spec|
+      eval(File.read(local_specification_path), nil, local_specification_path).tap do |spec|
         spec.loaded_from = @loaded_from
       end
     end


### PR DESCRIPTION
Not strictly necessary, but there is no reason not to be helpful and set the path
