### PR TITLE
Allow `Gem.default_user_install` to be overridden

### DIFF
--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -236,6 +236,18 @@ module Gem
   end
 
   ##
+  # Enables automatic installation into user directory
+
+  def self.default_user_install # :nodoc:
+    if !ENV.key?("GEM_HOME") && (File.exist?(Gem.dir) && !File.writable?(Gem.dir))
+      Gem.ui.say "Defaulting to user installation because default installation directory (#{Gem.dir}) is not writable."
+      return true
+    end
+
+    false
+  end
+
+  ##
   # Install extensions into lib as well as into the extension directory.
 
   def self.install_extension_in_lib # :nodoc:

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -684,10 +684,7 @@ class Gem::Installer
         # * `true`: `--user-install`
         # * `false`: `--no-user-install` and
         # * `nil`: option was not specified
-        if options[:user_install]
-          @gem_home = Gem.user_dir
-        elsif options[:user_install].nil? && !ENV.key?("GEM_HOME") && (File.exist?(Gem.dir) && !File.writable?(Gem.dir))
-          say "Defaulting to user installation because default installation directory (#{Gem.dir}) is not writable."
+        if options[:user_install] || (options[:user_install].nil? && Gem.default_user_install)
           @gem_home = Gem.user_dir
         end
       end


### PR DESCRIPTION
For Ruby re-distributors, the "auto-user-install" might be the right default. Therefore printing warning about installing into user directory is not always desirable. Let the "auto-user-install" feature to be customizable.

I have mentioned this is coming in #7236. But I have not really tested this yet.

And of course, the naming ... Not sure if the `auto_user_install` is the most descriptive method name.

Also, there is not test. Not sure if there should be one thought, because this will work only as long as it is not overridden by the Ruby executing the test suite. With such test case, we might end up with similar issues as #7187