### PR TITLE
Fix Bundler setup instructions

### DIFF
--- a/bundler/doc/development/SETUP.md
+++ b/bundler/doc/development/SETUP.md
@@ -6,31 +6,27 @@ To work on Bundler, you'll probably want to do a couple of things:
 
 * Install `graphviz` package using your package manager:
 
-        $ sudo apt-get install graphviz -y
+        sudo apt-get install graphviz -y
 
     And for OS X (with brew installed):
 
-        $ brew install graphviz
+        brew install graphviz
 
-* Install development dependencies from the rubygems root directory:
+* Install development dependencies and Bundler's test dependencies from the rubygems root directory:
 
-        $ rake setup
+        bin/rake setup spec:parallel_deps
 
 * Change into the bundler directory:
 
-        $ cd bundler
-
-* Install Bundler's test dependencies:
-
-        $ bin/rake spec:parallel_deps
+        cd bundler
 
 * Now you can run the test suite in parallel:
 
-        $ bin/parallel_rspec
+        bin/parallel_rspec
 
 * Set up a shell alias to run Bundler from your clone, e.g. a Bash alias ([follow these instructions](https://www.moncefbelyamani.com/create-aliases-in-bash-profile-to-assign-shortcuts-for-common-terminal-commands/) for adding aliases to your `~/.bashrc` profile):
 
-        $ alias dbundle='ruby /path/to/bundler/repo/spec/support/bundle.rb'
+        alias dbundle='ruby /path/to/bundler/repo/spec/support/bundle.rb'
 
 ## Jointly developing on Bundler and RubyGems
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Following the developer setup instructions led to failed commands.

## What is your fix for the problem, implemented in this PR?

The Rake command needs to be executed in the root directory _before_ switching to the bundler directory.
I reordered the instructions accordingly.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
