### PR TITLE
Fix universal lockfiles regression

### DIFF
--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -122,9 +122,7 @@ module Bundler
     # bad gem.
     def __materialize__(candidates, fallback_to_non_installable: Bundler.frozen_bundle?)
       search = candidates.reverse.find do |spec|
-        spec.is_a?(StubSpecification) ||
-          (spec.matches_current_ruby? &&
-            spec.matches_current_rubygems?)
+        spec.is_a?(StubSpecification) || spec.matches_current_metadata?
       end
       if search.nil? && fallback_to_non_installable
         search = candidates.last

--- a/bundler/lib/bundler/match_metadata.rb
+++ b/bundler/lib/bundler/match_metadata.rb
@@ -2,6 +2,10 @@
 
 module Bundler
   module MatchMetadata
+    def matches_current_metadata?
+      matches_current_ruby? && matches_current_rubygems?
+    end
+
     def matches_current_ruby?
       @required_ruby_version.satisfied_by?(Gem.ruby_version)
     end

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -64,7 +64,7 @@ module Bundler
         valid_platform = lookup.all? do |_, specs|
           spec = specs.first
           matching_specs = spec.source.specs.search([spec.name, spec.version])
-          platform_spec = GemHelpers.select_best_platform_match(matching_specs, platform).first
+          platform_spec = GemHelpers.select_best_platform_match(matching_specs, platform).find(&:matches_current_metadata?)
 
           if platform_spec
             new_specs << LazySpecification.from_spec(platform_spec)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If a platform specific variant would not match the current Ruby, we would still be considering it compatible with the initial resolution and adding its platform to the lockfile, but we would later fail to materialize it for installation due to not really being compatible.

## What is your fix for the problem, implemented in this PR?

Fix is to only add platforms for variants that are also compatible with current Ruby and RubyGems versions.

Fixes #7159.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
