### PR TITLE
Report possible error prior checking output of gem uninstall

### DIFF
--- a/test/rubygems/test_gem_commands_exec_command.rb
+++ b/test/rubygems/test_gem_commands_exec_command.rb
@@ -736,6 +736,8 @@ class TestGemCommandsExecCommand < Gem::TestCase
       rescue StandardError
         nil
       end
+
+      assert_empty @ui.error
       refute_includes @ui.output, "running gem exec with"
       assert_includes @ui.output, "Successfully uninstalled a-2\n"
 


### PR DESCRIPTION
Originally, the failed test case reported following error:

~~~
Failure: test_gem_exec_gem_uninstall(TestGemCommandsExecCommand):
  <""> was expected to include
  <"Successfully uninstalled a-2\n">.
/mnt/test/rubygems/test_gem_commands_exec_command.rb:742:in `block in test_gem_exec_gem_uninstall'
     739:
     740:       # assert_empty @ui.error
     741:       refute_includes @ui.output, "running gem exec with"
  => 742:       assert_includes @ui.output, "Successfully uninstalled a-2\n"
     743:
     744:       invoke "--verbose", "gem", "uninstall", "b"
     745:       assert_includes @ui.output, "Successfully uninstalled b-2\n"
/mnt/lib/rubygems/user_interaction.rb:46:in `use_ui'
/mnt/lib/rubygems/user_interaction.rb:69:in `use_ui'
/mnt/test/rubygems/test_gem_commands_exec_command.rb:726:in `test_gem_exec_gem_uninstall'
~~~

This does not tell much. Empty string is more often good sign, but not in this case. However, checking error output first helps with understanding possible issue:

~~~
Failure: test_gem_exec_gem_uninstall(TestGemCommandsExecCommand):
  <"ERROR:  While executing gem ... (Gem::FilePermissionError)\n" +
  "    You don't have write permissions for the /builddir/bin directory.\n" +
  "\t/mnt/lib/rubygems/uninstaller.rb:213:in `remove_executables'\n" +

... snip ...

/mnt/test/rubygems/test_gem_commands_exec_command.rb:740:in `block in test_gem_exec_gem_uninstall'
     737:         nil
     738:       end
     739:
  => 740:       assert_empty @ui.error
     741:       refute_includes @ui.output, "running gem exec with"
     742:       assert_includes @ui.output, "Successfully uninstalled a-2\n"
     743:
/mnt/lib/rubygems/user_interaction.rb:46:in `use_ui'
/mnt/lib/rubygems/user_interaction.rb:69:in `use_ui'
/mnt/test/rubygems/test_gem_commands_exec_command.rb:726:in `test_gem_exec_gem_uninstall'
~~~

BTW I have hit this in the context of #7119. This issue is caused by [operating_system.rb overriding](https://src.fedoraproject.org/rpms/ruby/blob/5bf57b1504871230600103083d77ff3502255e2e/f/operating_system.rb#_103) `Gem.operating_system_defaults` method and explicitly adding `--bindir` option.