### PR TITLE
Always revert or skip extended require of RubyGems

### DIFF
--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -373,11 +373,8 @@ module Bundler
     def replace_entrypoints(specs)
       specs_by_name = add_default_gems_to(specs)
 
-      if defined?(::Gem::BUNDLED_GEMS)
-        replace_require(specs)
-      else
-        reverse_rubygems_kernel_mixin
-      end
+      reverse_rubygems_kernel_mixin
+      replace_require(specs) if defined?(::Gem::BUNDLED_GEMS)
       replace_gem(specs, specs_by_name)
       stub_rubygems(specs)
       replace_bin_path(specs_by_name)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I misstaken to use extended `require` by RubyGems always on bundled gems feature.

## What is your fix for the problem, implemented in this PR?

I removed condition for `reverse_rubygems_kernel_mixin`. It always called before `replace_require`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
