### PR TITLE
Convert Bundler lockfile checksum validation to manual opt-in

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -18,7 +18,8 @@ module Bundler
       :platforms,
       :ruby_version,
       :lockfile,
-      :gemfiles
+      :gemfiles,
+      :locked_checksums
     )
 
     # Given a gemfile and lockfile creates a Bundler definition
@@ -92,6 +93,7 @@ module Bundler
         @locked_bundler_version = @locked_gems.bundler_version
         @locked_ruby_version = @locked_gems.ruby_version
         @originally_locked_specs = SpecSet.new(@locked_gems.specs)
+        @locked_checksums = @locked_gems.checksums
 
         if unlock != true
           @locked_deps    = @locked_gems.dependencies
@@ -112,6 +114,7 @@ module Bundler
         @originally_locked_specs = @locked_specs
         @locked_sources = []
         @locked_platforms = []
+        @locked_checksums = nil
       end
 
       locked_gem_sources = @locked_sources.select {|s| s.is_a?(Source::Rubygems) }
@@ -767,7 +770,7 @@ module Bundler
       sources.all_sources.each do |source|
         # has to be done separately, because we want to keep the locked checksum
         # store for a source, even when doing a full update
-        if @locked_gems && locked_source = @locked_gems.sources.find {|s| s == source && !s.equal?(source) }
+        if @locked_checksums && @locked_gems && locked_source = @locked_gems.sources.find {|s| s == source && !s.equal?(source) }
           source.checksum_store.merge!(locked_source.checksum_store)
         end
         # If the source is unlockable and the current command allows an unlock of

--- a/bundler/lib/bundler/endpoint_specification.rb
+++ b/bundler/lib/bundler/endpoint_specification.rb
@@ -125,7 +125,6 @@ module Bundler
         next unless v
         case k.to_s
         when "checksum"
-          next if Bundler.settings[:disable_checksum_validation]
           begin
             @checksum = Checksum.from_api(v.last, @spec_fetcher.uri)
           rescue ArgumentError => e

--- a/bundler/lib/bundler/lockfile_generator.rb
+++ b/bundler/lib/bundler/lockfile_generator.rb
@@ -67,6 +67,7 @@ module Bundler
     end
 
     def add_checksums
+      return unless definition.locked_checksums
       checksums = definition.resolve.map do |spec|
         spec.source.checksum_store.to_lock(spec)
       end

--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -24,7 +24,15 @@ module Bundler
       end
     end
 
-    attr_reader :sources, :dependencies, :specs, :platforms, :bundler_version, :ruby_version, :checksums
+    attr_reader(
+      :sources,
+      :dependencies,
+      :specs,
+      :platforms,
+      :bundler_version,
+      :ruby_version,
+      :checksums,
+    )
 
     BUNDLED      = "BUNDLED WITH"
     DEPENDENCIES = "DEPENDENCIES"
@@ -111,6 +119,9 @@ module Bundler
         elsif line == DEPENDENCIES
           @parse_method = :parse_dependency
         elsif line == CHECKSUMS
+          # This is a temporary solution to make this feature disabled by default
+          # for all gemfiles that don't already explicitly include the feature.
+          @checksums = true
           @parse_method = :parse_checksum
         elsif line == PLATFORMS
           @parse_method = :parse_platform
@@ -228,8 +239,6 @@ module Bundler
       version = Gem::Version.new(version)
       platform = platform ? Gem::Platform.new(platform) : Gem::Platform::RUBY
       full_name = Gem::NameTuple.new(name, version, platform).full_name
-      # Don't raise exception if there's a checksum for a gem that's not in the lockfile,
-      # we prefer to heal invalid lockfiles
       return unless spec = @specs[full_name]
 
       checksums.split(",") do |lock_checksum|

--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -103,15 +103,7 @@ module Bundler
     end
 
     def gem_checksum
-      return nil if Bundler.settings[:disable_checksum_validation]
-      return nil unless source = @package.instance_variable_get(:@gem)
-      return nil unless source.respond_to?(:with_read_io)
-
-      source.with_read_io do |io|
-        Checksum.from_gem(io, source.path)
-      ensure
-        io.rewind
-      end
+      Checksum.from_gem_package(@package)
     end
 
     private

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -56,6 +56,11 @@ RSpec.describe Bundler::Definition do
         s.add_dependency "rack", "1.0"
       end
 
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "foo", "1.0"
+        c.checksum gem_repo1, "rack", "1.0.0"
+      end
+
       bundle :install, :env => { "DEBUG" => "1" }
 
       expect(out).to match(/re-resolving dependencies/)
@@ -76,11 +81,7 @@ RSpec.describe Bundler::Definition do
 
         DEPENDENCIES
           foo!
-
-        CHECKSUMS
-          #{gem_no_checksum "foo", "1.0"}
-          #{checksum_for_repo_gem gem_repo1, "rack", "1.0.0"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       G
@@ -110,6 +111,11 @@ RSpec.describe Bundler::Definition do
         s.add_development_dependency "net-ssh", "1.0"
       end
 
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "foo", "1.0"
+        c.checksum gem_repo1, "rack", "1.0.0"
+      end
+
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "foo", :path => "#{lib_path("foo")}"
@@ -135,17 +141,17 @@ RSpec.describe Bundler::Definition do
 
         DEPENDENCIES
           foo!
-
-        CHECKSUMS
-          #{gem_no_checksum "foo", "1.0"}
-          #{checksum_for_repo_gem gem_repo1, "rack", "1.0.0"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       G
     end
 
     it "for a locked gem for another platform" do
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "only_java", "1.1", "java"
+      end
+
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "only_java", platform: :jruby
@@ -166,16 +172,17 @@ RSpec.describe Bundler::Definition do
 
         DEPENDENCIES
           only_java
-
-        CHECKSUMS
-          only_java (1.1-java)
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       G
     end
 
     it "for a rubygems gem" do
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo1, "foo", "1.0"
+      end
+
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem "foo"
@@ -195,10 +202,7 @@ RSpec.describe Bundler::Definition do
 
         DEPENDENCIES
           foo
-
-        CHECKSUMS
-          #{checksum_for_repo_gem gem_repo1, "foo", "1.0"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       G

--- a/bundler/spec/cache/gems_spec.rb
+++ b/bundler/spec/cache/gems_spec.rb
@@ -289,10 +289,23 @@ RSpec.describe "bundle cache" do
       expect(cached_gem("rack-1.0.0")).to exist
     end
 
-    it "raises an error when the gem file is altered and produces a different checksum" do
+    it "raises an error when the gem is altered and produces a different checksum" do
       cached_gem("rack-1.0.0").rmtree
       build_gem "rack", "1.0.0", :path => bundled_app("vendor/cache")
+
+      checksums = checksums_section do |c|
+        c.checksum gem_repo1, "rack", "1.0.0"
+      end
+
       simulate_new_machine
+
+      lockfile <<-L
+        GEM
+          remote: #{file_uri_for(gem_repo2)}/
+          specs:
+            rack (1.0.0)
+        #{checksums}
+      L
 
       bundle :install, :raise_on_error => false
       expect(exitstatus).to eq(37)
@@ -301,6 +314,22 @@ RSpec.describe "bundle cache" do
 
       expect(cached_gem("rack-1.0.0")).to exist
       cached_gem("rack-1.0.0").rmtree
+      bundle :install
+      expect(cached_gem("rack-1.0.0")).to exist
+    end
+
+    it "installs a modified gem with a non-matching checksum when checksums is not opted in" do
+      cached_gem("rack-1.0.0").rmtree
+      build_gem "rack", "1.0.0", :path => bundled_app("vendor/cache")
+      simulate_new_machine
+
+      lockfile <<-L
+        GEM
+          remote: #{file_uri_for(gem_repo2)}/
+          specs:
+            rack (1.0.0)
+      L
+
       bundle :install
       expect(cached_gem("rack-1.0.0")).to exist
     end

--- a/bundler/spec/commands/check_spec.rb
+++ b/bundler/spec/commands/check_spec.rb
@@ -406,6 +406,12 @@ RSpec.describe "bundle check" do
     it "returns success when the Gemfile is satisfied and generates a correct lockfile" do
       system_gems "depends_on_rack-1.0", "rack-1.0", :gem_repo => gem_repo4, :path => default_bundle_path
       bundle :check
+
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "depends_on_rack", "1.0"
+        c.no_checksum "rack", "1.0"
+      end
+
       expect(out).to include("The Gemfile's dependencies are satisfied")
       expect(lockfile).to eq <<~L
         GEM
@@ -424,11 +430,7 @@ RSpec.describe "bundle check" do
 
         DEPENDENCIES
           depends_on_rack!
-
-        CHECKSUMS
-          depends_on_rack (1.0)
-          rack (1.0)
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -468,6 +470,12 @@ RSpec.describe "bundle check" do
 
       bundle "check --verbose", :dir => tmp.join("bundle-check-issue")
 
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo4, "awesome_print", "1.0"
+        c.no_checksum "bundle-check-issue", "9999"
+        c.checksum gem_repo2, "dex-dispatch-engine", "1.0"
+      end
+
       expect(File.read(tmp.join("bundle-check-issue/Gemfile.lock"))).to eq <<~L
         PATH
           remote: .
@@ -491,12 +499,7 @@ RSpec.describe "bundle check" do
         DEPENDENCIES
           bundle-check-issue!
           dex-dispatch-engine!
-
-        CHECKSUMS
-          #{checksum_for_repo_gem gem_repo4, "awesome_print", "1.0"}
-          bundle-check-issue (9999)
-          #{checksum_for_repo_gem gem_repo2, "dex-dispatch-engine", "1.0"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -622,6 +622,7 @@ RSpec.describe "bundle install with gem sources" do
       end
 
       it "writes current Ruby version to Gemfile.lock" do
+        checksums = checksums_section_when_existing
         expect(lockfile).to eq <<~L
          GEM
            remote: #{file_uri_for(gem_repo1)}/
@@ -631,9 +632,7 @@ RSpec.describe "bundle install with gem sources" do
            #{lockfile_platforms}
 
          DEPENDENCIES
-
-         CHECKSUMS
-
+         #{checksums}
          RUBY VERSION
             #{Bundler::RubyVersion.system}
 
@@ -648,6 +647,8 @@ RSpec.describe "bundle install with gem sources" do
           source "#{file_uri_for(gem_repo1)}"
         G
 
+        checksums = checksums_section_when_existing
+
         expect(lockfile).to eq <<~L
          GEM
            remote: #{file_uri_for(gem_repo1)}/
@@ -657,9 +658,7 @@ RSpec.describe "bundle install with gem sources" do
            #{lockfile_platforms}
 
          DEPENDENCIES
-
-         CHECKSUMS
-
+         #{checksums}
          RUBY VERSION
             #{Bundler::RubyVersion.system}
 
@@ -1074,11 +1073,11 @@ RSpec.describe "bundle install with gem sources" do
         gem "loofah", "~> 2.12.0"
       G
 
-      checksums = checksum_section do |c|
-        c.repo_gem gem_repo4, "crass", "1.0.6"
-        c.repo_gem gem_repo4, "loofah", "2.12.0"
-        c.repo_gem gem_repo4, "nokogiri", "1.12.4", "x86_64-darwin"
-        c.repo_gem gem_repo4, "racca", "1.5.2"
+      checksums = checksums_section do |c|
+        c.checksum gem_repo4, "crass", "1.0.6"
+        c.checksum gem_repo4, "loofah", "2.12.0"
+        c.checksum gem_repo4, "nokogiri", "1.12.4", "x86_64-darwin"
+        c.checksum gem_repo4, "racca", "1.5.2"
       end
 
       lockfile <<-L
