### PR TITLE
Explicitly define `@default_specifications_dir` for tests

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -370,7 +370,7 @@ class Gem::TestCase < Test::Unit::TestCase
 
     ENV["GEM_PRIVATE_KEY_PASSPHRASE"] = PRIVATE_KEY_PASSPHRASE
 
-    Gem.instance_variable_set(:@default_specifications_dir, nil)
+    Gem.instance_variable_set(:@default_specifications_dir, File.join(@gemhome, "specifications", "default"))
     if Gem.java_platform?
       @orig_default_gem_home = RbConfig::CONFIG["default_gem_home"]
       RbConfig::CONFIG["default_gem_home"] = @gemhome


### PR DESCRIPTION
Resetting `@default_specifications_dir` to `nil` means that the `Gem.default_specifications_dir` needs to be invoked. However, given that this method might be overridden by operating_system.rb and similar, this might lead to various test failures. Providing the default value makes the issues go away.

Please note that this single line reduced the number of test failures for ruby/ruby/pull/8761 from ~80 to just ~4 and fixes most of my concerns raised in #7119