### PR TITLE
Don't check `LIBRUBY_RELATIVE` in truffleruby to signal a bash prelude in rubygems binstubs

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -226,7 +226,8 @@ class Gem::Installer
       line = io.gets
       shebang = /^#!.*ruby/
 
-      if load_relative_enabled?
+      # TruffleRuby uses a bash prelude in default launchers
+      if load_relative_enabled? || RUBY_ENGINE == "truffleruby"
         until line.nil? || line =~ shebang do
           line = io.gets
         end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`gem install rails` on a truffleruby install with upgraded RubyGems hangs with the following command prompt:

```
racc's executable "racc" conflicts with /Users/deivid/.asdf/installs/ruby/truffleruby-dev/bin/racc
Overwrite the executable? [yN]
```
 
## What is your fix for the problem, implemented in this PR?

My fix is to upstream TruffleRuby monkey patch to RubyGems, where they force RubyGems to skip the checking whether a binstub was generated by RubyGems. Apparently truffle ruby always ships binstubs with a bash prelude, regardless of `LIBRUBY_RELATIVE`, so I think this makes sense.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
