### PR TITLE
Make temp gem home independent of pwd

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -290,7 +290,7 @@ class Gem::TestCase < Test::Unit::TestCase
   def setup
     @orig_hooks = {}
     @orig_env = ENV.to_hash
-    @tmp = File.expand_path("tmp")
+    @tmp = File.expand_path("../../tmp", __dir__)
 
     FileUtils.mkdir_p @tmp
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Under some circumstances, we may end up with a very long temp directory during tests, as shown at #7132.

## What is your fix for the problem, implemented in this PR?

My diagnosis was that if at the point of setting the temp gem home directory for a test we have not changed back from the temp gem home of the previous test, we could end up creating a temp home nested inside the previous temp gem home.

The long directory causing issues at #7132 looks like that's what's happening.

I guess we can avoid this issue by making this code independent from the current working directory.

Closes #7132.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
