### PR TITLE
Fix daily Bundler CI

### DIFF
--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -387,7 +387,7 @@ RSpec.describe "bundle lock" do
         build_gem "sequel", "5.72.0" do |s|
           s.add_dependency "bigdecimal", ">= 0"
         end
-        build_gem "bigdecimal", %w[1.4.4 3.1.4]
+        build_gem "bigdecimal", %w[1.4.4 99.1.4]
       end
 
       gemfile <<~G
@@ -417,7 +417,7 @@ RSpec.describe "bundle lock" do
     it "adds the latest version of the new dependency" do
       bundle "lock --minor --update sequel"
 
-      expect(the_bundle.locked_gems.specs.map(&:full_name)).to eq(%w[sequel-5.72.0 bigdecimal-3.1.4].sort)
+      expect(the_bundle.locked_gems.specs.map(&:full_name)).to eq(%w[sequel-5.72.0 bigdecimal-99.1.4].sort)
     end
   end
 


### PR DESCRIPTION




## What was the end-user or developer problem that led to this PR?

[Daily Bundler CI](https://github.com/rubygems/rubygems/actions/runs/6791813468/job/18464010210#step:6:163) against ruby-head is failing because ruby-head now uses bigdecimal 3.1.5, so that gets locked by this spec.

## What is your fix for the problem, implemented in this PR?

Bump fake big decimal version used by this test to 99.1.4, so that the test is stable until bigdecimal 99.1.5 is bundled with Ruby :)

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
