### PR TITLE
test_bundled_ca.rb: Add Net::OpenTimeout as a offline case.

### DIFF
--- a/test/rubygems/test_bundled_ca.rb
+++ b/test/rubygems/test_bundled_ca.rb
@@ -33,7 +33,7 @@ class TestGemBundledCA < Gem::TestCase
     http.verify_mode = OpenSSL::SSL::VERIFY_PEER
     http.cert_store = bundled_certificate_store
     http.get("/")
-  rescue Errno::ENOENT, Errno::ETIMEDOUT, SocketError
+  rescue Errno::ENOENT, Errno::ETIMEDOUT, SocketError, Net::OpenTimeout
     pend "#{host} seems offline, I can't tell whether ssl would work."
   rescue OpenSSL::SSL::SSLError => e
     # Only fail for certificate verification errors


### PR DESCRIPTION
It seems that when DNS connection is enabled, but the TCP connection is disabled in a way, the `Net::HTTP.connect` raises `Net::OpenTimeout`. And I want to skip the tests in this case.

https://github.com/ruby/net-http/blob/042faf74e77d786ff60dff81555f6ec4f21e77a9/lib/net/http.rb#L1601-L1608

```
  1) Error:
TestBundledCA#test_accessing_new_index:
Net::OpenTimeout: execution expired
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:987:in `initialize'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:987:in `open'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:987:in `block in connect'
    /builddir/build/BUILD/ruby-3.0.4/lib/timeout.rb:107:in `timeout'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:985:in `connect'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:970:in `do_start'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:959:in `start'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:1512:in `request'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:1270:in `get'
    /builddir/build/BUILD/ruby-3.0.4/test/rubygems/test_bundled_ca.rb:34:in `assert_https'
    /builddir/build/BUILD/ruby-3.0.4/test/rubygems/test_bundled_ca.rb:58:in `test_accessing_new_index'
...
```

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

In the CentOS build system s390x pipeline, where DNS connection is enabled, but the TCP connection is disabled in a way currently, the `Net::HTTP.connect` raises `Net::OpenTimeout` in the follwoing 4 tests. And I want to skip the tests in this case.

```
  1) Error:
TestBundledCA#test_accessing_new_index:
Net::OpenTimeout: execution expired
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:987:in `initialize'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:987:in `open'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:987:in `block in connect'
    /builddir/build/BUILD/ruby-3.0.4/lib/timeout.rb:107:in `timeout'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:985:in `connect'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:970:in `do_start'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:959:in `start'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:1512:in `request'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:1270:in `get'
    /builddir/build/BUILD/ruby-3.0.4/test/rubygems/test_bundled_ca.rb:34:in `assert_https'
    /builddir/build/BUILD/ruby-3.0.4/test/rubygems/test_bundled_ca.rb:58:in `test_accessing_new_index'
  2) Error:
TestBundledCA#test_accessing_rubygems:
Net::OpenTimeout: execution expired
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:987:in `initialize'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:987:in `open'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:987:in `block in connect'
    /builddir/build/BUILD/ruby-3.0.4/lib/timeout.rb:107:in `timeout'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:985:in `connect'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:970:in `do_start'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:959:in `start'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:1512:in `request'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:1270:in `get'
    /builddir/build/BUILD/ruby-3.0.4/test/rubygems/test_bundled_ca.rb:34:in `assert_https'
    /builddir/build/BUILD/ruby-3.0.4/test/rubygems/test_bundled_ca.rb:46:in `test_accessing_rubygems'
  3) Error:
TestBundledCA#test_accessing_staging:
Net::OpenTimeout: execution expired
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:987:in `initialize'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:987:in `open'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:987:in `block in connect'
    /builddir/build/BUILD/ruby-3.0.4/lib/timeout.rb:107:in `timeout'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:985:in `connect'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:970:in `do_start'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:959:in `start'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:1512:in `request'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:1270:in `get'
    /builddir/build/BUILD/ruby-3.0.4/test/rubygems/test_bundled_ca.rb:34:in `assert_https'
    /builddir/build/BUILD/ruby-3.0.4/test/rubygems/test_bundled_ca.rb:54:in `test_accessing_staging'
  4) Error:
TestBundledCA#test_accessing_www_rubygems:
Net::OpenTimeout: execution expired
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:987:in `initialize'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:987:in `open'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:987:in `block in connect'
    /builddir/build/BUILD/ruby-3.0.4/lib/timeout.rb:107:in `timeout'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:985:in `connect'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:970:in `do_start'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:959:in `start'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:1512:in `request'
    /builddir/build/BUILD/ruby-3.0.4/lib/net/http.rb:1270:in `get'
    /builddir/build/BUILD/ruby-3.0.4/test/rubygems/test_bundled_ca.rb:34:in `assert_https'
    /builddir/build/BUILD/ruby-3.0.4/test/rubygems/test_bundled_ca.rb:50:in `test_accessing_www_rubygems'
```

Personally, I think this state of the build system is a kind of infra bug, and I am afraid that skipping `Net::OpenTimeout` may unintentionally hide a real bug of the RubyGems or Net::HTTP libraries. However, if it is no problem, I would like this PR to be merged to pass the tests in the CentOS stream build system.

You can see https://issues.redhat.com/browse/CS-1820 for details.

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

I added the `Net::HTTP.connect` to pend the tests.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

The style test passed on my local.

```
$ ruby -v
ruby 3.3.0dev (2023-11-07T10:22:30Z master ced84beb25) [x86_64-linux]

$ which rake
~/.local/ruby-3.3.0dev-debug-ced84beb25/bin/rake

$ rake rubocop
Bundle complete! 2 Gemfile dependencies, 14 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
/home/jaruga/.local/ruby-3.3.0dev-debug-ced84beb25/lib/ruby/gems/3.3.0+0/gems/rubocop-1.52.1/lib/rubocop/formatter/html_formatter.rb:3: warning: base64 which will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec.
Inspecting 768 files
................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

768 files inspected, no offenses detected
```
