### PR TITLE
Prefer String#each_line in Gem::Command

### DIFF
--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -489,7 +489,7 @@ class Gem::Command
 
     @parser.separator nil
     @parser.separator "  Description:"
-    formatted.split("\n").each do |line|
+    formatted.each_line |line|
       @parser.separator "    #{line.rstrip}"
     end
   end
@@ -516,8 +516,8 @@ class Gem::Command
 
     @parser.separator nil
     @parser.separator "  #{title}:"
-    content.split(/\n/).each do |line|
-      @parser.separator "    #{line}"
+    content.each_line do |line|
+      @parser.separator "    #{line.rstrip}"
     end
   end
 
@@ -526,7 +526,7 @@ class Gem::Command
 
     @parser.separator nil
     @parser.separator "  Summary:"
-    wrap(@summary, 80 - 4).split("\n").each do |line|
+    wrap(@summary, 80 - 4).each_line do |line|
       @parser.separator "    #{line.strip}"
     end
   end

--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -489,7 +489,7 @@ class Gem::Command
 
     @parser.separator nil
     @parser.separator "  Description:"
-    formatted.each_line |line|
+    formatted.each_line do |line|
       @parser.separator "    #{line.rstrip}"
     end
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

``String#split`` without a block creates an intermediate array and requires a call to ``Array#each`` to iterate.

## What is your fix for the problem, implemented in this PR?

Replace ``String#split("\n").each`` with ``String#each_line``.
``String#each_line`` is simpler and more readable.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes - behavior expected to be the same, no tests changed
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
