### PR TITLE
Improve default gem handling by treating default gems as any other gem

### DIFF
--- a/bundler/lib/bundler/cli/common.rb
+++ b/bundler/lib/bundler/cli/common.rb
@@ -57,6 +57,9 @@ module Bundler
         specs << spec if regexp && spec.name =~ regexp
       end
 
+      default_spec = default_gem_spec(name)
+      specs << default_spec if default_spec
+
       case specs.count
       when 0
         dep_in_other_group = Bundler.definition.current_dependencies.find {|dep|dep.name == name }
@@ -73,6 +76,12 @@ module Bundler
       end
     rescue RegexpError
       raise GemNotFound, gem_not_found_message(name, Bundler.definition.dependencies)
+    end
+
+    def self.default_gem_spec(name)
+      return unless Gem::Specification.respond_to?(:find_all_by_name)
+      gem_spec = Gem::Specification.find_all_by_name(name).last
+      gem_spec if gem_spec&.default_gem?
     end
 
     def self.ask_for_spec_from(specs)

--- a/bundler/lib/bundler/cli/info.rb
+++ b/bundler/lib/bundler/cli/info.rb
@@ -36,10 +36,6 @@ module Bundler
       gem_spec if gem_spec&.default_gem?
     end
 
-    def spec_not_found(gem_name)
-      raise GemNotFound, Bundler::CLI::Common.gem_not_found_message(gem_name, Bundler.definition.dependencies)
-    end
-
     def print_gem_version(spec)
       Bundler.ui.info spec.version.to_s
     end

--- a/bundler/lib/bundler/cli/info.rb
+++ b/bundler/lib/bundler/cli/info.rb
@@ -25,15 +25,8 @@ module Bundler
 
     private
 
-    def spec_for_gem(gem_name)
-      spec = Bundler.definition.specs.find {|s| s.name == gem_name }
-      spec || default_gem_spec(gem_name) || Bundler::CLI::Common.select_spec(gem_name, :regex_match)
-    end
-
-    def default_gem_spec(gem_name)
-      return unless Gem::Specification.respond_to?(:find_all_by_name)
-      gem_spec = Gem::Specification.find_all_by_name(gem_name).last
-      gem_spec if gem_spec&.default_gem?
+    def spec_for_gem(name)
+      Bundler::CLI::Common.select_spec(name, :regex_match)
     end
 
     def print_gem_version(spec)

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -509,7 +509,7 @@ module Bundler
     end
 
     def all_specs
-      Gem::Specification.stubs.map do |stub|
+      Gem::Specification.stubs.reject(&:default_gem?).map do |stub|
         StubSpecification.from_stub(stub)
       end
     end

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -225,11 +225,7 @@ module Bundler
         cached_path = cached_path(spec)
         if cached_path.nil?
           remote_spec = remote_specs.search(spec).first
-          if remote_spec
-            cached_path = fetch_gem(remote_spec)
-          else
-            Bundler.ui.warn "#{spec.full_name} is built in to Ruby, and can't be cached because your Gemfile doesn't have any sources that contain it."
-          end
+          cached_path = fetch_gem(remote_spec)
         end
         cached_path
       end

--- a/bundler/spec/cache/gems_spec.rb
+++ b/bundler/spec/cache/gems_spec.rb
@@ -102,8 +102,8 @@ RSpec.describe "bundle cache" do
 
     it "uses builtin gems when installing to system gems" do
       bundle "config set path.system true"
-      install_gemfile %(source "#{file_uri_for(gem_repo1)}"; gem 'json', '#{default_json_version}'), verbose: true
-      expect(out).to include("Using json #{default_json_version}")
+      install_gemfile %(source "#{file_uri_for(gem_repo2)}"; gem 'json', '#{default_json_version}'), verbose: true
+      expect(out).to include("Installing json #{default_json_version}")
     end
 
     it "caches remote and builtin gems" do
@@ -142,19 +142,6 @@ RSpec.describe "bundle cache" do
 
       bundle "install --local"
       expect(the_bundle).to include_gems("builtin_gem_2 1.0.2")
-    end
-
-    it "errors if the builtin gem isn't available to cache" do
-      bundle "config set path.system true"
-
-      install_gemfile <<-G
-        source "#{file_uri_for(gem_repo1)}"
-        gem 'json', '#{default_json_version}'
-      G
-
-      bundle :cache, raise_on_error: false
-      expect(exitstatus).to_not eq(0)
-      expect(err).to include("json-#{default_json_version} is built in to Ruby, and can't be cached")
     end
   end
 

--- a/bundler/spec/commands/open_spec.rb
+++ b/bundler/spec/commands/open_spec.rb
@@ -164,7 +164,6 @@ RSpec.describe "bundle open" do
 
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
-        gem "json"
       G
     end
 

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1281,6 +1281,10 @@ end
 
   describe "with gemified standard libraries" do
     it "does not load Digest", :ruby_repo do
+      build_repo2 do
+        build_gem "digest"
+      end
+
       build_git "bar", gemspec: false do |s|
         s.write "lib/bar/version.rb", %(BAR_VERSION = '1.0')
         s.write "bar.gemspec", <<-G
@@ -1299,7 +1303,7 @@ end
       end
 
       gemfile <<-G
-        source "#{file_uri_for(gem_repo1)}"
+        source "#{file_uri_for(gem_repo2)}"
         gem "bar", :git => "#{lib_path("bar-1.0")}"
       G
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler behaves inconsistently in presence of default gems, and that can be confusing. See for example the situation in https://github.com/ruby/ruby/pull/9163#issuecomment-1846994447.

## What is your fix for the problem, implemented in this PR?

My fix is that, once a default gem is specified directly in the Gemfile, or resolved as a transitive dependency, it becomes part of the bundle and gets treated as a "regular gem", so it's cached, explicitly installed in the configured location, etc.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
