### PR TITLE
bundle lock/install --checksums

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -214,6 +214,8 @@ module Bundler
       "Install using defaults tuned for deployment environments"
     method_option "frozen", :type => :boolean, :banner =>
       "Do not allow the Gemfile.lock to be updated after this install"
+    method_option "checksums", :type => :boolean, :default => false, :banner =>
+      "Enable gem checksum verification"
     method_option "full-index", :type => :boolean, :banner =>
       "Fall back to using the single-file index of all gems"
     method_option "gemfile", :type => :string, :banner =>
@@ -658,6 +660,8 @@ module Bundler
       "do not attempt to fetch remote gemspecs and use the local gem cache only"
     method_option "print", :type => :boolean, :default => false, :banner =>
       "print the lockfile to STDOUT instead of writing to the file system"
+    method_option "checksums", :type => :boolean, :default => false, :banner =>
+      "Enable gem checksum verification"
     method_option "gemfile", :type => :string, :banner =>
       "Use the specified gemfile instead of Gemfile"
     method_option "lockfile", :type => :string, :default => nil, :banner =>

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -56,7 +56,7 @@ module Bundler
 
       Plugin.gemfile_install(Bundler.default_gemfile) if Bundler.feature_flag.plugins?
 
-      definition = Bundler.definition
+      definition = Bundler.definition(checksums: options["checksums"])
       definition.validate_runtime!
 
       installer = Installer.install(Bundler.root, definition, options)
@@ -166,6 +166,10 @@ module Bundler
       Bundler.settings.set_command_option_if_given :no_install, options["no-install"]
 
       Bundler.settings.set_command_option_if_given :clean, options["clean"]
+
+      if Bundler.settings[:disable_checksum_validation] && options["checksums"]
+        raise InvalidOption, "Cannot specify --checksums with bundle config disable_checksum_validation true"
+      end
 
       normalize_groups if options[:without] || options[:with]
 

--- a/bundler/lib/bundler/cli/lock.rb
+++ b/bundler/lib/bundler/cli/lock.rb
@@ -31,7 +31,14 @@ module Bundler
         update = { :conservative => conservative }
       elsif update && bundler
         update = { :bundler => bundler }
+      else
+        update = { :update => update }
       end
+
+      if Bundler.settings[:disable_checksum_validation] && options[:checksums]
+        raise InvalidOption, "Cannot specify --checksums with bundle config disable_checksum_validation true"
+      end
+      update[:checksums] = options[:checksums]
 
       Bundler.settings.temporary(:frozen => false) do
         definition = Bundler.definition(update)

--- a/bundler/lib/bundler/lockfile_generator.rb
+++ b/bundler/lib/bundler/lockfile_generator.rb
@@ -67,6 +67,7 @@ module Bundler
     end
 
     def add_checksums
+      return unless definition.locked_checksums
       checksums = definition.resolve.map do |spec|
         spec.source.checksum_store.to_lock(spec)
       end

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -56,6 +56,11 @@ RSpec.describe Bundler::Definition do
         s.add_dependency "rack", "1.0"
       end
 
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "foo", "1.0"
+        c.checksum gem_repo1, "rack", "1.0.0"
+      end
+
       bundle :install, :env => { "DEBUG" => "1" }
 
       expect(out).to match(/re-resolving dependencies/)
@@ -76,10 +81,7 @@ RSpec.describe Bundler::Definition do
 
         DEPENDENCIES
           foo!
-
-        CHECKSUMS
-          #{gem_no_checksum "foo", "1.0"}
-          #{checksum_for_repo_gem gem_repo1, "rack", "1.0.0"}
+        #{checksums}
 
         BUNDLED WITH
            #{Bundler::VERSION}
@@ -110,6 +112,11 @@ RSpec.describe Bundler::Definition do
         s.add_development_dependency "net-ssh", "1.0"
       end
 
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "foo", "1.0"
+        c.checksum gem_repo1, "rack", "1.0.0"
+      end
+
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "foo", :path => "#{lib_path("foo")}"
@@ -135,17 +142,17 @@ RSpec.describe Bundler::Definition do
 
         DEPENDENCIES
           foo!
-
-        CHECKSUMS
-          #{gem_no_checksum "foo", "1.0"}
-          #{checksum_for_repo_gem gem_repo1, "rack", "1.0.0"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       G
     end
 
     it "for a locked gem for another platform" do
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "only_java", "1.1", "java"
+      end
+
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "only_java", platform: :jruby
@@ -166,16 +173,17 @@ RSpec.describe Bundler::Definition do
 
         DEPENDENCIES
           only_java
-
-        CHECKSUMS
-          only_java (1.1-java)
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       G
     end
 
     it "for a rubygems gem" do
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo1, "foo", "1.0"
+      end
+
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "foo"
@@ -195,9 +203,7 @@ RSpec.describe Bundler::Definition do
 
         DEPENDENCIES
           foo
-
-        CHECKSUMS
-          #{checksum_for_repo_gem gem_repo1, "foo", "1.0"}
+        #{checksums}
 
         BUNDLED WITH
            #{Bundler::VERSION}

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -82,7 +82,6 @@ RSpec.describe Bundler::Definition do
         DEPENDENCIES
           foo!
         #{checksums}
-
         BUNDLED WITH
            #{Bundler::VERSION}
       G
@@ -204,7 +203,6 @@ RSpec.describe Bundler::Definition do
         DEPENDENCIES
           foo
         #{checksums}
-
         BUNDLED WITH
            #{Bundler::VERSION}
       G

--- a/bundler/spec/commands/check_spec.rb
+++ b/bundler/spec/commands/check_spec.rb
@@ -406,6 +406,12 @@ RSpec.describe "bundle check" do
     it "returns success when the Gemfile is satisfied and generates a correct lockfile" do
       system_gems "depends_on_rack-1.0", "rack-1.0", :gem_repo => gem_repo4, :path => default_bundle_path
       bundle :check
+
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "depends_on_rack", "1.0"
+        c.no_checksum "rack", "1.0"
+      end
+
       expect(out).to include("The Gemfile's dependencies are satisfied")
       expect(lockfile).to eq <<~L
         GEM
@@ -424,11 +430,7 @@ RSpec.describe "bundle check" do
 
         DEPENDENCIES
           depends_on_rack!
-
-        CHECKSUMS
-          depends_on_rack (1.0)
-          rack (1.0)
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -468,6 +470,12 @@ RSpec.describe "bundle check" do
 
       bundle "check --verbose", :dir => tmp.join("bundle-check-issue")
 
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo4, "awesome_print", "1.0"
+        c.no_checksum "bundle-check-issue", "9999"
+        c.checksum gem_repo2, "dex-dispatch-engine", "1.0"
+      end
+
       expect(File.read(tmp.join("bundle-check-issue/Gemfile.lock"))).to eq <<~L
         PATH
           remote: .
@@ -491,12 +499,7 @@ RSpec.describe "bundle check" do
         DEPENDENCIES
           bundle-check-issue!
           dex-dispatch-engine!
-
-        CHECKSUMS
-          #{checksum_for_repo_gem gem_repo4, "awesome_print", "1.0"}
-          bundle-check-issue (9999)
-          #{checksum_for_repo_gem gem_repo2, "dex-dispatch-engine", "1.0"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -1039,11 +1039,11 @@ RSpec.describe "bundle install with gem sources" do
         gem "loofah", "~> 2.12.0"
       G
 
-      checksums = checksum_section do |c|
-        c.repo_gem gem_repo4, "crass", "1.0.6"
-        c.repo_gem gem_repo4, "loofah", "2.12.0"
-        c.repo_gem gem_repo4, "nokogiri", "1.12.4", "x86_64-darwin"
-        c.repo_gem gem_repo4, "racca", "1.5.2"
+      checksums = checksums_section do |c|
+        c.checksum gem_repo4, "crass", "1.0.6"
+        c.checksum gem_repo4, "loofah", "2.12.0"
+        c.checksum gem_repo4, "nokogiri", "1.12.4", "x86_64-darwin"
+        c.checksum gem_repo4, "racca", "1.5.2"
       end
 
       lockfile <<-L
@@ -1064,10 +1064,7 @@ RSpec.describe "bundle install with gem sources" do
 
         DEPENDENCIES
           loofah (~> 2.12.0)
-
-        CHECKSUMS
-          #{checksums}
-
+        #{checksums}
         RUBY VERSION
            #{Bundler::RubyVersion.system}
 
@@ -1083,13 +1080,7 @@ RSpec.describe "bundle install with gem sources" do
         bundle "install", :artifice => "compact_index"
       end
 
-      expected_checksums = checksum_section do |c|
-        c.repo_gem gem_repo4, "crass", "1.0.6"
-        c.repo_gem gem_repo4, "loofah", "2.12.0"
-        c.repo_gem gem_repo4, "nokogiri", "1.12.4", "x86_64-darwin"
-        c.repo_gem gem_repo4, "nokogiri", "1.12.4", "x86_64-linux"
-        c.repo_gem gem_repo4, "racca", "1.5.2"
-      end
+      checksums.checksum(gem_repo4, "nokogiri", "1.12.4", "x86_64-linux")
 
       expect(lockfile).to eq <<~L
         GEM
@@ -1111,10 +1102,7 @@ RSpec.describe "bundle install with gem sources" do
 
         DEPENDENCIES
           loofah (~> 2.12.0)
-
-        CHECKSUMS
-          #{expected_checksums}
-
+        #{checksums}
         RUBY VERSION
            #{Bundler::RubyVersion.system}
 

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -587,6 +587,7 @@ RSpec.describe "bundle install with gem sources" do
       end
 
       it "writes current Ruby version to Gemfile.lock" do
+        checksums = checksums_section_when_existing
         expect(lockfile).to eq <<~L
          GEM
            remote: #{file_uri_for(gem_repo1)}/
@@ -596,9 +597,7 @@ RSpec.describe "bundle install with gem sources" do
            #{lockfile_platforms}
 
          DEPENDENCIES
-
-         CHECKSUMS
-
+         #{checksums}
          RUBY VERSION
             #{Bundler::RubyVersion.system}
 
@@ -613,6 +612,8 @@ RSpec.describe "bundle install with gem sources" do
           source "#{file_uri_for(gem_repo1)}"
         G
 
+        checksums = checksums_section_when_existing
+
         expect(lockfile).to eq <<~L
          GEM
            remote: #{file_uri_for(gem_repo1)}/
@@ -622,9 +623,7 @@ RSpec.describe "bundle install with gem sources" do
            #{lockfile_platforms}
 
          DEPENDENCIES
-
-         CHECKSUMS
-
+         #{checksums}
          RUBY VERSION
             #{Bundler::RubyVersion.system}
 
@@ -1080,7 +1079,13 @@ RSpec.describe "bundle install with gem sources" do
         bundle "install", :artifice => "compact_index"
       end
 
-      checksums.checksum(gem_repo4, "nokogiri", "1.12.4", "x86_64-linux")
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "crass", "1.0.6"
+        c.no_checksum "loofah", "2.12.0"
+        c.no_checksum "nokogiri", "1.12.4", "x86_64-darwin"
+        c.no_checksum "racca", "1.5.2"
+        c.no_checksum "nokogiri", "1.12.4", "x86_64-linux"
+      end
 
       expect(lockfile).to eq <<~L
         GEM

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -1126,9 +1126,7 @@ RSpec.describe "bundle lock" do
 
         DEPENDENCIES
           debug
-
-        CHECKSUMS
-
+        #{checksums_section}
         BUNDLED WITH
            #{Bundler::VERSION}
       L

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -11,16 +11,16 @@ RSpec.describe "bundle lock" do
       gem "foo"
     G
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem repo, "actionmailer", "2.3.2"
-      c.repo_gem repo, "actionpack", "2.3.2"
-      c.repo_gem repo, "activerecord", "2.3.2"
-      c.repo_gem repo, "activeresource", "2.3.2"
-      c.repo_gem repo, "activesupport", "2.3.2"
-      c.repo_gem repo, "foo", "1.0"
-      c.repo_gem repo, "rails", "2.3.2"
-      c.repo_gem repo, "rake", "13.0.1"
-      c.repo_gem repo, "weakling", "0.0.3"
+    checksums = checksums_section do |c|
+      c.checksum repo, "actionmailer", "2.3.2"
+      c.checksum repo, "actionpack", "2.3.2"
+      c.checksum repo, "activerecord", "2.3.2"
+      c.checksum repo, "activeresource", "2.3.2"
+      c.checksum repo, "activesupport", "2.3.2"
+      c.checksum repo, "foo", "1.0"
+      c.checksum repo, "rails", "2.3.2"
+      c.checksum repo, "rake", "13.0.1"
+      c.checksum repo, "weakling", "0.0.3"
     end
 
     @lockfile = <<~L
@@ -53,10 +53,7 @@ RSpec.describe "bundle lock" do
         foo
         rails
         weakling
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -65,13 +62,11 @@ RSpec.describe "bundle lock" do
   it "prints a lockfile when there is no existing lockfile with --print" do
     bundle "lock --print"
 
-    # No checksums because no way to get them from a file uri source
-    # + no existing lockfile that has them
-    expect(out).to eq(remove_checksums_from_lockfile(@lockfile.chomp))
+    expect(out).to eq(@lockfile.chomp)
   end
 
   it "prints a lockfile when there is an existing lockfile with --print" do
-    lockfile @lockfile
+    lockfile remove_checksums_section_from_lockfile(@lockfile)
 
     bundle "lock --print"
 
@@ -81,26 +76,47 @@ RSpec.describe "bundle lock" do
   it "writes a lockfile when there is no existing lockfile" do
     bundle "lock"
 
+    expect(read_lockfile).to eq(@lockfile)
+  end
+
+  it "writes a lockfile when there is no existing lockfile" do
+    bundle "lock"
+
     # No checksums because no way to get them from a file uri source
     # + no existing lockfile that has them
-    expect(read_lockfile).to eq(remove_checksums_from_lockfile(@lockfile))
+    expect(read_lockfile).to eq(@lockfile)
+  end
+
+  it "prints a lockfile without fetching new checksums if the existing lockfile had no checksums" do
+    lockfile remove_checksums_from_lockfile(@lockfile)
+
+    bundle "lock --print"
+
+    expect(out).to eq(remove_checksums_from_lockfile(@lockfile))
   end
 
   it "writes a lockfile when there is an outdated lockfile using --update" do
+    lockfile remove_checksums_from_lockfile(@lockfile.gsub("2.3.2", "2.3.1"), " (2.3.1)")
+
+    bundle "lock --update"
+
+    expect(read_lockfile).to eq(remove_checksums_from_lockfile(@lockfile))
+  end
+
+  it "writes a lockfile with checksums on --update when checksums exist" do
     lockfile @lockfile.gsub("2.3.2", "2.3.1")
 
     bundle "lock --update"
 
