### PR TITLE
Changelogs for RubyGems 3.4.22 and Bundler 2.4.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+# 3.4.22 / 2023-11-09
+
+## Enhancements:
+
+* Update SPDX license list as of 2023-10-05. Pull request
+  [#7040](https://github.com/rubygems/rubygems/pull/7040) by
+  github-actions[bot]
+* Remove unnecessary rescue. Pull request
+  [#7109](https://github.com/rubygems/rubygems/pull/7109) by
+  deivid-rodriguez
+* Installs bundler 2.4.22 as a default gem.
+
+## Bug fixes:
+
+* Handle empty array at built-in YAML serializer. Pull request
+  [#7099](https://github.com/rubygems/rubygems/pull/7099) by hsbt
+* Ignore non-tar format `.gem` files during search. Pull request
+  [#7095](https://github.com/rubygems/rubygems/pull/7095) by dearblue
+* Allow explicitly uninstalling multiple versions of same gem. Pull
+  request [#7063](https://github.com/rubygems/rubygems/pull/7063) by
+  kstevens715
+
+## Performance:
+
+* Avoid regexp match on every call to `Gem::Platform.local`. Pull request
+  [#7104](https://github.com/rubygems/rubygems/pull/7104) by segiddins
+
+## Documentation:
+
+* Get `Gem::Specification#extensions_dir` documented. Pull request
+  [#6218](https://github.com/rubygems/rubygems/pull/6218) by
+  deivid-rodriguez
+
 # 3.4.21 / 2023-10-17
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,24 @@
+# 2.4.22 (November 9, 2023)
+
+## Enhancements:
+
+  - Add Bundler::Plugin.loaded? helper [#6964](https://github.com/rubygems/rubygems/pull/6964)
+  - Give better error when previous installation folder is insecure to remove [#7030](https://github.com/rubygems/rubygems/pull/7030)
+  - Set file path when eval-ing local specification in EndpointSpecification [#7106](https://github.com/rubygems/rubygems/pull/7106)
+  - Git ignore the proper files for the CI service selected for `bundle gem` [#7101](https://github.com/rubygems/rubygems/pull/7101)
+  - Update vendored thor to v1.3.0 [#7078](https://github.com/rubygems/rubygems/pull/7078)
+  - Restore using old way of passing Ruby version to resolver [#7066](https://github.com/rubygems/rubygems/pull/7066)
+  - Bump vendored net-http-persistent to 4.0.2 [#6787](https://github.com/rubygems/rubygems/pull/6787)
+
+## Bug fixes:
+
+  - Fix regression when installing native extensions on universal rubies [#7077](https://github.com/rubygems/rubygems/pull/7077)
+  - Only remove bundler plugin gem when it's inside the cache [#7001](https://github.com/rubygems/rubygems/pull/7001)
+  - Don't show bug report template when GEM_HOME has no writable bit [#7113](https://github.com/rubygems/rubygems/pull/7113)
+  - Fix regression in old git versions [#7114](https://github.com/rubygems/rubygems/pull/7114)
+  - Handle empty array at built-in YAML serializer [#7099](https://github.com/rubygems/rubygems/pull/7099)
+  - Fix force_ruby_platform: when the lockfile only locks the ruby platform [#6936](https://github.com/rubygems/rubygems/pull/6936)
+
 # 2.4.21 (October 17, 2023)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.4.22 and Bundler 2.4.22 into master.