### PR TITLE
Stop remembering cli flags like `--jobs` or `--retry` in configuration

### DIFF
--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -46,6 +46,20 @@ module Bundler
       update_requires_all_flag
     ].freeze
 
+    REMEMBERED_KEYS = %w[
+      bin
+      cache_all
+      clean
+      deployment
+      frozen
+      no_prune
+      path
+      shebang
+      path.system
+      without
+      with
+    ].freeze
+
     NUMBER_KEYS = %w[
       jobs
       redirect
@@ -115,7 +129,7 @@ module Bundler
     end
 
     def set_command_option(key, value)
-      if Bundler.feature_flag.forget_cli_options?
+      if !is_remembered(key) || Bundler.feature_flag.forget_cli_options?
         temporary(key => value)
         value
       else
@@ -372,6 +386,10 @@ module Bundler
 
     def is_array(key)
       ARRAY_KEYS.include?(self.class.key_to_s(key))
+    end
+
+    def is_remembered(key)
+      REMEMBERED_KEYS.include?(self.class.key_to_s(key))
     end
 
     def is_credential(key)

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -1288,4 +1288,14 @@ RSpec.describe "bundle install with gem sources" do
       expect(err).to include("Could not find compatible versions")
     end
   end
+
+  context "when --jobs option given" do
+    before do
+      install_gemfile "source \"#{file_uri_for(gem_repo1)}\"", :jobs => 1
+    end
+
+    it "does not save the flag to config" do
+      expect(bundled_app(".bundle/config")).not_to exist
+    end
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We're still remembering CLI flags for backwards compatibility. However, this is only necessary for a few selected flags.

## What is your fix for the problem, implemented in this PR?

Stop remembering flags like `--jobs`, or `--retry`.

This is stacked on top of #7189 and #7190.

Closes #7181.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