-    expect(read_lockfile).to eq(remove_checksums_from_lockfile(@lockfile, "(2.3.2)"))
+    expect(read_lockfile).to eq(@lockfile)
   end
 
-  it "writes a lockfile when there is an outdated lockfile using a bundle is frozen" do
+  it "writes a lockfile when there is an outdated lockfile and bundle is frozen" do
     lockfile @lockfile.gsub("2.3.2", "2.3.1")
 
     bundle "lock --update", :env => { "BUNDLE_FROZEN" => "true" }
 
-    # No checksums for the updated gems
-    expect(read_lockfile).to eq(remove_checksums_from_lockfile(@lockfile, "(2.3.2)"))
+    expect(read_lockfile).to eq(@lockfile)
   end
 
   it "does not fetch remote specs when using the --local option" do
@@ -109,11 +125,24 @@ RSpec.describe "bundle lock" do
     expect(err).to match(/locally installed gems/)
   end
 
+  it "does not fetch remote checksums with --local" do
+    lockfile remove_checksums_from_lockfile(@lockfile)
+
+    bundle "lock --print --local"
+
+    # No checksums because --local prevents fetching them
+    expect(out).to eq(remove_checksums_from_lockfile(@lockfile).chomp)
+  end
+
   it "works with --gemfile flag" do
     create_file "CustomGemfile", <<-G
       source "#{file_uri_for(repo)}"
       gem "foo"
     G
+    checksums = checksums_section do |c|
+      c.no_checksum "foo", "1.0"
+    end
+
     lockfile = <<~L
       GEM
         remote: #{file_uri_for(repo)}/
@@ -125,10 +154,7 @@ RSpec.describe "bundle lock" do
 
       DEPENDENCIES
         foo
-
-      CHECKSUMS
-        #{gem_no_checksum "foo", "1.0"}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -151,16 +177,16 @@ RSpec.describe "bundle lock" do
     bundle "install"
     bundle "lock --lockfile=lock"
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem repo, "actionmailer", "2.3.2"
-      c.repo_gem repo, "actionpack", "2.3.2"
-      c.repo_gem repo, "activerecord", "2.3.2"
-      c.repo_gem repo, "activeresource", "2.3.2"
-      c.repo_gem repo, "activesupport", "2.3.2"
-      c.repo_gem repo, "foo", "1.0"
-      c.repo_gem repo, "rails", "2.3.2"
-      c.repo_gem repo, "rake", "13.0.1"
-      c.repo_gem repo, "weakling", "0.0.3"
+    checksums = checksums_section do |c|
+      c.checksum repo, "actionmailer", "2.3.2"
+      c.checksum repo, "actionpack", "2.3.2"
+      c.checksum repo, "activerecord", "2.3.2"
+      c.checksum repo, "activeresource", "2.3.2"
+      c.checksum repo, "activesupport", "2.3.2"
+      c.checksum repo, "foo", "1.0"
+      c.checksum repo, "rails", "2.3.2"
+      c.checksum repo, "rake", "13.0.1"
+      c.checksum repo, "weakling", "0.0.3"
     end
 
     lockfile = <<~L
@@ -193,10 +219,7 @@ RSpec.describe "bundle lock" do
         foo
         rails
         weakling
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -510,6 +533,11 @@ RSpec.describe "bundle lock" do
       end
     end
 
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo4, "nokogiri", "1.12.0"
+      c.checksum gem_repo4, "nokogiri", "1.12.0", "x86_64-darwin"
+    end
+
     simulate_platform "x86_64-darwin-22" do
       install_gemfile <<~G
         source "#{file_uri_for(gem_repo4)}"
@@ -531,14 +559,12 @@ RSpec.describe "bundle lock" do
 
       DEPENDENCIES
         nokogiri
-
-      CHECKSUMS
-        #{checksum_for_repo_gem gem_repo4, "nokogiri", "1.12.0"}
-        #{checksum_for_repo_gem gem_repo4, "nokogiri", "1.12.0", "x86_64-darwin"}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
+
+    checksums.delete("nokogiri", "1.12.0", Gem::Platform::RUBY)
 
     simulate_platform "x86_64-darwin-22" do
       bundle "lock --remove-platform ruby"
@@ -555,10 +581,7 @@ RSpec.describe "bundle lock" do
 
       DEPENDENCIES
         nokogiri
-
-      CHECKSUMS
-        #{checksum_for_repo_gem gem_repo4, "nokogiri", "1.12.0", "x86_64-darwin"}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -606,6 +629,13 @@ RSpec.describe "bundle lock" do
       gem "gssapi"
     G
 
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "ffi", "1.9.14", "x86-mingw32"
+      c.no_checksum "gssapi", "1.2.0"
+      c.no_checksum "mixlib-shellout", "2.2.6", "universal-mingw32"
+      c.no_checksum "win32-process", "0.8.3"
+    end
+
     simulate_platform(x86_mingw32) { bundle :lock }
 
     expect(lockfile).to eq <<~G
@@ -626,19 +656,16 @@ RSpec.describe "bundle lock" do
       DEPENDENCIES
         gssapi
         mixlib-shellout
-
-      CHECKSUMS
-        #{gem_no_checksum "ffi", "1.9.14", "x86-mingw32"}
-        #{gem_no_checksum "gssapi", "1.2.0"}
-        #{gem_no_checksum "mixlib-shellout", "2.2.6", "universal-mingw32"}
-        #{gem_no_checksum "win32-process", "0.8.3"}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
 
     bundle "config set --local force_ruby_platform true"
     bundle :lock
+
+    checksums.no_checksum "ffi", "1.9.14"
+    checksums.no_checksum "mixlib-shellout", "2.2.6"
 
     expect(lockfile).to eq <<~G
       GEM
@@ -661,15 +688,7 @@ RSpec.describe "bundle lock" do
       DEPENDENCIES
         gssapi
         mixlib-shellout
-
-      CHECKSUMS
-        #{gem_no_checksum "ffi", "1.9.14"}
-        #{gem_no_checksum "ffi", "1.9.14", "x86-mingw32"}
-        #{gem_no_checksum "gssapi", "1.2.0"}
-        #{gem_no_checksum "mixlib-shellout", "2.2.6"}
-        #{gem_no_checksum "mixlib-shellout", "2.2.6", "universal-mingw32"}
-        #{gem_no_checksum "win32-process", "0.8.3"}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -735,6 +754,11 @@ RSpec.describe "bundle lock" do
 
     simulate_platform(Gem::Platform.new("x86_64-darwin-19")) { bundle "lock" }
 
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "libv8", "8.4.255.0", "x86_64-darwin-19"
+      c.no_checksum "libv8", "8.4.255.0", "x86_64-darwin-20"
+    end
+
     expect(lockfile).to eq <<~G
       GEM
         remote: #{file_uri_for(gem_repo4)}/
@@ -748,11 +772,7 @@ RSpec.describe "bundle lock" do
 
       DEPENDENCIES
         libv8
-
-      CHECKSUMS
-        #{gem_no_checksum "libv8", "8.4.255.0", "x86_64-darwin-19"}
-        #{gem_no_checksum "libv8", "8.4.255.0", "x86_64-darwin-20"}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -767,6 +787,11 @@ RSpec.describe "bundle lock" do
       build_gem "libv8", "8.4.255.0" do |s|
         s.platform = "x86_64-darwin-20"
       end
+    end
+
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo4, "libv8", "8.4.255.0", "x86_64-darwin-19"
+      c.checksum gem_repo4, "libv8", "8.4.255.0", "x86_64-darwin-20"
     end
 
     gemfile <<-G
@@ -787,11 +812,7 @@ RSpec.describe "bundle lock" do
 
       DEPENDENCIES
         libv8
-
-      CHECKSUMS
-        #{checksum_for_repo_gem gem_repo4, "libv8", "8.4.255.0", "x86_64-darwin-19"}
-        #{checksum_for_repo_gem gem_repo4, "libv8", "8.4.255.0", "x86_64-darwin-20"}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -960,16 +981,16 @@ RSpec.describe "bundle lock" do
     it "does not implicitly update" do
       bundle "lock"
 
-      expected_checksums = checksum_section do |c|
-        c.repo_gem repo, "actionmailer", "2.3.2"
-        c.repo_gem repo, "actionpack", "2.3.2"
-        c.repo_gem repo, "activerecord", "2.3.2"
-        c.repo_gem repo, "activeresource", "2.3.2"
-        c.repo_gem repo, "activesupport", "2.3.2"
-        c.repo_gem repo, "foo", "1.0"
-        c.repo_gem repo, "rails", "2.3.2"
-        c.repo_gem repo, "rake", "13.0.1"
-        c.repo_gem repo, "weakling", "0.0.3"
+      checksums = checksums_section do |c|
+        c.checksum repo, "actionmailer", "2.3.2"
+        c.checksum repo, "actionpack", "2.3.2"
+        c.checksum repo, "activerecord", "2.3.2"
+        c.checksum repo, "activeresource", "2.3.2"
+        c.checksum repo, "activesupport", "2.3.2"
+        c.checksum repo, "foo", "1.0"
+        c.checksum repo, "rails", "2.3.2"
+        c.checksum repo, "rake", "13.0.1"
+        c.checksum repo, "weakling", "0.0.3"
       end
 
       expected_lockfile = <<~L
@@ -1002,10 +1023,7 @@ RSpec.describe "bundle lock" do
           foo
           rails
           weakling
-
-        CHECKSUMS
-          #{expected_checksums}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -1017,16 +1035,16 @@ RSpec.describe "bundle lock" do
       gemfile gemfile.gsub('"foo"', '"foo", "2.0"')
       bundle "lock"
 
-      expected_checksums = checksum_section do |c|
-        c.repo_gem repo, "actionmailer", "2.3.2"
-        c.repo_gem repo, "actionpack", "2.3.2"
-        c.repo_gem repo, "activerecord", "2.3.2"
-        c.repo_gem repo, "activeresource", "2.3.2"
-        c.repo_gem repo, "activesupport", "2.3.2"
+      checksums = checksums_section do |c|
+        c.checksum repo, "actionmailer", "2.3.2"
+        c.checksum repo, "actionpack", "2.3.2"
+        c.checksum repo, "activerecord", "2.3.2"
+        c.checksum repo, "activeresource", "2.3.2"
+        c.checksum repo, "activesupport", "2.3.2"
         c.no_checksum "foo", "2.0"
-        c.repo_gem repo, "rails", "2.3.2"
-        c.repo_gem repo, "rake", "13.0.1"
-        c.repo_gem repo, "weakling", "0.0.3"
+        c.checksum repo, "rails", "2.3.2"
+        c.checksum repo, "rake", "13.0.1"
+        c.checksum repo, "weakling", "0.0.3"
       end
 
       expected_lockfile = <<~L
@@ -1059,10 +1077,7 @@ RSpec.describe "bundle lock" do
           foo (= 2.0)
           rails
           weakling
-
-        CHECKSUMS
-          #{expected_checksums}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -1122,6 +1137,11 @@ RSpec.describe "bundle lock" do
         bundle "lock"
       end
 
+      checksums = checksums_section do |c|
+        c.no_checksum "debug", "1.6.3"
+        c.no_checksum "irb", "1.5.0"
+      end
+
       expect(lockfile).to eq <<~L
         GEM
           remote: #{file_uri_for(gem_repo4)}/
@@ -1136,11 +1156,7 @@ RSpec.describe "bundle lock" do
 
         DEPENDENCIES
           debug
-
-        CHECKSUMS
-          #{gem_no_checksum "debug", "1.6.3"}
-          #{gem_no_checksum "irb", "1.5.0"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -1422,6 +1438,11 @@ RSpec.describe "bundle lock" do
     end
 
     it "locks ruby specs" do
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "foo", "1.0"
+        c.no_checksum "nokogiri", "1.14.2"
+      end
+
       simulate_platform "x86_64-linux" do
         bundle "lock"
       end
@@ -1443,11 +1464,7 @@ RSpec.describe "bundle lock" do
 
         DEPENDENCIES
           foo!
-
-        CHECKSUMS
-          #{gem_no_checksum "foo", "1.0"}
-          #{gem_no_checksum "nokogiri", "1.14.2"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -1508,6 +1525,13 @@ RSpec.describe "bundle lock" do
     end
 
     it "does not downgrade top level dependencies" do
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "actionpack", "7.0.4.3"
+        c.no_checksum "activesupport", "7.0.4.3"
+        c.no_checksum "govuk_app_config", "4.13.0"
+        c.no_checksum "railties", "7.0.4.3"
+      end
+
       simulate_platform "arm64-darwin-22" do
         bundle "lock"
       end
@@ -1530,13 +1554,7 @@ RSpec.describe "bundle lock" do
         DEPENDENCIES
           activesupport (= 7.0.4.3)
           govuk_app_config
-
-        CHECKSUMS
-          #{gem_no_checksum "actionpack", "7.0.4.3"}
-          #{gem_no_checksum "activesupport", "7.0.4.3"}
-          #{gem_no_checksum "govuk_app_config", "4.13.0"}
-          #{gem_no_checksum "railties", "7.0.4.3"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -275,6 +275,11 @@ RSpec.describe "bundle update" do
         gem "countries"
       G
 
+      checksums = checksums_section_when_existing do |c|
+        c.checksum(gem_repo4, "countries", "3.1.0")
+        c.checksum(gem_repo4, "country_select", "5.1.0")
+      end
+
       lockfile <<~L
         GEM
           remote: #{file_uri_for(gem_repo4)}/
@@ -289,11 +294,7 @@ RSpec.describe "bundle update" do
         DEPENDENCIES
           countries
           country_select
-
-        CHECKSUMS
-          #{checksum_for_repo_gem(gem_repo4, "countries", "3.1.0")}
-          #{checksum_for_repo_gem(gem_repo4, "country_select", "5.1.0")}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -509,9 +510,9 @@ RSpec.describe "bundle update" do
 
       original_lockfile = lockfile
 
-      expected_checksums = checksum_section do |c|
-        c.repo_gem gem_repo4, "activesupport", "6.0.4.1"
-        c.repo_gem gem_repo4, "tzinfo", "1.2.9"
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo4, "activesupport", "6.0.4.1"
+        c.checksum gem_repo4, "tzinfo", "1.2.9"
       end
 
       expected_lockfile = <<~L
@@ -527,10 +528,7 @@ RSpec.describe "bundle update" do
 
         DEPENDENCIES
           activesupport (~> 6.0.0)
-
-        CHECKSUMS
-          #{expected_checksums}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -1152,9 +1150,10 @@ RSpec.describe "bundle update --ruby" do
       G
 
       gemfile <<-G
-          source "#{file_uri_for(gem_repo1)}"
+        source "#{file_uri_for(gem_repo1)}"
       G
     end