@@ -1099,10 +1098,7 @@ RSpec.describe "bundle install with gem sources" do
 
         DEPENDENCIES
           loofah (~> 2.12.0)
-
-        CHECKSUMS
-          #{checksums}
-
+        #{checksums}
         RUBY VERSION
            #{Bundler::RubyVersion.system}
 
@@ -1118,12 +1114,12 @@ RSpec.describe "bundle install with gem sources" do
         bundle "install", :artifice => "compact_index"
       end
 
-      expected_checksums = checksum_section do |c|
-        c.repo_gem gem_repo4, "crass", "1.0.6"
-        c.repo_gem gem_repo4, "loofah", "2.12.0"
-        c.repo_gem gem_repo4, "nokogiri", "1.12.4", "x86_64-darwin"
-        c.repo_gem gem_repo4, "nokogiri", "1.12.4", "x86_64-linux"
-        c.repo_gem gem_repo4, "racca", "1.5.2"
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo4, "crass", "1.0.6"
+        c.checksum gem_repo4, "loofah", "2.12.0"
+        c.checksum gem_repo4, "nokogiri", "1.12.4", "x86_64-darwin"
+        c.checksum gem_repo4, "racca", "1.5.2"
+        c.checksum gem_repo4, "nokogiri", "1.12.4", "x86_64-linux"
       end
 
       expect(lockfile).to eq <<~L
@@ -1146,10 +1142,7 @@ RSpec.describe "bundle install with gem sources" do
 
         DEPENDENCIES
           loofah (~> 2.12.0)
-
-        CHECKSUMS
-          #{expected_checksums}
-
+        #{checksums}
         RUBY VERSION
            #{Bundler::RubyVersion.system}
 

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -275,6 +275,11 @@ RSpec.describe "bundle update" do
         gem "countries"
       G
 
+      checksums = checksums_section_when_existing do |c|
+        c.checksum(gem_repo4, "countries", "3.1.0")
+        c.checksum(gem_repo4, "country_select", "5.1.0")
+      end
+
       lockfile <<~L
         GEM
           remote: #{file_uri_for(gem_repo4)}/
@@ -289,11 +294,7 @@ RSpec.describe "bundle update" do
         DEPENDENCIES
           countries
           country_select
-
-        CHECKSUMS
-          #{checksum_for_repo_gem(gem_repo4, "countries", "3.1.0")}
-          #{checksum_for_repo_gem(gem_repo4, "country_select", "5.1.0")}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -509,9 +510,9 @@ RSpec.describe "bundle update" do
 
       original_lockfile = lockfile
 
-      expected_checksums = checksum_section do |c|
-        c.repo_gem gem_repo4, "activesupport", "6.0.4.1"
-        c.repo_gem gem_repo4, "tzinfo", "1.2.9"
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo4, "activesupport", "6.0.4.1"
+        c.checksum gem_repo4, "tzinfo", "1.2.9"
       end
 
       expected_lockfile = <<~L
@@ -527,10 +528,7 @@ RSpec.describe "bundle update" do
 
         DEPENDENCIES
           activesupport (~> 6.0.0)
-
-        CHECKSUMS
-          #{expected_checksums}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -1152,9 +1150,10 @@ RSpec.describe "bundle update --ruby" do
       G
 
       gemfile <<-G
-          source "#{file_uri_for(gem_repo1)}"
+        source "#{file_uri_for(gem_repo1)}"
       G
     end
+
     it "removes the Ruby from the Gemfile.lock" do
       bundle "update --ruby"
 
@@ -1167,8 +1166,6 @@ RSpec.describe "bundle update --ruby" do
          #{lockfile_platforms}
 
        DEPENDENCIES
-
-       CHECKSUMS
 
        BUNDLED WITH
           #{Bundler::VERSION}
@@ -1184,30 +1181,29 @@ RSpec.describe "bundle update --ruby" do
       G
 
       gemfile <<-G
-          ruby '~> #{current_ruby_minor}'
-          source "#{file_uri_for(gem_repo1)}"
+        ruby '~> #{current_ruby_minor}'
+        source "#{file_uri_for(gem_repo1)}"
       G
     end
+
     it "updates the Gemfile.lock with the latest version" do
       bundle "update --ruby"
 
       expect(lockfile).to eq <<~L
-       GEM
-         remote: #{file_uri_for(gem_repo1)}/
-         specs:
+        GEM
+          remote: #{file_uri_for(gem_repo1)}/
+          specs:
 
-       PLATFORMS
-         #{lockfile_platforms}
+        PLATFORMS
+          #{lockfile_platforms}
 
-       DEPENDENCIES
+        DEPENDENCIES
 
-       CHECKSUMS
+        RUBY VERSION
+           #{Bundler::RubyVersion.system}
 
-       RUBY VERSION
-          #{Bundler::RubyVersion.system}
-
-       BUNDLED WITH
-          #{Bundler::VERSION}
+        BUNDLED WITH
+           #{Bundler::VERSION}
       L
     end
   end
@@ -1257,6 +1253,7 @@ RSpec.describe "bundle update --ruby" do
           source "#{file_uri_for(gem_repo1)}"
       G
     end
+
     it "updates the Gemfile.lock with the latest version" do
       bundle "update --ruby"
 
@@ -1288,11 +1285,14 @@ RSpec.describe "bundle update --bundler" do
       build_gem "rack", "1.0"
     end
 
+    checksums = checksums_section_when_existing do |c|
+      c.checksum(gem_repo4, "rack", "1.0")
+    end
+
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo4)}"
       gem "rack"
     G
-    expected_checksum = checksum_for_repo_gem(gem_repo4, "rack", "1.0")
     expect(lockfile).to eq <<~L
       GEM
         remote: #{file_uri_for(gem_repo4)}/
@@ -1304,10 +1304,7 @@ RSpec.describe "bundle update --bundler" do
 
       DEPENDENCIES
         rack
-
-      CHECKSUMS
-        #{expected_checksum}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -1327,10 +1324,7 @@ RSpec.describe "bundle update --bundler" do
 
       DEPENDENCIES
         rack
-
-      CHECKSUMS
-        #{expected_checksum}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -1351,6 +1345,10 @@ RSpec.describe "bundle update --bundler" do
     G
     lockfile lockfile.sub(/(^\s*)#{Bundler::VERSION}($)/, "2.3.9")
 
+    checksums = checksums_section_when_existing do |c|
+      c.checksum(gem_repo4, "rack", "1.0")
+    end
+
     bundle :update, :bundler => true, :artifice => "compact_index", :verbose => true
     expect(out).to include("Using bundler #{Bundler::VERSION}")
 
@@ -1365,10 +1363,7 @@ RSpec.describe "bundle update --bundler" do
 
       DEPENDENCIES
         rack
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo4, "rack", "1.0")}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -1458,8 +1453,11 @@ RSpec.describe "bundle update --bundler" do
     bundle :update, :bundler => "2.3.0.dev", :verbose => "true"
 
     # Only updates properly on modern RubyGems.
-
     if Gem.rubygems_version >= Gem::Version.new("3.3.0.dev")
+      checksums = checksums_section_when_existing do |c|
+        c.checksum(gem_repo4, "rack", "1.0")
+      end
+
       expect(lockfile).to eq <<~L
         GEM
           remote: #{file_uri_for(gem_repo4)}/
@@ -1471,10 +1469,7 @@ RSpec.describe "bundle update --bundler" do
 
         DEPENDENCIES
           rack
-
-        CHECKSUMS
-          #{checksum_for_repo_gem(gem_repo4, "rack", "1.0")}
-
+        #{checksums}
         BUNDLED WITH
            2.3.0.dev
       L
@@ -1500,6 +1495,9 @@ RSpec.describe "bundle update --bundler" do
     expect(out).not_to include("Fetching gem metadata from https://rubygems.org/")
 
     # Only updates properly on modern RubyGems.
+    checksums = checksums_section_when_existing do |c|
+      c.checksum(gem_repo4, "rack", "1.0")
+    end
 
     if Gem.rubygems_version >= Gem::Version.new("3.3.0.dev")
       expect(lockfile).to eq <<~L
@@ -1513,10 +1511,7 @@ RSpec.describe "bundle update --bundler" do
 
         DEPENDENCIES
           rack
-
-        CHECKSUMS
-          #{checksum_for_repo_gem(gem_repo4, "rack", "1.0")}
-
+        #{checksums}
         BUNDLED WITH
            2.3.9
       L

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -28,14 +28,14 @@ RSpec.describe "bundle install from an existing gemspec" do
     x64_mingw_archs.join("\n  ")
   end
 
-  let(:x64_mingw_checksums) do
-    x64_mingw_archs.map do |arch|
+  def x64_mingw_checksums(checksums)
+    x64_mingw_archs.each do |arch|
       if arch == "x64-mingw-ucrt"
-        gem_no_checksum "platform_specific", "1.0", arch
+        checksums.no_checksum "platform_specific", "1.0", arch
       else
-        checksum_for_repo_gem gem_repo2, "platform_specific", "1.0", arch
+        checksums.checksum gem_repo2, "platform_specific", "1.0", arch
       end
-    end.join("\n  ")
+    end
   end
 
   it "should install runtime and development dependencies" do
@@ -368,6 +368,10 @@ RSpec.describe "bundle install from an existing gemspec" do
         gemspec :path => "../foo"
       G
 
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "foo", "1.0"
+      end
+
       lockfile <<-L
         PATH
           remote: ../foo
@@ -385,7 +389,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
         DEPENDENCIES
           foo!
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -459,6 +463,13 @@ RSpec.describe "bundle install from an existing gemspec" do
           it "keeps all platform dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 RUBY"
 
+            checksums = checksums_section_when_existing do |c|
+              c.no_checksum "foo", "1.0"
+              c.checksum gem_repo2, "platform_specific", "1.0"
+              c.checksum gem_repo2, "platform_specific", "1.0", "java"
+              x64_mingw_checksums(c)
+            end
+
             expect(lockfile).to eq <<~L
               PATH
                 remote: .
@@ -480,13 +491,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
               DEPENDENCIES
                 foo!
-
-              CHECKSUMS
-                foo (1.0)
-                #{checksum_for_repo_gem gem_repo2, "platform_specific", "1.0"}
-                #{checksum_for_repo_gem gem_repo2, "platform_specific", "1.0", "java"}
-                #{x64_mingw_checksums}
-
+              #{checksums}
               BUNDLED WITH
                  #{Bundler::VERSION}
             L
@@ -498,6 +503,13 @@ RSpec.describe "bundle install from an existing gemspec" do
 
           it "keeps all platform dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 RUBY"
+
+            checksums = checksums_section_when_existing do |c|
+              c.no_checksum "foo", "1.0"
+              c.checksum gem_repo2, "platform_specific", "1.0"
+              c.checksum gem_repo2, "platform_specific", "1.0", "java"
+              x64_mingw_checksums(c)
+            end
 
             expect(lockfile).to eq <<~L
               PATH
@@ -520,13 +532,7 @@ RSpec.describe "bundle install from an existing gemspec" do
               DEPENDENCIES
                 foo!
                 platform_specific
-
-              CHECKSUMS
-                foo (1.0)
-                #{checksum_for_repo_gem gem_repo2, "platform_specific", "1.0"}
-                #{checksum_for_repo_gem gem_repo2, "platform_specific", "1.0", "java"}
-                #{x64_mingw_checksums}
-
+              #{checksums}
               BUNDLED WITH
                  #{Bundler::VERSION}
             L
@@ -539,6 +545,14 @@ RSpec.describe "bundle install from an existing gemspec" do
 
           it "keeps all platform dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "indirect_platform_specific 1.0", "platform_specific 1.0 RUBY"
