### PR TITLE
Try to load Gem::BUNDLED_GEMS on Bundler

### DIFF
--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -374,6 +374,11 @@ module Bundler
       specs_by_name = add_default_gems_to(specs)
 
       reverse_rubygems_kernel_mixin
+      begin
+        # bundled_gems only provide with Ruby 3.3 or later
+        require "bundled_gems"
+      rescue LoadError
+      end unless defined?(::Gem::BUNDLED_GEMS)
       replace_require(specs) if defined?(::Gem::BUNDLED_GEMS)
       replace_gem(specs, specs_by_name)
       stub_rubygems(specs)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bundle exec ruby foo.rb` ignore to load gem_prelude.rb. Because warnings feature is not working with `bundle exec ruby`.

https://github.com/ruby/ruby/pull/9136

## What is your fix for the problem, implemented in this PR?

Force load `bundled_gems` in `rubygems_integration.rb` if it's not loaded.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
