### PR TITLE
lock_platform directive in Gemfile

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -1058,6 +1058,7 @@ module Bundler
       platforms.reverse_each do |platform|
         next if local_platform == platform ||
                 @new_platforms.include?(platform) ||
+                @locked_platforms.include?(platform) ||
                 @path_changes ||
                 @dependency_changes ||
                 @locked_spec_with_invalid_deps ||

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -33,6 +33,7 @@ module Bundler
       @install_conditionals = []
       @optional_groups      = []
       @platforms            = []
+      @lock_platforms       = []
       @env                  = nil
       @ruby_version         = nil
       @gemspecs             = []
@@ -228,7 +229,7 @@ module Bundler
 
     def to_definition(lockfile, unlock)
       check_primary_source_safety
-      Definition.new(lockfile, @dependencies, @sources, unlock, @ruby_version, @optional_groups, @gemfiles)
+      Definition.new(lockfile, @dependencies, @sources, unlock, @ruby_version, @optional_groups, @gemfiles, @lock_platforms)
     end
 
     def group(*args, &blk)
@@ -261,6 +262,19 @@ module Bundler
       platforms.each { @platforms.pop }
     end
     alias_method :platform, :platforms
+
+    # Name collision, working around it for a proof
+    def lock_platform(*platforms)
+      platforms.each do |p|
+        gem_platform = Gem::Platform.new(p)
+        # TODO: this is copied from lock
+        if gem_platform.to_s == "unknown"
+          Bundler.ui.warn "The platform `#{platform_string}` is unknown to RubyGems " \
+            "and adding it will likely lead to resolution errors"
+        end
+        @lock_platforms << gem_platform
+      end
+    end
 
     def env(name)
       old = @env

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -267,7 +267,6 @@ module Bundler
     def lock_platform(*platforms)
       platforms.each do |p|
         gem_platform = Gem::Platform.new(p)
-        # TODO: this is copied from lock
         if gem_platform.to_s == "unknown"
           raise GemfileError, "Unknown lock_platform #{platform_string.inspect} in Gemfile"
         end

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -269,8 +269,7 @@ module Bundler
         gem_platform = Gem::Platform.new(p)
         # TODO: this is copied from lock
         if gem_platform.to_s == "unknown"
-          Bundler.ui.warn "The platform `#{platform_string}` is unknown to RubyGems " \
-            "and adding it will likely lead to resolution errors"
+          raise GemfileError, "Unknown lock_platform #{platform_string.inspect} in Gemfile"
         end
         @lock_platforms << gem_platform
       end

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -459,6 +459,44 @@ RSpec.describe "bundle install with specific platforms" do
     expect(err).to include(error_message).once
   end
 
+  it "does not resolve if a locked platform does not match any of available platform specific variants for a top level dependency" do
+    build_repo4 do
+      build_gem("sorbet-static", "0.5.6433") {|s| s.platform = "x86_64-linux" }
+      build_gem("sorbet-static", "0.5.6433") {|s| s.platform = "universal-darwin-20" }
+    end
+
+    gemfile <<~G
+      source "#{file_uri_for(gem_repo4)}"
+
+      lock_platform "arm64-darwin-21"
+
+      gem "sorbet-static", "0.5.6433"
+    G
+
+    error_message = <<~ERROR.strip
+      Could not find gems matching 'sorbet-static (= 0.5.6433)' valid for all resolution platforms (arm64-darwin-21, arm64-darwin-20) in rubygems repository #{file_uri_for(gem_repo4)}/ or installed locally.
+
+      The source contains the following gems matching 'sorbet-static (= 0.5.6433)':
+        * sorbet-static-0.5.6433-universal-darwin-20
+        * sorbet-static-0.5.6433-x86_64-linux
+    ERROR
+
+    # simulate a platform that is available and is not the locked platform
+    simulate_platform "arm64-darwin-20" do
+      bundle "lock", :raise_on_error => false
+    end
+
+    expect(err).to include(error_message).once
+
+    # Make sure it doesn't print error twice in verbose mode
+
+    simulate_platform "arm64-darwin-20" do
+      bundle "lock --verbose", :raise_on_error => false
+    end
+
+    expect(err).to include(error_message).once
+  end
+
   it "does not generate a lockfile if ruby platform is forced and some gem has no ruby variant available" do
     build_repo4 do
       build_gem("sorbet-static", "0.5.9889") {|s| s.platform = Gem::Platform.local }

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -469,4 +469,56 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
       end
     end
   end