+
     it "removes the Ruby from the Gemfile.lock" do
       bundle "update --ruby"
 
@@ -1167,8 +1166,6 @@ RSpec.describe "bundle update --ruby" do
          #{lockfile_platforms}
 
        DEPENDENCIES
-
-       CHECKSUMS
 
        BUNDLED WITH
           #{Bundler::VERSION}
@@ -1184,30 +1181,29 @@ RSpec.describe "bundle update --ruby" do
       G
 
       gemfile <<-G
-          ruby '~> #{current_ruby_minor}'
-          source "#{file_uri_for(gem_repo1)}"
+        ruby '~> #{current_ruby_minor}'
+        source "#{file_uri_for(gem_repo1)}"
       G
     end
+
     it "updates the Gemfile.lock with the latest version" do
       bundle "update --ruby"
 
       expect(lockfile).to eq <<~L
-       GEM
-         remote: #{file_uri_for(gem_repo1)}/
-         specs:
+        GEM
+          remote: #{file_uri_for(gem_repo1)}/
+          specs:
 
-       PLATFORMS
-         #{lockfile_platforms}
+        PLATFORMS
+          #{lockfile_platforms}
 
-       DEPENDENCIES
+        DEPENDENCIES
 
-       CHECKSUMS
+        RUBY VERSION
+           #{Bundler::RubyVersion.system}
 
-       RUBY VERSION
-          #{Bundler::RubyVersion.system}
-
-       BUNDLED WITH
-          #{Bundler::VERSION}
+        BUNDLED WITH
+           #{Bundler::VERSION}
       L
     end
   end
@@ -1257,6 +1253,7 @@ RSpec.describe "bundle update --ruby" do
           source "#{file_uri_for(gem_repo1)}"
       G
     end
+
     it "updates the Gemfile.lock with the latest version" do
       bundle "update --ruby"
 
@@ -1288,11 +1285,14 @@ RSpec.describe "bundle update --bundler" do
       build_gem "rack", "1.0"
     end
 
+    checksums = checksums_section_when_existing do |c|
+      c.checksum(gem_repo4, "rack", "1.0")
+    end
+
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo4)}"
       gem "rack"
     G
-    expected_checksum = checksum_for_repo_gem(gem_repo4, "rack", "1.0")
     expect(lockfile).to eq <<~L
       GEM
         remote: #{file_uri_for(gem_repo4)}/
@@ -1304,10 +1304,7 @@ RSpec.describe "bundle update --bundler" do
 
       DEPENDENCIES
         rack
-
-      CHECKSUMS
-        #{expected_checksum}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -1327,10 +1324,7 @@ RSpec.describe "bundle update --bundler" do
 
       DEPENDENCIES
         rack
-
-      CHECKSUMS
-        #{expected_checksum}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -1351,6 +1345,10 @@ RSpec.describe "bundle update --bundler" do
     G
     lockfile lockfile.sub(/(^\s*)#{Bundler::VERSION}($)/, "2.3.9")
 
+    checksums = checksums_section_when_existing do |c|
+      c.checksum(gem_repo4, "rack", "1.0")
+    end
+
     bundle :update, :bundler => true, :artifice => "compact_index", :verbose => true
     expect(out).to include("Using bundler #{Bundler::VERSION}")
 
@@ -1365,10 +1363,7 @@ RSpec.describe "bundle update --bundler" do
 
       DEPENDENCIES
         rack
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo4, "rack", "1.0")}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -1458,8 +1453,11 @@ RSpec.describe "bundle update --bundler" do
     bundle :update, :bundler => "2.3.0.dev", :verbose => "true"
 
     # Only updates properly on modern RubyGems.
-
     if Gem.rubygems_version >= Gem::Version.new("3.3.0.dev")
+      checksums = checksums_section_when_existing do |c|
+        c.checksum(gem_repo4, "rack", "1.0")
+      end
+
       expect(lockfile).to eq <<~L
         GEM
           remote: #{file_uri_for(gem_repo4)}/
@@ -1471,10 +1469,7 @@ RSpec.describe "bundle update --bundler" do
 
         DEPENDENCIES
           rack
-
-        CHECKSUMS
-          #{checksum_for_repo_gem(gem_repo4, "rack", "1.0")}
-
+        #{checksums}
         BUNDLED WITH
            2.3.0.dev
       L
@@ -1500,6 +1495,9 @@ RSpec.describe "bundle update --bundler" do
     expect(out).not_to include("Fetching gem metadata from https://rubygems.org/")
 
     # Only updates properly on modern RubyGems.
+    checksums = checksums_section_when_existing do |c|
+      c.checksum(gem_repo4, "rack", "1.0")
+    end
 
     if Gem.rubygems_version >= Gem::Version.new("3.3.0.dev")
       expect(lockfile).to eq <<~L
@@ -1513,10 +1511,7 @@ RSpec.describe "bundle update --bundler" do
 
         DEPENDENCIES
           rack
-
-        CHECKSUMS
-          #{checksum_for_repo_gem(gem_repo4, "rack", "1.0")}
-
+        #{checksums}
         BUNDLED WITH
            2.3.9
       L

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -386,6 +386,9 @@ RSpec.describe "bundle install from an existing gemspec" do
         DEPENDENCIES
           foo!
 
+        CHECKSUMS
+          foo (1.0)
+
         BUNDLED WITH
            #{Bundler::VERSION}
       L

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -28,14 +28,14 @@ RSpec.describe "bundle install from an existing gemspec" do
     x64_mingw_archs.join("\n  ")
   end
 
-  let(:x64_mingw_checksums) do
-    x64_mingw_archs.map do |arch|
+  def x64_mingw_checksums(checksums)
+    x64_mingw_archs.each do |arch|
       if arch == "x64-mingw-ucrt"
-        gem_no_checksum "platform_specific", "1.0", arch
+        checksums.no_checksum "platform_specific", "1.0", arch
       else
-        checksum_for_repo_gem gem_repo2, "platform_specific", "1.0", arch
+        checksums.checksum gem_repo2, "platform_specific", "1.0", arch
       end
-    end.join("\n  ")
+    end
   end
 
   it "should install runtime and development dependencies" do
@@ -368,6 +368,10 @@ RSpec.describe "bundle install from an existing gemspec" do
         gemspec :path => "../foo"
       G
 
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "foo", "1.0"
+      end
+
       lockfile <<-L
         PATH
           remote: ../foo
@@ -385,10 +389,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
         DEPENDENCIES
           foo!
-
-        CHECKSUMS
-          foo (1.0)
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -462,6 +463,14 @@ RSpec.describe "bundle install from an existing gemspec" do
           it "keeps all platform dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 RUBY"
 
+            checksums = checksums_section_when_existing do |c|
+              c.no_checksum "foo", "1.0"
+              c.checksum gem_repo2, "platform_specific", "1.0"
+              c.checksum gem_repo2, "platform_specific", "1.0", "java"
+              x64_mingw_checksums(c)
+            end
+
+
             expect(lockfile).to eq <<~L
               PATH
                 remote: .
@@ -483,13 +492,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
               DEPENDENCIES
                 foo!
-
-              CHECKSUMS
-                foo (1.0)
-                #{checksum_for_repo_gem gem_repo2, "platform_specific", "1.0"}
-                #{checksum_for_repo_gem gem_repo2, "platform_specific", "1.0", "java"}
-                #{x64_mingw_checksums}
-
+              #{checksums}
               BUNDLED WITH
                  #{Bundler::VERSION}
             L
@@ -501,6 +504,13 @@ RSpec.describe "bundle install from an existing gemspec" do
 
           it "keeps all platform dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 RUBY"
+
+            checksums = checksums_section_when_existing do |c|
+              c.no_checksum "foo", "1.0"
+              c.checksum gem_repo2, "platform_specific", "1.0"
+              c.checksum gem_repo2, "platform_specific", "1.0", "java"
+              x64_mingw_checksums(c)
+            end
 
             expect(lockfile).to eq <<~L
               PATH
@@ -523,13 +533,7 @@ RSpec.describe "bundle install from an existing gemspec" do
               DEPENDENCIES
                 foo!
                 platform_specific
-
-              CHECKSUMS
-                foo (1.0)
-                #{checksum_for_repo_gem gem_repo2, "platform_specific", "1.0"}
-                #{checksum_for_repo_gem gem_repo2, "platform_specific", "1.0", "java"}
-                #{x64_mingw_checksums}
-
+              #{checksums}
               BUNDLED WITH
                  #{Bundler::VERSION}
             L
@@ -542,6 +546,14 @@ RSpec.describe "bundle install from an existing gemspec" do
 
           it "keeps all platform dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "indirect_platform_specific 1.0", "platform_specific 1.0 RUBY"
+
+            checksums = checksums_section_when_existing do |c|
+              c.no_checksum "foo", "1.0"
+              c.checksum gem_repo2, "indirect_platform_specific", "1.0"
+              c.checksum gem_repo2, "platform_specific", "1.0"
+              c.checksum gem_repo2, "platform_specific", "1.0", "java"
+              x64_mingw_checksums(c)
+            end
 
             expect(lockfile).to eq <<~L
               PATH
@@ -566,14 +578,7 @@ RSpec.describe "bundle install from an existing gemspec" do
               DEPENDENCIES
                 foo!
                 indirect_platform_specific
-
-              CHECKSUMS
-                foo (1.0)
-                #{checksum_for_repo_gem gem_repo2, "indirect_platform_specific", "1.0"}
-                #{checksum_for_repo_gem gem_repo2, "platform_specific", "1.0"}
-                #{checksum_for_repo_gem gem_repo2, "platform_specific", "1.0", "java"}
-                #{x64_mingw_checksums}
-
+              #{checksums}
               BUNDLED WITH
                  #{Bundler::VERSION}
             L
@@ -637,6 +642,12 @@ RSpec.describe "bundle install from an existing gemspec" do
         gemspec :path => "../chef"
       G
 
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "chef", "17.1.17"
+        c.no_checksum "chef", "17.1.17", "universal-mingw32"
+        c.checksum gem_repo4, "win32-api", "1.5.3", "universal-mingw32"
+      end
+
       initial_lockfile = <<~L
         PATH
           remote: ../chef
@@ -657,12 +668,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
         DEPENDENCIES
           chef!
-
-        CHECKSUMS
-          chef (17.1.17)
-          chef (17.1.17-universal-mingw32)
-          #{checksum_for_repo_gem gem_repo4, "win32-api", "1.5.3", "universal-mingw32"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -700,6 +706,12 @@ RSpec.describe "bundle install from an existing gemspec" do
     end
 
     it "does not remove the platform specific specs from the lockfile when re-resolving due to gemspec changes" do
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "activeadmin", "2.9.0"
+        c.no_checksum "jruby-openssl", "0.10.7", "java"
+        c.checksum gem_repo4, "railties", "6.1.4"
+      end
+
       expect(lockfile).to eq <<~L
         PATH
           remote: ../activeadmin
@@ -719,12 +731,7 @@ RSpec.describe "bundle install from an existing gemspec" do
         DEPENDENCIES
           activeadmin!
           jruby-openssl
-
-        CHECKSUMS
-          activeadmin (2.9.0)
-          jruby-openssl (0.10.7-java)
-          #{checksum_for_repo_gem gem_repo4, "railties", "6.1.4"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L

--- a/bundler/spec/install/gemfile/install_if_spec.rb
+++ b/bundler/spec/install/gemfile/install_if_spec.rb
@@ -18,6 +18,13 @@ RSpec.describe "bundle install with install_if conditionals" do
     expect(the_bundle).not_to include_gems("thin")
     expect(the_bundle).not_to include_gems("foo")
 
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo1, "activesupport", "2.3.5"
+      c.no_checksum "foo", "1.0"
+      c.checksum gem_repo1, "rack", "1.0.0"
+      c.no_checksum "thin", "1.0"
+    end
+
     expect(lockfile).to eq <<~L
       GEM
         remote: #{file_uri_for(gem_repo1)}/
@@ -36,13 +43,7 @@ RSpec.describe "bundle install with install_if conditionals" do
         foo
         rack
         thin
-
-      CHECKSUMS
-        #{checksum_for_repo_gem gem_repo1, "activesupport", "2.3.5"}
-        #{gem_no_checksum "foo", "1.0"}
-        #{checksum_for_repo_gem gem_repo1, "rack", "1.0.0"}
-        #{gem_no_checksum "thin", "1.0"}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L

--- a/bundler/spec/install/gemfile/path_spec.rb
+++ b/bundler/spec/install/gemfile/path_spec.rb
@@ -98,6 +98,11 @@ RSpec.describe "bundle install with explicit source paths" do
       gem "aaa", :path => "./aaa"
     G
 
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "aaa", "1.0"
+      c.no_checksum "demo", "1.0"
+    end
+
     lockfile = <<~L
       PATH
         remote: .
@@ -119,11 +124,7 @@ RSpec.describe "bundle install with explicit source paths" do
       DEPENDENCIES
         aaa!
         demo!
-
-      CHECKSUMS
-        #{gem_no_checksum("aaa", "1.0")}
-        #{gem_no_checksum("demo", "1.0")}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -345,6 +346,11 @@ RSpec.describe "bundle install with explicit source paths" do
 
     lockfile_path = lib_path("foo/Gemfile.lock")
 
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "foo", "0.1.0"
+      c.checksum gem_repo4, "graphql", "2.0.15"
+    end
+
     original_lockfile = <<~L
       PATH
         remote: .
@@ -362,11 +368,7 @@ RSpec.describe "bundle install with explicit source paths" do
 
       DEPENDENCIES
         foo!
-
-      CHECKSUMS
-        #{gem_no_checksum("foo", "0.1.0")}
-        #{checksum_for_repo_gem(gem_repo4, "graphql", "2.0.15")}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -673,6 +675,11 @@ RSpec.describe "bundle install with explicit source paths" do
 
       expect(the_bundle).to include_gems "rack 0.9.1"
 
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "foo", "1.0"
+        c.checksum gem_repo1, "rack", "0.9.1"
+      end
+
       expect(lockfile).to eq <<~G
         PATH
           remote: #{lib_path("foo")}
@@ -690,11 +697,7 @@ RSpec.describe "bundle install with explicit source paths" do
 
         DEPENDENCIES
           foo!
-
-        CHECKSUMS
-          #{gem_no_checksum("foo", "1.0")}
-          #{checksum_for_repo_gem(gem_repo1, "rack", "0.9.1")}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       G
@@ -722,11 +725,7 @@ RSpec.describe "bundle install with explicit source paths" do
 
         DEPENDENCIES
           foo!
-
-        CHECKSUMS
-          #{gem_no_checksum("foo", "1.0")}
-          #{checksum_for_repo_gem(gem_repo1, "rack", "0.9.1")}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       G
@@ -742,6 +741,11 @@ RSpec.describe "bundle install with explicit source paths" do
       bundle "install"
 
       expect(the_bundle).to include_gems "rack 0.9.1"
