### PR TITLE
update Magnus library in Rust extension gem template

### DIFF
--- a/bundler/lib/bundler/templates/newgem/ext/newgem/Cargo.toml.tt
+++ b/bundler/lib/bundler/templates/newgem/ext/newgem/Cargo.toml.tt
@@ -12,4 +12,4 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-magnus = { version = "0.6" }
+magnus = { version = "0.6.2" }


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

[Magnus](https://github.com/matsadler/magnus), the Ruby bindings library used in the template for a Rust extension gem has released a newer version. It would be helpful if the generated gem skeleton used the latest version.

## What is your fix for the problem, implemented in this PR?

The version number has been updated in the template Cargo.toml, and a few changes have been made to lib.rs.tt to account for API changes.

The newer version of Magnus uses the [rb-sys](https://github.com/oxidize-rb/rb-sys)' new stable API for `RArray` and `RString`. This update will increase stability of Rust gems to be used with different versions of Ruby.
Also, the newer version fixes the compile error in `RString#bytes` feature.

Thank you @matsadler @ianks and @gmalette for these update on Magnus!

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