+
+  it "will add platform directly specified by a gemfile" do
+    simulate_platform "x86-darwin-100"
+
+    build_repo4 do
+      build_gem "nokogiri", "1.13.8"
+      build_gem "nokogiri", "1.13.8" do |s|
+        s.platform = "aarch64-linux"
+      end
+    end
+
+    install_gemfile <<-G
+      source "#{file_uri_for(gem_repo4)}"
+
+      lock_platform "aarch64-linux"
+
+      gem "nokogiri"
+    G
+
+    checksums = checksum_section do |c|
+      c.repo_gem gem_repo4, "nokogiri", "1.13.8"
+      # TODO: This is wrong, the point is to get the checksum
+      # Figure out why it's not fetching them for other platforms
+      c.no_checksum "nokogiri", "1.13.8", "aarch64-linux"
+      # c.repo_gem gem_repo4, "nokogiri", "1.13.8", "aarch64-linux"
+    end
+
+    expected_lockfile = <<~L
+      GEM
+        remote: #{file_uri_for(gem_repo4)}/
+        specs:
+          nokogiri (1.13.8)
+          nokogiri (1.13.8-aarch64-linux)
+
+      PLATFORMS
+        aarch64-linux
+        x86-darwin-100
+
+      DEPENDENCIES
+        nokogiri
+
+      CHECKSUMS
+        #{checksums}
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    # TODO: "nokogiri was expected to be of platform ruby but was ruby"
+    # expect(the_bundle).to include_gems "nokogiri 1.13.8 ruby"
+    expect(lockfile).to eq(expected_lockfile)
+  end
 end

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -480,6 +480,25 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
       end
     end
 
+    lockfile <<-L
+      GEM
+        remote: #{file_uri_for(gem_repo4)}/
+        specs:
+          nokogiri (1.13.8)
+
+      PLATFORMS
+        ruby
+
+      DEPENDENCIES
+        nokogiri
+
+      CHECKSUMS
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo4)}"
 
@@ -505,7 +524,82 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
 
       PLATFORMS
         aarch64-linux
-        x86-darwin-100
+        ruby
+
+      DEPENDENCIES
+        nokogiri
+
+      CHECKSUMS
+        #{checksums}
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    # TODO: "nokogiri was expected to be of platform ruby but was ruby"
+    # expect(the_bundle).to include_gems "nokogiri 1.13.8 ruby"
+    expect(lockfile).to eq(expected_lockfile)
+  end
+
+  it "adds platforms specified by a gemfile" do
+    simulate_platform "x86-darwin-100"
+
+    build_repo4 do
+      build_gem "nokogiri", "1.13.8"
+      build_gem "nokogiri", "1.13.8" do |s|
+        s.platform = "aarch64-linux"
+      end
+      build_gem "nokogiri", "1.13.8" do |s|
+        s.platform = "x86_64-linux"
+      end
+    end
+
+    lockfile <<-L
+      GEM
+        remote: #{file_uri_for(gem_repo4)}/
+        specs:
+          nokogiri (1.13.8)
+
+      PLATFORMS
+        ruby
+
+      DEPENDENCIES
+        nokogiri
+
+      CHECKSUMS
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    install_gemfile <<-G
+      source "#{file_uri_for(gem_repo4)}"
+
+      lock_platform "aarch64-linux", "x86_64-linux"
+
+      gem "nokogiri"
+    G
+
+    checksums = checksum_section do |c|
+      c.repo_gem gem_repo4, "nokogiri", "1.13.8"
+      # TODO: This is wrong, the point is to get the checksum
+      # Figure out why it's not fetching them for other platforms
+      c.no_checksum "nokogiri", "1.13.8", "aarch64-linux"
+      c.no_checksum "nokogiri", "1.13.8", "x86_64-linux"
+    end
+
+    expected_lockfile = <<~L
+      GEM
+        remote: #{file_uri_for(gem_repo4)}/
+        specs:
+          nokogiri (1.13.8)
+          nokogiri (1.13.8-aarch64-linux)
+          nokogiri (1.13.8-x86_64-linux)
+
+      PLATFORMS
+        aarch64-linux
+        ruby
+        x86_64-linux
 
       DEPENDENCIES
         nokogiri


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