+
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "foo", "1.0"
+        c.checksum gem_repo1, "rack", "0.9.1"
+      end
 
       expect(lockfile).to eq <<~G
         PATH
@@ -760,11 +764,7 @@ RSpec.describe "bundle install with explicit source paths" do
 
         DEPENDENCIES
           foo!
-
-        CHECKSUMS
-          #{gem_no_checksum("foo", "1.0")}
-          #{checksum_for_repo_gem(gem_repo1, "rack", "0.9.1")}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       G
@@ -775,6 +775,8 @@ RSpec.describe "bundle install with explicit source paths" do
       end
 
       bundle "install"
+
+      checksums.checksum gem_repo1, "rake", "13.0.1"
 
       expect(lockfile).to eq <<~G
         PATH
@@ -795,12 +797,7 @@ RSpec.describe "bundle install with explicit source paths" do
 
         DEPENDENCIES
           foo!
-
-        CHECKSUMS
-          #{gem_no_checksum("foo", "1.0")}
-          #{checksum_for_repo_gem(gem_repo1, "rack", "0.9.1")}
-          #{checksum_for_repo_gem(gem_repo1, "rake", "13.0.1")}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       G
@@ -811,6 +808,10 @@ RSpec.describe "bundle install with explicit source paths" do
     it "does not remove existing ruby platform" do
       build_lib "foo", "1.0", :path => lib_path("foo") do |s|
         s.add_dependency "rack", "0.9.1"
+      end
+
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "foo", "1.0"
       end
 
       lockfile <<~L
@@ -824,15 +825,14 @@ RSpec.describe "bundle install with explicit source paths" do
 
         DEPENDENCIES
           foo!
-
-        CHECKSUMS
-          foo (1.0)
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
 
       bundle "lock"
+
+      checksums.no_checksum "rack", "0.9.1"
 
       expect(lockfile).to eq <<~G
         PATH
@@ -851,11 +851,7 @@ RSpec.describe "bundle install with explicit source paths" do
 
         DEPENDENCIES
           foo!
-
-        CHECKSUMS
-          #{gem_no_checksum("foo", "1.0")}
-          #{gem_no_checksum("rack", "0.9.1")}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       G

--- a/bundler/spec/install/gemfile/path_spec.rb
+++ b/bundler/spec/install/gemfile/path_spec.rb
@@ -825,6 +825,9 @@ RSpec.describe "bundle install with explicit source paths" do
         DEPENDENCIES
           foo!
 
+        CHECKSUMS
+          foo (1.0)
+
         BUNDLED WITH
            #{Bundler::VERSION}
       L

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -203,6 +203,15 @@ RSpec.describe "bundle install across platforms" do
       gem "pry"
     G
 
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo4, "coderay", "1.1.2"
+      c.checksum gem_repo4, "empyrean", "0.1.0"
+      c.checksum gem_repo4, "ffi", "1.9.23", "java"
+      c.checksum gem_repo4, "method_source", "0.9.0"
+      c.checksum gem_repo4, "pry", "0.11.3", "java"
+      c.checksum gem_repo4, "spoon", "0.0.6"
+    end
+
     expect(lockfile).to eq <<~L
       GEM
         remote: #{file_uri_for(gem_repo4)}/
@@ -224,20 +233,15 @@ RSpec.describe "bundle install across platforms" do
       DEPENDENCIES
         empyrean (= 0.1.0)
         pry
-
-      CHECKSUMS
-        #{checksum_for_repo_gem gem_repo4, "coderay", "1.1.2"}
-        #{checksum_for_repo_gem gem_repo4, "empyrean", "0.1.0"}
-        #{checksum_for_repo_gem gem_repo4, "ffi", "1.9.23", "java"}
-        #{checksum_for_repo_gem gem_repo4, "method_source", "0.9.0"}
-        #{checksum_for_repo_gem gem_repo4, "pry", "0.11.3", "java"}
-        #{checksum_for_repo_gem gem_repo4, "spoon", "0.0.6"}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
 
     bundle "lock --add-platform ruby"
+
+    good_checksums = checksums.dup
+    good_checksums.no_checksum("pry", "0.11.3")
 
     good_lockfile = <<~L
       GEM
@@ -264,16 +268,7 @@ RSpec.describe "bundle install across platforms" do
       DEPENDENCIES
         empyrean (= 0.1.0)
         pry
-
-      CHECKSUMS
-        #{checksum_for_repo_gem gem_repo4, "coderay", "1.1.2"}
-        #{checksum_for_repo_gem gem_repo4, "empyrean", "0.1.0"}
-        #{checksum_for_repo_gem gem_repo4, "ffi", "1.9.23", "java"}
-        #{checksum_for_repo_gem gem_repo4, "method_source", "0.9.0"}
-        pry (0.11.3)
-        #{checksum_for_repo_gem gem_repo4, "pry", "0.11.3", "java"}
-        #{checksum_for_repo_gem gem_repo4, "spoon", "0.0.6"}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -306,15 +301,7 @@ RSpec.describe "bundle install across platforms" do
       DEPENDENCIES
         empyrean (= 0.1.0)
         pry
-
-      CHECKSUMS
-        #{checksum_for_repo_gem gem_repo4, "coderay", "1.1.2"}
-        #{checksum_for_repo_gem gem_repo4, "empyrean", "0.1.0"}
-        #{checksum_for_repo_gem gem_repo4, "ffi", "1.9.23", "java"}
-        #{checksum_for_repo_gem gem_repo4, "method_source", "0.9.0"}
-        #{checksum_for_repo_gem gem_repo4, "pry", "0.11.3", "java"}
-        #{checksum_for_repo_gem gem_repo4, "spoon", "0.0.6"}
-
+      #{checksums}
       BUNDLED WITH
          1.16.1
     L
@@ -388,6 +375,11 @@ RSpec.describe "bundle install across platforms" do
   end
 
   it "keeps existing platforms when installing with force_ruby_platform" do
+    checksums = checksums_section do |c|
+      c.no_checksum "platform_specific", "1.0"
+      c.no_checksum "platform_specific", "1.0", "java"
+    end
+
     lockfile <<-G
       GEM
         remote: #{file_uri_for(gem_repo1)}/
@@ -399,10 +391,7 @@ RSpec.describe "bundle install across platforms" do
 
       DEPENDENCIES
         platform_specific
-
-      CHECKSUMS
-        #{gem_no_checksum "platform_specific", "1.0"}
-        #{gem_no_checksum "platform_specific", "1.0", "java"}
+      #{checksums}
     G
 
     bundle "config set --local force_ruby_platform true"
@@ -427,11 +416,7 @@ RSpec.describe "bundle install across platforms" do
 
       DEPENDENCIES
         platform_specific
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo1, "platform_specific", "1.0")}
-        #{gem_no_checksum "platform_specific", "1.0", "java"}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -600,9 +585,7 @@ RSpec.describe "bundle install with platform conditionals" do
 
       DEPENDENCIES
         rack
-
-      CHECKSUMS
-
+      #{checksums_section_when_existing}
       BUNDLED WITH
          #{Bundler::VERSION}
     L

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -399,6 +399,10 @@ RSpec.describe "bundle install across platforms" do
 
       DEPENDENCIES
         platform_specific
+
+      CHECKSUMS
+        #{gem_no_checksum "platform_specific", "1.0"}
+        #{gem_no_checksum "platform_specific", "1.0", "java"}
     G
 
     bundle "config set --local force_ruby_platform true"

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -308,104 +308,165 @@ RSpec.describe "bundle install with gems on multiple sources" do
           G
         end
 
-        it "fails when the two sources don't have the same checksum", :bundler => "< 3" do
-          bundle :install, :artifice => "compact_index", :raise_on_error => false
+        context "with checksums enabled" do
+          before do
+            lockfile <<~L
+              GEM
+                remote: https://gem.repo1/
+                remote: https://gem.repo2/
+                specs:
+                  rack (1.0.0)
 
-          expect(err).to eq(<<~E.strip)
-            [DEPRECATED] Your Gemfile contains multiple global sources. Using `source` more than once without a block is a security risk, and may result in installing unexpected gems. To resolve this warning, use a block to indicate which gems should come from the secondary source.
-            Bundler found mismatched checksums. This is a potential security risk.
-              #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
-                from the API at https://gem.repo2/
-              #{checksum_for_repo_gem(gem_repo1, "rack", "1.0.0")}
-                from the API at https://gem.repo1/
+              PLATFORMS
+                #{local_platform}
 
-            Mismatched checksums each have an authoritative source:
-              1. the API at https://gem.repo2/
-              2. the API at https://gem.repo1/
-            You may need to alter your Gemfile sources to resolve this issue.
+              DEPENDENCIES
+                depends_on_rack!
 
-            To ignore checksum security warnings, disable checksum validation with
-              `bundle config set --local disable_checksum_validation true`
-          E
-          expect(exitstatus).to eq(37)
-        end
-
-        it "fails when the two sources agree, but the local gem calculates a different checksum", :bundler => "< 3" do
-          rack_checksum = "c0ffee11" * 8
-          bundle :install, :artifice => "compact_index", :env => { "BUNDLER_SPEC_RACK_CHECKSUM" => rack_checksum }, :raise_on_error => false
-
-          expect(err).to eq(<<~E.strip)
-            [DEPRECATED] Your Gemfile contains multiple global sources. Using `source` more than once without a block is a security risk, and may result in installing unexpected gems. To resolve this warning, use a block to indicate which gems should come from the secondary source.
-            Bundler found mismatched checksums. This is a potential security risk.
-              rack (1.0.0) sha256=#{rack_checksum}
-                from the API at https://gem.repo2/
-                and the API at https://gem.repo1/
-              #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
-                from the gem at #{default_bundle_path("cache", "rack-1.0.0.gem")}
-
-            If you trust the API at https://gem.repo2/, to resolve this issue you can:
-              1. remove the gem at #{default_bundle_path("cache", "rack-1.0.0.gem")}
-              2. run `bundle install`
-
-            To ignore checksum security warnings, disable checksum validation with
-              `bundle config set --local disable_checksum_validation true`
-          E
-          expect(exitstatus).to eq(37)
-        end
-
-        it "installs from the other source and warns about ambiguous gems when the sources have the same checksum", :bundler => "< 3" do
-          gem_checksum = checksum_for_repo_gem(gem_repo2, "rack", "1.0.0").split(Bundler::Checksum::ALGO_SEPARATOR).last
-          bundle :install, :artifice => "compact_index", :env => { "BUNDLER_SPEC_RACK_CHECKSUM" => gem_checksum, "DEBUG" => "1" }
-
-          expect(err).to include("Warning: the gem 'rack' was found in multiple sources.")
-          expect(err).to include("Installed from: https://gem.repo2")
-
-          expected_checksums = checksum_section do |c|
-            c.repo_gem gem_repo3, "depends_on_rack", "1.0.1"
-            c.repo_gem gem_repo2, "rack", "1.0.0"
-          end
-
-          expect(lockfile).to eq <<~L
-            GEM
-              remote: https://gem.repo1/
-              remote: https://gem.repo2/
-              specs:
+              CHECKSUMS
                 rack (1.0.0)
 
-            GEM
-              remote: https://gem.repo3/
-              specs:
-                depends_on_rack (1.0.1)
-                  rack
+              BUNDLED WITH
+                #{Bundler::VERSION}
+            L
+          end
 
-            PLATFORMS
-              #{lockfile_platforms}
+          it "fails when the two sources don't have the same checksum", :bundler => "< 3" do
+            bundle :install, :artifice => "compact_index", :raise_on_error => false
 
-            DEPENDENCIES
-              depends_on_rack!
+            expect(err).to eq(<<~E.strip)
+              [DEPRECATED] Your Gemfile contains multiple global sources. Using `source` more than once without a block is a security risk, and may result in installing unexpected gems. To resolve this warning, use a block to indicate which gems should come from the secondary source.
+              Bundler found mismatched checksums. This is a potential security risk.
+                #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
+                  from the API at https://gem.repo2/
+                #{checksum_for_repo_gem(gem_repo1, "rack", "1.0.0")}
+                  from the API at https://gem.repo1/
 
-            CHECKSUMS
-              #{expected_checksums}
+              Mismatched checksums each have an authoritative source:
+                1. the API at https://gem.repo2/
+                2. the API at https://gem.repo1/
+              You may need to alter your Gemfile sources to resolve this issue.
 
-            BUNDLED WITH
-               #{Bundler::VERSION}
-          L
+              To ignore checksum security warnings, disable checksum validation with
+                `bundle config set --local disable_checksum_validation true`
+            E
+            expect(exitstatus).to eq(37)
+          end
 
-          previous_lockfile = lockfile
-          expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
-          expect(lockfile).to eq(previous_lockfile)
+          it "fails when the two sources agree, but the local gem calculates a different checksum", :bundler => "< 3" do
+            rack_checksum = "c0ffee11" * 8
+            bundle :install, :artifice => "compact_index", :env => { "BUNDLER_SPEC_RACK_CHECKSUM" => rack_checksum }, :raise_on_error => false
+
+            expect(err).to eq(<<~E.strip)
+              [DEPRECATED] Your Gemfile contains multiple global sources. Using `source` more than once without a block is a security risk, and may result in installing unexpected gems. To resolve this warning, use a block to indicate which gems should come from the secondary source.
+              Bundler found mismatched checksums. This is a potential security risk.
+                rack (1.0.0) sha256=#{rack_checksum}
+                  from the API at https://gem.repo2/
+                  and the API at https://gem.repo1/
+                #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
+                  from the gem at #{default_bundle_path("cache", "rack-1.0.0.gem")}
+
+              If you trust the API at https://gem.repo2/, to resolve this issue you can:
+                1. remove the gem at #{default_bundle_path("cache", "rack-1.0.0.gem")}
+                2. run `bundle install`
+
+              To ignore checksum security warnings, disable checksum validation with
+                `bundle config set --local disable_checksum_validation true`
+            E
+            expect(exitstatus).to eq(37)
+          end
+
+          it "installs from the other source and warns about ambiguous gems when the sources have the same checksum", :bundler => "< 3" do
+            gem_checksum = checksum_for_repo_gem(gem_repo2, "rack", "1.0.0").split("-").last
+            bundle :install, :artifice => "compact_index", :env => { "BUNDLER_SPEC_RACK_CHECKSUM" => gem_checksum, "DEBUG" => "1" }
+
+            expect(err).to include("Warning: the gem 'rack' was found in multiple sources.")
+            expect(err).to include("Installed from: https://gem.repo2")
+
+            checksums = checksums_section do |c|
+              c.checksum gem_repo3, "depends_on_rack", "1.0.1"
+              c.checksum gem_repo2, "rack", "1.0.0"
+            end
+
+            expect(lockfile).to eq <<~L
+              GEM
+                remote: https://gem.repo1/
+                remote: https://gem.repo2/
+                specs:
+                  rack (1.0.0)
+
+              GEM
+                remote: https://gem.repo3/
+                specs:
+                  depends_on_rack (1.0.1)
+                    rack
+
+              PLATFORMS
+                #{local_platform}
+
+              DEPENDENCIES
+                depends_on_rack!
+              #{checksums}
+              BUNDLED WITH
+                 #{Bundler::VERSION}
+            L
+
+            previous_lockfile = lockfile
+            expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
+            expect(lockfile).to eq(previous_lockfile)
+          end
+
+          it "installs from the other source and warns about ambiguous gems when checksum validation is disabled", :bundler => "< 3" do
+            bundle "config set --local disable_checksum_validation true"
+            bundle :install, :artifice => "compact_index"
+
+            expect(err).to include("Warning: the gem 'rack' was found in multiple sources.")
+            expect(err).to include("Installed from: https://gem.repo2")
+
+            checksums = checksums_section do |c|
+              c.no_checksum "depends_on_rack", "1.0.1"
+              c.no_checksum "rack", "1.0.0"
+            end
+
+            expect(lockfile).to eq <<~L
+              GEM
+                remote: https://gem.repo1/
+                remote: https://gem.repo2/
+                specs:
+                  rack (1.0.0)
+
+              GEM
+                remote: https://gem.repo3/
+                specs:
+                  depends_on_rack (1.0.1)
+                    rack
+
+              PLATFORMS
+                #{local_platform}
+
+              DEPENDENCIES
+                depends_on_rack!
+              #{checksums}
+
+              BUNDLED WITH
+                 #{Bundler::VERSION}
+            L
+
+            previous_lockfile = lockfile
+            expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
+            expect(lockfile).to eq(previous_lockfile)
+          end
         end
 
