### PR TITLE
Ignore `default_path` test cases for Ruby with custom configuration

### DIFF
--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -577,6 +577,8 @@ class TestGem < Gem::TestCase
   end
 
   def test_default_path
+    original_gem_default_path?
+
     vendordir(File.join(@tempdir, "vendor")) do
       FileUtils.rm_rf Gem.user_home
 
@@ -587,6 +589,8 @@ class TestGem < Gem::TestCase
   end
 
   def test_default_path_missing_vendor
+    original_gem_default_path?
+
     vendordir(nil) do
       FileUtils.rm_rf Gem.user_home
 
@@ -597,6 +601,8 @@ class TestGem < Gem::TestCase
   end
 
   def test_default_path_user_home
+    original_gem_default_path?
+
     vendordir(File.join(@tempdir, "vendor")) do
       expected = [Gem.user_dir, Gem.default_dir]
 
@@ -605,6 +611,8 @@ class TestGem < Gem::TestCase
   end
 
   def test_default_path_vendor_dir
+    original_gem_default_path?
+
     vendordir(File.join(@tempdir, "vendor")) do
       FileUtils.mkdir_p Gem.vendor_dir
 
@@ -1798,5 +1806,11 @@ class TestGem < Gem::TestCase
 
   def util_cache_dir
     File.join Gem.dir, "cache"
+  end
+
+  def original_gem_default_path?
+    unless Gem.method(:default_path).source_location.first.match? "lib/rubygems/defaults.rb"
+      pend "Gem.default_path likely differs from original RubyGems implementation"
+    end
   end
 end


### PR DESCRIPTION
RubyGems provides means to override their defaults, such as `Gem.default_path` method. With such configuration, the following errors might be observed:

~~~
    1) Failure:
  TestGem#test_default_path_vendor_dir [/home/runner/work/ruby/ruby/src/test/rubygems/test_gem.rb:612]:
  <["/home/runner/work/ruby/ruby/build/tmp/test_rubygems_20231110-59661-qs43ch/gemhome",
   "/home/runner/work/ruby/ruby/build/tmp/test_rubygems_20231110-59661-qs43ch/vendor/gems/3.3.0+0"]> expected but was
  <["/home/runner/work/ruby/ruby/build/tmp/test_rubygems_20231110-59661-qs43ch/gemhome",
   "/home/runner/work/ruby/ruby/build/tmp/test_rubygems_20231110-59661-qs43ch/vendor/gems/3.3.0+0",
   "/usr/local/lib/ruby/bundled_gems/3.3.0+0",
   "/usr/local/lib/ruby/default_gems/3.3.0+0"]>.
  make: *** [uncommon.mk:943: yes-test-all] Error 4

    2) Failure:
  TestGem#test_default_path_missing_vendor [/home/runner/work/ruby/ruby/src/test/rubygems/test_gem.rb:592]:
  <["/home/runner/work/ruby/ruby/build/tmp/test_rubygems_20231110-59661-c41yb7/gemhome"]> expected but was
  <["/home/runner/work/ruby/ruby/build/tmp/test_rubygems_20231110-59661-c41yb7/gemhome",
   "/usr/local/lib/ruby/bundled_gems/3.3.0+0",
   "/usr/local/lib/ruby/default_gems/3.3.0+0"]>.

    3) Failure:
  TestGem#test_default_path_user_home [/home/runner/work/ruby/ruby/src/test/rubygems/test_gem.rb:600]:
  <["/home/runner/work/ruby/ruby/build/tmp/test_rubygems_20231110-59661-5mm6uc/userhome/.local/share/gem/ruby/3.3.0+0",
   "/home/runner/work/ruby/ruby/build/tmp/test_rubygems_20231110-59661-5mm6uc/gemhome"]> expected but was
  <["/home/runner/work/ruby/ruby/build/tmp/test_rubygems_20231110-59661-5mm6uc/userhome/.local/share/gem/ruby/3.3.0+0",
   "/home/runner/work/ruby/ruby/build/tmp/test_rubygems_20231110-59661-5mm6uc/gemhome",
   "/usr/local/lib/ruby/bundled_gems/3.3.0+0",
   "/usr/local/lib/ruby/default_gems/3.3.0+0"]>.

    4) Failure:
  TestGem#test_default_path [/home/runner/work/ruby/ruby/src/test/rubygems/test_gem.rb:582]:
  <["/home/runner/work/ruby/ruby/build/tmp/test_rubygems_20231110-59661-kan9o5/gemhome"]> expected but was
  <["/home/runner/work/ruby/ruby/build/tmp/test_rubygems_20231110-59661-kan9o5/gemhome",
   "/usr/local/lib/ruby/bundled_gems/3.3.0+0",
   "/usr/local/lib/ruby/default_gems/3.3.0+0"]>.
~~~

Of course the `Gem.default_path` could be stubbed, but testing stub should not be the point.

Therefore, just detect if `Gem.default_path` was customized and ignore the test cases.

This is going to address the last 4 test failures referred in #7119 / ruby/ruby#8761 and I can't see other way around 🫤