### PR TITLE
Don't show bug report template when GEM_HOME has no writable bit

### DIFF
--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -45,6 +45,14 @@ module Bundler
       spec
     end
 
+    def pre_install_checks
+      super
+    rescue Gem::FilePermissionError
+      # Ignore permission checks in RubyGems. Instead, go on, and try to write
+      # for real. We properly handle permission errors when they happen.
+      nil
+    end
+
     def generate_plugins
       return unless Gem::Installer.instance_methods(false).include?(:generate_plugins)
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bug report template being displayed to users:  https://github.com/rubygems/rubygems/discussions/7111.

## What is your fix for the problem, implemented in this PR?

My fix is to remove raising if GEM_HOME does not satisfy `File.writable?`.

Instead, don't check that at all and proceed.

If something fails to be written inside GEM_HOME, we'll eventually fail with a proper permissions error.

In addition to that, the writable bit in GEM_HOME is not even reliable, because only the immediate parent is actually checked when writing. For example,

```
$ mkdir -p foo/bar
$ chmod -w foo
$ touch foo/bar/baz # writes without issue
```

Closes https://github.com/rubygems/rubygems/discussions/7111.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
