### PR TITLE
More robust writability check for gem home

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -351,6 +351,9 @@ class Gem::Installer
     run_post_install_hooks
 
     spec
+  rescue Errno::EACCES => e
+    # Permission denied - /path/to/foo
+    raise Gem::FilePermissionError, e.message.split(" - ").last
   end
 
   def run_pre_install_hooks # :nodoc:
@@ -716,7 +719,6 @@ class Gem::Installer
 
   def verify_gem_home # :nodoc:
     FileUtils.mkdir_p gem_home, :mode => options[:dir_mode] && 0o755
-    raise Gem::FilePermissionError, gem_home unless File.writable?(gem_home)
   end
 
   def verify_spec

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -193,7 +193,7 @@ ERROR:  Could not find a valid gem 'bar' (= 0.5) (required by 'foo' (>= 0)) in a
     pend "skipped in root privilege" if Process.uid.zero?
 
     spec_fetcher do |fetcher|
-      fetcher.gem "a", 2
+      fetcher.download "a", 2
     end
 
     @cmd.options[:user_install] = false
@@ -204,12 +204,14 @@ ERROR:  Could not find a valid gem 'bar' (= 0.5) (required by 'foo' (>= 0)) in a
       FileUtils.chmod 0o755, @userhome
       FileUtils.chmod 0o555, @gemhome
 
-      assert_raise Gem::FilePermissionError do
+      assert_raise Gem::MockGemUi::SystemExitException, @ui.error do
         @cmd.execute
       end
     ensure
       FileUtils.chmod 0o755, @gemhome
     end
+
+    assert_equal %w[a-2], @cmd.installed_specs.map(&:full_name).sort
   end
 
   def test_execute_local_missing

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -192,30 +192,23 @@ ERROR:  Could not find a valid gem 'bar' (= 0.5) (required by 'foo' (>= 0)) in a
     pend "skipped on MS Windows (chmod has no effect)" if Gem.win_platform?
     pend "skipped in root privilege" if Process.uid.zero?
 
-    specs = spec_fetcher do |fetcher|
+    spec_fetcher do |fetcher|
       fetcher.gem "a", 2
     end
 
     @cmd.options[:user_install] = false
 
-    FileUtils.mv specs["a-2"].cache_file, @tempdir
-
     @cmd.options[:args] = %w[a]
 
     use_ui @ui do
-      orig_dir = Dir.pwd
-      begin
-        FileUtils.chmod 0o755, @userhome
-        FileUtils.chmod 0o555, @gemhome
+      FileUtils.chmod 0o755, @userhome
+      FileUtils.chmod 0o555, @gemhome
 
-        Dir.chdir @tempdir
-        assert_raise Gem::FilePermissionError do
-          @cmd.execute
-        end
-      ensure
-        Dir.chdir orig_dir
-        FileUtils.chmod 0o755, @gemhome
+      assert_raise Gem::FilePermissionError do
+        @cmd.execute
       end
+    ensure
+      FileUtils.chmod 0o755, @gemhome
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This PR fixes the same issue fixed by https://github.com/rubygems/rubygems/pull/7113 for Bundler, but for RubyGems.

TL;DR `File.writable?` is not a reliable way of checking writability of a folder.

## What is your fix for the problem, implemented in this PR?

Try to write, and rescue any permission errors if they happen.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
