### PR TITLE
Simplify remembered flags deprecation message

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -888,7 +888,7 @@ module Bundler
       Bundler::SharedHelpers.major_deprecation 2,
         "The `#{flag_name}` flag is deprecated because it relies on being " \
         "remembered across bundler invocations, which bundler will no longer " \
-        "do in future versions. Instead please use `bundle config set --local #{name.tr("-", "_")} " \
+        "do in future versions. Instead please use `bundle config set #{name.tr("-", "_")} " \
         "'#{value}'`, and stop using this flag"
     end
   end

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -884,12 +884,13 @@ module Bundler
 
       value = options[name]
       value = value.join(" ").to_s if option.type == :array
+      value = "'#{value}'" unless option.type == :boolean
 
       Bundler::SharedHelpers.major_deprecation 2,
         "The `#{flag_name}` flag is deprecated because it relies on being " \
         "remembered across bundler invocations, which bundler will no longer " \
         "do in future versions. Instead please use `bundle config set #{name.tr("-", "_")} " \
-        "'#{value}'`, and stop using this flag"
+        "#{value}`, and stop using this flag"
     end
   end
 end

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -370,16 +370,16 @@ RSpec.describe "major deprecations" do
     end
 
     {
-      "clean" => ["clean", true],
-      "deployment" => ["deployment", true],
-      "frozen" => ["frozen", true],
-      "no-deployment" => ["deployment", false],
-      "no-prune" => ["no_prune", true],
-      "path" => ["path", "vendor/bundle"],
-      "shebang" => ["shebang", "ruby27"],
-      "system" => ["system", true],
-      "without" => ["without", "development"],
-      "with" => ["with", "development"],
+      "clean" => ["clean", "true"],
+      "deployment" => ["deployment", "true"],
+      "frozen" => ["frozen", "true"],
+      "no-deployment" => ["deployment", "false"],
+      "no-prune" => ["no_prune", "true"],
+      "path" => ["path", "'vendor/bundle'"],
+      "shebang" => ["shebang", "'ruby27'"],
+      "system" => ["system", "true"],
+      "without" => ["without", "'development'"],
+      "with" => ["with", "'development'"],
     }.each do |name, expectations|
       option_name, value = *expectations
       flag_name = "--#{name}"
@@ -395,7 +395,7 @@ RSpec.describe "major deprecations" do
             "The `#{flag_name}` flag is deprecated because it relies on " \
             "being remembered across bundler invocations, which bundler " \
             "will no longer do in future versions. Instead please use " \
-            "`bundle config set #{option_name} '#{value}'`, and stop using this flag"
+            "`bundle config set #{option_name} #{value}`, and stop using this flag"
           )
         end
 

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe "major deprecations" do
       expect(deprecations).to include(
         "The `--path` flag is deprecated because it relies on being " \
         "remembered across bundler invocations, which bundler will no " \
-        "longer do in future versions. Instead please use `bundle config set --local " \
+        "longer do in future versions. Instead please use `bundle config set " \
         "path 'vendor/bundle'`, and stop using this flag"
       )
     end
@@ -147,7 +147,7 @@ RSpec.describe "major deprecations" do
       expect(deprecations).to include(
         "The `--path` flag is deprecated because it relies on being " \
         "remembered across bundler invocations, which bundler will no " \
-        "longer do in future versions. Instead please use `bundle config set --local " \
+        "longer do in future versions. Instead please use `bundle config set " \
         "path 'vendor/bundle'`, and stop using this flag"
       )
     end
@@ -395,7 +395,7 @@ RSpec.describe "major deprecations" do
             "The `#{flag_name}` flag is deprecated because it relies on " \
             "being remembered across bundler invocations, which bundler " \
             "will no longer do in future versions. Instead please use " \
-            "`bundle config set --local #{option_name} '#{value}'`, and stop using this flag"
+            "`bundle config set #{option_name} '#{value}'`, and stop using this flag"
           )
         end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This deprecation message recommends `bundle config set --local`, however `bundle config` is now local by default. It also quotes some values unnecessarily.

## What is your fix for the problem, implemented in this PR?

Simplify the deprecation message.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
