### PR TITLE
Don't memoize in NameTuple lock_name

### DIFF
--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -361,12 +361,11 @@ module Gem
     end
 
     def lock_name
-      @lock_name ||=
-        if platform == Gem::Platform::RUBY
-          "#{name} (#{version})"
-        else
-          "#{name} (#{version}-#{platform})"
-        end
+      if platform == Gem::Platform::RUBY
+        "#{name} (#{version})"
+      else
+        "#{name} (#{version}-#{platform})"
+      end
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Seems unnecessary. `LazySpecification` already memoizes `lock_name`. It seems like it will be created 2 times at most, which doesn't seem worth the memory usage. No other `NameTuple` instance method memoizes.

## What is your fix for the problem, implemented in this PR?

Remove memoization from `NameTuple#lock_name`.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