+
+            checksums = checksums_section_when_existing do |c|
+              c.no_checksum "foo", "1.0"
+              c.checksum gem_repo2, "indirect_platform_specific", "1.0"
+              c.checksum gem_repo2, "platform_specific", "1.0"
+              c.checksum gem_repo2, "platform_specific", "1.0", "java"
+              x64_mingw_checksums(c)
+            end
 
             expect(lockfile).to eq <<~L
               PATH
@@ -563,14 +577,7 @@ RSpec.describe "bundle install from an existing gemspec" do
               DEPENDENCIES
                 foo!
                 indirect_platform_specific
-
-              CHECKSUMS
-                foo (1.0)
-                #{checksum_for_repo_gem gem_repo2, "indirect_platform_specific", "1.0"}
-                #{checksum_for_repo_gem gem_repo2, "platform_specific", "1.0"}
-                #{checksum_for_repo_gem gem_repo2, "platform_specific", "1.0", "java"}
-                #{x64_mingw_checksums}
-
+              #{checksums}
               BUNDLED WITH
                  #{Bundler::VERSION}
             L
@@ -634,6 +641,12 @@ RSpec.describe "bundle install from an existing gemspec" do
         gemspec :path => "../chef"
       G
 
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "chef", "17.1.17"
+        c.no_checksum "chef", "17.1.17", "universal-mingw32"
+        c.checksum gem_repo4, "win32-api", "1.5.3", "universal-mingw32"
+      end
+
       initial_lockfile = <<~L
         PATH
           remote: ../chef
@@ -654,12 +667,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
         DEPENDENCIES
           chef!
-
-        CHECKSUMS
-          chef (17.1.17)
-          chef (17.1.17-universal-mingw32)
-          #{checksum_for_repo_gem gem_repo4, "win32-api", "1.5.3", "universal-mingw32"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -697,6 +705,12 @@ RSpec.describe "bundle install from an existing gemspec" do
     end
 
     it "does not remove the platform specific specs from the lockfile when re-resolving due to gemspec changes" do
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "activeadmin", "2.9.0"
+        c.no_checksum "jruby-openssl", "0.10.7", "java"
+        c.checksum gem_repo4, "railties", "6.1.4"
+      end
+
       expect(lockfile).to eq <<~L
         PATH
           remote: ../activeadmin
@@ -716,12 +730,7 @@ RSpec.describe "bundle install from an existing gemspec" do
         DEPENDENCIES
           activeadmin!
           jruby-openssl
-
-        CHECKSUMS
-          activeadmin (2.9.0)
-          jruby-openssl (0.10.7-java)
-          #{checksum_for_repo_gem gem_repo4, "railties", "6.1.4"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L

--- a/bundler/spec/install/gemfile/install_if_spec.rb
+++ b/bundler/spec/install/gemfile/install_if_spec.rb
@@ -18,6 +18,13 @@ RSpec.describe "bundle install with install_if conditionals" do
     expect(the_bundle).not_to include_gems("thin")
     expect(the_bundle).not_to include_gems("foo")
 
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo1, "activesupport", "2.3.5"
+      c.no_checksum "foo", "1.0"
+      c.checksum gem_repo1, "rack", "1.0.0"
+      c.no_checksum "thin", "1.0"
+    end
+
     expect(lockfile).to eq <<~L
       GEM
         remote: #{file_uri_for(gem_repo1)}/
@@ -36,13 +43,7 @@ RSpec.describe "bundle install with install_if conditionals" do
         foo
         rack
         thin
-
-      CHECKSUMS
-        #{checksum_for_repo_gem gem_repo1, "activesupport", "2.3.5"}
-        #{gem_no_checksum "foo", "1.0"}
-        #{checksum_for_repo_gem gem_repo1, "rack", "1.0.0"}
-        #{gem_no_checksum "thin", "1.0"}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L

--- a/bundler/spec/install/gemfile/path_spec.rb
+++ b/bundler/spec/install/gemfile/path_spec.rb
@@ -98,6 +98,11 @@ RSpec.describe "bundle install with explicit source paths" do
       gem "aaa", :path => "./aaa"
     G
 
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "aaa", "1.0"
+      c.no_checksum "demo", "1.0"
+    end
+
     lockfile = <<~L
       PATH
         remote: .
@@ -119,11 +124,7 @@ RSpec.describe "bundle install with explicit source paths" do
       DEPENDENCIES
         aaa!
         demo!
-
-      CHECKSUMS
-        #{gem_no_checksum("aaa", "1.0")}
-        #{gem_no_checksum("demo", "1.0")}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -345,6 +346,11 @@ RSpec.describe "bundle install with explicit source paths" do
 
     lockfile_path = lib_path("foo/Gemfile.lock")
 
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "foo", "0.1.0"
+      c.checksum gem_repo4, "graphql", "2.0.15"
+    end
+
     original_lockfile = <<~L
       PATH
         remote: .
@@ -362,11 +368,7 @@ RSpec.describe "bundle install with explicit source paths" do
 
       DEPENDENCIES
         foo!
-
-      CHECKSUMS
-        #{gem_no_checksum("foo", "0.1.0")}
-        #{checksum_for_repo_gem(gem_repo4, "graphql", "2.0.15")}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -673,6 +675,11 @@ RSpec.describe "bundle install with explicit source paths" do
 
       expect(the_bundle).to include_gems "rack 0.9.1"
 
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "foo", "1.0"
+        c.checksum gem_repo1, "rack", "0.9.1"
+      end
+
       expect(lockfile).to eq <<~G
         PATH
           remote: #{lib_path("foo")}
@@ -690,11 +697,7 @@ RSpec.describe "bundle install with explicit source paths" do
 
         DEPENDENCIES
           foo!
-
-        CHECKSUMS
-          #{gem_no_checksum("foo", "1.0")}
-          #{checksum_for_repo_gem(gem_repo1, "rack", "0.9.1")}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       G
@@ -722,11 +725,7 @@ RSpec.describe "bundle install with explicit source paths" do
 
         DEPENDENCIES
           foo!
-
-        CHECKSUMS
-          #{gem_no_checksum("foo", "1.0")}
-          #{checksum_for_repo_gem(gem_repo1, "rack", "0.9.1")}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       G
@@ -742,6 +741,11 @@ RSpec.describe "bundle install with explicit source paths" do
       bundle "install"
 
       expect(the_bundle).to include_gems "rack 0.9.1"
+
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "foo", "1.0"
+        c.checksum gem_repo1, "rack", "0.9.1"
+      end
 
       expect(lockfile).to eq <<~G
         PATH
@@ -760,11 +764,7 @@ RSpec.describe "bundle install with explicit source paths" do
 
         DEPENDENCIES
           foo!
-
-        CHECKSUMS
-          #{gem_no_checksum("foo", "1.0")}
-          #{checksum_for_repo_gem(gem_repo1, "rack", "0.9.1")}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       G
@@ -775,6 +775,8 @@ RSpec.describe "bundle install with explicit source paths" do
       end
 
       bundle "install"
+
+      checksums.checksum gem_repo1, "rake", "13.0.1"
 
       expect(lockfile).to eq <<~G
         PATH
@@ -795,12 +797,7 @@ RSpec.describe "bundle install with explicit source paths" do
 
         DEPENDENCIES
           foo!
-
-        CHECKSUMS
-          #{gem_no_checksum("foo", "1.0")}
-          #{checksum_for_repo_gem(gem_repo1, "rack", "0.9.1")}
-          #{checksum_for_repo_gem(gem_repo1, "rake", "13.0.1")}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       G
@@ -811,6 +808,10 @@ RSpec.describe "bundle install with explicit source paths" do
     it "does not remove existing ruby platform" do
       build_lib "foo", "1.0", :path => lib_path("foo") do |s|
         s.add_dependency "rack", "0.9.1"
+      end
+
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "foo", "1.0"
       end
 
       lockfile <<~L
@@ -824,12 +825,14 @@ RSpec.describe "bundle install with explicit source paths" do
 
         DEPENDENCIES
           foo!
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
 
       bundle "lock"
+
+      checksums.no_checksum "rack", "0.9.1"
 
       expect(lockfile).to eq <<~G
         PATH
@@ -848,11 +851,7 @@ RSpec.describe "bundle install with explicit source paths" do
 
         DEPENDENCIES
           foo!
-
-        CHECKSUMS
-          #{gem_no_checksum("foo", "1.0")}
-          #{gem_no_checksum("rack", "0.9.1")}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       G

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -203,6 +203,15 @@ RSpec.describe "bundle install across platforms" do
       gem "pry"
     G
 
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo4, "coderay", "1.1.2"
+      c.checksum gem_repo4, "empyrean", "0.1.0"
+      c.checksum gem_repo4, "ffi", "1.9.23", "java"
+      c.checksum gem_repo4, "method_source", "0.9.0"
+      c.checksum gem_repo4, "pry", "0.11.3", "java"
+      c.checksum gem_repo4, "spoon", "0.0.6"
+    end
+
     expect(lockfile).to eq <<~L
       GEM
         remote: #{file_uri_for(gem_repo4)}/
@@ -224,15 +233,7 @@ RSpec.describe "bundle install across platforms" do
       DEPENDENCIES
         empyrean (= 0.1.0)
         pry
-
-      CHECKSUMS
-        #{checksum_for_repo_gem gem_repo4, "coderay", "1.1.2"}
-        #{checksum_for_repo_gem gem_repo4, "empyrean", "0.1.0"}
-        #{checksum_for_repo_gem gem_repo4, "ffi", "1.9.23", "java"}
-        #{checksum_for_repo_gem gem_repo4, "method_source", "0.9.0"}
-        #{checksum_for_repo_gem gem_repo4, "pry", "0.11.3", "java"}
-        #{checksum_for_repo_gem gem_repo4, "spoon", "0.0.6"}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -264,16 +265,7 @@ RSpec.describe "bundle install across platforms" do
       DEPENDENCIES
         empyrean (= 0.1.0)
         pry
-
-      CHECKSUMS
-        #{checksum_for_repo_gem gem_repo4, "coderay", "1.1.2"}
-        #{checksum_for_repo_gem gem_repo4, "empyrean", "0.1.0"}
-        #{checksum_for_repo_gem gem_repo4, "ffi", "1.9.23", "java"}
-        #{checksum_for_repo_gem gem_repo4, "method_source", "0.9.0"}
-        pry (0.11.3)
-        #{checksum_for_repo_gem gem_repo4, "pry", "0.11.3", "java"}
-        #{checksum_for_repo_gem gem_repo4, "spoon", "0.0.6"}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -306,15 +298,7 @@ RSpec.describe "bundle install across platforms" do
       DEPENDENCIES
         empyrean (= 0.1.0)
         pry
-
-      CHECKSUMS
-        #{checksum_for_repo_gem gem_repo4, "coderay", "1.1.2"}
-        #{checksum_for_repo_gem gem_repo4, "empyrean", "0.1.0"}
-        #{checksum_for_repo_gem gem_repo4, "ffi", "1.9.23", "java"}
-        #{checksum_for_repo_gem gem_repo4, "method_source", "0.9.0"}
-        #{checksum_for_repo_gem gem_repo4, "pry", "0.11.3", "java"}
-        #{checksum_for_repo_gem gem_repo4, "spoon", "0.0.6"}
-
+      #{checksums}
       BUNDLED WITH
          1.16.1
     L
@@ -388,6 +372,11 @@ RSpec.describe "bundle install across platforms" do
   end
 
   it "keeps existing platforms when installing with force_ruby_platform" do
+    checksums = checksums_section do |c|
+      c.no_checksum "platform_specific", "1.0"
+      c.no_checksum "platform_specific", "1.0", "java"
+    end
+
     lockfile <<-G
       GEM
         remote: #{file_uri_for(gem_repo1)}/
