### PR TITLE
Remove non-transparent requirement added to prerelease gems

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2674,19 +2674,12 @@ class Gem::Specification < Gem::BasicSpecification
   rubygems_deprecate :validate_permissions
 
   ##
-  # Set the version to +version+, potentially also setting
-  # required_rubygems_version if +version+ indicates it is a
-  # prerelease.
+  # Set the version to +version+.
 
   def version=(version)
     @version = Gem::Version.create(version)
     return if @version.nil?
 
-    # skip to set required_ruby_version when pre-released rubygems.
-    # It caused to raise CircularDependencyError
-    if @version.prerelease? && (@name.nil? || @name.strip != "rubygems")
-      self.required_rubygems_version = "> 1.3.1"
-    end
     invalidate_memoized_attributes
   end
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2005,12 +2005,6 @@ dependencies: []
     assert_equal Gem::Platform.new("ppc-darwin"), @a1.platform
   end
 
-  def test_prerelease_spec_adds_required_rubygems_version
-    @prerelease = util_spec("tardis", "2.2.0.a")
-    refute @prerelease.required_rubygems_version.satisfied_by?(Gem::Version.new("1.3.1"))
-    assert @prerelease.required_rubygems_version.satisfied_by?(Gem::Version.new("1.4.0"))
-  end
-
   def test_require_paths
     enable_shared "no" do
       ext_spec


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I recall this requirement confusing me while working in the resolver, since it could lead to different resolution process when working in master (2.5.0.dev currently) than when working with a released version.

It feels non transparent and too magical. I think we can safely assume these days that all RubyGems and Bundler versions that will ever bundle a new gem created in 2023 support prereleases.

So this non transparent requirement is not necessary. It should be the gem author to explicitly add this kind of constraint, not RubyGems. Setting the version of a gem should do just that, set the version.

This has also caused Circular require issues in the past, and has special conditions attached to workaround that.

## What is your fix for the problem, implemented in this PR?

Remove the extra constraint.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
