### PR TITLE
`extension_in_lib` helper for `TestGemExtBuilder`

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -158,6 +158,14 @@ class Gem::TestCase < Test::Unit::TestCase
   end
 
   ##
+  # Overrides the Gem.install_extension_in_lib function and restores the
+  # original when the block ends
+  #
+  def extension_in_lib(value = true) # :nodoc:
+    Gem.stub(:install_extension_in_lib, value) { yield }
+  end
+
+  ##
   # Sets the vendordir entry in RbConfig::CONFIG to +value+ and restores the
   # original value when the block ends
   #

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -106,38 +106,41 @@ install:
 
   def test_build_extensions
     pend "terminates on mswin" if vc_windows? && ruby_repo?
-    @spec.extensions << "ext/extconf.rb"
 
-    ext_dir = File.join @spec.gem_dir, "ext"
+    extension_in_lib do
+      @spec.extensions << "ext/extconf.rb"
 
-    FileUtils.mkdir_p ext_dir
+      ext_dir = File.join @spec.gem_dir, "ext"
 
-    extconf_rb = File.join ext_dir, "extconf.rb"
+      FileUtils.mkdir_p ext_dir
 
-    File.open extconf_rb, "w" do |f|
-      f.write <<-'RUBY'
-        require 'mkmf'
+      extconf_rb = File.join ext_dir, "extconf.rb"
 
-        create_makefile 'a'
-      RUBY
+      File.open extconf_rb, "w" do |f|
+        f.write <<-'RUBY'
+          require 'mkmf'
+
+          create_makefile 'a'
+        RUBY
+      end
+
+      ext_lib_dir = File.join ext_dir, "lib"
+      FileUtils.mkdir ext_lib_dir
+      FileUtils.touch File.join ext_lib_dir, "a.rb"
+      FileUtils.mkdir File.join ext_lib_dir, "a"
+      FileUtils.touch File.join ext_lib_dir, "a", "b.rb"
+
+      use_ui @ui do
+        @builder.build_extensions
+      end
+
+      assert_path_exist @spec.extension_dir
+      assert_path_exist @spec.gem_build_complete_path
+      assert_path_exist File.join @spec.extension_dir, "gem_make.out"
+      assert_path_exist File.join @spec.extension_dir, "a.rb"
+      assert_path_exist File.join @spec.gem_dir, "lib", "a.rb"
+      assert_path_exist File.join @spec.gem_dir, "lib", "a", "b.rb"
     end
-
-    ext_lib_dir = File.join ext_dir, "lib"
-    FileUtils.mkdir ext_lib_dir
-    FileUtils.touch File.join ext_lib_dir, "a.rb"
-    FileUtils.mkdir File.join ext_lib_dir, "a"
-    FileUtils.touch File.join ext_lib_dir, "a", "b.rb"
-
-    use_ui @ui do
-      @builder.build_extensions
-    end
-
-    assert_path_exist @spec.extension_dir
-    assert_path_exist @spec.gem_build_complete_path
-    assert_path_exist File.join @spec.extension_dir, "gem_make.out"
-    assert_path_exist File.join @spec.extension_dir, "a.rb"
-    assert_path_exist File.join @spec.gem_dir, "lib", "a.rb"
-    assert_path_exist File.join @spec.gem_dir, "lib", "a", "b.rb"
   end
 
   def test_build_extensions_with_gemhome_with_space

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -153,54 +153,41 @@ install:
   end
 
   def test_build_extensions_install_ext_only
-    class << Gem
-      alias_method :orig_install_extension_in_lib, :install_extension_in_lib
-
-      remove_method :install_extension_in_lib
-
-      def Gem.install_extension_in_lib
-        false
-      end
-    end
     pend "terminates on mswin" if vc_windows? && ruby_repo?
 
-    @spec.extensions << "ext/extconf.rb"
+    extension_in_lib(false) do
+      @spec.extensions << "ext/extconf.rb"
 
-    ext_dir = File.join @spec.gem_dir, "ext"
+      ext_dir = File.join @spec.gem_dir, "ext"
 
-    FileUtils.mkdir_p ext_dir
+      FileUtils.mkdir_p ext_dir
 
-    extconf_rb = File.join ext_dir, "extconf.rb"
+      extconf_rb = File.join ext_dir, "extconf.rb"
 
-    File.open extconf_rb, "w" do |f|
-      f.write <<-'RUBY'
-        require 'mkmf'
+      File.open extconf_rb, "w" do |f|
+        f.write <<-'RUBY'
+          require 'mkmf'
 
-        create_makefile 'a'
-      RUBY
-    end
+          create_makefile 'a'
+        RUBY
+      end
 