@@ -399,6 +388,7 @@ RSpec.describe "bundle install across platforms" do
 
       DEPENDENCIES
         platform_specific
+      #{checksums}
     G
 
     bundle "config set --local force_ruby_platform true"
@@ -407,6 +397,8 @@ RSpec.describe "bundle install across platforms" do
       source "#{file_uri_for(gem_repo1)}"
       gem "platform_specific"
     G
+
+    checksums.checksum gem_repo1, "platform_specific", "1.0"
 
     expect(the_bundle).to include_gem "platform_specific 1.0 RUBY"
 
@@ -423,11 +415,7 @@ RSpec.describe "bundle install across platforms" do
 
       DEPENDENCIES
         platform_specific
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo1, "platform_specific", "1.0")}
-        #{gem_no_checksum "platform_specific", "1.0", "java"}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -596,9 +584,7 @@ RSpec.describe "bundle install with platform conditionals" do
 
       DEPENDENCIES
         rack
-
-      CHECKSUMS
-
+      #{checksums_section_when_existing}
       BUNDLED WITH
          #{Bundler::VERSION}
     L

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -28,15 +28,32 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
 
       it "refuses to install mismatched checksum because one gem has been tampered with", :bundler => "< 3" do
+        lockfile <<~L
+          GEM
+            remote: https://gem.repo3/
+            remote: https://gem.repo1/
+            specs:
+              rack (1.0.0)
+
+          PLATFORMS
+            #{local_platform}
+
+          DEPENDENCIES
+            depends_on_rack!
+
+          BUNDLED WITH
+            #{Bundler::VERSION}
+        L
+
         bundle :install, :artifice => "compact_index", :raise_on_error => false
 
         expect(exitstatus).to eq(37)
         expect(err).to eq <<~E.strip
           [DEPRECATED] Your Gemfile contains multiple global sources. Using `source` more than once without a block is a security risk, and may result in installing unexpected gems. To resolve this warning, use a block to indicate which gems should come from the secondary source.
           Bundler found mismatched checksums. This is a potential security risk.
-            #{checksum_for_repo_gem(gem_repo1, "rack", "1.0.0")}
+            #{checksum_to_lock(gem_repo1, "rack", "1.0.0")}
               from the API at https://gem.repo1/
-            #{checksum_for_repo_gem(gem_repo3, "rack", "1.0.0")}
+            #{checksum_to_lock(gem_repo3, "rack", "1.0.0")}
               from the API at https://gem.repo3/
 
           Mismatched checksums each have an authoritative source:
@@ -129,7 +146,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
     end
 
     it "works in standalone mode", :bundler => "< 3" do
-      gem_checksum = checksum_for_repo_gem(gem_repo4, "foo", "1.0").split(Bundler::Checksum::ALGO_SEPARATOR).last
+      gem_checksum = checksum_digest(gem_repo4, "foo", "1.0")
       bundle "install --standalone", :artifice => "compact_index", :env => { "BUNDLER_SPEC_FOO_CHECKSUM" => gem_checksum }
     end
   end
@@ -314,9 +331,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
           expect(err).to eq(<<~E.strip)
             [DEPRECATED] Your Gemfile contains multiple global sources. Using `source` more than once without a block is a security risk, and may result in installing unexpected gems. To resolve this warning, use a block to indicate which gems should come from the secondary source.
             Bundler found mismatched checksums. This is a potential security risk.
-              #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
+              #{checksum_to_lock(gem_repo2, "rack", "1.0.0")}
                 from the API at https://gem.repo2/
-              #{checksum_for_repo_gem(gem_repo1, "rack", "1.0.0")}
+              #{checksum_to_lock(gem_repo1, "rack", "1.0.0")}
                 from the API at https://gem.repo1/
 
             Mismatched checksums each have an authoritative source:
@@ -340,7 +357,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
               rack (1.0.0) sha256=#{rack_checksum}
                 from the API at https://gem.repo2/
                 and the API at https://gem.repo1/
-              #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
+              #{checksum_to_lock(gem_repo2, "rack", "1.0.0")}
                 from the gem at #{default_bundle_path("cache", "rack-1.0.0.gem")}
 
             If you trust the API at https://gem.repo2/, to resolve this issue you can:
@@ -354,15 +371,15 @@ RSpec.describe "bundle install with gems on multiple sources" do
         end
 
         it "installs from the other source and warns about ambiguous gems when the sources have the same checksum", :bundler => "< 3" do
-          gem_checksum = checksum_for_repo_gem(gem_repo2, "rack", "1.0.0").split(Bundler::Checksum::ALGO_SEPARATOR).last
+          gem_checksum = checksum_digest(gem_repo2, "rack", "1.0.0")
           bundle :install, :artifice => "compact_index", :env => { "BUNDLER_SPEC_RACK_CHECKSUM" => gem_checksum, "DEBUG" => "1" }
 
           expect(err).to include("Warning: the gem 'rack' was found in multiple sources.")
           expect(err).to include("Installed from: https://gem.repo2")
 
-          expected_checksums = checksum_section do |c|
-            c.repo_gem gem_repo3, "depends_on_rack", "1.0.1"
-            c.repo_gem gem_repo2, "rack", "1.0.0"
+          checksums = checksums_section_when_existing do |c|
+            c.checksum gem_repo3, "depends_on_rack", "1.0.1"
+            c.checksum gem_repo2, "rack", "1.0.0"
           end
 
           expect(lockfile).to eq <<~L
@@ -383,10 +400,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
             DEPENDENCIES
               depends_on_rack!
-
-            CHECKSUMS
-              #{expected_checksums}
-
+            #{checksums}
             BUNDLED WITH
                #{Bundler::VERSION}
           L
@@ -403,7 +417,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           expect(err).to include("Warning: the gem 'rack' was found in multiple sources.")
           expect(err).to include("Installed from: https://gem.repo2")
 
-          expected_checksums = checksum_section do |c|
+          checksums = checksums_section_when_existing do |c|
             c.no_checksum "depends_on_rack", "1.0.1"
             c.no_checksum "rack", "1.0.0"
           end
@@ -426,10 +440,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
             DEPENDENCIES
               depends_on_rack!
-
-            CHECKSUMS
-              #{expected_checksums}
-
+            #{checksums}
             BUNDLED WITH
                #{Bundler::VERSION}
           L
@@ -772,6 +783,21 @@ RSpec.describe "bundle install with gems on multiple sources" do
           end
         G
 
+        @locked_checksums = checksums_section_when_existing do |c|
+          c.checksum gem_repo2, "activesupport", "6.0.3.4"
+          c.checksum gem_repo2, "concurrent-ruby", "1.1.8"
+          c.checksum gem_repo2, "connection_pool", "2.2.3"
+          c.checksum gem_repo2, "i18n", "1.8.9"
+          c.checksum gem_repo2, "minitest", "5.14.3"
+          c.checksum gem_repo2, "rack", "2.2.3"
+          c.checksum gem_repo2, "redis", "4.2.5"
+          c.checksum gem_repo2, "sidekiq", "6.1.3"
+          c.checksum gem_repo3, "sidekiq-pro", "5.2.1"
+          c.checksum gem_repo2, "thread_safe", "0.3.6"
+          c.checksum gem_repo2, "tzinfo", "1.2.9"
+          c.checksum gem_repo2, "zeitwerk", "2.4.2"
+        end
+
         lockfile <<~L
           GEM
             remote: https://gem.repo2/
@@ -808,7 +834,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           DEPENDENCIES
             activesupport
             sidekiq-pro!
-
+          #{@locked_checksums}
           BUNDLED WITH
              #{Bundler::VERSION}
         L
@@ -824,21 +850,6 @@ RSpec.describe "bundle install with gems on multiple sources" do
         expect(the_bundle).not_to include_gems("tzinfo 2.0.4")
         expect(the_bundle).to include_gems("concurrent-ruby 1.1.8")
         expect(the_bundle).not_to include_gems("concurrent-ruby 1.1.9")
-
-        expected_checksums = checksum_section do |c|
-          c.repo_gem gem_repo2, "activesupport", "6.0.3.4"
-          c.repo_gem gem_repo2, "concurrent-ruby", "1.1.8"
-          c.repo_gem gem_repo2, "connection_pool", "2.2.3"
-          c.repo_gem gem_repo2, "i18n", "1.8.9"
-          c.repo_gem gem_repo2, "minitest", "5.14.3"
-          c.repo_gem gem_repo2, "rack", "2.2.3"
-          c.repo_gem gem_repo2, "redis", "4.2.5"
-          c.repo_gem gem_repo2, "sidekiq", "6.1.3"
-          c.repo_gem gem_repo3, "sidekiq-pro", "5.2.1"
-          c.repo_gem gem_repo2, "thread_safe", "0.3.6"
-          c.repo_gem gem_repo2, "tzinfo", "1.2.9"
-          c.repo_gem gem_repo2, "zeitwerk", "2.4.2"
-        end
 
         expect(lockfile).to eq <<~L
           GEM
@@ -879,10 +890,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           DEPENDENCIES
             activesupport
             sidekiq-pro!
-
-          CHECKSUMS
-            #{expected_checksums}
-
+          #{@locked_checksums}
           BUNDLED WITH
              #{Bundler::VERSION}
         L
@@ -923,24 +931,16 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
         expect(the_bundle).not_to include_gems("activesupport 6.0.3.4")
         expect(the_bundle).to include_gems("activesupport 6.1.2.1")
+        @locked_checksums.checksum gem_repo2, "activesupport", "6.1.2.1"
+
         expect(the_bundle).not_to include_gems("tzinfo 1.2.9")
         expect(the_bundle).to include_gems("tzinfo 2.0.4")
+        @locked_checksums.checksum gem_repo2, "tzinfo", "2.0.4"
+        @locked_checksums.delete "thread_safe"
+
         expect(the_bundle).not_to include_gems("concurrent-ruby 1.1.8")
         expect(the_bundle).to include_gems("concurrent-ruby 1.1.9")
-
-        expected_checksums = checksum_section do |c|
-          c.repo_gem gem_repo2, "activesupport", "6.1.2.1"
-          c.repo_gem gem_repo2, "concurrent-ruby", "1.1.9"
-          c.repo_gem gem_repo2, "connection_pool", "2.2.3"
-          c.repo_gem gem_repo2, "i18n", "1.8.9"
-          c.repo_gem gem_repo2, "minitest", "5.14.3"
-          c.repo_gem gem_repo2, "rack", "2.2.3"
-          c.repo_gem gem_repo2, "redis", "4.2.5"
-          c.repo_gem gem_repo2, "sidekiq", "6.1.3"
-          c.repo_gem gem_repo3, "sidekiq-pro", "5.2.1"
-          c.repo_gem gem_repo2, "tzinfo", "2.0.4"
-          c.repo_gem gem_repo2, "zeitwerk", "2.4.2"
-        end
+        @locked_checksums.checksum gem_repo2, "concurrent-ruby", "1.1.9"
 
         expect(lockfile).to eq <<~L
           GEM
@@ -980,10 +980,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           DEPENDENCIES
             activesupport
             sidekiq-pro!
-
-          CHECKSUMS
-            #{expected_checksums}
-
+          #{@locked_checksums}
           BUNDLED WITH
              #{Bundler::VERSION}
         L
@@ -1000,20 +997,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         expect(the_bundle).to include_gems("concurrent-ruby 1.1.9")
         expect(the_bundle).not_to include_gems("concurrent-ruby 1.1.8")
 
