### PR TITLE
Use `Minitest::TestTask` in a template file for `minitest`

### DIFF
--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -11,7 +11,7 @@ module Bundler
   class CLI::Gem
     TEST_FRAMEWORK_VERSIONS = {
       "rspec" => "3.0",
-      "minitest" => "5.0",
+      "minitest" => "5.16",
       "test-unit" => "3.0",
     }.freeze
 

--- a/bundler/lib/bundler/templates/newgem/Rakefile.tt
+++ b/bundler/lib/bundler/templates/newgem/Rakefile.tt
@@ -4,13 +4,9 @@ require "bundler/gem_tasks"
 <% default_task_names = [config[:test_task]].compact -%>
 <% case config[:test] -%>
 <% when "minitest" -%>
-require "rake/testtask"
+require "minitest/test_task"
 
-Rake::TestTask.new(:test) do |t|
-  t.libs << "test"
-  t.libs << "lib"
-  t.test_files = FileList["test/**/test_*.rb"]
-end
+Minitest::TestTask.create
 
 <% when "test-unit" -%>
 require "rake/testtask"

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -801,13 +801,9 @@ RSpec.describe "bundle gem" do
           # frozen_string_literal: true
 
           require "bundler/gem_tasks"
-          require "rake/testtask"
+          require "minitest/test_task"
 
-          Rake::TestTask.new(:test) do |t|
-            t.libs << "test"
-            t.libs << "lib"
-            t.test_files = FileList["test/**/test_*.rb"]
-          end
+          Minitest::TestTask.create
 
           task default: :test
         RAKEFILE


### PR DESCRIPTION

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

`minitest` has introduced a rake task for running test on 5.16.0. https://github.com/minitest/minitest/blob/master/History.rdoc#5160--2022-06-14-

This has some tasks related to running tests and it's useful for `minitest` users I think.
https://github.com/minitest/minitest#rake-tasks-

This PR changed to use the task in a template file for `minitest`

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
