### PR TITLE
Override initialize in bundle rubygems_ext for NameTuple

### DIFF
--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -334,11 +334,16 @@ module Gem
   require "rubygems/name_tuple"
 
   class NameTuple
-    def self.new(name, version, platform="ruby")
-      if Gem::Platform === platform
-        super(name, version, platform.to_s)
-      else
-        super
+    # Versions of RubyGems before about 3.5.0 don't to_s the platform.
+    unless Gem::NameTuple.new("a", Gem::Version.new("1"), Gem::Platform.new("x86_64-linux")).platform.is_a?(String)
+      alias_method :initialize_with_platform, :initialize
+
+      def initialize(name, version, platform=Gem::Platform::RUBY)
+        if Gem::Platform === platform
+          initialize_with_platform(name, version, platform.to_s)
+        else
+          initialize_with_platform(name, version, platform)
+        end
       end
     end
 

--- a/bundler/spec/other/ext_spec.rb
+++ b/bundler/spec/other/ext_spec.rb
@@ -63,3 +63,23 @@ RSpec.describe "Gem::SourceIndex#refresh!" do
     run "Gem::SourceIndex.new([]).refresh!", raise_on_error: false
   end
 end
+
+RSpec.describe "Gem::NameTuple" do
+  describe "#initialize" do
+    it "creates a Gem::NameTuple with equality regardless of platform type" do
+      gem_platform = Gem::NameTuple.new "a", v("1"), pl("x86_64-linux")
+      str_platform = Gem::NameTuple.new "a", v("1"), "x86_64-linux"
+      expect(gem_platform).to eq(str_platform)
+      expect(gem_platform.hash).to eq(str_platform.hash)
+      expect(gem_platform.to_a).to eq(str_platform.to_a)
+    end
+  end
+
+  describe "#lock_name" do
+    it "returns the lock name" do
+      expect(Gem::NameTuple.new("a", v("1.0.0"), pl("x86_64-linux")).lock_name).to eq("a (1.0.0-x86_64-linux)")
+      expect(Gem::NameTuple.new("a", v("1.0.0"), "ruby").lock_name).to eq("a (1.0.0)")
+      expect(Gem::NameTuple.new("a", v("1.0.0")).lock_name).to eq("a (1.0.0)")
+    end
+  end
+end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In PR #7229 we were discussing alternative ways to add this back-ported feature.

## What is your fix for the problem, implemented in this PR?

This avoids overriding `.new` by aliasing initialize to see if it makes any difference on segfaults. Guards tho feature better against rubygems that already have the feature.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
