### PR TITLE
Use String#unpack1 available since ruby 3.0

### DIFF
--- a/bundler/lib/bundler/checksum.rb
+++ b/bundler/lib/bundler/checksum.rb
@@ -43,8 +43,7 @@ module Bundler
         return digest if digest.match?(/\A[0-9a-f]{64}\z/i)
         if digest.match?(%r{\A[-0-9a-z_+/]{43}={0,2}\z}i)
           digest = digest.tr("-_", "+/") # fix urlsafe base64
-          # transform to hex. Use unpack1 when we drop older rubies
-          return digest.unpack("m0").first.unpack("H*").first
+          return digest.unpack1("m0").unpack1("H*")
         end
         raise ArgumentError, "#{digest.inspect} is not a valid SHA256 hex or base64 digest"
       end

--- a/bundler/lib/bundler/digest.rb
+++ b/bundler/lib/bundler/digest.rb
@@ -50,7 +50,7 @@ module Bundler
           words.map!.with_index {|word, index| SHA1_MASK & (word + mutated[index]) }
         end
 
-        words.pack("N*").unpack("H*").first
+        words.pack("N*").unpack1("H*")
       end
 
       private

--- a/lib/rubygems/package/old.rb
+++ b/lib/rubygems/package/old.rb
@@ -70,7 +70,7 @@ class Gem::Package::Old < Gem::Package
           file_data << line
         end
 
-        file_data = file_data.strip.unpack("m")[0]
+        file_data = file_data.strip.unpack1("m")
         file_data = Zlib::Inflate.inflate file_data
 
         raise Gem::Package::FormatError, "#{full_name} in #{@gem} is corrupt" if


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

PR #7116 dropped support for rubies that didn't support `String#unpack1`. 

## What is your fix for the problem, implemented in this PR?

Convert `unpack(*).first` to `unpack1` where possible.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
