### PR TITLE
Remove no longer necessary workaround for old RubyGems

### DIFF
--- a/bundler/spec/commands/config_spec.rb
+++ b/bundler/spec/commands/config_spec.rb
@@ -443,7 +443,7 @@ E
       expect(err).to be_empty
 
       ruby(<<~RUBY)
-        require "#{entrypoint}"
+        require "bundler"
         print Bundler.settings.mirror_for("https://rails-assets.org")
       RUBY
       expect(out).to eq("https://rails-assets.org/")
@@ -451,7 +451,7 @@ E
 
       bundle "config set mirror.all http://localhost:9293"
       ruby(<<~RUBY)
-        require "#{entrypoint}"
+        require "bundler"
         print Bundler.settings.mirror_for("https://rails-assets.org")
       RUBY
       expect(out).to eq("http://localhost:9293/")

--- a/bundler/spec/install/gemfile/groups_spec.rb
+++ b/bundler/spec/install/gemfile/groups_spec.rb
@@ -349,7 +349,7 @@ RSpec.describe "bundle install with groups" do
       G
 
       ruby <<-R
-        require "#{entrypoint}"
+        require "bundler"
         Bundler.setup :default
         Bundler.require :default
         puts RACK

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -1733,7 +1733,7 @@ RSpec.describe "the lockfile format" do
 
         expect do
           ruby <<-RUBY
-                   require '#{entrypoint}'
+                   require 'bundler'
                    Bundler.setup
                  RUBY
         end.not_to change { File.mtime(bundled_app_lock) }

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -503,7 +503,7 @@ RSpec.describe "major deprecations" do
       G
 
       ruby <<-RUBY
-        require '#{entrypoint}'
+        require 'bundler'
 
         Bundler.setup
         Bundler.setup

--- a/bundler/spec/realworld/double_check_spec.rb
+++ b/bundler/spec/realworld/double_check_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe "double checking sources", :realworld => true do
     RUBY
 
     cmd = <<-RUBY
-      require "#{entrypoint}"
+      require "bundler"
       require "#{spec_dir}/support/artifice/vcr"
-      require "#{entrypoint}/inline"
+      require "bundler/inline"
       gemfile(true) do
         source "https://rubygems.org"
         gem "rails", path: "."

--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "bundler/inline#gemfile" do
   def script(code, options = {})
-    requires = ["#{entrypoint}/inline"]
+    requires = ["bundler/inline"]
     requires.unshift "#{spec_dir}/support/artifice/" + options.delete(:artifice) if options.key?(:artifice)
     requires = requires.map {|r| "require '#{r}'" }.join("\n")
     ruby("#{requires}\n\n" + code, options)
@@ -95,7 +95,7 @@ RSpec.describe "bundler/inline#gemfile" do
 
   it "lets me use my own ui object" do
     script <<-RUBY, :artifice => "endpoint"
-      require '#{entrypoint}'
+      require 'bundler'
       class MyBundlerUI < Bundler::UI::Shell
         def confirm(msg, newline = nil)
           puts "CONFIRMED!"
@@ -114,7 +114,7 @@ RSpec.describe "bundler/inline#gemfile" do
 
   it "has an option for quiet installation" do
     script <<-RUBY, :artifice => "endpoint"
-      require '#{entrypoint}/inline'
+      require 'bundler/inline'
 
       gemfile(true, :quiet => true) do
         source "https://notaserver.com"
@@ -140,7 +140,7 @@ RSpec.describe "bundler/inline#gemfile" do
 
   it "does not mutate the option argument" do
     script <<-RUBY
-      require '#{entrypoint}'
+      require 'bundler'
       options = { :ui => Bundler::UI::Shell.new }
       gemfile(false, options) do
         source "#{file_uri_for(gem_repo1)}"
@@ -259,7 +259,7 @@ RSpec.describe "bundler/inline#gemfile" do
     system_gems "rack-1.0.0"
 
     script <<-RUBY
-      require '#{entrypoint}'
+      require 'bundler'
       ui = Bundler::UI::Shell.new
       ui.level = "confirm"
 
@@ -279,7 +279,7 @@ RSpec.describe "bundler/inline#gemfile" do
     system_gems "rack-1.0.0"
 
     script <<-RUBY
-      require '#{entrypoint}'
+      require 'bundler'
       ui = Bundler::UI::Shell.new
       ui.level = "confirm"
       gemfile(true, ui: ui) do
@@ -302,7 +302,7 @@ RSpec.describe "bundler/inline#gemfile" do
     system_gems "rack-1.0.0"
 
     script <<-RUBY
-      require '#{entrypoint}'
+      require 'bundler'
       ui = Bundler::UI::Shell.new
       ui.level = "confirm"
       gemfile(true, ui: ui) do
@@ -339,7 +339,7 @@ RSpec.describe "bundler/inline#gemfile" do
     end
 
     script <<-RUBY
