### PR TITLE
Allow auto-install to install missing git gems

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -805,7 +805,7 @@ module Bundler
 
       begin
         Bundler.definition.specs
-      rescue GemNotFound
+      rescue GemNotFound, GitError
         Bundler.ui.info "Automatically installing missing gems."
         Bundler.reset!
         invoke :install, []

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -615,6 +615,23 @@ RSpec.describe "bundle exec" do
     expect(out).to include("Installing foo 1.0")
   end
 
+  it "performs an automatic bundle install with git gems" do
+    build_git "foo" do |s|
+      s.executables = "foo"
+    end
+    gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
+      gem "rack", "0.9.1"
+      gem "foo", :git => "#{lib_path("foo-1.0")}"
+    G
+
+    bundle "config set auto_install 1"
+    bundle "exec foo"
+    expect(out).to include("Fetching rack 0.9.1")
+    expect(out).to include("Fetching #{lib_path("foo-1.0")}")
+    expect(out.lines).to end_with("1.0")
+  end
+
   it "loads the correct optparse when `auto_install` is set, and optparse is a dependency" do
     if Gem.rubygems_version < Gem::Version.new("3.3.0.a")
       skip "optparse is a default gem, and rubygems loads it during install"


### PR DESCRIPTION
Currently, auto-install with git gems fails, when
it would succeed with a rubygems-source gem

Fix the issue by doing the same fallback for git errors as we do for
missing gems, the git errors should only bubble up in these cases when
the gem is not installed, meaning we want to go through the install flow
(and any persistent errors will be raised through there)

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)