### PR TITLE
Prefer String#split with block

### DIFF
--- a/bundler/lib/bundler/compact_index_client/cache.rb
+++ b/bundler/lib/bundler/compact_index_client/cache.rb
@@ -32,7 +32,7 @@ module Bundler
         lines(versions_path).each do |line|
           name, versions_string, info_checksum = line.split(" ", 3)
           info_checksums_by_name[name] = info_checksum || ""
-          versions_string.split(",").each do |version|
+          versions_string.split(",") do |version|
             delete = version.delete_prefix!("-")
             version = version.split("-", 2).unshift(name)
             if delete

--- a/bundler/lib/bundler/yaml_serializer.rb
+++ b/bundler/lib/bundler/yaml_serializer.rb
@@ -55,7 +55,7 @@ module Bundler
       stack = [res]
       last_hash = nil
       last_empty_key = nil
-      str.split(/\r?\n/).each do |line|
+      str.split(/\r?\n/) do |line|
         if match = HASH_REGEX.match(line)
           indent, key, quote, val = match.captures
           convert_to_backward_compatible_key!(key)

--- a/lib/rubygems/yaml_serializer.rb
+++ b/lib/rubygems/yaml_serializer.rb
@@ -55,7 +55,7 @@ module Gem
       stack = [res]
       last_hash = nil
       last_empty_key = nil
-      str.split(/\r?\n/).each do |line|
+      str.split(/\r?\n/) do |line|
         if match = HASH_REGEX.match(line)
           indent, key, quote, val = match.captures
           convert_to_backward_compatible_key!(key)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

String#split without a block creates an intermediate array and requires a call to Array#each to iterate.

## What is your fix for the problem, implemented in this PR?

String#split supports a block since Ruby 2.6, avoiding such intermediate array.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes - No behavior change, previous tests are enough
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
