### PR TITLE
Remove unnecessary rescue

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -356,11 +356,6 @@ class Gem::Installer
     run_post_install_hooks
 
     spec
-
-  # TODO: This rescue is in the wrong place. What is raising this exception?
-  # move this rescue to around the code that actually might raise it.
-  rescue Zlib::GzipFile::Error
-    raise Gem::InstallError, "gzip error installing #{gem}"
   end
 
   def run_pre_install_hooks # :nodoc:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Nothing, just found this TODO while working on something else and thought I'd fix it.

## What is your fix for the problem, implemented in this PR?

This error is already rescued at `Gem::Package` and re-raised as `Gem::Package::FormatError`. So it should not be needed here.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
