### PR TITLE
Provide more insightful test_realworld_upgraded_default_gem(TestGemRequire) error output

### DIFF
--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -471,11 +471,11 @@ class TestGemRequire < Gem::TestCase
     File.write(path, code)
 
     output = Gem::Util.popen({ "GEM_HOME" => @gemhome }, *ruby_with_rubygems_in_load_path, path).strip
-    assert $?.success?
     refute_empty output
     assert_equal "999.99.9", output.lines[0].chomp
     # Make sure only files from the newer json gem are loaded, and no files from the default json gem
     assert_equal ["#{@gemhome}/gems/json-999.99.9/lib/json.rb"], output.lines.grep(%r{/gems/json-}).map(&:chomp)
+    assert $?.success?
   end
 
   def test_default_gem_and_normal_gem


### PR DESCRIPTION
Original output:

~~~
Failure: test_realworld_upgraded_default_gem(TestGemRequire): <false> is not true. /mnt/test/rubygems/test_require.rb:474:in `test_realworld_upgraded_default_gem'
     471:     File.write(path, code)
     472:
     473:     output = Gem::Util.popen({ "GEM_HOME" => @gemhome }, *ruby_with_rubygems_in_load_path, path).strip
  => 474:     assert $?.success?
     475:     refute_empty output
     476:     assert_equal "999.99.9", output.lines[0].chomp
     477:     # Make sure only files from the newer json gem are loaded, and no files from the default json gem
~~~

New output:

~~~
Failure: test_realworld_upgraded_default_gem(TestGemRequire) /mnt/test/rubygems/test_require.rb:474:in `test_realworld_upgraded_default_gem'
     471:     File.write(path, code)
     472:
     473:     output = Gem::Util.popen({ "GEM_HOME" => @gemhome }, *ruby_with_rubygems_in_load_path, path).strip
  => 474:     assert_equal "999.99.9", output.lines[0].chomp
     475:     # Make sure only files from the newer json gem are loaded, and no files from the default json gem
     476:     assert_equal ["#{@gemhome}/gems/json-999.99.9/lib/json.rb"], output.lines.grep(%r{/gems/json-}).map(&:chomp)
     477:     assert $?.success?
<"999.99.9"> expected but was
<"/mnt/tmp/test_rubygems_20231109-27890-kd68d4/test_realworld_upgraded_default_gem.rb:3:in `<main>': undefined method `version' for nil:NilClass (NoMethodError)">

diff:
?                               9    99                                           .99.9
? /mnt/tmp/test_rubygems_2023110 -278 0-kd68d4/test_realworld_upgraded_default_gem rb:3:in `<main>': undefined method `version' for nil:NilClass (NoMethodError)
? ++++++++++++++++++++++++++++++ ++++ ? ????
~~~

It is more valuable to check the command output then the error code. If the command fails for some reason, the output probably contains some detail, while checking the return code tells not much.

Also, removing the excessive output content check, when the output is later inspeced in more detail.

