### PR TITLE
Lock gem versions for C ext dependencies (#8918)

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -25,7 +25,7 @@ jobs:
         ruby:
           # - { name: ruby-2.3, value: 2.3.8 }
           # - { name: ruby-2.4, value: 2.4.10 }
-          - { name: ruby-2.5, value: 2.5.9 }
+          # - { name: ruby-2.5, value: 2.5.9 }
           - { name: ruby-2.6, value: 2.6.10 }
           - { name: ruby-2.7, value: 2.7.6 }
           - { name: ruby-3.0, value: 3.0.4 }
@@ -38,7 +38,7 @@ jobs:
         exclude:
           # - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.3, value: 2.3.8 } }
           # - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.4, value: 2.4.10 } }
-          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.5, value: 2.5.9 } }
+          # - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.5, value: 2.5.9 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-2.6, value: 2.6.10 } }
 
         include:

--- a/bundler/tool/bundler/rubocop_gems.rb
+++ b/bundler/tool/bundler/rubocop_gems.rb
@@ -2,7 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "rubocop", "~> 1.7"
+gem "rubocop", "1.31.0"
+gem "parser", "3.2.2.2"
 
 gem "minitest"
 gem "rake"

--- a/bundler/tool/bundler/rubocop_gems.rb.lock
+++ b/bundler/tool/bundler/rubocop_gems.rb.lock
@@ -3,17 +3,11 @@ GEM
   specs:
     ast (2.4.2)
     diff-lcs (1.5.0)
-    json (2.6.1)
-    json (2.6.1-java)
-    language_server-protocol (3.17.0.3)
     minitest (5.20.0)
     parallel (1.23.0)
-    parser (3.2.2.4)
+    parser (3.2.2.2)
       ast (~> 2.4.1)
-      racc
     power_assert (2.0.3)
-    racc (1.7.1)
-    racc (1.7.1-java)
     rainbow (3.1.1)
     rake (13.1.0)
     rake-compiler (1.2.5)
@@ -33,17 +27,15 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.1)
-    rubocop (1.57.2)
-      json (~> 2.3)
-      language_server-protocol (>= 3.17.0)
+    rubocop (1.31.0)
       parallel (~> 1.10)
-      parser (>= 3.2.2.4)
+      parser (>= 3.1.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.28.1, < 2.0)
+      rubocop-ast (>= 1.18.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 2.4.0, < 3.0)
+      unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.30.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
@@ -67,10 +59,11 @@ PLATFORMS
 
 DEPENDENCIES
   minitest
+  parser (= 3.2.2.2)
   rake
   rake-compiler
   rspec
-  rubocop (~> 1.7)
+  rubocop (= 1.31.0)
   test-unit
 
 BUNDLED WITH

--- a/bundler/tool/bundler/standard_gems.rb
+++ b/bundler/tool/bundler/standard_gems.rb
@@ -2,7 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "standard", "~> 1.0"
+gem "standard", "1.12.1"
+gem "parser", "3.2.2.2"
 
 gem "minitest"
 gem "rake"

--- a/bundler/tool/bundler/standard_gems.rb.lock
+++ b/bundler/tool/bundler/standard_gems.rb.lock
@@ -2,20 +2,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    base64 (0.1.1)
     diff-lcs (1.5.0)
-    json (2.6.1)
-    json (2.6.1-java)
-    language_server-protocol (3.17.0.3)
-    lint_roller (1.1.0)
     minitest (5.20.0)
     parallel (1.23.0)
-    parser (3.2.2.4)
+    parser (3.2.2.2)
       ast (~> 2.4.1)
-      racc
     power_assert (2.0.3)
-    racc (1.7.1)
-    racc (1.7.1-java)
     rainbow (3.1.1)
     rake (13.1.0)
     rake-compiler (1.2.5)
@@ -35,36 +27,24 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.1)
-    rubocop (1.56.4)
-      base64 (~> 0.1.1)
-      json (~> 2.3)
-      language_server-protocol (>= 3.17.0)
+    rubocop (1.29.1)
       parallel (~> 1.10)
-      parser (>= 3.2.2.3)
+      parser (>= 3.1.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.28.1, < 2.0)
+      rubocop-ast (>= 1.17.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 2.4.0, < 3.0)
+      unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.30.0)
       parser (>= 3.2.1.0)
-    rubocop-performance (1.19.1)
+    rubocop-performance (1.13.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.13.0)
-    standard (1.31.2)
-      language_server-protocol (~> 3.17.0.2)
-      lint_roller (~> 1.0)
-      rubocop (~> 1.56.4)
-      standard-custom (~> 1.0.0)
-      standard-performance (~> 1.2)
-    standard-custom (1.0.2)
-      lint_roller (~> 1.0)
-      rubocop (~> 1.50)
-    standard-performance (1.2.1)
-      lint_roller (~> 1.1)
-      rubocop-performance (~> 1.19.1)
+    standard (1.12.1)
+      rubocop (= 1.29.1)
+      rubocop-performance (= 1.13.3)
     test-unit (3.6.1)
       power_assert
     unicode-display_width (2.5.0)
@@ -85,10 +65,11 @@ PLATFORMS
 
 DEPENDENCIES
   minitest
+  parser (= 3.2.2.2)
   rake
   rake-compiler
   rspec
-  standard (~> 1.0)
+  standard (= 1.12.1)
   test-unit
 
 BUNDLED WITH


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This is maintenance commits.

In ruby core repository, It failed to install C extensions like json, racc. Because there is no installed Ruby on GitHub Actions.

## What is your fix for the problem, implemented in this PR?

I downgrade `rubycop` and `standard` gem versions without `json` and `racc` dependencies.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
