### PR TITLE
Do not pollute the global namespace

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -766,23 +766,23 @@ class Gem::Installer
 
 require 'rubygems'
 #{gemdeps_load(spec.name)}
-version = "#{Gem::Requirement.default_prerelease}"
+"#{Gem::Requirement.default_prerelease}".tap { |version|
 
-str = ARGV.first
-if str
-  str = str.b[/\\A_(.*)_\\z/, 1]
-  if str and Gem::Version.correct?(str)
-    #{explicit_version_requirement(spec.name)}
-    ARGV.shift
+  if ARGV.first =~ /\\A_(.*)_\\z/
+    str = $1
+    if Gem::Version.correct?(str)
+      #{explicit_version_requirement(spec.name)}
+      ARGV.shift
+    end
   end
-end
 
-if Gem.respond_to?(:activate_bin_path)
-load Gem.activate_bin_path('#{spec.name}', '#{bin_file_name}', version)
-else
-gem #{spec.name.dump}, version
-load Gem.bin_path(#{spec.name.dump}, #{bin_file_name.dump}, version)
-end
+  if Gem.respond_to?(:activate_bin_path)
+    load Gem.activate_bin_path('#{spec.name}', '#{bin_file_name}', version)
+  else
+    gem #{spec.name.dump}, version
+    load Gem.bin_path(#{spec.name.dump}, #{bin_file_name.dump}, version)
+  end
+}
 TEXT
   end
 
@@ -799,9 +799,9 @@ TEXT
     code = "version = str"
     return code unless name == "bundler"
 
-    code += <<-TEXT
+    code << <<-TEXT
 
-    ENV['BUNDLER_VERSION'] = str
+      ENV['BUNDLER_VERSION'] = str
 TEXT
   end
 


### PR DESCRIPTION
Inside a Gem executable you get:

    TOPLEVEL_BINDING.local_variables    #=> [:version, :str]

This is not fair.

I decided to propose an `Object#tap` call because defining a function would pollute `TOPLEVEL_BINDING.private_methods`.

Maybe an even better way to solve the problem is to put the variable assignments and usage into a `module Gem ; ... ; end` block.