-        it "installs from the other source and warns about ambiguous gems when checksum validation is disabled", :bundler => "< 3" do
-          bundle "config set --local disable_checksum_validation true"
+        it "installs from the other source and warns about ambiguous gems but not about checksum mismatch", :bundler => "< 3" do
           bundle :install, :artifice => "compact_index"
 
           expect(err).to include("Warning: the gem 'rack' was found in multiple sources.")
           expect(err).to include("Installed from: https://gem.repo2")
 
-          expected_checksums = checksum_section do |c|
-            c.no_checksum "depends_on_rack", "1.0.1"
-            c.no_checksum "rack", "1.0.0"
+          checksums = checksums_section do |c|
+            c.checksum gem_repo3, "depends_on_rack", "1.0.1"
+            c.checksum gem_repo2, "rack", "1.0.0"
           end
 
           expect(lockfile).to eq <<~L
@@ -426,10 +487,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
             DEPENDENCIES
               depends_on_rack!
-
-            CHECKSUMS
-              #{expected_checksums}
-
+            #{checksums}
             BUNDLED WITH
                #{Bundler::VERSION}
           L
@@ -772,6 +830,21 @@ RSpec.describe "bundle install with gems on multiple sources" do
           end
         G
 
+        @locked_checksums = checksums_section do |c|
+          c.checksum gem_repo2, "activesupport", "6.0.3.4"
+          c.checksum gem_repo2, "concurrent-ruby", "1.1.8"
+          c.checksum gem_repo2, "connection_pool", "2.2.3"
+          c.checksum gem_repo2, "i18n", "1.8.9"
+          c.checksum gem_repo2, "minitest", "5.14.3"
+          c.checksum gem_repo2, "rack", "2.2.3"
+          c.checksum gem_repo2, "redis", "4.2.5"
+          c.checksum gem_repo2, "sidekiq", "6.1.3"
+          c.checksum gem_repo3, "sidekiq-pro", "5.2.1"
+          c.checksum gem_repo2, "thread_safe", "0.3.6"
+          c.checksum gem_repo2, "tzinfo", "1.2.9"
+          c.checksum gem_repo2, "zeitwerk", "2.4.2"
+        end
+
         lockfile <<~L
           GEM
             remote: https://gem.repo2/
@@ -808,6 +881,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           DEPENDENCIES
             activesupport
             sidekiq-pro!
+          #{@locked_checksums}
 
           BUNDLED WITH
              #{Bundler::VERSION}
@@ -824,21 +898,6 @@ RSpec.describe "bundle install with gems on multiple sources" do
         expect(the_bundle).not_to include_gems("tzinfo 2.0.4")
         expect(the_bundle).to include_gems("concurrent-ruby 1.1.8")
         expect(the_bundle).not_to include_gems("concurrent-ruby 1.1.9")
-
-        expected_checksums = checksum_section do |c|
-          c.repo_gem gem_repo2, "activesupport", "6.0.3.4"
-          c.repo_gem gem_repo2, "concurrent-ruby", "1.1.8"
-          c.repo_gem gem_repo2, "connection_pool", "2.2.3"
-          c.repo_gem gem_repo2, "i18n", "1.8.9"
-          c.repo_gem gem_repo2, "minitest", "5.14.3"
-          c.repo_gem gem_repo2, "rack", "2.2.3"
-          c.repo_gem gem_repo2, "redis", "4.2.5"
-          c.repo_gem gem_repo2, "sidekiq", "6.1.3"
-          c.repo_gem gem_repo3, "sidekiq-pro", "5.2.1"
-          c.repo_gem gem_repo2, "thread_safe", "0.3.6"
-          c.repo_gem gem_repo2, "tzinfo", "1.2.9"
-          c.repo_gem gem_repo2, "zeitwerk", "2.4.2"
-        end
 
         expect(lockfile).to eq <<~L
           GEM
@@ -879,9 +938,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           DEPENDENCIES
             activesupport
             sidekiq-pro!
-
-          CHECKSUMS
-            #{expected_checksums}
+          #{@locked_checksums}
 
           BUNDLED WITH
              #{Bundler::VERSION}
@@ -923,24 +980,16 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
         expect(the_bundle).not_to include_gems("activesupport 6.0.3.4")
         expect(the_bundle).to include_gems("activesupport 6.1.2.1")
+        @locked_checksums.repo_gem gem_repo2, "activesupport", "6.1.2.1"
+
         expect(the_bundle).not_to include_gems("tzinfo 1.2.9")
         expect(the_bundle).to include_gems("tzinfo 2.0.4")
+        @locked_checksums.repo_gem gem_repo2, "tzinfo", "2.0.4"
+        @locked_checksums.delete "thread_safe"
+
         expect(the_bundle).not_to include_gems("concurrent-ruby 1.1.8")
         expect(the_bundle).to include_gems("concurrent-ruby 1.1.9")
-
-        expected_checksums = checksum_section do |c|
-          c.repo_gem gem_repo2, "activesupport", "6.1.2.1"
-          c.repo_gem gem_repo2, "concurrent-ruby", "1.1.9"
-          c.repo_gem gem_repo2, "connection_pool", "2.2.3"
-          c.repo_gem gem_repo2, "i18n", "1.8.9"
-          c.repo_gem gem_repo2, "minitest", "5.14.3"
-          c.repo_gem gem_repo2, "rack", "2.2.3"
-          c.repo_gem gem_repo2, "redis", "4.2.5"
-          c.repo_gem gem_repo2, "sidekiq", "6.1.3"
-          c.repo_gem gem_repo3, "sidekiq-pro", "5.2.1"
-          c.repo_gem gem_repo2, "tzinfo", "2.0.4"
-          c.repo_gem gem_repo2, "zeitwerk", "2.4.2"
-        end
+        @locked_checksums.repo_gem gem_repo2, "concurrent-ruby", "1.1.9"
 
         expect(lockfile).to eq <<~L
           GEM
@@ -980,9 +1029,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           DEPENDENCIES
             activesupport
             sidekiq-pro!
-
-          CHECKSUMS
-            #{expected_checksums}
+          #{@locked_checksums}
 
           BUNDLED WITH
              #{Bundler::VERSION}
@@ -1000,20 +1047,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         expect(the_bundle).to include_gems("concurrent-ruby 1.1.9")
         expect(the_bundle).not_to include_gems("concurrent-ruby 1.1.8")
 
-        expected_checksums = checksum_section do |c|
-          c.repo_gem gem_repo2, "activesupport", "6.0.3.4"
-          c.repo_gem gem_repo2, "concurrent-ruby", "1.1.9"
-          c.repo_gem gem_repo2, "connection_pool", "2.2.3"
-          c.repo_gem gem_repo2, "i18n", "1.8.9"
-          c.repo_gem gem_repo2, "minitest", "5.14.3"
-          c.repo_gem gem_repo2, "rack", "2.2.3"
-          c.repo_gem gem_repo2, "redis", "4.2.5"
-          c.repo_gem gem_repo2, "sidekiq", "6.1.3"
-          c.repo_gem gem_repo3, "sidekiq-pro", "5.2.1"
-          c.repo_gem gem_repo2, "thread_safe", "0.3.6"
-          c.repo_gem gem_repo2, "tzinfo", "1.2.9"
-          c.repo_gem gem_repo2, "zeitwerk", "2.4.2"
-        end
+        @locked_checksums.repo_gem gem_repo2, "concurrent-ruby", "1.1.9"
 
         expect(lockfile).to eq <<~L
           GEM
@@ -1054,9 +1088,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           DEPENDENCIES
             activesupport
             sidekiq-pro!
-
-          CHECKSUMS
-            #{expected_checksums}
+          #{@locked_checksums}
 
           BUNDLED WITH
              #{Bundler::VERSION}
@@ -1125,10 +1157,10 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
 
       it "installs from the default source without any warnings or errors and generates a proper lockfile" do
-        expected_checksums = checksum_section do |c|
-          c.repo_gem gem_repo3, "handsoap", "0.2.5.5"
-          c.repo_gem gem_repo2, "nokogiri", "1.11.1"
-          c.repo_gem gem_repo2, "racca", "1.5.2"
+        checksums = checksums_section do |c|
+          c.checksum gem_repo3, "handsoap", "0.2.5.5"
+          c.checksum gem_repo2, "nokogiri", "1.11.1"
+          c.checksum gem_repo2, "racca", "1.5.2"
         end
 
         expected_lockfile = <<~L
@@ -1151,10 +1183,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           DEPENDENCIES
             handsoap!
             nokogiri
-
-          CHECKSUMS
-            #{expected_checksums}
-
+          #{checksums}
           BUNDLED WITH
              #{Bundler::VERSION}
         L
@@ -1712,9 +1741,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
     it "upgrades the lockfile correctly" do
       bundle "lock --update", :artifice => "compact_index"
 
-      expected_checksums = checksum_section do |c|
-        c.repo_gem gem_repo2, "capybara", "2.5.0"
-        c.repo_gem gem_repo4, "mime-types", "3.0.0"
+      checksums = checksums_section do |c|
+        c.checksum gem_repo2, "capybara", "2.5.0"
+        c.checksum gem_repo4, "mime-types", "3.0.0"
       end
 
       expect(lockfile).to eq <<~L
@@ -1735,10 +1764,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         DEPENDENCIES
           capybara (~> 2.5.0)
           mime-types (~> 3.0)!
-
-        CHECKSUMS
-          #{expected_checksums}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -1831,9 +1857,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
     it "handles that fine" do
       bundle "install", :artifice => "compact_index_extra", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
 
-      expected_checksums = checksum_section do |c|
-        c.repo_gem gem_repo4, "pdf-writer", "1.1.8"
-        c.repo_gem gem_repo2, "ruport", "1.7.0.3"
+      checksums = checksums_section do |c|
+        c.checksum gem_repo4, "pdf-writer", "1.1.8"
+        c.checksum gem_repo2, "ruport", "1.7.0.3"
       end
 
       expect(lockfile).to eq <<~L
@@ -1853,10 +1879,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
         DEPENDENCIES
           ruport (= 1.7.0.3)!
-
-        CHECKSUMS
-          #{expected_checksums}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -1886,8 +1909,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
     it "handles that fine" do
       bundle "install --verbose", :artifice => "endpoint", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
 
-      expected_checksums = checksum_section do |c|
-        c.repo_gem gem_repo4, "pdf-writer", "1.1.8"
+      checksums = checksums_section do |c|
+        c.checksum gem_repo4, "pdf-writer", "1.1.8"
       end
 
       expect(lockfile).to eq <<~L
@@ -1901,10 +1924,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
         DEPENDENCIES
           pdf-writer (= 1.1.8)
-
-        CHECKSUMS
-          #{expected_checksums}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -66,6 +66,10 @@ RSpec.describe "bundle install with specific platforms" do
 
       gemfile google_protobuf
 
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo2, "google-protobuf", "3.0.0.alpha.4.0"
+      end
+
       # simulate lockfile created with old bundler, which only locks for ruby platform
       lockfile <<-L
         GEM
@@ -78,15 +82,14 @@ RSpec.describe "bundle install with specific platforms" do
 
         DEPENDENCIES
           google-protobuf
-
-        CHECKSUMS
-          google-protobuf (3.0.0.alpha.4.0)
-
+        #{checksums}
         BUNDLED WITH
            2.1.4
       L
 
       bundle "update", :env => { "BUNDLER_VERSION" => Bundler::VERSION }
+
+      checksums.checksum gem_repo2, "google-protobuf", "3.0.0.alpha.5.0.5.1"
 
       # make sure the platform that the platform specific dependency is used, since we're only locked to ruby
       expect(the_bundle).to include_gem("google-protobuf 3.0.0.alpha.5.0.5.1 universal-darwin")
@@ -103,10 +106,7 @@ RSpec.describe "bundle install with specific platforms" do
 
         DEPENDENCIES
           google-protobuf
-
-        CHECKSUMS
-          google-protobuf (3.0.0.alpha.5.0.5.1)
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -584,6 +584,11 @@ RSpec.describe "bundle install with specific platforms" do
       G
     end
 
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "nokogiri", "1.13.0", "x86_64-darwin"
+      c.no_checksum "sorbet-static", "0.5.10601", "x86_64-darwin"
+    end
+
     lockfile <<~L
       GEM
         remote: #{file_uri_for(gem_repo4)}/
@@ -599,11 +604,7 @@ RSpec.describe "bundle install with specific platforms" do
       DEPENDENCIES
         nokogiri
         sorbet-static
-
-      CHECKSUMS
-        #{gem_no_checksum "nokogiri", "1.13.0", "x86_64-darwin"}
-        #{gem_no_checksum "sorbet-static", "0.5.10601", "x86_64-darwin"}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -625,11 +626,7 @@ RSpec.describe "bundle install with specific platforms" do
       DEPENDENCIES
         nokogiri
         sorbet-static
