### PR TITLE
Fix `bundle install --system` deprecation advice

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -250,9 +250,11 @@ module Bundler
     def install
       SharedHelpers.major_deprecation(2, "The `--force` option has been renamed to `--redownload`") if ARGV.include?("--force")
 
-      %w[clean deployment frozen no-prune path shebang system without with].each do |option|
+      %w[clean deployment frozen no-prune path shebang without with].each do |option|
         remembered_flag_deprecation(option)
       end
+
+      print_remembered_flag_deprecation("--system", "path.system", "true") if ARGV.include?("--system")
 
       remembered_negative_flag_deprecation("no-deployment")
 

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -458,11 +458,7 @@ module Bundler
       bundle without having to download any additional gems.
     D
     def cache
-      SharedHelpers.major_deprecation 2,
-        "The `--all` flag is deprecated because it relies on being " \
-        "remembered across bundler invocations, which bundler will no longer " \
-        "do in future versions. Instead please use `bundle config set cache_all true`, " \
-        "and stop using this flag" if ARGV.include?("--all")
+      print_remembered_flag_deprecation("--all", "cache_all", "true") if ARGV.include?("--all")
 
       SharedHelpers.major_deprecation 2,
         "The `--path` flag is deprecated because its semantics are unclear. " \
@@ -886,11 +882,15 @@ module Bundler
       value = value.join(" ").to_s if option.type == :array
       value = "'#{value}'" unless option.type == :boolean
 
+      print_remembered_flag_deprecation(flag_name, name.tr("-", "_"), value)
+    end
+
+    def print_remembered_flag_deprecation(flag_name, option_name, option_value)
       Bundler::SharedHelpers.major_deprecation 2,
         "The `#{flag_name}` flag is deprecated because it relies on being " \
         "remembered across bundler invocations, which bundler will no longer " \
-        "do in future versions. Instead please use `bundle config set #{name.tr("-", "_")} " \
-        "#{value}`, and stop using this flag"
+        "do in future versions. Instead please use `bundle config set #{option_name} " \
+        "#{option_value}`, and stop using this flag"
     end
   end
 end

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -377,7 +377,7 @@ RSpec.describe "major deprecations" do
       "no-prune" => ["no_prune", "true"],
       "path" => ["path", "'vendor/bundle'"],
       "shebang" => ["shebang", "'ruby27'"],
-      "system" => ["system", "true"],
+      "system" => ["path.system", "true"],
       "without" => ["without", "'development'"],
       "with" => ["with", "'development'"],
     }.each do |name, expectations|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The `bundle install --system` command is recommending a setting that does not exist.

## What is your fix for the problem, implemented in this PR?

Fix the message to recommend the proper command.

This is stacked on top of #7189.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
