### PR TITLE
Only show "Defaulting to user installation" message when it matters.

### DIFF
--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -23,6 +23,15 @@ class Gem::Command
   Gem::OptionParser.accept Symbol, &:to_sym
 
   ##
+  # Names of commands that should print "Defaulting to user installation"
+  # warning.
+
+  COMMANDS_WITH_AUTO_INSTALL_DIR_WARNING = [
+    "install",
+    "update",
+  ].freeze
+
+  ##
   # The name of the command.
 
   attr_reader :command
@@ -323,7 +332,8 @@ class Gem::Command
     elsif @when_invoked
       @when_invoked.call options
     else
-      if Gem.paths.auto_user_install && !options[:install_dir] && !options[:user_install]
+      if COMMANDS_WITH_AUTO_INSTALL_DIR_WARNING.include?(@command) && \
+         Gem.paths.auto_user_install && !options[:install_dir] && !options[:user_install]
         self.ui.say "Defaulting to user installation because default installation directory (#{Gem.default_dir}) is not writable."
       end
 

--- a/test/rubygems/test_gem_command.rb
+++ b/test/rubygems/test_gem_command.rb
@@ -399,4 +399,66 @@ ERROR:  Possible alternatives: non_existent_with_hint
 
     assert_equal expected, @ui.error
   end
+
+  def test_show_defaulting_to_user_install_when_appropriate
+    omit "this test doesn't work with ruby-core setup" if ruby_repo?
+
+    Gem.stub(:default_dir, "/this-directory-does-not-exist") do
+      # Replace `Gem.paths` with a new instance, so `Gem.paths.auto_user_install`
+      # is accurate.
+      Gem.stub(:paths, Gem::PathSupport.new(ENV)) do
+        output_regex = "Defaulting to user installation"
+
+        test_command = Class.new(Gem::Command) do
+          def initialize
+            # "gem install" should ALWAYS print the warning.
+            super("install", "Gem::Command instance for testing")
+          end
+
+          def execute
+            true
+          end
+        end
+
+        cmd = test_command.new
+
+        use_ui @ui do
+          cmd.invoke
+          assert_match output_regex, @ui.output,
+            "Gem.default_dir = #{Gem.default_dir.inspect}\n" \
+            "Gem.paths.auto_user_install = #{Gem.paths.auto_user_install.inspect}"
+        end
+      end
+    end
+  end
+
+  def test_dont_show_defaulting_to_user_install_when_appropriate
+    Gem.stub(:default_dir, "/this-directory-does-not-exist") do
+      # Replace `Gem.paths` with a new instance, so `Gem.paths.auto_user_install`
+      # is accurate.
+      Gem.stub(:paths, Gem::PathSupport.new(ENV)) do
+        output_regex = /^Defaulting to user installation/
+
+        test_command = Class.new(Gem::Command) do
+          def initialize
+            # "gem blargh" should NEVER print the warning.
+            super("blargh", "Gem::Command instance for testing")
+          end
+
+          def execute
+            true
+          end
+        end
+
+        cmd = test_command.new
+
+        use_ui @ui do
+          cmd.invoke
+          assert_no_match output_regex, @ui.output,
+            "Gem.default_dir = #{Gem.default_dir.inspect}\n" \
+            "Gem.paths.auto_user_install = #{Gem.paths.auto_user_install.inspect}"
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

As implemented in #5327, the "Defaulting to user installation because default installation directory [...]" message was displayed for _every_ command, even if it wasn't relevant.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

I made it only print when it's relevant.

I'm not entirely happy with the approach I took, but it feels more maintainable than having it spread across every relevant command.

Before:

```
$ gem unpack boop-0.5.0.gem
Defaulting to user installation because default installation directory (/usr/local/lib/ruby/gems/3.1) is not writable.
Unpacked gem: '/usr/home/puppy/test/boop-0.5.0'
$
```

After:

```
$ gem unpack boop-0.5.0.gem
Unpacked gem: '/usr/home/puppy/test/boop-0.5.0'
$
```

Resolves #7082.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