-        expected_checksums = checksum_section do |c|
-          c.repo_gem gem_repo2, "activesupport", "6.0.3.4"
-          c.repo_gem gem_repo2, "concurrent-ruby", "1.1.9"
-          c.repo_gem gem_repo2, "connection_pool", "2.2.3"
-          c.repo_gem gem_repo2, "i18n", "1.8.9"
-          c.repo_gem gem_repo2, "minitest", "5.14.3"
-          c.repo_gem gem_repo2, "rack", "2.2.3"
-          c.repo_gem gem_repo2, "redis", "4.2.5"
-          c.repo_gem gem_repo2, "sidekiq", "6.1.3"
-          c.repo_gem gem_repo3, "sidekiq-pro", "5.2.1"
-          c.repo_gem gem_repo2, "thread_safe", "0.3.6"
-          c.repo_gem gem_repo2, "tzinfo", "1.2.9"
-          c.repo_gem gem_repo2, "zeitwerk", "2.4.2"
-        end
+        @locked_checksums.checksum gem_repo2, "concurrent-ruby", "1.1.9"
 
         expect(lockfile).to eq <<~L
           GEM
@@ -1054,10 +1038,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           DEPENDENCIES
             activesupport
             sidekiq-pro!
-
-          CHECKSUMS
-            #{expected_checksums}
-
+          #{@locked_checksums}
           BUNDLED WITH
              #{Bundler::VERSION}
         L
@@ -1125,10 +1106,10 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
 
       it "installs from the default source without any warnings or errors and generates a proper lockfile" do
-        expected_checksums = checksum_section do |c|
-          c.repo_gem gem_repo3, "handsoap", "0.2.5.5"
-          c.repo_gem gem_repo2, "nokogiri", "1.11.1"
-          c.repo_gem gem_repo2, "racca", "1.5.2"
+        checksums = checksums_section_when_existing do |c|
+          c.checksum gem_repo3, "handsoap", "0.2.5.5"
+          c.checksum gem_repo2, "nokogiri", "1.11.1"
+          c.checksum gem_repo2, "racca", "1.5.2"
         end
 
         expected_lockfile = <<~L
@@ -1151,10 +1132,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           DEPENDENCIES
             handsoap!
             nokogiri
-
-          CHECKSUMS
-            #{expected_checksums}
-
+          #{checksums}
           BUNDLED WITH
              #{Bundler::VERSION}
         L
@@ -1243,7 +1221,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
           DEPENDENCIES
             rack!
-
+          #{checksums_section}
           BUNDLED WITH
              #{Bundler::VERSION}
         L
@@ -1302,8 +1280,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
         bundle "install", :artifice => "compact_index", :raise_on_error => false
 
-        api_checksum1 = checksum_for_repo_gem(gem_repo1, "rack", "0.9.1").split("sha256=").last
-        api_checksum3 = checksum_for_repo_gem(gem_repo3, "rack", "0.9.1").split("sha256=").last
+        api_checksum1 = checksum_digest(gem_repo1, "rack", "0.9.1")
+        api_checksum3 = checksum_digest(gem_repo3, "rack", "0.9.1")
 
         expect(exitstatus).to eq(37)
         expect(err).to eq(<<~E.strip)
@@ -1712,9 +1690,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
     it "upgrades the lockfile correctly" do
       bundle "lock --update", :artifice => "compact_index"
 
-      expected_checksums = checksum_section do |c|
-        c.repo_gem gem_repo2, "capybara", "2.5.0"
-        c.repo_gem gem_repo4, "mime-types", "3.0.0"
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo2, "capybara", "2.5.0"
+        c.checksum gem_repo4, "mime-types", "3.0.0"
       end
 
       expect(lockfile).to eq <<~L
@@ -1735,10 +1713,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         DEPENDENCIES
           capybara (~> 2.5.0)
           mime-types (~> 3.0)!
-
-        CHECKSUMS
-          #{expected_checksums}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -1774,6 +1749,11 @@ RSpec.describe "bundle install with gems on multiple sources" do
     it "handles that fine" do
       bundle "install", :artifice => "compact_index_extra", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
 
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo4, "pdf-writer", "1.1.8"
+        c.checksum gem_repo2, "ruport", "1.7.0.3"
+      end
+
       expect(lockfile).to eq <<~L
         GEM
           remote: https://localgemserver.test/
@@ -1791,11 +1771,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
         DEPENDENCIES
           ruport (= 1.7.0.3)!
-
-        CHECKSUMS
-          #{checksum_for_repo_gem gem_repo4, "pdf-writer", "1.1.8"}
-          #{checksum_for_repo_gem gem_repo2, "ruport", "1.7.0.3"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -1831,9 +1807,9 @@ RSpec.describe "bundle install with gems on multiple sources" do
     it "handles that fine" do
       bundle "install", :artifice => "compact_index_extra", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
 
-      expected_checksums = checksum_section do |c|
-        c.repo_gem gem_repo4, "pdf-writer", "1.1.8"
-        c.repo_gem gem_repo2, "ruport", "1.7.0.3"
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo4, "pdf-writer", "1.1.8"
+        c.checksum gem_repo2, "ruport", "1.7.0.3"
       end
 
       expect(lockfile).to eq <<~L
@@ -1853,10 +1829,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
         DEPENDENCIES
           ruport (= 1.7.0.3)!
-
-        CHECKSUMS
-          #{expected_checksums}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -1886,8 +1859,8 @@ RSpec.describe "bundle install with gems on multiple sources" do
     it "handles that fine" do
       bundle "install --verbose", :artifice => "endpoint", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
 
-      expected_checksums = checksum_section do |c|
-        c.repo_gem gem_repo4, "pdf-writer", "1.1.8"
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo4, "pdf-writer", "1.1.8"
       end
 
       expect(lockfile).to eq <<~L
@@ -1901,10 +1874,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
         DEPENDENCIES
           pdf-writer (= 1.1.8)
-
-        CHECKSUMS
-          #{expected_checksums}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -66,6 +66,10 @@ RSpec.describe "bundle install with specific platforms" do
 
       gemfile google_protobuf
 
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo2, "google-protobuf", "3.0.0.alpha.4.0"
+      end
+
       # simulate lockfile created with old bundler, which only locks for ruby platform
       lockfile <<-L
         GEM
@@ -78,15 +82,14 @@ RSpec.describe "bundle install with specific platforms" do
 
         DEPENDENCIES
           google-protobuf
-
-        CHECKSUMS
-          google-protobuf (3.0.0.alpha.4.0)
-
+        #{checksums}
         BUNDLED WITH
            2.1.4
       L
 
       bundle "update", :env => { "BUNDLER_VERSION" => Bundler::VERSION }
+
+      checksums.checksum gem_repo2, "google-protobuf", "3.0.0.alpha.5.0.5.1"
 
       # make sure the platform that the platform specific dependency is used, since we're only locked to ruby
       expect(the_bundle).to include_gem("google-protobuf 3.0.0.alpha.5.0.5.1 universal-darwin")
@@ -103,10 +106,7 @@ RSpec.describe "bundle install with specific platforms" do
 
         DEPENDENCIES
           google-protobuf
-
-        CHECKSUMS
-          google-protobuf (3.0.0.alpha.5.0.5.1)
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -528,11 +528,11 @@ RSpec.describe "bundle install with specific platforms" do
 
     bundle "update"
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo4, "sorbet", "0.5.10160"
-      c.repo_gem gem_repo4, "sorbet-runtime", "0.5.10160"
-      c.repo_gem gem_repo4, "sorbet-static", "0.5.10160", Gem::Platform.local
-      c.repo_gem gem_repo4, "sorbet-static-and-runtime", "0.5.10160"
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo4, "sorbet", "0.5.10160"
+      c.checksum gem_repo4, "sorbet-runtime", "0.5.10160"
+      c.checksum gem_repo4, "sorbet-static", "0.5.10160", Gem::Platform.local
+      c.checksum gem_repo4, "sorbet-static-and-runtime", "0.5.10160"
     end
 
     expect(lockfile).to eq <<~L
@@ -552,10 +552,7 @@ RSpec.describe "bundle install with specific platforms" do
 
       DEPENDENCIES
         sorbet-static-and-runtime
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -587,6 +584,11 @@ RSpec.describe "bundle install with specific platforms" do
       G
     end
 
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "nokogiri", "1.13.0", "x86_64-darwin"
+      c.no_checksum "sorbet-static", "0.5.10601", "x86_64-darwin"
+    end
+
     lockfile <<~L
       GEM
         remote: #{file_uri_for(gem_repo4)}/
@@ -602,7 +604,7 @@ RSpec.describe "bundle install with specific platforms" do
       DEPENDENCIES
         nokogiri
         sorbet-static
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -624,11 +626,7 @@ RSpec.describe "bundle install with specific platforms" do
       DEPENDENCIES
         nokogiri
         sorbet-static
-
-      CHECKSUMS
-        #{gem_no_checksum "nokogiri", "1.13.0", "x86_64-darwin"}
-        #{gem_no_checksum "sorbet-static", "0.5.10601", "x86_64-darwin"}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -682,11 +680,11 @@ RSpec.describe "bundle install with specific platforms" do
 
     bundle "update"
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo4, "sorbet", "0.5.10160"
-      c.repo_gem gem_repo4, "sorbet-runtime", "0.5.10160"
-      c.repo_gem gem_repo4, "sorbet-static", "0.5.10160", Gem::Platform.local
-      c.repo_gem gem_repo4, "sorbet-static-and-runtime", "0.5.10160"
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo4, "sorbet", "0.5.10160"
+      c.checksum gem_repo4, "sorbet-runtime", "0.5.10160"
+      c.checksum gem_repo4, "sorbet-static", "0.5.10160", Gem::Platform.local
+      c.checksum gem_repo4, "sorbet-static-and-runtime", "0.5.10160"
     end
 
     expect(lockfile).to eq <<~L
@@ -706,10 +704,7 @@ RSpec.describe "bundle install with specific platforms" do
 
       DEPENDENCIES
         sorbet-static-and-runtime
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -760,9 +755,9 @@ RSpec.describe "bundle install with specific platforms" do
 
       bundle "update"
 
-      expected_checksums = checksum_section do |c|
-        c.repo_gem gem_repo4, "nokogiri", "1.14.0", "x86_64-linux"
-        c.repo_gem gem_repo4, "sorbet-static", "0.5.10696", "x86_64-linux"
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo4, "nokogiri", "1.14.0", "x86_64-linux"
+        c.checksum gem_repo4, "sorbet-static", "0.5.10696", "x86_64-linux"
       end
 
       expect(lockfile).to eq <<~L
@@ -778,10 +773,7 @@ RSpec.describe "bundle install with specific platforms" do
         DEPENDENCIES
           nokogiri
           sorbet-static
-
-        CHECKSUMS
-          #{expected_checksums}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -807,6 +799,11 @@ RSpec.describe "bundle install with specific platforms" do
         gem "sorbet-static", "= 0.5.10549"
       G
 
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo4, "sorbet-static", "0.5.10549", "universal-darwin-20"
+        c.checksum gem_repo4, "sorbet-static", "0.5.10549", "universal-darwin-21"
+      end
+
       # Make sure the lockfile is missing sorbet-static-0.5.10549-universal-darwin-21
       lockfile <<~L
         GEM
@@ -819,16 +816,14 @@ RSpec.describe "bundle install with specific platforms" do
 
         DEPENDENCIES
           sorbet-static (= 0.5.10549)
-
-        CHECKSUMS
-          #{checksum_for_repo_gem gem_repo4, "sorbet-static", "0.5.10549", "universal-darwin-20"}
-          #{checksum_for_repo_gem gem_repo4, "sorbet-static", "0.5.10549", "universal-darwin-21"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
 
       bundle "install"