-      require '#{entrypoint}'
+      require 'bundler'
       ui = Bundler::UI::Shell.new
       ui.level = "confirm"
       gemfile(true, ui: ui) do

--- a/bundler/spec/runtime/load_spec.rb
+++ b/bundler/spec/runtime/load_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "Bundler.load" do
       G
 
       ruby <<-RUBY
-        require "#{entrypoint}"
+        require "bundler"
         Bundler.setup :default
         Bundler.require :default
         puts RACK

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
 
     ruby <<-R
       begin
-        require '#{entrypoint}'
+        require 'bundler'
         Bundler.ui.silence { Bundler.setup }
       rescue Bundler::GemNotFound => e
         puts "WIN"

--- a/bundler/spec/runtime/require_spec.rb
+++ b/bundler/spec/runtime/require_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe "Bundler.require" do
       G
 
       cmd = <<-RUBY
-        require '#{entrypoint}'
+        require 'bundler'
         Bundler.require
       RUBY
       ruby(cmd)

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe "Bundler.setup" do
     G
 
     ruby <<-R
-      require '#{entrypoint}'
+      require 'bundler'
 
       begin
         Bundler.setup
@@ -441,7 +441,7 @@ RSpec.describe "Bundler.setup" do
       break_git!
 
       ruby <<-R
-        require "#{entrypoint}"
+        require "bundler"
 
         begin
           Bundler.setup
@@ -1187,7 +1187,7 @@ end
     context "is not present" do
       it "does not change the lock" do
         lockfile lock_with(nil)
-        ruby "require '#{entrypoint}/setup'"
+        ruby "require 'bundler/setup'"
         expect(lockfile).to eq lock_with(nil)
       end
     end
@@ -1206,7 +1206,7 @@ end
       it "does not change the lock" do
         system_gems "bundler-1.10.1"
         lockfile lock_with("1.10.1")
-        ruby "require '#{entrypoint}/setup'"
+        ruby "require 'bundler/setup'"
         expect(lockfile).to eq lock_with("1.10.1")
       end
     end
@@ -1304,7 +1304,7 @@ end
       bundle :install
 
       ruby <<-RUBY
-        require '#{entrypoint}/setup'
+        require 'bundler/setup'
         puts defined?(::Digest) ? "Digest defined" : "Digest undefined"
         require 'digest'
       RUBY
@@ -1314,7 +1314,7 @@ end
     it "does not load Psych" do
       gemfile "source \"#{file_uri_for(gem_repo1)}\""
       ruby <<-RUBY
-        require '#{entrypoint}/setup'
+        require 'bundler/setup'
         puts defined?(Psych::VERSION) ? Psych::VERSION : "undefined"
         require 'psych'
         puts Psych::VERSION

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -60,7 +60,7 @@ module Spec
     def run(cmd, *args)
       opts = args.last.is_a?(Hash) ? args.pop : {}
       groups = args.map(&:inspect).join(", ")
-      setup = "require '#{entrypoint}' ; Bundler.ui.silence { Bundler.setup(#{groups}) }"
+      setup = "require 'bundler' ; Bundler.ui.silence { Bundler.setup(#{groups}) }"
       ruby([setup, cmd].join(" ; "), opts)
     end
 

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -225,13 +225,6 @@ module Spec
       root.join("lib")
     end
 
-    # Sometimes rubygems version under test does not include
-    # https://github.com/rubygems/rubygems/pull/2728 and will not always end up
-    # activating the current bundler. In that case, require bundler absolutely.
-    def entrypoint
-      Gem.rubygems_version < Gem::Version.new("3.1.a") ? "#{lib_dir}/bundler" : "bundler"
-    end
-
     def global_plugin_gem(*args)
       home ".bundle", "plugin", "gems", *args
     end

--- a/bundler/spec/support/rubygems_version_manager.rb
+++ b/bundler/spec/support/rubygems_version_manager.rb
@@ -30,11 +30,10 @@ class RubygemsVersionManager
       rubygems_default_path = rubygems_path + "/defaults"
 
       bundler_path = rubylibdir + "/bundler"
-      bundler_exemptions = Gem.rubygems_version < Gem::Version.new("3.2.0") ? [bundler_path + "/errors.rb"] : []
 
       bad_loaded_features = $LOADED_FEATURES.select do |loaded_feature|
         (loaded_feature.start_with?(rubygems_path) && !loaded_feature.start_with?(rubygems_default_path)) ||
-          (loaded_feature.start_with?(bundler_path) && !bundler_exemptions.any? {|bundler_exemption| loaded_feature.start_with?(bundler_exemption) })
+          loaded_feature.start_with?(bundler_path)
       end
 
       errors = if bad_loaded_features.any?


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Nothing, just opportunities to remove unnecessary stuff. This is a follow up to #7116.

## What is your fix for the problem, implemented in this PR?

Some tests were using workarounds to avoid loading the default copy of bundler, instead of the copy under test. They are no longer necessary due to no longer supporting older RubyGems that had bugs causing the unintended behaviour. 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