There are two problems I aim to solve:

#### 1. First deploys can fail because the platform is not added

When a new user creates an application from a generator or template, they get a Gemfile that does not make it easy to see or declare the platform they use for deployment. It's not currently possible to add default platforms without additional steps. Deployment platform is not obvious, not immediately visible and not declarative within the most obvious place to declare dependencies, the Gemfile.

Many options have been proposed, including [always locking linux](https://github.com/rubygems/rubygems/pull/5700) or [locking available platforms](https://github.com/ruby/ruby/commit/435eb56f6175b7c9a16121ec8441f7492fa9aec5) which have resulted in [at least one problem](https://github.com/rubygems/rubygems/issues/7159).

This is notably different than a previous attempt, way back in 2016, to add a similar DSL (#4895). This proposed option is purely additive and does not restrict the user to only installing on certain platforms. It simply ensures that a given platform is always present. The original solution 7 years ago resulted in force ruby platform.

My assumptions are as follows:

* Most people deploy to `x86_64-linux` or know when they are not.
* Most people will look at their Gemfile but almost never look at their whole Gemfile.lock
* People not deploying to `x86_64-linux` would recognize and correct the platform if it is at the top of their Gemfile, but will mostly not notice when we automatically add a platform to their Gemfile.lock.

#### 2. The deployment platform is important, and yet it is ephemeral

You could theoretically completely regenerate your Gemfile.lock by deleting and reinstalling (generating a fully new resolution), and it might work. However, you would _always_ lose your locked platforms because they are not specified anywhere outside of the generated lockfile. Although this sort of regeneration is not recommended, it points out that locked platforms are ephemeral.

This is fine for most platforms. It's ok if we auto-add different darwin versions when a developer installs, but the deployment platform _should_ be added since it will be auto-added, or it will fail on frozen installs. Since it is a strict deployment dependency that we auto-add if it's missing, it should be intentionally declared in the Gemfile.

Additionally, when we lock to checksums this will make it possible to lock checksums for the deployment platform more successfully, instead of allowing production to install without checksum verification or to fail when a frozen bundle is used and the deployment platform is not locked.

## What is your fix for the problem, implemented in this PR?

Let's cut to the chase here. This is part of `rails new`:

```
         run  bundle install
Fetching gem metadata from https://rubygems.org/...........
Resolving dependencies...
Fetching public_suffix 5.0.4
Fetching nokogiri 1.15.5 (arm64-darwin)
Fetching nio4r 2.6.0
Installing public_suffix 5.0.4
Installing nio4r 2.6.0 with native extensions
Installing nokogiri 1.15.5 (arm64-darwin)
Fetching loofah 2.22.0
Installing loofah 2.22.0
Bundle complete! 14 Gemfile dependencies, 82 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
         run  bundle lock --add-platform=x86_64-linux
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Writing lockfile to /Users/martinemde/Projects/tmp/rails712/Gemfile.lock
         run  bundle lock --add-platform=aarch64-linux
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Writing lockfile to /Users/martinemde/Projects/tmp/rails712/Gemfile.lock
```

This causes 3 resolves and adds two additional platforms by default.

Let's allow rails to generate the following Gemfile and run only one resolve:

```Gemfile
source "https://rubygems.org"

# Update this with your production deployment platforms
lock_platforms "x86_64-linux", "aarch64-linux"

ruby "3.2.2"

# Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
gem "rails", "~> 7.1.2"
# SNIP...
```

Since Gemfiles are often generated or cargo culted from other Gemfiles, adding an option for specifying locked platforms in the Gemfile makes it more likely that initial deploys will succeed and already have the platformed gems for the deployment platform.

This PR adds a new Gemfile directive, `lock_platform`, that may be included by default in generated Gemfiles or added to declare and ensure the deployment platform (or other desired platforms).

**This pull request is currently a draft to show a proof of concept and not all tangential cases have been considered. Please call out any problems you see that may result from this approach.**

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
