### PR TITLE
Use GitHub Discussions with report suggestion

### DIFF
--- a/bundler/lib/bundler/friendly_errors.rb
+++ b/bundler/lib/bundler/friendly_errors.rb
@@ -78,7 +78,7 @@ module Bundler
       Bundler.ui.error <<~EOS, nil, :yellow
 
         First, try this link to see if there are any existing issue reports for this error:
-        #{issues_url(e)}
+        #{discussions_url(e)}
 
         If there aren't any reports for this error yet, please fill in the new issue form located at #{new_issue_url}, and copy and paste the report template above in there.
       EOS
@@ -99,12 +99,12 @@ module Bundler
       EOS
     end
 
-    def issues_url(exception)
+    def discussions_url(exception)
       message = exception.message.lines.first.tr(":", " ").chomp
       message = message.split("-").first if exception.is_a?(Errno)
       require "cgi"
       "https://github.com/rubygems/rubygems/search?q=" \
-        "#{CGI.escape(message)}&type=Issues"
+        "#{CGI.escape(message)}&type=Discussions"
     end
 
     def new_issue_url

--- a/bundler/lib/bundler/friendly_errors.rb
+++ b/bundler/lib/bundler/friendly_errors.rb
@@ -108,7 +108,7 @@ module Bundler
     end
 
     def new_issue_url
-      "https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md"
+      "https://github.com/rubygems/rubygems/discussions/new?category=q-a"
     end
   end
 

--- a/bundler/lib/bundler/friendly_errors.rb
+++ b/bundler/lib/bundler/friendly_errors.rb
@@ -77,7 +77,7 @@ module Bundler
 
       Bundler.ui.error <<~EOS, nil, :yellow
 
-        First, try this link to see if there are any existing issue reports for this error:
+        First, try this link to see if anyone has reported this error:
         #{discussions_url(e)}
 
         If there aren't any reports for this error yet, please fill in the new issue form located at #{new_issue_url}, and copy and paste the report template above in there.

--- a/bundler/lib/bundler/friendly_errors.rb
+++ b/bundler/lib/bundler/friendly_errors.rb
@@ -80,7 +80,7 @@ module Bundler
         First, try this link to see if anyone has reported this error:
         #{discussions_url(e)}
 
-        If there aren't any reports for this error yet, please fill in the new issue form located at #{new_issue_url}, and copy and paste the report template above in there.
+        If there aren't any reports for this error yet, please fill in the new issue form located at #{new_discussion_url}, and copy and paste the report template above in there.
       EOS
     end
 
@@ -107,7 +107,7 @@ module Bundler
         "#{CGI.escape(message)}&type=Discussions"
     end
 
-    def new_issue_url
+    def new_discussion_url
       "https://github.com/rubygems/rubygems/discussions/new?category=q-a"
     end
   end

--- a/bundler/spec/bundler/friendly_errors_spec.rb
+++ b/bundler/spec/bundler/friendly_errors_spec.rb
@@ -209,7 +209,7 @@ First line of the exception message
 Second line of the exception message
 END
 
-      expect(Bundler::FriendlyErrors.discussions_url(exception)).to eq("https://github.com/rubygems/rubygems/search?q=First+line+of+the+exception+message&type=Issues")
+      expect(Bundler::FriendlyErrors.discussions_url(exception)).to eq("https://github.com/rubygems/rubygems/search?q=First+line+of+the+exception+message&type=Discussions")
     end
 
     it "generates the url without colons" do
@@ -228,7 +228,7 @@ END
       allow(exception).to receive(:is_a?).with(Errno).and_return(true)
       discussions_url = Bundler::FriendlyErrors.discussions_url(exception)
       expect(discussions_url).not_to include("/Users/foo/bar")