-
-      CHECKSUMS
-        #{gem_no_checksum "nokogiri", "1.13.0", "x86_64-darwin"}
-        #{gem_no_checksum "sorbet-static", "0.5.10601", "x86_64-darwin"}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -802,6 +799,11 @@ RSpec.describe "bundle install with specific platforms" do
         gem "sorbet-static", "= 0.5.10549"
       G
 
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo4, "sorbet-static", "0.5.10549", "universal-darwin-20"
+        c.checksum gem_repo4, "sorbet-static", "0.5.10549", "universal-darwin-21"
+      end
+
       # Make sure the lockfile is missing sorbet-static-0.5.10549-universal-darwin-21
       lockfile <<~L
         GEM
@@ -814,16 +816,14 @@ RSpec.describe "bundle install with specific platforms" do
 
         DEPENDENCIES
           sorbet-static (= 0.5.10549)
-
-        CHECKSUMS
-          #{checksum_for_repo_gem gem_repo4, "sorbet-static", "0.5.10549", "universal-darwin-20"}
-          #{checksum_for_repo_gem gem_repo4, "sorbet-static", "0.5.10549", "universal-darwin-21"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
 
       bundle "install"
+
+      checksums.no_checksum "sorbet-static", "0.5.10549", "universal-darwin-21"
 
       expect(lockfile).to eq <<~L
         GEM
@@ -837,11 +837,7 @@ RSpec.describe "bundle install with specific platforms" do
 
         DEPENDENCIES
           sorbet-static (= 0.5.10549)
-
-        CHECKSUMS
-          #{checksum_for_repo_gem gem_repo4, "sorbet-static", "0.5.10549", "universal-darwin-20"}
-          #{gem_no_checksum "sorbet-static", "0.5.10549", "universal-darwin-21"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -888,6 +884,11 @@ RSpec.describe "bundle install with specific platforms" do
 
     bundle "lock --update"
 
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "nokogiri", "1.13.8"
+      c.no_checksum "nokogiri", "1.13.8", Gem::Platform.local
+    end
+
     updated_lockfile = <<~L
       GEM
         remote: #{file_uri_for(gem_repo4)}/
@@ -901,11 +902,7 @@ RSpec.describe "bundle install with specific platforms" do
       DEPENDENCIES
         nokogiri
         tzinfo (~> 1.2)
-
-      CHECKSUMS
-        #{gem_no_checksum "nokogiri", "1.13.8"}
-        #{gem_no_checksum "nokogiri", "1.13.8", Gem::Platform.local}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -926,6 +923,11 @@ RSpec.describe "bundle install with specific platforms" do
       gem "rack"
     G
 
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "concurrent-ruby", "1.2.2"
+      c.no_checksum "rack", "3.0.7"
+    end
+
     lockfile <<~L
       GEM
         remote: #{file_uri_for(gem_repo4)}/
@@ -937,11 +939,7 @@ RSpec.describe "bundle install with specific platforms" do
 
       DEPENDENCIES
         concurrent-ruby
-
-      CHECKSUMS
-        #{gem_no_checksum "concurrent-ruby", "1.2.2"}
-        #{gem_no_checksum "rack", "3.0.7"}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -961,11 +959,7 @@ RSpec.describe "bundle install with specific platforms" do
       DEPENDENCIES
         concurrent-ruby
         rack
-
-      CHECKSUMS
-        #{gem_no_checksum "concurrent-ruby", "1.2.2"}
-        #{gem_no_checksum "rack", "3.0.7"}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -1028,6 +1022,10 @@ RSpec.describe "bundle install with specific platforms" do
         gem "nokogiri", "1.14.0"
       G
 
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo4, "nokogiri", "1.14.0", "x86_64-linux"
+      end
+
       lockfile <<~L
         GEM
           remote: #{file_uri_for(gem_repo4)}/
@@ -1039,15 +1037,16 @@ RSpec.describe "bundle install with specific platforms" do
 
         DEPENDENCIES
           nokogiri (= 1.14.0)
-
-        CHECKSUMS
-          #{checksum_for_repo_gem gem_repo4, "nokogiri", "1.14.0", "x86_64-linux"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
 
       bundle :install
+
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo4, "nokogiri", "1.14.0"
+      end
 
       expect(lockfile).to eq(<<~L)
         GEM
@@ -1060,10 +1059,7 @@ RSpec.describe "bundle install with specific platforms" do
 
         DEPENDENCIES
           nokogiri (= 1.14.0)
-
-        CHECKSUMS
-          #{checksum_for_repo_gem gem_repo4, "nokogiri", "1.14.0"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -1103,6 +1099,12 @@ RSpec.describe "bundle install with specific platforms" do
 
       bundle "lock"
 
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "nokogiri", "1.14.0"
+        c.no_checksum "nokogiri", "1.14.0", "arm-linux"
+        c.no_checksum "nokogiri", "1.14.0", "x86_64-linux"
+      end
+
       # locks all compatible platforms, excluding Java and Windows
       expect(lockfile).to eq(<<~L)
         GEM
@@ -1119,12 +1121,7 @@ RSpec.describe "bundle install with specific platforms" do
 
         DEPENDENCIES
           nokogiri
-
-        CHECKSUMS
-          #{gem_no_checksum "nokogiri", "1.14.0"}
-          #{gem_no_checksum "nokogiri", "1.14.0", "arm-linux"}
-          #{gem_no_checksum "nokogiri", "1.14.0", "x86_64-linux"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -1139,6 +1136,10 @@ RSpec.describe "bundle install with specific platforms" do
       FileUtils.rm bundled_app_lock
 
       bundle "lock"
+
+      checksums.delete "nokogiri", "arm-linux"
+      checksums.no_checksum "sorbet-static", "0.5.10696", "universal-darwin-22"
+      checksums.no_checksum "sorbet-static", "0.5.10696", "x86_64-linux"
 
       # locks only platforms compatible with all gems in the bundle
       expect(lockfile).to eq(<<~L)
@@ -1157,13 +1158,7 @@ RSpec.describe "bundle install with specific platforms" do
         DEPENDENCIES
           nokogiri
           sorbet-static
-
-        CHECKSUMS
-          #{gem_no_checksum "nokogiri", "1.14.0"}
-          #{gem_no_checksum "nokogiri", "1.14.0", "x86_64-linux"}
-          #{gem_no_checksum "sorbet-static", "0.5.10696", "universal-darwin-22"}
-          #{gem_no_checksum "sorbet-static", "0.5.10696", "x86_64-linux"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -1193,10 +1188,10 @@ RSpec.describe "bundle install with specific platforms" do
       gem "sass-embedded"
     G
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo4, "nokogiri", "1.15.5"
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo4, "nokogiri", "1.15.5"
       c.no_checksum "sass-embedded", "1.69.5"
-      c.repo_gem gem_repo4, "sass-embedded", "1.69.5", "x86_64-linux-gnu"
+      c.checksum gem_repo4, "sass-embedded", "1.69.5", "x86_64-linux-gnu"
     end
 
     simulate_platform "x86_64-linux" do
@@ -1218,10 +1213,7 @@ RSpec.describe "bundle install with specific platforms" do
         DEPENDENCIES
           nokogiri
           sass-embedded
-
-        CHECKSUMS
-          #{expected_checksums}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -528,11 +528,11 @@ RSpec.describe "bundle install with specific platforms" do
 
     bundle "update"
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo4, "sorbet", "0.5.10160"
-      c.repo_gem gem_repo4, "sorbet-runtime", "0.5.10160"
-      c.repo_gem gem_repo4, "sorbet-static", "0.5.10160", Gem::Platform.local
-      c.repo_gem gem_repo4, "sorbet-static-and-runtime", "0.5.10160"
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo4, "sorbet", "0.5.10160"
+      c.checksum gem_repo4, "sorbet-runtime", "0.5.10160"
+      c.checksum gem_repo4, "sorbet-static", "0.5.10160", Gem::Platform.local
+      c.checksum gem_repo4, "sorbet-static-and-runtime", "0.5.10160"
     end
 
     expect(lockfile).to eq <<~L
@@ -552,10 +552,7 @@ RSpec.describe "bundle install with specific platforms" do
 
       DEPENDENCIES
         sorbet-static-and-runtime
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -602,6 +599,10 @@ RSpec.describe "bundle install with specific platforms" do
       DEPENDENCIES
         nokogiri
         sorbet-static
+
+      CHECKSUMS
+        #{gem_no_checksum "nokogiri", "1.13.0", "x86_64-darwin"}
+        #{gem_no_checksum "sorbet-static", "0.5.10601", "x86_64-darwin"}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -682,11 +683,11 @@ RSpec.describe "bundle install with specific platforms" do
 
     bundle "update"
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo4, "sorbet", "0.5.10160"
-      c.repo_gem gem_repo4, "sorbet-runtime", "0.5.10160"
-      c.repo_gem gem_repo4, "sorbet-static", "0.5.10160", Gem::Platform.local
-      c.repo_gem gem_repo4, "sorbet-static-and-runtime", "0.5.10160"
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo4, "sorbet", "0.5.10160"
+      c.checksum gem_repo4, "sorbet-runtime", "0.5.10160"
+      c.checksum gem_repo4, "sorbet-static", "0.5.10160", Gem::Platform.local
+      c.checksum gem_repo4, "sorbet-static-and-runtime", "0.5.10160"
     end
 
     expect(lockfile).to eq <<~L
@@ -706,10 +707,7 @@ RSpec.describe "bundle install with specific platforms" do
 
       DEPENDENCIES
         sorbet-static-and-runtime
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -760,9 +758,9 @@ RSpec.describe "bundle install with specific platforms" do
 
       bundle "update"
 
-      expected_checksums = checksum_section do |c|
-        c.repo_gem gem_repo4, "nokogiri", "1.14.0", "x86_64-linux"
-        c.repo_gem gem_repo4, "sorbet-static", "0.5.10696", "x86_64-linux"
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo4, "nokogiri", "1.14.0", "x86_64-linux"
+        c.checksum gem_repo4, "sorbet-static", "0.5.10696", "x86_64-linux"
       end
 
       expect(lockfile).to eq <<~L
@@ -778,10 +776,7 @@ RSpec.describe "bundle install with specific platforms" do
         DEPENDENCIES
           nokogiri
           sorbet-static
-
-        CHECKSUMS
-          #{expected_checksums}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -943,6 +938,10 @@ RSpec.describe "bundle install with specific platforms" do
       DEPENDENCIES
         concurrent-ruby
 
+      CHECKSUMS
+        #{gem_no_checksum "concurrent-ruby", "1.2.2"}
+        #{gem_no_checksum "rack", "3.0.7"}
+
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -1040,6 +1039,9 @@ RSpec.describe "bundle install with specific platforms" do
 
         DEPENDENCIES
           nokogiri (= 1.14.0)
+
+        CHECKSUMS
+          #{checksum_for_repo_gem gem_repo4, "nokogiri", "1.14.0", "x86_64-linux"}
 
         BUNDLED WITH
            #{Bundler::VERSION}

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -876,8 +876,26 @@ The checksum of /versions does not match the checksum provided by the server! So
   end
 
   describe "checksum validation" do
+    before do
+      # enable checksums by adding the CHECKSUMS section to the lockfile
+      lockfile <<-L
+        GEM
+          remote: #{source_uri}
+          specs:
+            rack (1.0.0)
+
+        PLATFORMS
+          ruby
+
+        DEPENDENCIES
+        #{checksums_section}
+        BUNDLED WITH
+            #{Bundler::VERSION}
+      L
+    end
+
     it "handles checksums from the server in base64" do
-      api_checksum = checksum_for_repo_gem(gem_repo1, "rack", "1.0.0").split("sha256=").last
+      api_checksum = checksum_digest(gem_repo1, "rack", "1.0.0")
       rack_checksum = [[api_checksum].pack("H*")].pack("m0")
       install_gemfile <<-G, :artifice => "compact_index", :env => { "BUNDLER_SPEC_RACK_CHECKSUM" => rack_checksum }
         source "#{source_uri}"
@@ -894,8 +912,6 @@ The checksum of /versions does not match the checksum provided by the server! So
         gem "rack"
       G
 
-      api_checksum = checksum_for_repo_gem(gem_repo1, "rack", "1.0.0").split("sha256=").last
-
       gem_path = if Bundler.feature_flag.global_gem_cache?
         default_cache_path.dirname.join("cache", "gems", "localgemserver.test.80.dd34752a738ee965a2a4298dc16db6c5", "rack-1.0.0.gem")
       else
@@ -907,7 +923,7 @@ The checksum of /versions does not match the checksum provided by the server! So
         Bundler found mismatched checksums. This is a potential security risk.
           rack (1.0.0) sha256=2222222222222222222222222222222222222222222222222222222222222222
             from the API at http://localgemserver.test/
-          rack (1.0.0) sha256=#{api_checksum}
+          #{checksum_to_lock(gem_repo1, "rack", "1.0.0")}
             from the gem at #{gem_path}
 
         If you trust the API at http://localgemserver.test/, to resolve this issue you can:
@@ -972,6 +988,7 @@ Running `bundle update rails` should fix the problem.
     G
     gem_command "uninstall activemerchant"
     bundle "update rails", :artifice => "compact_index"
