### PR TITLE
Support again Pathname objects in the replaced require

### DIFF
--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -244,6 +244,7 @@ module Bundler
       [::Kernel.singleton_class, ::Kernel].each do |kernel_class|
         kernel_class.send(:alias_method, :no_warning_require, :require)
         kernel_class.send(:define_method, :require) do |name|
+          name = File.path(name)
           if message = ::Gem::BUNDLED_GEMS.warning?(name, specs: specs) # rubocop:disable Style/HashSyntax
             warn message, :uplevel => 1
           end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?
So I am trying to try shoulda-matches ( https://github.com/thoughtbot/shoulda-matchers/commit/a5e3133296b5443340e92f06039f751a92935e38 ) test suite and it fails a lot like:

```
An error occurred while loading ./spec/unit/shoulda/matchers/routing/route_matcher_spec.rb.
Failure/Error: require 'unit_spec_helper'

NoMethodError:
  undefined method `tr' for an instance of Pathname
# /builddir/build/BUILD/spec/support/unit/rails_application.rb:170:in `load_environment'
# /builddir/build/BUILD/spec/support/unit/rails_application.rb:27:in `load'
# /builddir/build/BUILD/spec/support/unit/load_environment.rb:8:in `<top (required)>'
# /builddir/build/BUILD/spec/unit_spec_helper.rb:1:in `require_relative'
# /builddir/build/BUILD/spec/unit_spec_helper.rb:1:in `<top (required)>'
# ./spec/unit/shoulda/matchers/routing/route_matcher_spec.rb:1:in `<top (required)>'
# /usr/share/gems/gems/bundler-2.5.0.dev/libexec/bundle:37:in `block in <top (required)>'
# /usr/share/gems/gems/bundler-2.5.0.dev/libexec/bundle:29:in `<top (required)>'
```

`unit/rails_application.rb: 170` is  https://github.com/thoughtbot/shoulda-matchers/blob/a5e3133296b5443340e92f06039f751a92935e38/spec/support/unit/rails_application.rb#L170

So it seems that it is expected that replaced require supports Pathname objects, once it was modified so:
https://github.com/rubygems/rubygems/pull/6837

But again it seems this support got broken by:
https://github.com/rubygems/rubygems/pull/7056

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?
This patch enables support again for Pathname objects in the replaced require, as is done as https://github.com/rubygems/rubygems/pull/6837 , which is a bit modified as https://github.com/rubygems/rubygems/pull/6839

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
