### PR TITLE
Add `--json` output option to bundle-outdated

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -420,6 +420,7 @@ module Bundler
     method_option "filter-patch", :type => :boolean, :banner => "Only list patch newer versions"
     method_option "parseable", :aliases => "--porcelain", :type => :boolean, :banner =>
       "Use minimal formatting for more parseable output"
+    method_option "json", :type => :boolean, :banner => "Produce parseable json output"
     method_option "only-explicit", :type => :boolean, :banner =>
       "Only list gems specified in your Gemfile, not their dependencies"
     def outdated(*gems)

--- a/bundler/lib/bundler/cli/outdated.rb
+++ b/bundler/lib/bundler/cli/outdated.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "json"
-
 module Bundler
   class CLI::Outdated
     attr_reader :options, :gems, :options_include_groups, :filter_options_patch, :sources, :strict
@@ -180,6 +178,7 @@ module Bundler
     end
 
     def print_gems_json(gems_list)
+      require "json"
       data = gems_list.map do |gem|
         gem_data_for(
           gem[:current_spec],


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?
Building a dependency-managment nag-ops gem, we needed to parse the output of bundle-outdated. That output _is_ parseable (especially with the `--parseable` flag supplied), but I've been spoiled by tools that take the effort out of it entirely (and we see some value in exposing more information than is currently visible in that output as well).

## What is your fix for the problem, implemented in this PR?
Adding to bundle-outdated a `--json` flag, analogous to `--parseable`, but which produces json-structured data instead of human-readable line-oriented data about outdated gems.

## Make sure the following tasks are checked

- [✅] Describe the problem / feature
- [✅] Write [tests] (https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes (I could happily be more exhaustive if you like, but I tried to keep the testing comparable to the other tests on this tool)
- [✅ ] Write code to solve the problem
- [✅ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