-    expect(lockfile.scan(/activemerchant \(/).size).to eq(2) # Once in the specs, and once in CHECKSUMS
+    count = lockfile.match?("CHECKSUMS") ? 2 : 1 # Once in the specs, and once in CHECKSUMS
+    expect(lockfile.scan(/activemerchant \(/).size).to eq(count)
   end
 end

--- a/bundler/spec/install/gems/flex_spec.rb
+++ b/bundler/spec/install/gems/flex_spec.rb
@@ -268,6 +268,11 @@ RSpec.describe "bundle flex_install" do
     it "should work when you install" do
       bundle "install"
 
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo1, "rack", "0.9.1"
+        c.checksum gem_repo1, "rack-obama", "1.0"
+      end
+
       expect(lockfile).to eq <<~L
         GEM
           remote: #{file_uri_for(gem_repo1)}/
@@ -282,11 +287,7 @@ RSpec.describe "bundle flex_install" do
         DEPENDENCIES
           rack (= 0.9.1)
           rack-obama
-
-        CHECKSUMS
-          #{checksum_for_repo_gem gem_repo1, "rack", "0.9.1"}
-          #{checksum_for_repo_gem gem_repo1, "rack-obama", "1.0"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -312,6 +313,10 @@ RSpec.describe "bundle flex_install" do
         gem "rack"
       G
 
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo1, "rack", "1.0.0"
+      end
+
       expect(lockfile).to eq <<~L
         GEM
           remote: #{file_uri_for(gem_repo1)}/
@@ -327,10 +332,7 @@ RSpec.describe "bundle flex_install" do
 
         DEPENDENCIES
           rack
-
-        CHECKSUMS
-          #{checksum_for_repo_gem gem_repo1, "rack", "1.0.0"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -268,6 +268,9 @@ RSpec.describe "bundle install with install-time dependencies" do
             DEPENDENCIES
               parallel_tests
 
+            CHECKSUMS
+              #{checksum_for_repo_gem gem_repo2, "parallel_tests", "3.8.0"}
+
             BUNDLED WITH
                #{Bundler::VERSION}
           L
@@ -348,6 +351,10 @@ RSpec.describe "bundle install with install-time dependencies" do
 
             DEPENDENCIES
               parallel_tests
+
+            CHECKSUMS
+              #{checksum_for_repo_gem gem_repo2, "rubocop", "1.35.0"}
+              #{checksum_for_repo_gem gem_repo2, "rubocop-ast", "1.21.0"}
 
             BUNDLED WITH
                #{Bundler::VERSION}

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -256,6 +256,10 @@ RSpec.describe "bundle install with install-time dependencies" do
             gem 'parallel_tests'
           G
 
+          checksums = checksums_section do |c|
+            c.checksum gem_repo2, "parallel_tests", "3.8.0"
+          end
+
           lockfile <<~L
             GEM
               remote: http://localgemserver.test/
@@ -267,10 +271,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
             DEPENDENCIES
               parallel_tests
-
-            CHECKSUMS
-              #{checksum_for_repo_gem gem_repo2, "parallel_tests", "3.8.0"}
-
+            #{checksums}
             BUNDLED WITH
                #{Bundler::VERSION}
           L
@@ -278,6 +279,10 @@ RSpec.describe "bundle install with install-time dependencies" do
 
         it "automatically updates lockfile to use the older version" do
           bundle "install --verbose", :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }
+
+          checksums = checksums_section_when_existing do |c|
+            c.no_checksum "parallel_tests", "3.7.0"
+          end
 
           expect(lockfile).to eq <<~L
             GEM
@@ -290,10 +295,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
             DEPENDENCIES
               parallel_tests
-
-            CHECKSUMS
-              #{checksum_for_repo_gem gem_repo2, "parallel_tests", "3.7.0"}
-
+            #{checksums}
             BUNDLED WITH
                #{Bundler::VERSION}
           L
@@ -338,6 +340,11 @@ RSpec.describe "bundle install with install-time dependencies" do
             gem 'rubocop'
           G
 
+          checksums = checksums_section do |c|
+            c.checksum gem_repo2, "rubocop", "1.35.0"
+            c.checksum gem_repo2, "rubocop-ast", "1.21.0"
+          end
+
           lockfile <<~L
             GEM
               remote: http://localgemserver.test/
@@ -351,11 +358,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
             DEPENDENCIES
               parallel_tests
-
-            CHECKSUMS
-              #{checksum_for_repo_gem gem_repo2, "rubocop", "1.35.0"}
-              #{checksum_for_repo_gem gem_repo2, "rubocop-ast", "1.21.0"}
-
+            #{checksums}
             BUNDLED WITH
                #{Bundler::VERSION}
           L
@@ -363,6 +366,11 @@ RSpec.describe "bundle install with install-time dependencies" do
 
         it "automatically updates lockfile to use the older compatible versions" do
           bundle "install --verbose", :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }
+
+          checksums = checksums_section_when_existing do |c|
+            c.no_checksum "rubocop", "1.28.2"
+            c.no_checksum "rubocop-ast", "1.17.0"
+          end
 
           expect(lockfile).to eq <<~L
             GEM
@@ -377,11 +385,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
             DEPENDENCIES
               rubocop
-
-            CHECKSUMS
-              #{checksum_for_repo_gem gem_repo2, "rubocop", "1.28.2"}
-              #{checksum_for_repo_gem gem_repo2, "rubocop-ast", "1.17.0"}
-
+            #{checksums}
             BUNDLED WITH
                #{Bundler::VERSION}
           L

--- a/bundler/spec/install/yanked_spec.rb
+++ b/bundler/spec/install/yanked_spec.rb
@@ -160,10 +160,6 @@ RSpec.context "when resolving a bundle that includes yanked gems, but unlocking 
         bar
         foo
 
-      CHECKSUMS
-        #{gem_no_checksum "bar", "2.0.0"}
-        #{gem_no_checksum "foo", "9.0.0"}
-
       BUNDLED WITH
          #{Bundler::VERSION}
     L

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -300,7 +300,7 @@ RSpec.describe "the lockfile format" do
       gem "rack-obama", ">= 1.0"
     G
 
-    checksums = checksums_section do |c|
+    checksums = checksums_section_when_existing do |c|
       c.checksum gem_repo2, "rack", "1.0.0"
       c.checksum gem_repo2, "rack-obama", "1.0"
     end
@@ -339,7 +339,7 @@ RSpec.describe "the lockfile format" do
       end
     G
 
-    checksums = checksums_section do |c|
+    checksums = checksums_section_when_existing do |c|
       c.checksum gem_repo2, "rack", "1.0.0"
       c.checksum gem_repo2, "rack-obama", "1.0"
     end
@@ -377,7 +377,7 @@ RSpec.describe "the lockfile format" do
       gem "net-sftp"
     G
 
-    checksums = checksums_section do |c|
+    checksums = checksums_section_when_existing do |c|
       c.checksum gem_repo2, "net-sftp", "1.1.1"
       c.checksum gem_repo2, "net-ssh", "1.0"
     end
@@ -795,7 +795,7 @@ RSpec.describe "the lockfile format" do
       gem "rack", :source => "#{file_uri_for(gem_repo2)}/"
     G
 
-    checksums = checksums_section do |c|
+    checksums = checksums_section_when_existing do |c|
       c.checksum gem_repo2, "rack", "1.0.0"
     end
 
@@ -825,7 +825,7 @@ RSpec.describe "the lockfile format" do
       gem "rack-obama"
     G
 
-    checksums = checksums_section do |c|
+    checksums = checksums_section_when_existing do |c|
       c.checksum gem_repo2, "actionpack", "2.3.2"
       c.checksum gem_repo2, "activesupport", "2.3.2"
       c.checksum gem_repo2, "rack", "1.0.0"
@@ -866,7 +866,7 @@ RSpec.describe "the lockfile format" do
       gem "rails"
     G
 
-    checksums = checksums_section do |c|
+    checksums = checksums_section_when_existing do |c|
       c.checksum gem_repo2, "actionmailer", "2.3.2"
       c.checksum gem_repo2, "actionpack", "2.3.2"
       c.checksum gem_repo2, "activerecord", "2.3.2"
@@ -924,7 +924,7 @@ RSpec.describe "the lockfile format" do
       gem 'double_deps'
     G
 
-    checksums = checksums_section do |c|
+    checksums = checksums_section_when_existing do |c|
       c.checksum gem_repo2, "double_deps", "1.0"
       c.checksum gem_repo2, "net-ssh", "1.0"
     end
@@ -956,7 +956,7 @@ RSpec.describe "the lockfile format" do
       gem "rack-obama", ">= 1.0", :require => "rack/obama"
     G
 
-    checksums = checksums_section do |c|
+    checksums = checksums_section_when_existing do |c|
       c.checksum gem_repo2, "rack", "1.0.0"
       c.checksum gem_repo2, "rack-obama", "1.0"
     end
@@ -987,7 +987,7 @@ RSpec.describe "the lockfile format" do
       gem "rack-obama", ">= 1.0", :group => :test
     G
 
-    checksums = checksums_section do |c|
+    checksums = checksums_section_when_existing do |c|
       c.checksum gem_repo2, "rack", "1.0.0"
       c.checksum gem_repo2, "rack-obama", "1.0"
     end
@@ -1209,7 +1209,7 @@ RSpec.describe "the lockfile format" do
       gem "platform_specific"
     G
 
-    checksums = checksums_section do |c|
+    checksums = checksums_section_when_existing do |c|
       c.checksum gem_repo2, "platform_specific", "1.0", "universal-java-16"
     end
 

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe "the lockfile format" do
   end
 
   it "generates a simple lockfile for a single source, gem" do
+    checksums = checksums_section_when_existing do |c|
+      c.checksum(gem_repo2, "rack", "1.0.0")
+    end
+
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}"
 
@@ -23,10 +27,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -77,9 +78,6 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -134,6 +132,10 @@ RSpec.describe "the lockfile format" do
   it "does not update the lockfile's bundler version if nothing changed during bundle install, and uses the latest version", :rubygems => "< 3.3.0.a" do
     version = "#{Bundler::VERSION.split(".").first}.0.0.a"
 
+    checksums = checksums_section do |c|
+      c.checksum(gem_repo2, "rack", "1.0.0")
+    end
+
     lockfile <<-L
       GEM
         remote: #{file_uri_for(gem_repo2)}/
@@ -145,10 +147,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
-
+      #{checksums}
       BUNDLED WITH
          #{version}
     L
@@ -173,10 +172,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
-
+      #{checksums}
       BUNDLED WITH
          #{version}
     G
@@ -213,9 +209,6 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack (> 0)
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -264,9 +257,6 @@ RSpec.describe "the lockfile format" do
       DEPENDENCIES
         rack
 
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
-
       BUNDLED WITH
          #{current_version}
     G
@@ -279,9 +269,9 @@ RSpec.describe "the lockfile format" do
       gem "rack-obama"
     G
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo2, "rack", "1.0.0"
-      c.repo_gem gem_repo2, "rack-obama", "1.0"
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo2, "rack", "1.0.0"
+      c.checksum gem_repo2, "rack-obama", "1.0"
     end
 
     expect(lockfile).to eq <<~G
@@ -297,10 +287,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack-obama
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -313,9 +300,9 @@ RSpec.describe "the lockfile format" do
       gem "rack-obama", ">= 1.0"
     G
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo2, "rack", "1.0.0"
-      c.repo_gem gem_repo2, "rack-obama", "1.0"
+    checksums = checksums_section do |c|
+      c.checksum gem_repo2, "rack", "1.0.0"
+      c.checksum gem_repo2, "rack-obama", "1.0"
     end
 
     expect(lockfile).to eq <<~G
@@ -331,10 +318,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack-obama (>= 1.0)
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -355,9 +339,9 @@ RSpec.describe "the lockfile format" do
       end
     G
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo2, "rack", "1.0.0"
-      c.repo_gem gem_repo2, "rack-obama", "1.0"
+    checksums = checksums_section do |c|
+      c.checksum gem_repo2, "rack", "1.0.0"
+      c.checksum gem_repo2, "rack-obama", "1.0"
     end
 
     expect(lockfile).to eq <<~G
@@ -381,10 +365,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack-obama (>= 1.0)!
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -396,9 +377,9 @@ RSpec.describe "the lockfile format" do
       gem "net-sftp"
     G
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo2, "net-sftp", "1.1.1"
-      c.repo_gem gem_repo2, "net-ssh", "1.0"
+    checksums = checksums_section do |c|
+      c.checksum gem_repo2, "net-sftp", "1.1.1"
+      c.checksum gem_repo2, "net-ssh", "1.0"
     end
 
     expect(lockfile).to eq <<~G
@@ -414,10 +395,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         net-sftp
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -432,6 +410,10 @@ RSpec.describe "the lockfile format" do
       source "#{file_uri_for(gem_repo1)}"
       gem "foo", :git => "#{lib_path("foo-1.0")}"
     G
+
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "foo", "1.0"
+    end
 
     expect(lockfile).to eq <<~G
       GIT
@@ -449,10 +431,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
-
-      CHECKSUMS
-        foo (1.0)
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -500,6 +479,10 @@ RSpec.describe "the lockfile format" do
   it "serializes global git sources" do
     git = build_git "foo"
 
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "foo", "1.0"
+    end
+
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       git "#{lib_path("foo-1.0")}" do
@@ -523,10 +506,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
-
-      CHECKSUMS
-        foo (1.0)
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -535,6 +515,10 @@ RSpec.describe "the lockfile format" do
   it "generates a lockfile with a ref for a single pinned source, git gem with a branch requirement" do
     git = build_git "foo"
     update_git "foo", :branch => "omg"
+
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "foo", "1.0"
+    end
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -558,10 +542,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
-
-      CHECKSUMS
-        foo (1.0)
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -570,6 +551,10 @@ RSpec.describe "the lockfile format" do
   it "generates a lockfile with a ref for a single pinned source, git gem with a tag requirement" do
     git = build_git "foo"
     update_git "foo", :tag => "omg"
+
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "foo", "1.0"
+    end
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -593,10 +578,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
-
-      CHECKSUMS
-        foo (1.0)
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -683,10 +665,6 @@ RSpec.describe "the lockfile format" do
       DEPENDENCIES
         ckeditor!
 
-      CHECKSUMS
-        #{gem_no_checksum "ckeditor", "4.0.8"}
-        #{gem_no_checksum "orm_adapter", "0.4.1"}
-
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -694,6 +672,10 @@ RSpec.describe "the lockfile format" do
 
   it "serializes pinned path sources to the lockfile" do
     build_lib "foo"
+
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "foo", "1.0"
+    end
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -715,10 +697,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
-
-      CHECKSUMS
-        foo (1.0)
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -726,6 +705,10 @@ RSpec.describe "the lockfile format" do
 
   it "serializes pinned path sources to the lockfile even when packaging" do
     build_lib "foo"
+
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "foo", "1.0"
+    end
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -751,10 +734,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
-
-      CHECKSUMS
-        foo (1.0)
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -763,6 +743,12 @@ RSpec.describe "the lockfile format" do
   it "sorts serialized sources by type" do
     build_lib "foo"
     bar = build_git "bar"
+
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "foo", "1.0"
+      c.no_checksum "bar", "1.0"
+      c.checksum gem_repo2, "rack", "1.0.0"
+    end
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}/"
@@ -796,12 +782,7 @@ RSpec.describe "the lockfile format" do
         bar!
         foo!
         rack
-
-      CHECKSUMS
-        bar (1.0)
-        foo (1.0)
-        #{checksum_for_repo_gem gem_repo2, "rack", "1.0.0"}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -814,8 +795,8 @@ RSpec.describe "the lockfile format" do
       gem "rack", :source => "#{file_uri_for(gem_repo2)}/"
     G
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo2, "rack", "1.0.0"
+    checksums = checksums_section do |c|
+      c.checksum gem_repo2, "rack", "1.0.0"
     end
 
     expect(lockfile).to eq <<~G
