### PR TITLE
Figure out why we need to override `Gem::NameTuple.new`

### DIFF
--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -352,14 +352,6 @@ module Gem
   require "rubygems/name_tuple"
 
   class NameTuple
-    def self.new(name, version, platform="ruby")
-      if Gem::Platform === platform
-        super(name, version, platform.to_s)
-      else
-        super
-      end
-    end
-
     def lock_name
       @lock_name ||=
         if platform == Gem::Platform::RUBY

--- a/lib/rubygems/name_tuple.rb
+++ b/lib/rubygems/name_tuple.rb
@@ -12,6 +12,9 @@ class Gem::NameTuple
 
     # Mimic rubygems before string platform in NameTuple
     # platform &&= platform.to_s
+    return @platform = platform if platform.is_a?(Gem::Platform)
+    # end mimic
+
     platform = Gem::Platform::RUBY if !platform || platform.empty?
     @platform = platform
   end

--- a/lib/rubygems/name_tuple.rb
+++ b/lib/rubygems/name_tuple.rb
@@ -10,7 +10,8 @@ class Gem::NameTuple
     @name = name
     @version = version
 
-    platform &&= platform.to_s
+    # Mimic rubygems before string platform in NameTuple
+    # platform &&= platform.to_s
     platform = Gem::Platform::RUBY if !platform || platform.empty?
     @platform = platform
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Just trying to figure out why this is needed because it's very non standard.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
