### PR TITLE
Devcontainer / Github Codespace

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,27 @@
+ARG RUBY_VERSION=3.2
+
+FROM ruby:${RUBY_VERSION}-alpine
+
+ENV USERNAME=vscode \
+    UID=1000 \
+    GID=1000
+
+# Install the git-credential-manager package via the dotnet tooling to 
+RUN apk update && apk add --no-cache \
+    github-cli \
+    git \
+    build-base \
+    bash \
+    mandoc \
+    man-pages \
+    sudo
+
+# create non-root group and user
+RUN addgroup -g $GID $USERNAME \
+    && adduser -s /bin/bash -u $UID -G $USERNAME $USERNAME --disabled-password --gecos ""
+
+# set sudo permissions for vscode user
+RUN echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME
+RUN chmod 0440 /etc/sudoers.d/$USERNAME
+
+USER $USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+{
+	"name": "RubyGems",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"remoteUser": "vscode",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"onCreateCommand": "rake setup",
+	// Use 'updateContentCommand' to run commands when the container is updated.
+	"updateContentCommand": "rake update",
+	// Configure tool-specific properties.
+	"containerEnv": {
+		"EDITOR": "code --wait",
+		"GIT_EDITOR": "code --wait"
+	},
+	"customizations": {
+		"codespaces": {
+			"openFiles": [
+				"README.md",
+				"CONTRIBUTING.md"
+			]
+		},
+		"vscode": {
+			"extensions": [
+				"Shopify.ruby-lsp"
+			]
+		}
+	}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,31 +1,31 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 {
-	"name": "RubyGems",
-	"build": {
-		"dockerfile": "Dockerfile"
-	},
-	"remoteUser": "vscode",
-	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"onCreateCommand": "rake setup",
-	// Use 'updateContentCommand' to run commands when the container is updated.
-	"updateContentCommand": "rake update",
-	// Configure tool-specific properties.
-	"containerEnv": {
-		"EDITOR": "code --wait",
-		"GIT_EDITOR": "code --wait"
-	},
-	"customizations": {
-		"codespaces": {
-			"openFiles": [
-				"README.md",
-				"CONTRIBUTING.md"
-			]
-		},
-		"vscode": {
-			"extensions": [
-				"Shopify.ruby-lsp"
-			]
-		}
-	}
+  "name": "RubyGems",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "remoteUser": "vscode",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "onCreateCommand": "rake setup",
+  // Use 'updateContentCommand' to run commands when the container is updated.
+  "updateContentCommand": "rake update",
+  // Configure tool-specific properties.
+  "containerEnv": {
+    "EDITOR": "code --wait",
+    "GIT_EDITOR": "code --wait"
+  },
+  "customizations": {
+    "codespaces": {
+      "openFiles": [
+        "README.md",
+        "CONTRIBUTING.md"
+      ]
+    },
+    "vscode": {
+      "extensions": [
+        "Shopify.ruby-lsp"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Next week, contributors from the RubyGems/RubyGems.org/Bundler team will be attending the [RubyConf community day](https://rubyconf.org/faq#community-day), a day where attendees can meet face-to-face with Ruby Open-Source maintainers and learn the ins-and-outs of projects and possibly look to make some contributions.

To cut down on setup time and having maintainers fidgeting with various differing environments, I want to provide a way to  create environments super easily and have people onboarded with as little hassle as possible. 

## What is your fix for the problem, implemented in this PR?

This Pull Request adds [https://containers.dev](devcontainer ) / [GitHub Codespace](https://docs.github.com/en/codespaces/overview) configuration that automates:
* Setting up an isolated development environment
* Installs the necessary OS / Language / Library packages
* Setups the project to be ready for development.

After setup has been completed, users can then start writing code and testing their changes as if it were running on a MacBook / Linux Laptop.

## Notes

The devcontainer setup is fairly straightforward, but I made a trade-off with the Docker image the devcontainer is loaded into. Microsoft ships a [Ruby devcontainer](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/ruby) image, which unfortunately uses the RVM tool to install and manage the Ruby Environment. We could manipulate the environment to not involve RVM, but I felt it was too confusing, and instead we should opt to use the well-known [base Ruby image](https://hub.docker.com/_/ruby/).

The trade-off for this means that we need to set up the devcontainer ourselves by:
* installing the required packages
* create a non-root user

But I'm confident this does not add much complexity that places a burden on maintainers and any issues couldn't be easily resolved.