### PR TITLE
Fix installing from source with same default bundler version already installed

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -25,6 +25,7 @@ jobs:
           - { name: "3.0", value: 3.0.6 }
           - { name: "3.1", value: 3.1.4 }
           - { name: "3.2", value: 3.2.2 }
+          - { name: "3.3", value: 3.3.0-preview3 }
           - { name: jruby-9.4, value: jruby-9.4.2.0 }
           - { name: truffleruby-23, value: truffleruby-23.1.1 }
         openssl:

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -374,13 +374,16 @@ By default, this RubyGems will install gem as:
     end
 
     bundler_spec = Dir.chdir("bundler") { Gem::Specification.load("bundler.gemspec") }
-    default_spec_path = File.join(specs_dir, "#{bundler_spec.full_name}.gemspec")
+    full_name = bundler_spec.full_name
+    gemspec_path = "#{full_name}.gemspec"
+
+    default_spec_path = File.join(specs_dir, gemspec_path)
     Gem.write_binary(default_spec_path, bundler_spec.to_ruby)
 
     bundler_spec = Gem::Specification.load(default_spec_path)
 
     # Remove gemspec that was same version of vendored bundler.
-    normal_gemspec = File.join(default_dir, "specifications", "bundler-#{bundler_spec.version}.gemspec")
+    normal_gemspec = File.join(default_dir, "specifications", gemspec_path)
     if File.file? normal_gemspec
       File.delete normal_gemspec
     end
@@ -388,7 +391,7 @@ By default, this RubyGems will install gem as:
     # Remove gem files that were same version of vendored bundler.
     if File.directory? bundler_spec.gems_dir
       Dir.entries(bundler_spec.gems_dir).
-        select {|default_gem| File.basename(default_gem) == "bundler-#{bundler_spec.version}" }.
+        select {|default_gem| File.basename(default_gem) == full_name }.
         each {|default_gem| rm_r File.join(bundler_spec.gems_dir, default_gem) }
     end
 

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -373,12 +373,12 @@ By default, this RubyGems will install gem as:
       target_specs_dir
     end
 
-    bundler_spec = Dir.chdir("bundler") { Gem::Specification.load("bundler.gemspec") }
-    full_name = bundler_spec.full_name
+    new_bundler_spec = Dir.chdir("bundler") { Gem::Specification.load("bundler.gemspec") }
+    full_name = new_bundler_spec.full_name
     gemspec_path = "#{full_name}.gemspec"
 
     default_spec_path = File.join(specs_dir, gemspec_path)
-    Gem.write_binary(default_spec_path, bundler_spec.to_ruby)
+    Gem.write_binary(default_spec_path, new_bundler_spec.to_ruby)
 
     bundler_spec = Gem::Specification.load(default_spec_path)
 
@@ -395,16 +395,16 @@ By default, this RubyGems will install gem as:
         each {|default_gem| rm_r File.join(bundler_spec.gems_dir, default_gem) }
     end
 
-    bundler_bin_dir = bundler_spec.bin_dir
+    bundler_bin_dir = new_bundler_spec.bin_dir
     mkdir_p bundler_bin_dir, mode: 0o755
     bundler_spec.executables.each do |e|
-      cp File.join("bundler", bundler_spec.bindir, e), File.join(bundler_bin_dir, e)
+      cp File.join("bundler", new_bundler_spec.bindir, e), File.join(bundler_bin_dir, e)
     end
 
     require_relative "../installer"
 
     Dir.chdir("bundler") do
-      built_gem = Gem::Package.build(bundler_spec)
+      built_gem = Gem::Package.build(new_bundler_spec)
       begin
         Gem::Installer.at(
           built_gem,
@@ -421,9 +421,9 @@ By default, this RubyGems will install gem as:
       end
     end
 
-    bundler_spec.executables.each {|executable| bin_file_names << target_bin_path(bin_dir, executable) }
+    new_bundler_spec.executables.each {|executable| bin_file_names << target_bin_path(bin_dir, executable) }
 
-    say "Bundler #{bundler_spec.version} installed"
+    say "Bundler #{new_bundler_spec.version} installed"
   end
 
   def make_destination_dirs


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Extracting this bug fix from #7233. When installing bundler from source code, installation will fail if the same Bundler version is already the default Bundler gem. This is happens, for example, when installing from source using Ruby 3.3.0-preview3.

## What is your fix for the problem, implemented in this PR?

The problem is caused by the discrepancy between bindir folder in the pristine ruby 3.3.0-preview3 tarball, and the bindir folder in bundler's upstream source code.

This discrepancy is getting normalized at https://github.com/ruby/ruby/pull/9165, but it's also a bug that the bindir used to loop through upstream executables is the one of the previously installed default gem, and not the one from Bundler sources themselves.

This PR fixes that.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