+
+      checksums.no_checksum "sorbet-static", "0.5.10549", "universal-darwin-21"
 
       expect(lockfile).to eq <<~L
         GEM
@@ -842,11 +837,7 @@ RSpec.describe "bundle install with specific platforms" do
 
         DEPENDENCIES
           sorbet-static (= 0.5.10549)
-
-        CHECKSUMS
-          #{checksum_for_repo_gem gem_repo4, "sorbet-static", "0.5.10549", "universal-darwin-20"}
-          #{gem_no_checksum "sorbet-static", "0.5.10549", "universal-darwin-21"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -893,6 +884,11 @@ RSpec.describe "bundle install with specific platforms" do
 
     bundle "lock --update"
 
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "nokogiri", "1.13.8"
+      c.no_checksum "nokogiri", "1.13.8", Gem::Platform.local
+    end
+
     updated_lockfile = <<~L
       GEM
         remote: #{file_uri_for(gem_repo4)}/
@@ -906,11 +902,7 @@ RSpec.describe "bundle install with specific platforms" do
       DEPENDENCIES
         nokogiri
         tzinfo (~> 1.2)
-
-      CHECKSUMS
-        #{gem_no_checksum "nokogiri", "1.13.8"}
-        #{gem_no_checksum "nokogiri", "1.13.8", Gem::Platform.local}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -931,6 +923,11 @@ RSpec.describe "bundle install with specific platforms" do
       gem "rack"
     G
 
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "concurrent-ruby", "1.2.2"
+      c.no_checksum "rack", "3.0.7"
+    end
+
     lockfile <<~L
       GEM
         remote: #{file_uri_for(gem_repo4)}/
@@ -942,7 +939,7 @@ RSpec.describe "bundle install with specific platforms" do
 
       DEPENDENCIES
         concurrent-ruby
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -962,11 +959,7 @@ RSpec.describe "bundle install with specific platforms" do
       DEPENDENCIES
         concurrent-ruby
         rack
-
-      CHECKSUMS
-        #{gem_no_checksum "concurrent-ruby", "1.2.2"}
-        #{gem_no_checksum "rack", "3.0.7"}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -1029,6 +1022,10 @@ RSpec.describe "bundle install with specific platforms" do
         gem "nokogiri", "1.14.0"
       G
 
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo4, "nokogiri", "1.14.0", "x86_64-linux"
+      end
+
       lockfile <<~L
         GEM
           remote: #{file_uri_for(gem_repo4)}/
@@ -1040,12 +1037,16 @@ RSpec.describe "bundle install with specific platforms" do
 
         DEPENDENCIES
           nokogiri (= 1.14.0)
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
 
       bundle :install
+
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo4, "nokogiri", "1.14.0"
+      end
 
       expect(lockfile).to eq(<<~L)
         GEM
@@ -1058,10 +1059,7 @@ RSpec.describe "bundle install with specific platforms" do
 
         DEPENDENCIES
           nokogiri (= 1.14.0)
-
-        CHECKSUMS
-          #{checksum_for_repo_gem gem_repo4, "nokogiri", "1.14.0"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -1101,6 +1099,12 @@ RSpec.describe "bundle install with specific platforms" do
 
       bundle "lock"
 
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "nokogiri", "1.14.0"
+        c.no_checksum "nokogiri", "1.14.0", "arm-linux"
+        c.no_checksum "nokogiri", "1.14.0", "x86_64-linux"
+      end
+
       # locks all compatible platforms, excluding Java and Windows
       expect(lockfile).to eq(<<~L)
         GEM
@@ -1117,12 +1121,7 @@ RSpec.describe "bundle install with specific platforms" do
 
         DEPENDENCIES
           nokogiri
-
-        CHECKSUMS
-          #{gem_no_checksum "nokogiri", "1.14.0"}
-          #{gem_no_checksum "nokogiri", "1.14.0", "arm-linux"}
-          #{gem_no_checksum "nokogiri", "1.14.0", "x86_64-linux"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -1137,6 +1136,10 @@ RSpec.describe "bundle install with specific platforms" do
       FileUtils.rm bundled_app_lock
 
       bundle "lock"
+
+      checksums.delete "nokogiri", "arm-linux"
+      checksums.no_checksum "sorbet-static", "0.5.10696", "universal-darwin-22"
+      checksums.no_checksum "sorbet-static", "0.5.10696", "x86_64-linux"
 
       # locks only platforms compatible with all gems in the bundle
       expect(lockfile).to eq(<<~L)
@@ -1155,13 +1158,7 @@ RSpec.describe "bundle install with specific platforms" do
         DEPENDENCIES
           nokogiri
           sorbet-static
-
-        CHECKSUMS
-          #{gem_no_checksum "nokogiri", "1.14.0"}
-          #{gem_no_checksum "nokogiri", "1.14.0", "x86_64-linux"}
-          #{gem_no_checksum "sorbet-static", "0.5.10696", "universal-darwin-22"}
-          #{gem_no_checksum "sorbet-static", "0.5.10696", "x86_64-linux"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -1191,10 +1188,10 @@ RSpec.describe "bundle install with specific platforms" do
       gem "sass-embedded"
     G
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo4, "nokogiri", "1.15.5"
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo4, "nokogiri", "1.15.5"
       c.no_checksum "sass-embedded", "1.69.5"
-      c.repo_gem gem_repo4, "sass-embedded", "1.69.5", "x86_64-linux-gnu"
+      c.checksum gem_repo4, "sass-embedded", "1.69.5", "x86_64-linux-gnu"
     end
 
     simulate_platform "x86_64-linux" do
@@ -1216,10 +1213,7 @@ RSpec.describe "bundle install with specific platforms" do
         DEPENDENCIES
           nokogiri
           sass-embedded
-
-        CHECKSUMS
-          #{expected_checksums}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L

--- a/bundler/spec/install/gems/flex_spec.rb
+++ b/bundler/spec/install/gems/flex_spec.rb
@@ -268,6 +268,11 @@ RSpec.describe "bundle flex_install" do
     it "should work when you install" do
       bundle "install"
 
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo1, "rack", "0.9.1"
+        c.checksum gem_repo1, "rack-obama", "1.0"
+      end
+
       expect(lockfile).to eq <<~L
         GEM
           remote: #{file_uri_for(gem_repo1)}/
@@ -282,11 +287,7 @@ RSpec.describe "bundle flex_install" do
         DEPENDENCIES
           rack (= 0.9.1)
           rack-obama
-
-        CHECKSUMS
-          #{checksum_for_repo_gem gem_repo1, "rack", "0.9.1"}
-          #{checksum_for_repo_gem gem_repo1, "rack-obama", "1.0"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -312,6 +313,10 @@ RSpec.describe "bundle flex_install" do
         gem "rack"
       G
 
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo1, "rack", "1.0.0"
+      end
+
       expect(lockfile).to eq <<~L
         GEM
           remote: #{file_uri_for(gem_repo1)}/
@@ -327,10 +332,7 @@ RSpec.describe "bundle flex_install" do
 
         DEPENDENCIES
           rack
-
-        CHECKSUMS
-          #{checksum_for_repo_gem gem_repo1, "rack", "1.0.0"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -256,6 +256,10 @@ RSpec.describe "bundle install with install-time dependencies" do
             gem 'parallel_tests'
           G
 
+          checksums = checksums_section do |c|
+            c.checksum gem_repo2, "parallel_tests", "3.8.0"
+          end
+
           lockfile <<~L
             GEM
               remote: http://localgemserver.test/
@@ -267,7 +271,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
             DEPENDENCIES
               parallel_tests
-
+            #{checksums}
             BUNDLED WITH
                #{Bundler::VERSION}
           L
@@ -275,6 +279,10 @@ RSpec.describe "bundle install with install-time dependencies" do
 
         it "automatically updates lockfile to use the older version" do
           bundle "install --verbose", :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }
+
+          checksums = checksums_section_when_existing do |c|
+            c.checksum gem_repo2, "parallel_tests", "3.7.0"
+          end
 
           expect(lockfile).to eq <<~L
             GEM
@@ -287,10 +295,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
             DEPENDENCIES
               parallel_tests
-
-            CHECKSUMS
-              #{checksum_for_repo_gem gem_repo2, "parallel_tests", "3.7.0"}
-
+            #{checksums}
             BUNDLED WITH
                #{Bundler::VERSION}
           L
@@ -335,6 +340,11 @@ RSpec.describe "bundle install with install-time dependencies" do
             gem 'rubocop'
           G
 
+          checksums = checksums_section do |c|
+            c.checksum gem_repo2, "rubocop", "1.35.0"
+            c.checksum gem_repo2, "rubocop-ast", "1.21.0"
+          end
+
           lockfile <<~L
             GEM
               remote: http://localgemserver.test/
@@ -348,7 +358,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
             DEPENDENCIES
               parallel_tests
-
+            #{checksums}
             BUNDLED WITH
                #{Bundler::VERSION}
           L
@@ -356,6 +366,11 @@ RSpec.describe "bundle install with install-time dependencies" do
 
         it "automatically updates lockfile to use the older compatible versions" do
           bundle "install --verbose", :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }
+
+          checksums = checksums_section_when_existing do |c|
+            c.checksum gem_repo2, "rubocop", "1.28.2"
+            c.checksum gem_repo2, "rubocop-ast", "1.17.0"
+          end
 
           expect(lockfile).to eq <<~L
             GEM
@@ -370,11 +385,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
             DEPENDENCIES
               rubocop
-
-            CHECKSUMS
-              #{checksum_for_repo_gem gem_repo2, "rubocop", "1.28.2"}
-              #{checksum_for_repo_gem gem_repo2, "rubocop-ast", "1.17.0"}
-
+            #{checksums}
             BUNDLED WITH
                #{Bundler::VERSION}
           L

--- a/bundler/spec/install/yanked_spec.rb
+++ b/bundler/spec/install/yanked_spec.rb
@@ -160,10 +160,6 @@ RSpec.context "when resolving a bundle that includes yanked gems, but unlocking 
         bar
         foo
 
-      CHECKSUMS
-        #{gem_no_checksum "bar", "2.0.0"}
-        #{gem_no_checksum "foo", "9.0.0"}
-
       BUNDLED WITH
          #{Bundler::VERSION}
     L

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe "the lockfile format" do
   end
 
   it "generates a simple lockfile for a single source, gem" do
+    checksums = checksums_section_when_existing do |c|
+      c.checksum(gem_repo2, "rack", "1.0.0")
+    end
+
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}"
 
@@ -23,10 +27,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -77,9 +78,6 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -134,6 +132,10 @@ RSpec.describe "the lockfile format" do
   it "does not update the lockfile's bundler version if nothing changed during bundle install, and uses the latest version", :rubygems => "< 3.3.0.a" do
     version = "#{Bundler::VERSION.split(".").first}.0.0.a"
 
+    checksums = checksums_section do |c|
+      c.checksum(gem_repo2, "rack", "1.0.0")
+    end
+
     lockfile <<-L
       GEM
         remote: #{file_uri_for(gem_repo2)}/
@@ -145,10 +147,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
-
+      #{checksums}
       BUNDLED WITH
          #{version}
     L
@@ -173,10 +172,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
-
+      #{checksums}
       BUNDLED WITH
          #{version}
     G
@@ -213,9 +209,6 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack (> 0)
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
 
       BUNDLED WITH
          #{Bundler::VERSION}
@@ -264,9 +257,6 @@ RSpec.describe "the lockfile format" do
       DEPENDENCIES
         rack
 
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
-
       BUNDLED WITH
          #{current_version}
     G
