### PR TITLE
bundle lock: Always touch the lockfile

### DIFF
--- a/bundler/lib/bundler/cli/lock.rb
+++ b/bundler/lib/bundler/cli/lock.rb
@@ -64,6 +64,7 @@ module Bundler
           file = file ? File.expand_path(file) : Bundler.default_lockfile
           puts "Writing lockfile to #{file}"
           definition.lock(file)
+          FileUtils.touch(file)
         end
       end
 

--- a/bundler/lib/bundler/cli/lock.rb
+++ b/bundler/lib/bundler/cli/lock.rb
@@ -64,7 +64,6 @@ module Bundler
           file = file ? File.expand_path(file) : Bundler.default_lockfile
           puts "Writing lockfile to #{file}"
           definition.lock(file)
-          FileUtils.touch(file)
         end
       end
 

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -342,7 +342,10 @@ module Bundler
 
       preserve_unknown_sections ||= !updating_major && (Bundler.frozen_bundle? || !(unlocking? || @unlocking_bundler))
 
-      return if file && File.exist?(file) && lockfiles_equal?(@lockfile_contents, contents, preserve_unknown_sections)
+      if file && File.exist?(file) && lockfiles_equal?(@lockfile_contents, contents, preserve_unknown_sections)
+        FileUtils.touch(file)
+        return
+      end
 
       if Bundler.frozen_bundle?
         Bundler.ui.error "Cannot write a changed lockfile while frozen."

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -343,7 +343,7 @@ module Bundler
       preserve_unknown_sections ||= !updating_major && (Bundler.frozen_bundle? || !(unlocking? || @unlocking_bundler))
 
       if file && File.exist?(file) && lockfiles_equal?(@lockfile_contents, contents, preserve_unknown_sections)
-        FileUtils.touch(file)
+        SharedHelpers.filesystem_access(file) {|p| FileUtils.touch(p) }
         return
       end
 

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -95,6 +95,22 @@ RSpec.describe "bundle lock" do
     expect(out).to eq(remove_checksums_from_lockfile(@lockfile).chomp)
   end
 
+  it "touches the lockfile when there is an existing lockfile that does not need changes" do
+    lockfile @lockfile
+
+    expect do
+      bundle "lock"
+    end.to change { bundled_app_lock.mtime }
+  end
+
+  it "does not touch lockfile with --print" do
+    lockfile @lockfile
+
+    expect do
+      bundle "lock --print"
+    end.not_to change { bundled_app_lock.mtime }
+  end
+
   it "writes a lockfile when there is an outdated lockfile using --update" do
     lockfile remove_checksums_from_lockfile(@lockfile.gsub("2.3.2", "2.3.1"), " (2.3.1)")
 


### PR DESCRIPTION
Fixes #7120.

## What was the end-user or developer problem that led to this PR?

In #7120, @hadmut mentioned problems with Make-based build pipelines: `Gemfile.lock` would not be "touched" (receive an updated file modification date) when running `bundle lock` is a no-op (i.e. the lockfile already matches the `Gemfile`).

## What is your fix for the problem, implemented in this PR?

An explicit `FileUtils.touch` call. 🤓 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
