### PR TITLE
Use globals variables for standard input/output

### DIFF
--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -193,7 +193,7 @@ class Gem::StreamUI
   # then special operations (like asking for passwords) will use the TTY
   # commands to disable character echo.
 
-  def initialize(in_stream, out_stream, err_stream=STDERR, usetty=true)
+  def initialize(in_stream, out_stream, err_stream=$stderr, usetty=true)
     @ins = in_stream
     @outs = out_stream
     @errs = err_stream
@@ -591,8 +591,8 @@ class Gem::StreamUI
 end
 
 ##
-# Subclass of StreamUI that instantiates the user interaction using STDIN,
-# STDOUT, and STDERR.
+# Subclass of StreamUI that instantiates the user interaction using $stdin,
+# $stdout, and $stderr.
 
 class Gem::ConsoleUI < Gem::StreamUI
   ##
@@ -600,7 +600,7 @@ class Gem::ConsoleUI < Gem::StreamUI
   # stdin, output to stdout and warnings or errors to stderr.
 
   def initialize
-    super STDIN, STDOUT, STDERR, true
+    super $stdin, $stdout, $stderr, true
   end
 end
 

--- a/test/rubygems/test_gem_console_ui.rb
+++ b/test/rubygems/test_gem_console_ui.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative "helper"
+require "rubygems/user_interaction"
+
+class TestGemConsoleUI < Gem::TestCase
+  def test_output_can_be_captured_by_test_unit
+    output = capture_output do
+      ui = Gem::ConsoleUI.new
+
+      ui.alert_error "test error"
+      ui.alert_warning "test warning"
+      ui.alert "test alert"
+    end
+
+    assert_equal "INFO:  test alert\n", output.first
+    assert_equal "ERROR:  test error\n" + "WARNING:  test warning\n", output.last
+  end
+end


### PR DESCRIPTION
Replace use of `STDIN`, `STDOUT` and `STDERR` constants by their `$stdin`, `$stdout` and `$stderr` global variable equivalents.

This enables easier testing via standard means, such as `assert_output` for minitest or `expect { print 'foo' }.to output.to_stdout` for RSpec test suites.

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

In eaa315b95ee4887f1980a5819a05dc2d3d49f4c1 the `Gem::MockGemUi` was hidden from external use, breaking other [project](https://github.com/enkessler/childprocess/issues/190) test cases. I thought it should be pretty straight forward to not use the `Gem::MockGemUi`, so the test case could look like:

~~~
expect { gemspec.validate }.not_to output(/warn/i).to_stderr
~~~

However, RubyGems using `STDERR`, that did not work.

## What is your fix for the problem, implemented in this PR?

I can't see why RubyGems should use `STDERR`, when it could use `$stderr` instead, enabling usage of standard test frameworks methods to check the output.

However, I have not tried to execute the test suite, so I might be surprised.

Please note that there are also other places where the constants are still used, especially in Bundler.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