@@ -279,9 +269,9 @@ RSpec.describe "the lockfile format" do
       gem "rack-obama"
     G
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo2, "rack", "1.0.0"
-      c.repo_gem gem_repo2, "rack-obama", "1.0"
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo2, "rack", "1.0.0"
+      c.checksum gem_repo2, "rack-obama", "1.0"
     end
 
     expect(lockfile).to eq <<~G
@@ -297,10 +287,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack-obama
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -313,9 +300,9 @@ RSpec.describe "the lockfile format" do
       gem "rack-obama", ">= 1.0"
     G
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo2, "rack", "1.0.0"
-      c.repo_gem gem_repo2, "rack-obama", "1.0"
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo2, "rack", "1.0.0"
+      c.checksum gem_repo2, "rack-obama", "1.0"
     end
 
     expect(lockfile).to eq <<~G
@@ -331,10 +318,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack-obama (>= 1.0)
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -355,9 +339,9 @@ RSpec.describe "the lockfile format" do
       end
     G
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo2, "rack", "1.0.0"
-      c.repo_gem gem_repo2, "rack-obama", "1.0"
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo2, "rack", "1.0.0"
+      c.checksum gem_repo2, "rack-obama", "1.0"
     end
 
     expect(lockfile).to eq <<~G
@@ -381,10 +365,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack-obama (>= 1.0)!
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -396,9 +377,9 @@ RSpec.describe "the lockfile format" do
       gem "net-sftp"
     G
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo2, "net-sftp", "1.1.1"
-      c.repo_gem gem_repo2, "net-ssh", "1.0"
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo2, "net-sftp", "1.1.1"
+      c.checksum gem_repo2, "net-ssh", "1.0"
     end
 
     expect(lockfile).to eq <<~G
@@ -414,10 +395,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         net-sftp
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -432,6 +410,10 @@ RSpec.describe "the lockfile format" do
       source "#{file_uri_for(gem_repo1)}"
       gem "foo", :git => "#{lib_path("foo-1.0")}"
     G
+
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "foo", "1.0"
+    end
 
     expect(lockfile).to eq <<~G
       GIT
@@ -449,10 +431,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
-
-      CHECKSUMS
-        foo (1.0)
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -500,6 +479,10 @@ RSpec.describe "the lockfile format" do
   it "serializes global git sources" do
     git = build_git "foo"
 
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "foo", "1.0"
+    end
+
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       git "#{lib_path("foo-1.0")}" do
@@ -523,10 +506,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
-
-      CHECKSUMS
-        foo (1.0)
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -535,6 +515,10 @@ RSpec.describe "the lockfile format" do
   it "generates a lockfile with a ref for a single pinned source, git gem with a branch requirement" do
     git = build_git "foo"
     update_git "foo", :branch => "omg"
+
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "foo", "1.0"
+    end
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -558,10 +542,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
-
-      CHECKSUMS
-        foo (1.0)
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -570,6 +551,10 @@ RSpec.describe "the lockfile format" do
   it "generates a lockfile with a ref for a single pinned source, git gem with a tag requirement" do
     git = build_git "foo"
     update_git "foo", :tag => "omg"
+
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "foo", "1.0"
+    end
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -593,10 +578,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
-
-      CHECKSUMS
-        foo (1.0)
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -683,10 +665,6 @@ RSpec.describe "the lockfile format" do
       DEPENDENCIES
         ckeditor!
 
-      CHECKSUMS
-        #{gem_no_checksum "ckeditor", "4.0.8"}
-        #{gem_no_checksum "orm_adapter", "0.4.1"}
-
       BUNDLED WITH
          #{Bundler::VERSION}
     L
@@ -694,6 +672,10 @@ RSpec.describe "the lockfile format" do
 
   it "serializes pinned path sources to the lockfile" do
     build_lib "foo"
+
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "foo", "1.0"
+    end
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -715,10 +697,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
-
-      CHECKSUMS
-        foo (1.0)
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -726,6 +705,10 @@ RSpec.describe "the lockfile format" do
 
   it "serializes pinned path sources to the lockfile even when packaging" do
     build_lib "foo"
+
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "foo", "1.0"
+    end
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -751,10 +734,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
-
-      CHECKSUMS
-        foo (1.0)
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -763,6 +743,12 @@ RSpec.describe "the lockfile format" do
   it "sorts serialized sources by type" do
     build_lib "foo"
     bar = build_git "bar"
+
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "foo", "1.0"
+      c.no_checksum "bar", "1.0"
+      c.checksum gem_repo2, "rack", "1.0.0"
+    end
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}/"
@@ -796,12 +782,7 @@ RSpec.describe "the lockfile format" do
         bar!
         foo!
         rack
-
-      CHECKSUMS
-        bar (1.0)
-        foo (1.0)
-        #{checksum_for_repo_gem gem_repo2, "rack", "1.0.0"}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -814,8 +795,8 @@ RSpec.describe "the lockfile format" do
       gem "rack", :source => "#{file_uri_for(gem_repo2)}/"
     G
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo2, "rack", "1.0.0"
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo2, "rack", "1.0.0"
     end
 
     expect(lockfile).to eq <<~G
@@ -829,10 +810,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack!
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -847,12 +825,12 @@ RSpec.describe "the lockfile format" do
       gem "rack-obama"
     G
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo2, "actionpack", "2.3.2"
-      c.repo_gem gem_repo2, "activesupport", "2.3.2"
-      c.repo_gem gem_repo2, "rack", "1.0.0"
-      c.repo_gem gem_repo2, "rack-obama", "1.0"
-      c.repo_gem gem_repo2, "thin", "1.0"
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo2, "actionpack", "2.3.2"
+      c.checksum gem_repo2, "activesupport", "2.3.2"
+      c.checksum gem_repo2, "rack", "1.0.0"
+      c.checksum gem_repo2, "rack-obama", "1.0"
+      c.checksum gem_repo2, "thin", "1.0"
     end
 
     expect(lockfile).to eq <<~G
@@ -875,10 +853,7 @@ RSpec.describe "the lockfile format" do
         actionpack
         rack-obama
         thin
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -891,14 +866,14 @@ RSpec.describe "the lockfile format" do
       gem "rails"
     G
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo2, "actionmailer", "2.3.2"
-      c.repo_gem gem_repo2, "actionpack", "2.3.2"
-      c.repo_gem gem_repo2, "activerecord", "2.3.2"
-      c.repo_gem gem_repo2, "activeresource", "2.3.2"
-      c.repo_gem gem_repo2, "activesupport", "2.3.2"
-      c.repo_gem gem_repo2, "rails", "2.3.2"
-      c.repo_gem gem_repo2, "rake", "13.0.1"
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo2, "actionmailer", "2.3.2"
+      c.checksum gem_repo2, "actionpack", "2.3.2"
+      c.checksum gem_repo2, "activerecord", "2.3.2"
+      c.checksum gem_repo2, "activeresource", "2.3.2"
+      c.checksum gem_repo2, "activesupport", "2.3.2"
+      c.checksum gem_repo2, "rails", "2.3.2"
+      c.checksum gem_repo2, "rake", "13.0.1"
     end
 
     expect(lockfile).to eq <<~G
@@ -927,10 +902,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rails
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -952,9 +924,9 @@ RSpec.describe "the lockfile format" do
       gem 'double_deps'
     G
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo2, "double_deps", "1.0"
-      c.repo_gem gem_repo2, "net-ssh", "1.0"
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo2, "double_deps", "1.0"
+      c.checksum gem_repo2, "net-ssh", "1.0"
     end
 
     expect(lockfile).to eq <<~G
@@ -971,10 +943,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         double_deps
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -987,9 +956,9 @@ RSpec.describe "the lockfile format" do
       gem "rack-obama", ">= 1.0", :require => "rack/obama"
     G
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo2, "rack", "1.0.0"
-      c.repo_gem gem_repo2, "rack-obama", "1.0"
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo2, "rack", "1.0.0"
+      c.checksum gem_repo2, "rack-obama", "1.0"
     end
 
     expect(lockfile).to eq <<~G
@@ -1005,10 +974,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack-obama (>= 1.0)
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -1021,9 +987,9 @@ RSpec.describe "the lockfile format" do
       gem "rack-obama", ">= 1.0", :group => :test
     G
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo2, "rack", "1.0.0"
-      c.repo_gem gem_repo2, "rack-obama", "1.0"
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo2, "rack", "1.0.0"
+      c.checksum gem_repo2, "rack-obama", "1.0"
     end
 
     expect(lockfile).to eq <<~G
@@ -1039,10 +1005,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack-obama (>= 1.0)
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -1050,6 +1013,10 @@ RSpec.describe "the lockfile format" do
 
   it "stores relative paths when the path is provided in a relative fashion and in Gemfile dir" do
     build_lib "foo", :path => bundled_app("foo")
+
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "foo", "1.0"
+    end
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -1073,10 +1040,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
-
-      CHECKSUMS
-        foo (1.0)
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -1084,6 +1048,10 @@ RSpec.describe "the lockfile format" do
 
   it "stores relative paths when the path is provided in a relative fashion and is above Gemfile dir" do
     build_lib "foo", :path => bundled_app(File.join("..", "foo"))
+
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "foo", "1.0"
+    end
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -1107,10 +1075,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
-
-      CHECKSUMS
-        foo (1.0)
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -1118,6 +1083,10 @@ RSpec.describe "the lockfile format" do
 
   it "stores relative paths when the path is provided in an absolute fashion but is relative" do
     build_lib "foo", :path => bundled_app("foo")
+
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "foo", "1.0"
+    end
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -1141,10 +1110,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
-
-      CHECKSUMS
-        foo (1.0)
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -1152,6 +1118,10 @@ RSpec.describe "the lockfile format" do
 
   it "stores relative paths when the path is provided for gemspec" do
     build_lib("foo", :path => tmp.join("foo"))
+
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "foo", "1.0"
+    end
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -1173,16 +1143,17 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         foo!
-
-      CHECKSUMS
-        foo (1.0)
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
   end
 
   it "keeps existing platforms in the lockfile" do
+    checksums = checksums_section_when_existing do |c|
+      c.no_checksum "rack", "1.0.0"
+    end
+
     lockfile <<-G
       GEM
         remote: #{file_uri_for(gem_repo2)}/
@@ -1194,7 +1165,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -1204,6 +1175,8 @@ RSpec.describe "the lockfile format" do
 
       gem "rack"
     G
+
+    checksums.checksum(gem_repo2, "rack", "1.0.0")
 
     expect(lockfile).to eq <<~G
       GEM
@@ -1216,10 +1189,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -1239,8 +1209,8 @@ RSpec.describe "the lockfile format" do
       gem "platform_specific"
     G
 
-    expected_checksums = checksum_section do |c|
-      c.repo_gem gem_repo2, "platform_specific", "1.0", "universal-java-16"
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo2, "platform_specific", "1.0", "universal-java-16"
     end
 
     expect(lockfile).to eq <<~G
@@ -1254,16 +1224,18 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         platform_specific
-
-      CHECKSUMS
-        #{expected_checksums}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
   end
 
   it "does not add duplicate gems" do
+    checksums = checksums_section_when_existing do |c|
+      c.checksum(gem_repo2, "activesupport", "2.3.5")
+      c.checksum(gem_repo2, "rack", "1.0.0")
+    end
+
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}/"
       gem "rack"
@@ -1288,17 +1260,17 @@ RSpec.describe "the lockfile format" do
       DEPENDENCIES
         activesupport
         rack
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "activesupport", "2.3.5")}
-        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
   end
 
   it "does not add duplicate dependencies" do
+    checksums = checksums_section_when_existing do |c|
+      c.checksum(gem_repo2, "rack", "1.0.0")
+    end
+
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}/"
       gem "rack"