@@ -829,10 +810,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack!
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -847,12 +825,12 @@ RSpec.describe "the lockfile format" do
       gem "rack-obama"
     G
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo2, "actionpack", "2.3.2"
-      c.repo_gem gem_repo2, "activesupport", "2.3.2"
-      c.repo_gem gem_repo2, "rack", "1.0.0"
-      c.repo_gem gem_repo2, "rack-obama", "1.0"
-      c.repo_gem gem_repo2, "thin", "1.0"
+    checksums = checksums_section do |c|
+      c.checksum gem_repo2, "actionpack", "2.3.2"
+      c.checksum gem_repo2, "activesupport", "2.3.2"
+      c.checksum gem_repo2, "rack", "1.0.0"
+      c.checksum gem_repo2, "rack-obama", "1.0"
+      c.checksum gem_repo2, "thin", "1.0"
     end
 
     expect(lockfile).to eq <<~G
@@ -875,10 +853,7 @@ RSpec.describe "the lockfile format" do
         actionpack
         rack-obama
         thin
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -891,14 +866,14 @@ RSpec.describe "the lockfile format" do
       gem "rails"
     G
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo2, "actionmailer", "2.3.2"
-      c.repo_gem gem_repo2, "actionpack", "2.3.2"
-      c.repo_gem gem_repo2, "activerecord", "2.3.2"
-      c.repo_gem gem_repo2, "activeresource", "2.3.2"
-      c.repo_gem gem_repo2, "activesupport", "2.3.2"
-      c.repo_gem gem_repo2, "rails", "2.3.2"
-      c.repo_gem gem_repo2, "rake", "13.0.1"
+    checksums = checksums_section do |c|
+      c.checksum gem_repo2, "actionmailer", "2.3.2"
+      c.checksum gem_repo2, "actionpack", "2.3.2"
+      c.checksum gem_repo2, "activerecord", "2.3.2"
+      c.checksum gem_repo2, "activeresource", "2.3.2"
+      c.checksum gem_repo2, "activesupport", "2.3.2"
+      c.checksum gem_repo2, "rails", "2.3.2"
+      c.checksum gem_repo2, "rake", "13.0.1"
     end
 
     expect(lockfile).to eq <<~G
@@ -927,10 +902,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rails
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -952,9 +924,9 @@ RSpec.describe "the lockfile format" do
       gem 'double_deps'
     G
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo2, "double_deps", "1.0"
-      c.repo_gem gem_repo2, "net-ssh", "1.0"
+    checksums = checksums_section do |c|
+      c.checksum gem_repo2, "double_deps", "1.0"
+      c.checksum gem_repo2, "net-ssh", "1.0"
     end
 
     expect(lockfile).to eq <<~G
@@ -971,10 +943,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         double_deps
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -987,9 +956,9 @@ RSpec.describe "the lockfile format" do
       gem "rack-obama", ">= 1.0", :require => "rack/obama"
     G
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo2, "rack", "1.0.0"
-      c.repo_gem gem_repo2, "rack-obama", "1.0"
+    checksums = checksums_section do |c|
+      c.checksum gem_repo2, "rack", "1.0.0"
+      c.checksum gem_repo2, "rack-obama", "1.0"
     end
 
     expect(lockfile).to eq <<~G
@@ -1005,10 +974,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack-obama (>= 1.0)
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -1021,9 +987,9 @@ RSpec.describe "the lockfile format" do
       gem "rack-obama", ">= 1.0", :group => :test
     G
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo2, "rack", "1.0.0"
-      c.repo_gem gem_repo2, "rack-obama", "1.0"
+    checksums = checksums_section do |c|
+      c.checksum gem_repo2, "rack", "1.0.0"
+      c.checksum gem_repo2, "rack-obama", "1.0"
     end
 
     expect(lockfile).to eq <<~G
@@ -1039,10 +1005,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack-obama (>= 1.0)
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -1050,6 +1013,10 @@ RSpec.describe "the lockfile format" do
 
   it "stores relative paths when the path is provided in a relative fashion and in Gemfile dir" do
     build_lib "foo", :path => bundled_app("foo")
+
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "foo", "1.0"
+    end
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -1073,10 +1040,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
-
-      CHECKSUMS
-        foo (1.0)
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -1084,6 +1048,10 @@ RSpec.describe "the lockfile format" do
 
   it "stores relative paths when the path is provided in a relative fashion and is above Gemfile dir" do
     build_lib "foo", :path => bundled_app(File.join("..", "foo"))
+
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "foo", "1.0"
+    end
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -1107,10 +1075,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
-
-      CHECKSUMS
-        foo (1.0)
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -1118,6 +1083,10 @@ RSpec.describe "the lockfile format" do
 
   it "stores relative paths when the path is provided in an absolute fashion but is relative" do
     build_lib "foo", :path => bundled_app("foo")
+
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "foo", "1.0"
+    end
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -1141,10 +1110,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
-
-      CHECKSUMS
-        foo (1.0)
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -1152,6 +1118,10 @@ RSpec.describe "the lockfile format" do
 
   it "stores relative paths when the path is provided for gemspec" do
     build_lib("foo", :path => tmp.join("foo"))
+
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "foo", "1.0"
+    end
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -1173,16 +1143,17 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
-
-      CHECKSUMS
-        foo (1.0)
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
   end
 
   it "keeps existing platforms in the lockfile" do
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "rack", "1.0.0"
+    end
+
     lockfile <<-G
       GEM
         remote: #{file_uri_for(gem_repo2)}/
@@ -1194,7 +1165,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -1204,6 +1175,8 @@ RSpec.describe "the lockfile format" do
 
       gem "rack"
     G
+
+    checksums.checksum(gem_repo2, "rack", "1.0.0")
 
     expect(lockfile).to eq <<~G
       GEM
@@ -1216,10 +1189,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -1239,8 +1209,8 @@ RSpec.describe "the lockfile format" do
       gem "platform_specific"
     G
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo2, "platform_specific", "1.0", "universal-java-16"
+    checksums = checksums_section do |c|
+      c.checksum gem_repo2, "platform_specific", "1.0", "universal-java-16"
     end
 
     expect(lockfile).to eq <<~G
@@ -1254,16 +1224,18 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         platform_specific
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
   end
 
   it "does not add duplicate gems" do
+    checksums = checksums_section_when_existing do |c|
+      c.checksum(gem_repo2, "activesupport", "2.3.5")
+      c.checksum(gem_repo2, "rack", "1.0.0")
+    end
+
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}/"
       gem "rack"
@@ -1288,17 +1260,17 @@ RSpec.describe "the lockfile format" do
       DEPENDENCIES
         activesupport
         rack
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "activesupport", "2.3.5")}
-        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
   end
 
   it "does not add duplicate dependencies" do
+    checksums = checksums_section_when_existing do |c|
+      c.checksum(gem_repo2, "rack", "1.0.0")
+    end
+
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}/"
       gem "rack"
@@ -1316,16 +1288,17 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
   end
 
   it "does not add duplicate dependencies with versions" do
+    checksums = checksums_section_when_existing do |c|
+      c.checksum(gem_repo2, "rack", "1.0.0")
+    end
+
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}/"
       gem "rack", "1.0"
@@ -1343,16 +1316,17 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack (= 1.0)
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
   end
 
   it "does not add duplicate dependencies in different groups" do
+    checksums = checksums_section_when_existing do |c|
+      c.checksum(gem_repo2, "rack", "1.0.0")
+    end
+
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}/"
       gem "rack", "1.0", :group => :one
@@ -1370,10 +1344,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack (= 1.0)
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -1402,6 +1373,10 @@ RSpec.describe "the lockfile format" do
   end
 
   it "works correctly with multiple version dependencies" do
+    checksums = checksums_section_when_existing do |c|
+      c.checksum(gem_repo2, "rack", "0.9.1")
+    end
+
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}/"
       gem "rack", "> 0.9", "< 1.0"
@@ -1418,16 +1393,17 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack (> 0.9, < 1.0)
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "rack", "0.9.1")}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
   end
 
   it "captures the Ruby version in the lockfile" do
+    checksums = checksums_section_when_existing do |c|
+      c.checksum(gem_repo2, "rack", "0.9.1")
+    end
+
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}/"
       ruby '#{Gem.ruby_version}'
@@ -1445,10 +1421,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack (> 0.9, < 1.0)
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "rack", "0.9.1")}
-
+      #{checksums}
       RUBY VERSION
          #{Bundler::RubyVersion.system}
 
@@ -1526,10 +1499,6 @@ RSpec.describe "the lockfile format" do
       DEPENDENCIES
         direct_dependency
 
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo4, "direct_dependency", "4.5.6")}
-        #{checksum_for_repo_gem(gem_repo4, "indirect_dependency", "1.2.3")}
-
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -1583,10 +1552,6 @@ RSpec.describe "the lockfile format" do
 
         DEPENDENCIES
           minitest-bisect
-
-        CHECKSUMS
-          #{checksum_for_repo_gem(gem_repo4, "minitest-bisect", "1.6.0")}
-          #{checksum_for_repo_gem(gem_repo4, "path_expander", "1.1.1")}
 
         BUNDLED WITH
            #{Bundler::VERSION}
@@ -1653,10 +1618,6 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         minitest-bisect
-
-      CHECKSUMS
-        #{checksum_for_repo_gem gem_repo4, "minitest-bisect", "1.6.0"}
-        #{checksum_for_repo_gem gem_repo4, "path_expander", "1.1.1"}
 
       BUNDLED WITH
          #{Bundler::VERSION}

--- a/bundler/spec/plugins/source/example_spec.rb
+++ b/bundler/spec/plugins/source/example_spec.rb
@@ -70,6 +70,10 @@ RSpec.describe "real source plugins" do
     it "writes to lock file" do
       bundle "install"
 
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "a-path-gem", "1.0"
+      end
+
       expect(lockfile).to eq <<~G
         PLUGIN SOURCE
           remote: #{lib_path("a-path-gem-1.0")}
@@ -86,10 +90,7 @@ RSpec.describe "real source plugins" do
 
         DEPENDENCIES
           a-path-gem!
-
-        CHECKSUMS
-          a-path-gem (1.0)
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       G
@@ -339,6 +340,10 @@ RSpec.describe "real source plugins" do
       revision = revision_for(lib_path("ma-gitp-gem-1.0"))
       bundle "install"
 
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "ma-gitp-gem", "1.0"
+      end
+
       expect(lockfile).to eq <<~G
         PLUGIN SOURCE
           remote: #{file_uri_for(lib_path("ma-gitp-gem-1.0"))}
@@ -356,10 +361,7 @@ RSpec.describe "real source plugins" do
 
         DEPENDENCIES
           ma-gitp-gem!
-
-        CHECKSUMS
-          ma-gitp-gem (1.0)
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       G

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -73,6 +73,13 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
       build_gem "racca", "1.5.2"
     end
 
+    checksums = checksums_section do |c|
+      c.checksum gem_repo4, "mini_portile2", "2.5.0"
+      c.checksum gem_repo4, "nokogiri", "1.11.1"
+      c.checksum gem_repo4, "nokogiri", "1.11.1", Bundler.local_platform
+      c.checksum gem_repo4, "racca", "1.5.2"
+    end
+
     good_lockfile = <<~L
       GEM
         remote: #{file_uri_for(gem_repo4)}/
@@ -90,13 +97,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
 
       DEPENDENCIES
         nokogiri (~> 1.11)
-
-      CHECKSUMS
-        #{checksum_for_repo_gem gem_repo4, "mini_portile2", "2.5.0"}
-        #{checksum_for_repo_gem gem_repo4, "nokogiri", "1.11.1"}
-        #{checksum_for_repo_gem gem_repo4, "nokogiri", "1.11.1", Bundler.local_platform}
-        #{checksum_for_repo_gem gem_repo4, "racca", "1.5.2"}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1229,7 +1229,7 @@ end
           rack
 
         CHECKSUMS
-          #{checksum_for_repo_gem gem_repo1, "rack", "1.0.0"}
+          #{checksum_to_lock gem_repo1, "rack", "1.0.0"}
       L
 
       if ruby_version

--- a/bundler/spec/support/artifice/compact_index_partial_update_alt_range.rb
+++ b/bundler/spec/support/artifice/compact_index_partial_update_alt_range.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require_relative "helpers/compact_index"
+
+class CompactIndexPartialUpdate < CompactIndexAPI
+  # Stub the server to never return 304s. This simulates the behaviour of
+  # Fastly / Rubygems ignoring ETag headers.
+  def not_modified?(_checksum)
+    false
+  end
+
+  get "/versions" do
+    cached_versions_path = File.join(
+      Bundler.rubygems.user_home, ".bundle", "cache", "compact_index",
+      "localgemserver.test.80.dd34752a738ee965a2a4298dc16db6c5", "versions"
+    )
+    content = File.binread(cached_versions_path)
+
+    # Verify a cached copy of the versions file exists
+    unless content.start_with?("created_at: ")
+      raise("Cached versions file should be present and have content")
+    end
+
+    # Verify that a partial request is made, starting from the index of the
+    # final byte of the cached file.
+    unless env["HTTP_RANGE"] == "bytes=#{content.bytesize - 1}-"
+      raise("Range header should be present, and start from the index of the final byte of the cache.")
+    end
+
+    # it's possible for a server to return a larger range than requested as long as it satisfies the range request
+    start_range = content.bytesize - 8
+    header "Content-Range", "bytes #{start_range}-#{content.bytesize}/#{content.bytesize}"
+    env["HTTP_RANGE"] = "bytes=#{start_range}-" # trick the artifice so we don't have to re-implement the range parsing
+
+    etag_response do
+      # Return the exact contents of the cache.
+      File.binread(cached_versions_path)
+    end
+  end
+end
+
+require_relative "helpers/artifice"
+
+Artifice.activate_with(CompactIndexPartialUpdate)

--- a/bundler/spec/update/git_spec.rb
+++ b/bundler/spec/update/git_spec.rb
@@ -309,6 +309,11 @@ RSpec.describe "bundle update" do
 
       bundle "update --source bar"
 
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "foo", "2.0"
+        c.checksum gem_repo2, "rack", "1.0.0"
+      end
+
       expect(lockfile).to eq <<~G
         GIT
           remote: #{@git.path}
@@ -327,11 +332,7 @@ RSpec.describe "bundle update" do
         DEPENDENCIES
           foo!
           rack
-
-        CHECKSUMS
-          foo (2.0)
-          #{checksum_for_repo_gem gem_repo2, "rack", "1.0.0"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       G


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Users need to be able to opt-in to checksums.

## What is your fix for the problem, implemented in this PR?

I'm slowly fixing all the specs so that they generate checksums depending on if checksums exist already in the current lockfile so that we don't throw away all the specs. When checksums become enabled by default, we can just change the checksums_section method to ignore existing lockfile.

Note: I was starting to solve the problem of detecting when changes happened to the lockfile checksums, so some of this code is a bit excessive. It turns out that's a very difficult problem since some of the checksums are added for use in the lockfile _after_ installing the gems (when the checksums are calculated from the .gem), which means we can't detect modification of frozen lockfile before installation.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