-      expect(discussions_url).to eq("https://github.com/rubygems/rubygems/search?q=#{CGI.escape("Errno  EACCES  Permission denied @ dir_s_mkdir ")}&type=Issues")
+      expect(discussions_url).to eq("https://github.com/rubygems/rubygems/search?q=#{CGI.escape("Errno  EACCES  Permission denied @ dir_s_mkdir ")}&type=Discussions")
     end
   end
 end

--- a/bundler/spec/bundler/friendly_errors_spec.rb
+++ b/bundler/spec/bundler/friendly_errors_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe Bundler, "friendly errors" do
 
     it "includes error class, message and backlog" do
       error = StandardError.new
-      allow(Bundler::FriendlyErrors).to receive(:issues_url).and_return("")
+      allow(Bundler::FriendlyErrors).to receive(:discussions_url).and_return("")
 
       expect(error).to receive(:class).at_least(:once)
       expect(error).to receive(:message).at_least(:once)
@@ -196,11 +196,11 @@ RSpec.describe Bundler, "friendly errors" do
     end
   end
 
-  describe "#issues_url" do
+  describe "#discussions_url" do
     it "generates a search URL for the exception message" do
       exception = Exception.new("Exception message")
 
-      expect(Bundler::FriendlyErrors.issues_url(exception)).to eq("https://github.com/rubygems/rubygems/search?q=Exception+message&type=Issues")
+      expect(Bundler::FriendlyErrors.discussions_url(exception)).to eq("https://github.com/rubygems/rubygems/search?q=Exception+message&type=Discussions")
     end
 
     it "generates a search URL for only the first line of a multi-line exception message" do
@@ -209,16 +209,16 @@ First line of the exception message
 Second line of the exception message
 END
 
-      expect(Bundler::FriendlyErrors.issues_url(exception)).to eq("https://github.com/rubygems/rubygems/search?q=First+line+of+the+exception+message&type=Issues")
+      expect(Bundler::FriendlyErrors.discussions_url(exception)).to eq("https://github.com/rubygems/rubygems/search?q=First+line+of+the+exception+message&type=Issues")
     end
 
     it "generates the url without colons" do
       exception = Exception.new(<<END)
 Exception ::: with ::: colons :::
 END
-      issues_url = Bundler::FriendlyErrors.issues_url(exception)
-      expect(issues_url).not_to include("%3A")
-      expect(issues_url).to eq("https://github.com/rubygems/rubygems/search?q=#{CGI.escape("Exception     with     colons    ")}&type=Issues")
+      discussions_url = Bundler::FriendlyErrors.discussions_url(exception)
+      expect(discussions_url).not_to include("%3A")
+      expect(discussions_url).to eq("https://github.com/rubygems/rubygems/search?q=#{CGI.escape("Exception     with     colons    ")}&type=Discussions")
     end
 
     it "removes information after - for Errono::EACCES" do
@@ -226,9 +226,9 @@ END
 Errno::EACCES: Permission denied @ dir_s_mkdir - /Users/foo/bar/
 END
       allow(exception).to receive(:is_a?).with(Errno).and_return(true)
-      issues_url = Bundler::FriendlyErrors.issues_url(exception)
-      expect(issues_url).not_to include("/Users/foo/bar")
-      expect(issues_url).to eq("https://github.com/rubygems/rubygems/search?q=#{CGI.escape("Errno  EACCES  Permission denied @ dir_s_mkdir ")}&type=Issues")
+      discussions_url = Bundler::FriendlyErrors.discussions_url(exception)
+      expect(discussions_url).not_to include("/Users/foo/bar")
+      expect(discussions_url).to eq("https://github.com/rubygems/rubygems/search?q=#{CGI.escape("Errno  EACCES  Permission denied @ dir_s_mkdir ")}&type=Issues")
     end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`Bundler::FriendlyErrors` still suggests to report our issues. But their report is not helpful for developpers and mostly there is no response from first reporter. We should switch this template to discussions from issues. If we decide to handle it as issues, we can easily convert it to issues.

## What is your fix for the problem, implemented in this PR?

replaced GH issues to GH discussions.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
