### PR TITLE
Avoid re-compiling static regexp in a loop

### DIFF
--- a/bundler/lib/bundler/source/path.rb
+++ b/bundler/lib/bundler/source/path.rb
@@ -226,7 +226,7 @@ module Bundler
         # Some gem authors put absolute paths in their gemspec
         # and we have to save them from themselves
         spec.files = spec.files.map do |path|
-          next path unless /\A#{Pathname::SEPARATOR_PAT}/.match?(path)
+          next path unless /\A#{Pathname::SEPARATOR_PAT}/o.match?(path)
           next if File.directory?(path)
           begin
             Pathname.new(path).relative_path_from(gem_dir).to_s


### PR DESCRIPTION
Pathname::SEPARATOR_PAT is a constant and can safely be interpolated once, avoiding creating a new regexp object on every iteration

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)