@@ -1316,16 +1288,17 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
   end
 
   it "does not add duplicate dependencies with versions" do
+    checksums = checksums_section_when_existing do |c|
+      c.checksum(gem_repo2, "rack", "1.0.0")
+    end
+
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}/"
       gem "rack", "1.0"
@@ -1343,16 +1316,17 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack (= 1.0)
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
   end
 
   it "does not add duplicate dependencies in different groups" do
+    checksums = checksums_section_when_existing do |c|
+      c.checksum(gem_repo2, "rack", "1.0.0")
+    end
+
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}/"
       gem "rack", "1.0", :group => :one
@@ -1370,10 +1344,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack (= 1.0)
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "rack", "1.0.0")}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -1402,6 +1373,10 @@ RSpec.describe "the lockfile format" do
   end
 
   it "works correctly with multiple version dependencies" do
+    checksums = checksums_section_when_existing do |c|
+      c.checksum(gem_repo2, "rack", "0.9.1")
+    end
+
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}/"
       gem "rack", "> 0.9", "< 1.0"
@@ -1418,16 +1393,17 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack (> 0.9, < 1.0)
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "rack", "0.9.1")}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     G
   end
 
   it "captures the Ruby version in the lockfile" do
+    checksums = checksums_section_when_existing do |c|
+      c.checksum(gem_repo2, "rack", "0.9.1")
+    end
+
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}/"
       ruby '#{Gem.ruby_version}'
@@ -1445,10 +1421,7 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         rack (> 0.9, < 1.0)
-
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo2, "rack", "0.9.1")}
-
+      #{checksums}
       RUBY VERSION
          #{Bundler::RubyVersion.system}
 
@@ -1526,10 +1499,6 @@ RSpec.describe "the lockfile format" do
       DEPENDENCIES
         direct_dependency
 
-      CHECKSUMS
-        #{checksum_for_repo_gem(gem_repo4, "direct_dependency", "4.5.6")}
-        #{checksum_for_repo_gem(gem_repo4, "indirect_dependency", "1.2.3")}
-
       BUNDLED WITH
          #{Bundler::VERSION}
     G
@@ -1583,10 +1552,6 @@ RSpec.describe "the lockfile format" do
 
         DEPENDENCIES
           minitest-bisect
-
-        CHECKSUMS
-          #{checksum_for_repo_gem(gem_repo4, "minitest-bisect", "1.6.0")}
-          #{checksum_for_repo_gem(gem_repo4, "path_expander", "1.1.1")}
 
         BUNDLED WITH
            #{Bundler::VERSION}
@@ -1653,10 +1618,6 @@ RSpec.describe "the lockfile format" do
 
       DEPENDENCIES
         minitest-bisect
-
-      CHECKSUMS
-        #{checksum_for_repo_gem gem_repo4, "minitest-bisect", "1.6.0"}
-        #{checksum_for_repo_gem gem_repo4, "path_expander", "1.1.1"}
 
       BUNDLED WITH
          #{Bundler::VERSION}

--- a/bundler/spec/plugins/source/example_spec.rb
+++ b/bundler/spec/plugins/source/example_spec.rb
@@ -70,6 +70,10 @@ RSpec.describe "real source plugins" do
     it "writes to lock file" do
       bundle "install"
 
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "a-path-gem", "1.0"
+      end
+
       expect(lockfile).to eq <<~G
         PLUGIN SOURCE
           remote: #{lib_path("a-path-gem-1.0")}
@@ -86,10 +90,7 @@ RSpec.describe "real source plugins" do
 
         DEPENDENCIES
           a-path-gem!
-
-        CHECKSUMS
-          a-path-gem (1.0)
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       G
@@ -339,6 +340,10 @@ RSpec.describe "real source plugins" do
       revision = revision_for(lib_path("ma-gitp-gem-1.0"))
       bundle "install"
 
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "ma-gitp-gem", "1.0"
+      end
+
       expect(lockfile).to eq <<~G
         PLUGIN SOURCE
           remote: #{file_uri_for(lib_path("ma-gitp-gem-1.0"))}
@@ -356,10 +361,7 @@ RSpec.describe "real source plugins" do
 
         DEPENDENCIES
           ma-gitp-gem!
-
-        CHECKSUMS
-          ma-gitp-gem (1.0)
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       G

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -73,6 +73,13 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
       build_gem "racca", "1.5.2"
     end
 
+    checksums = checksums_section do |c|
+      c.checksum gem_repo4, "mini_portile2", "2.5.0"
+      c.checksum gem_repo4, "nokogiri", "1.11.1"
+      c.checksum gem_repo4, "nokogiri", "1.11.1", Bundler.local_platform
+      c.checksum gem_repo4, "racca", "1.5.2"
+    end
+
     good_lockfile = <<~L
       GEM
         remote: #{file_uri_for(gem_repo4)}/
@@ -90,13 +97,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
 
       DEPENDENCIES
         nokogiri (~> 1.11)
-
-      CHECKSUMS
-        #{checksum_for_repo_gem gem_repo4, "mini_portile2", "2.5.0"}
-        #{checksum_for_repo_gem gem_repo4, "nokogiri", "1.11.1"}
-        #{checksum_for_repo_gem gem_repo4, "nokogiri", "1.11.1", Bundler.local_platform}
-        #{checksum_for_repo_gem gem_repo4, "racca", "1.5.2"}
-
+      #{checksums}
       BUNDLED WITH
          #{Bundler::VERSION}
     L

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1216,6 +1216,10 @@ end
     let(:ruby_version) { nil }
 
     def lock_with(ruby_version = nil)
+      checksums = checksums_section do |c|
+        c.checksum gem_repo1, "rack", "1.0.0"
+      end
+
       lock = <<~L
         GEM
           remote: #{file_uri_for(gem_repo1)}/
@@ -1227,9 +1231,7 @@ end
 
         DEPENDENCIES
           rack
-
-        CHECKSUMS
-          #{checksum_for_repo_gem gem_repo1, "rack", "1.0.0"}
+        #{checksums}
       L
 
       if ruby_version

--- a/bundler/spec/support/checksums.rb
+++ b/bundler/spec/support/checksums.rb
@@ -3,46 +3,74 @@
 module Spec
   module Checksums
     class ChecksumsBuilder
-      def initialize(&block)
+      def initialize(enabled = true, &block)
+        @enabled = enabled
         @checksums = {}
         yield self if block_given?
       end
 
-      def repo_gem(repo, name, version, platform = Gem::Platform::RUBY)
+      def initialize_copy(original)
+        super
+        @checksums = @checksums.dup
+      end
+
+      def checksum(repo, name, version, platform = Gem::Platform::RUBY)
         name_tuple = Gem::NameTuple.new(name, version, platform)
         gem_file = File.join(repo, "gems", "#{name_tuple.full_name}.gem")
         File.open(gem_file, "rb") do |f|
-          @checksums[name_tuple] = Bundler::Checksum.from_gem(f, "#{gem_file} (via ChecksumsBuilder#repo_gem)")
+          register(name_tuple, Bundler::Checksum.from_gem(f, "#{gem_file} (via ChecksumsBuilder#checksum)"))
         end
       end
 
       def no_checksum(name, version, platform = Gem::Platform::RUBY)
         name_tuple = Gem::NameTuple.new(name, version, platform)
-        @checksums[name_tuple] = nil
+        register(name_tuple, nil)
       end
 
-      def to_lock
-        @checksums.map do |name_tuple, checksum|
+      def delete(name, platform = nil)
+        @checksums.reject! {|k, _| k.name == name && (platform.nil? || k.platform == platform) }
+      end
+
+      def to_s
+        return "" unless @enabled
+
+        locked_checksums = @checksums.map do |name_tuple, checksum|
           checksum &&= " #{checksum.to_lock}"
           "  #{name_tuple.lock_name}#{checksum}\n"
-        end.sort.join.strip
+        end
+
+        "\nCHECKSUMS\n#{locked_checksums.sort.join}"
+      end
+
+      private
+
+      def register(name_tuple, checksum)
+        delete(name_tuple.name, name_tuple.platform)
+        @checksums[name_tuple] = checksum
       end
     end
 
-    def checksum_section(&block)
-      ChecksumsBuilder.new(&block).to_lock
+    def checksums_section(enabled = true, &block)
+      ChecksumsBuilder.new(enabled, &block)
     end
 
-    def checksum_for_repo_gem(*args)
-      checksum_section do |c|
-        c.repo_gem(*args)
+    def checksums_section_when_existing(&block)
+      begin
+        enabled = lockfile.match?(/^CHECKSUMS$/)
+      rescue Errno::ENOENT
+        enabled = false
       end
+      checksums_section(enabled, &block)
     end
 
-    def gem_no_checksum(*args)
-      checksum_section do |c|
-        c.no_checksum(*args)
-      end
+    def checksum_to_lock(*args)
+      checksums_section do |c|
+        c.checksum(*args)
+      end.to_s.sub(/^CHECKSUMS\n/, "").strip
+    end
+
+    def checksum_digest(*args)
+      checksum_to_lock(*args).split(Bundler::Checksum::ALGO_SEPARATOR, 2).last
     end
 
     # if prefixes is given, removes all checksums where the line
@@ -50,6 +78,7 @@ module Spec
     # otherwise, removes all checksums from the lockfile
     def remove_checksums_from_lockfile(lockfile, *prefixes)
       head, remaining = lockfile.split(/^CHECKSUMS$/, 2)
+      return lockfile unless remaining
       checksums, tail = remaining.split("\n\n", 2)
 
       prefixes =
@@ -73,6 +102,13 @@ module Spec
         "\n\n",
         tail
       )
+    end
+
+    def remove_checksums_section_from_lockfile(lockfile)
+      head, remaining = lockfile.split(/^CHECKSUMS$/, 2)
+      return lockfile unless remaining
+      _checksums, tail = remaining.split("\n\n", 2)
+      head.concat(tail)
     end
   end
 end

--- a/bundler/spec/update/git_spec.rb
+++ b/bundler/spec/update/git_spec.rb
@@ -309,6 +309,11 @@ RSpec.describe "bundle update" do
 
       bundle "update --source bar"
 
+      checksums = checksums_section_when_existing do |c|
+        c.no_checksum "foo", "2.0"
+        c.checksum gem_repo2, "rack", "1.0.0"
+      end
+
       expect(lockfile).to eq <<~G
         GIT
           remote: #{@git.path}
@@ -327,11 +332,7 @@ RSpec.describe "bundle update" do
         DEPENDENCIES
           foo!
           rack
-
-        CHECKSUMS
-          foo (2.0)
-          #{checksum_for_repo_gem gem_repo2, "rack", "1.0.0"}
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       G


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I've not yet been able to finish the full-featured opt-in for checksums.

## What is your fix for the problem, implemented in this PR?

This makes bundler checksums a hidden opt-in feature. There are no commands which add the CHECKSUMS section to the lockfile and the feature will only be enabled if that section is found.

The actual behavior change is as follows:
* When checksums come from either the API or from a gem, we add them to the checksum store unless the settings disabled checksum validation.
* When checksums come from the lockfile, we always store them in the checksum store regardless of the disabled checksums setting.
* The presence of a checksum section, even empty, in the lockfile indicates that we should write a checksum section to the lockfile when we generate.
* When the disable checksums setting is set, we still read and write checksums to the lockfile, but since all other checksums won't be recorded, we will never compare them or raise an error.
* When the checksums section is not in the lockfile, the api and gem checksums will continue to be stored and compared, perpetuating the existing behavior of checksum verification with the server, but not writing any of them to the lockfile.
* Adding an empty CHECKSUMS section to the lockfile will enable the feature manually. We will follow up with more user-friendly commands to add and populate this new section.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
