### PR TITLE
Make `rake` just run RubyGems tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -83,7 +83,7 @@ namespace "test" do
   end
 end
 
-task :default => [:test, :spec]
+task :default => [:test]
 
 spec = Gem::Specification.load(File.expand_path("rubygems-update.gemspec", __dir__))
 v = spec.version


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This is just something very minor with a very easy workaround (just get used to running `rake test` instead), so happy to close if there's any disagreement.

My take is that the default `rake` task should be for something you run often. And I've never wanted to run both the RubyGems and Bundler test suites in sequence. Also my muscle memory keeps running this for RubyGems tests since that's how it worked for years until we integrated Rake tasks of Bundler and RubyGems. So the end result is that every time I run `rake`, I cancel Bundler tests once they start.

I know this does bring some nice symmetry, but I don't think it's useful. Again, happy to close if other maintainers disagree.

## What is your fix for the problem, implemented in this PR?

Only run RubyGems tests as the default task.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
