### PR TITLE
Make sure to `require "rubygems"` explicitly

### DIFF
--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -2,6 +2,8 @@
 
 require "pathname"
 
+require "rubygems" unless defined?(Gem)
+
 require "rubygems/specification"
 
 # We can't let `Gem::Source` be autoloaded in the `Gem::Specification#source`

--- a/bundler/spec/runtime/requiring_spec.rb
+++ b/bundler/spec/runtime/requiring_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe "Requiring bundler" do
+  it "takes care of requiring rubygems when entrypoint is bundler/setup" do
+    sys_exec("#{Gem.ruby} -I#{lib_dir} -rbundler/setup -e'puts true'", :env => { "RUBYOPT" => opt_add("--disable=gems", ENV["RUBYOPT"]) })
+
+    expect(last_command.stdboth).to eq("true")
+  end
+
+  it "takes care of requiring rubygems when requiring just bundler" do
+    sys_exec("#{Gem.ruby} -I#{lib_dir} -rbundler -e'puts true'", :env => { "RUBYOPT" => opt_add("--disable=gems", ENV["RUBYOPT"]) })
+
+    expect(last_command.stdboth).to eq("true")
+  end
+end

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1506,12 +1506,6 @@ end
       expect(err).to include "private method `require'"
     end
 
-    it "takes care of requiring rubygems" do
-      sys_exec("#{Gem.ruby} -I#{lib_dir} -rbundler/setup -e'puts true'", :env => { "RUBYOPT" => opt_add("--disable=gems", ENV["RUBYOPT"]) })
-
-      expect(last_command.stdboth).to eq("true")
-    end
-
     it "memoizes initial set of specs when requiring bundler/setup, so that even if further code mutates dependencies, Bundler.definition.specs is not affected" do
       install_gemfile <<~G
         source "#{file_uri_for(gem_repo1)}"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Requiring just bundler with `--disable=gems`, rubygems/deprecate.rb fails because `Gem` is not defined yet.
```sh-session
$ ruby --disable=gems -rbundler -ep
/opt/local/lib/ruby/3.3.0+0/rubygems/deprecate.rb:72:in `<top (required)>': uninitialized constant Gem (NameError)
	from /opt/local/lib/ruby/3.3.0+0/rubygems/specification.rb:10:in `require_relative'
	from /opt/local/lib/ruby/3.3.0+0/rubygems/specification.rb:10:in `<top (required)>'
	from /opt/local/lib/ruby/3.3.0+0/bundler/rubygems_ext.rb:5:in `require'
	from /opt/local/lib/ruby/3.3.0+0/bundler/rubygems_ext.rb:5:in `<top (required)>'
	from /opt/local/lib/ruby/3.3.0+0/bundler.rb:10:in `require_relative'
	from /opt/local/lib/ruby/3.3.0+0/bundler.rb:10:in `<top (required)>'
	from -e:in `require'
```

This happened in a CI too.
https://github.com/ruby/ruby/actions/runs/6793669817/job/18468881547?pr=8867#step:8:1049

## What is your fix for the problem, implemented in this PR?

Make sure to `require "rubygems"` explicitly in bundler/lib/bundler/rubygems_ext.rb.
This is also done in bundler/lib/bundler/rubygems_integration.rb, but bundler/lib/bundler.rb loads this file before it.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
