### PR TITLE
Warn for duplicate meta data links

### DIFF
--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -12,13 +12,14 @@ class Gem::SpecificationPolicy
   VALID_URI_PATTERN = %r{\Ahttps?:\/\/([^\s:@]+:[^\s:@]*@)?[A-Za-z\d\-]+(\.[A-Za-z\d\-]+)+\.?(:\d{1,5})?([\/?]\S*)?\z} # :nodoc:
 
   METADATA_LINK_KEYS = %w[
-    bug_tracker_uri
-    changelog_uri
-    documentation_uri
     homepage_uri
-    mailing_list_uri
+    changelog_uri
     source_code_uri
+    documentation_uri
     wiki_uri
+    mailing_list_uri
+    bug_tracker_uri
+    download_uri
     funding_uri
   ].freeze # :nodoc:
 
@@ -105,6 +106,8 @@ class Gem::SpecificationPolicy
     validate_extensions
 
     validate_removed_attributes
+
+    validate_unique_links
 
     if @warnings > 0
       if strict
@@ -499,6 +502,22 @@ You have specified rust based extension, but Cargo.lock is not part of the gem f
     warning <<-WARNING if rake_extension && !rake_dependency
 You have specified rake based extension, but rake is not added as dependency. It is recommended to add rake as a dependency in gemspec since there's no guarantee rake will be already installed.
     WARNING
+  end
+
+  def validate_unique_links
+    links = @specification.metadata.slice(*METADATA_LINK_KEYS)
+    grouped = links.group_by {|_key, uri| uri }
+    grouped.each do |uri, copies|
+      next unless copies.length > 1
+      keys = copies.map(&:first).join("\n  ")
+      warning <<~WARNING
+        You have specified the uri:
+          #{uri}
+        for all of the following keys:
+          #{keys}
+        Only the first one will be shown on rubygems.org
+      WARNING
+    end
   end
 
   def warning(statement) # :nodoc:

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3644,6 +3644,38 @@ Did you mean 'Ruby'?
     end
   end
 
+  def test_metadata_link_validation_warns_for_duplicates
+    util_setup_validate
+
+    Dir.chdir @tempdir do
+      @m2 = quick_gem "m", "2" do |s|
+        s.files = %w[lib/code.rb]
+        s.licenses = "BSD-2-Clause"
+        s.metadata = {
+          "source_code_uri" => "http://example.com",
+          "homepage_uri" => "http://example.com",
+          "changelog_uri" => "http://example.com/changelog",
+        }
+      end
+
+      use_ui @ui do
+        @m2.validate
+      end
+
+      expected = <<~EXPECTED
+        #{w}:  You have specified the uri:
+          http://example.com
+        for all of the following keys:
+          homepage_uri
+          source_code_uri
+        Only the first one will be shown on rubygems.org
+        #{w}:  See https://guides.rubygems.org/specification-reference/ for help
+      EXPECTED
+
+      assert_equal expected, @ui.error, "warning"
+    end
+  end
+
   def test_metadata_specs
     @m1 = quick_gem "m", "1" do |s|
       s.files = %w[lib/code.rb]


### PR DESCRIPTION
Match order of METADATA_LINK_KEYS to order used by rubygems.org in Links model Add missing download_uri key

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

This came out of a discussion around the fix to https://github.com/rubygems/rubygems.org/pull/3755

## What is your fix for the problem, implemented in this PR?

Per the suggestion from @simi I've added a warning when duplicate links are present in the metadata.

I also noticed the METADATA_LINK_KEYS constant was missing download_uri

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
