### PR TITLE
Support dynamic library loading with extension .so or .o

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -943,6 +943,13 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   end
 
   ##
+  # Suffixes for dynamic library require-able paths.
+
+  def self.dynamic_library_suffixes
+    @dynamic_library_suffixes ||= suffixes - [".rb"]
+  end
+
+  ##
   # Prints the amount of time the supplied block takes to run using the debug
   # UI output.
 

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -84,7 +84,13 @@ class Gem::BasicSpecification
       return false
     end
 
-    have_file? file, Gem.suffixes
+    is_soext = file.end_with?(".so", ".o")
+
+    if is_soext
+      have_file? file.delete_suffix(File.extname(file)), Gem.dynamic_library_suffixes
+    else
+      have_file? file, Gem.suffixes
+    end
   end
 
   def default_gem?

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1561,6 +1561,17 @@ dependencies: []
     assert_empty err
   end
 
+  def test_contains_requirable_file_extension_soext
+    ext_spec
+    dlext = RbConfig::CONFIG["DLEXT"]
+    @ext.files += ["lib/ext.#{dlext}"]
+
+    FileUtils.mkdir_p @ext.extension_dir
+    FileUtils.touch File.join(@ext.extension_dir, "ext.#{dlext}")
+    FileUtils.touch File.join(@ext.extension_dir, "gem.build_complete")
+    assert @ext.contains_requirable_file? "ext.so"
+  end
+
   def test_date
     assert_date @a1.date
   end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Ruby's native `require` can load dynamic libraries with .so or .o extensions that are not actually filename.

For example, on macOS the socket library name is "socket.bundle" and `require "socket.so"` will load successful.

```console
$ ruby -e 'p RbConfig::CONFIG["DLEXT"]; p require "socket.bundle"'
"bundle"
true
$ ruby -e 'p RbConfig::CONFIG["DLEXT"]; p require "socket.so"'
"bundle"
true
```

However, with the `require` provided by RubyGems, such loading does not work.

```console
$ gem install nokogiri
Building native extensions. This could take a while...
Successfully installed nokogiri-1.15.5
Parsing documentation for nokogiri-1.15.5
Done installing documentation for nokogiri after 0 seconds
1 gem installed
$ ruby -e 'p RbConfig::CONFIG["DLEXT"]; p require "nokogiri/nokogiri.bundle"'
"bundle"
true
$ ruby -e 'p RbConfig::CONFIG["DLEXT"]; p require "nokogiri/nokogiri.so"'
"bundle"
<internal:/Users/hogelog/.rbenv/versions/3.3.0-dev/lib/ruby/3.3.0+0/rubygems/core_ext/kernel_require.rb>:127:in `require': cannot load such file -- nokogiri/nokogiri.so (LoadError)
        from <internal:/Users/hogelog/.rbenv/versions/3.3.0-dev/lib/ruby/3.3.0+0/rubygems/core_ext/kernel_require.rb>:127:in `require'
        from -e:1:in `<main>'
```

In Ruby native require, `require "foo.so"` is a role process that "loads the dynamic library of foo (not the plain ruby .rb file)".
But such a thing is not possible in RubyGems require.

Since RubyGems overrides Ruby's native require, this functionality may be necessary as well.

### Reference 
The following documentation describes the native require behavior in Ruby.

https://github.com/ruby/ruby/blob/88d9a4d58af5c41a3258761dd6d0ea405fe47c07/load.c#L947-L990

However, this document also seems to describe something slightly different from Ruby's behavior, so I also suggest modifying this document.
https://github.com/ruby/ruby/pull/9180

## What is your fix for the problem, implemented in this PR?

I changed the behavior so that when checking if a file with a .so or .o extension is included in a gem, the extension is rewritten to DLEXT.
This behavior is consistent with Ruby native require.

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
