### PR TITLE
Revert PR to include response body with fetch errors

### DIFF
--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -234,7 +234,7 @@ class Gem::RemoteFetcher
 
       fetch_http(location, last_modified, head, depth + 1)
     else
-      raise FetchError.new("bad response #{response.message} #{response.code} #{response.body.strip}", uri)
+      raise FetchError.new("bad response #{response.message} #{response.code}", uri)
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This solution is potentially problematic and a better approach has been proposed. See https://github.com/rubygems/rubygems/pull/7148#discussion_r1391942547. 

## What is your fix for the problem, implemented in this PR?

Revert the PR to unblock cutting a release from master.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
