### PR TITLE
Fix invalid platform removal missing adjacent platforms

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -972,7 +972,7 @@ module Bundler
     def remove_invalid_platforms!(dependencies)
       return if Bundler.frozen_bundle?
 
-      platforms.each do |platform|
+      platforms.reverse_each do |platform|
         next if local_platform == platform ||
                 (@new_platform && platforms.last == platform) ||
                 @path_changes ||

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -746,6 +746,7 @@ RSpec.describe "bundle install with specific platforms" do
             sorbet-static (0.5.10696-x86_64-linux)
 
         PLATFORMS
+          aarch64-linux
           arm-linux
           x86_64-linux
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When researching #7169, I noticed if you had multiple invalid platforms then not all will be removed if they are located on adjacent lines. This is because we were modifying the array while iterating over it.

## What is your fix for the problem, implemented in this PR?

The fix is to iterate in reverse order, so we are not shifting things we've not yet reached.

The existing test was modified to include two invalid platforms rather than just one, which should in theory cover this bug.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