-    ext_lib_dir = File.join ext_dir, "lib"
-    FileUtils.mkdir ext_lib_dir
-    FileUtils.touch File.join ext_lib_dir, "a.rb"
-    FileUtils.mkdir File.join ext_lib_dir, "a"
-    FileUtils.touch File.join ext_lib_dir, "a", "b.rb"
+      ext_lib_dir = File.join ext_dir, "lib"
+      FileUtils.mkdir ext_lib_dir
+      FileUtils.touch File.join ext_lib_dir, "a.rb"
+      FileUtils.mkdir File.join ext_lib_dir, "a"
+      FileUtils.touch File.join ext_lib_dir, "a", "b.rb"
 
-    use_ui @ui do
-      @builder.build_extensions
-    end
+      use_ui @ui do
+        @builder.build_extensions
+      end
 
-    assert_path_exist @spec.extension_dir
-    assert_path_exist @spec.gem_build_complete_path
-    assert_path_exist File.join @spec.extension_dir, "gem_make.out"
-    assert_path_exist File.join @spec.extension_dir, "a.rb"
-    assert_path_not_exist File.join @spec.gem_dir, "lib", "a.rb"
-    assert_path_not_exist File.join @spec.gem_dir, "lib", "a", "b.rb"
-  ensure
-    class << Gem
-      remove_method :install_extension_in_lib
-
-      alias_method :install_extension_in_lib, :orig_install_extension_in_lib
+      assert_path_exist @spec.extension_dir
+      assert_path_exist @spec.gem_build_complete_path
+      assert_path_exist File.join @spec.extension_dir, "gem_make.out"
+      assert_path_exist File.join @spec.extension_dir, "a.rb"
+      assert_path_not_exist File.join @spec.gem_dir, "lib", "a.rb"
+      assert_path_not_exist File.join @spec.gem_dir, "lib", "a", "b.rb"
     end
   end
 


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

I am facing this test failures running RubyGems test suite on Fedora:

~~~
$ ./run_test.sh -n /test_build_extensions/
Loaded suite -e
Started
F
================================================================================
Failure: test_build_extensions(TestGemExtBuilder): <"/mnt/tmp/test_rubygems_20231108-15642-pg80i8/gemhome/gems/a-2/lib/a.rb"> was expected to exist
/mnt/test/rubygems/test_gem_ext_builder.rb:139:in `test_build_extensions'
     136:     assert_path_exist @spec.gem_build_complete_path
     137:     assert_path_exist File.join @spec.extension_dir, "gem_make.out"
     138:     assert_path_exist File.join @spec.extension_dir, "a.rb"
  => 139:     assert_path_exist File.join @spec.gem_dir, "lib", "a.rb"
     140:     assert_path_exist File.join @spec.gem_dir, "lib", "a", "b.rb"
     141:   end
     142: 
================================================================================
F
================================================================================
Failure: test_build_extensions_with_gemhome_with_space(TestGemExtBuilder): <"/mnt/tmp/test_rubygems_20231108-15642-q1njg2/gem home/gems/a-2/lib/a.rb"> was expected to exist
/mnt/test/rubygems/test_gem_ext_builder.rb:139:in `test_build_extensions'
/mnt/test/rubygems/test_gem_ext_builder.rb:152:in `test_build_extensions_with_gemhome_with_space'
     149:     @spec = util_spec "a"
     150:     @builder = Gem::Ext::Builder.new @spec, ""
     151: 
  => 152:     test_build_extensions
     153:   end
     154: 
     155:   def test_build_extensions_install_ext_only
================================================================================
Finished in 0.387516239 seconds.
--------------------------------------------------------------------------------
16 tests, 54 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
87.5% passed
--------------------------------------------------------------------------------
41.29 tests/s, 139.35 assertions/s
~~~

I have arrived at this issue looking at #7119. While these specific failures are not directly reproducible in my [Ruby POC](https://github.com/ruby/ruby/pull/8761), they are related, because they are caused by [`operating_system.rb` overrides](https://src.fedoraproject.org/rpms/ruby/blob/5bf57b1504871230600103083d77ff3502255e2e/f/operating_system.rb#_143-145).

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

The first patch introduces `extension_in_lib`, which is inspired by e.g. [`vendordir` helper](https://github.com/rubygems/rubygems/blob/a219c78e097cca90ba2ff446c153cb9844e68e6d/test/rubygems/helper.rb#L164). On background, it uses `stub` helper, which is probably better then the custom code.

The second patch makes use of `extension_in_lib` in the `test_build_extensions`, making sure the override shipped in Ruby does not influence the test result.

The only downside of this is that the `Gem.install_extension_in_lib` return value is not directly tested. But this is just configuration method, so I'm not sure it is worth of testing.
