### PR TITLE
Support drop followups

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For more information about how to use RubyGems, see our RubyGems basics guide at
 
 ## Requirements
 
-* RubyGems supports Ruby 2.6 or later.
+* RubyGems supports Ruby 3.0 or later.
 
 ## Installation
 

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -17,7 +17,7 @@ require_relative "bundler/build_metadata"
 # Bundler provides a consistent environment for Ruby projects by
 # tracking and installing the exact gems and versions that are needed.
 #
-# Since Ruby 2.6, Bundler is a part of Ruby's standard library.
+# Bundler is a part of Ruby's standard library.
 #
 # Bundler is used by creating _gemfiles_ listing all the project dependencies
 # and (optionally) their versions and then using

--- a/tool/bundler/test_gems.rb
+++ b/tool/bundler/test_gems.rb
@@ -7,8 +7,6 @@ gem "webrick", "1.7.0"
 gem "rack-test", "~> 1.1"
 gem "compact_index", "~> 0.15.0"
 gem "sinatra", "~> 2.0"
-# for Ruby 2.6. bundler/spec/install/gemfile/sources_spec.rb is failed with sinatra-2.0.8.1 and tilt-2.2.0.
-gem "tilt", "~> 2.0.11"
 gem "rake", "13.0.1"
 gem "builder", "~> 3.2"
 gem "rb_sys"

--- a/tool/bundler/test_gems.rb.lock
+++ b/tool/bundler/test_gems.rb.lock
@@ -20,7 +20,7 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
-    tilt (2.0.11)
+    tilt (2.3.0)
     webrick (1.7.0)
 
 PLATFORMS
@@ -43,7 +43,6 @@ DEPENDENCIES
   rb_sys
   rubygems-generate_index (~> 1.1)
   sinatra (~> 2.0)
-  tilt (~> 2.0.11)
   webrick (= 1.7.0)
 
 CHECKSUMS
@@ -58,7 +57,7 @@ CHECKSUMS
   ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
   rubygems-generate_index (1.1.2) sha256=b5cfafe811b18bc45780b4cccc92593cf3115d2c8ea2a9f93a253eb9b2a8b955
   sinatra (2.0.8.1) sha256=b8845f060fde0157940172a4d006b757f3ba6a5ea36326c7c9352c25391c3e66
-  tilt (2.0.11) sha256=7b180fc472cbdeb186c85d31c0f2d1e61a2c0d77e1d9fd0ca28482a9d972d6a0
+  tilt (2.3.0) sha256=82dd903d61213c63679d28e404ee8e10d1b0fdf5270f1ad0898ec314cc3e745c
   webrick (1.7.0) sha256=87e9b8e39947b7925338a5eb55427b11ce1f2b25a3645770ec9f39d8ebdb8cb4
 
 BUNDLED WITH


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Just cleaning up stuff.

## What is your fix for the problem, implemented in this PR?

We can remove a few more things after dropping Ruby 2.6 support.

Not sure about c241a889628db92a71b822894717ceddc0cfdbb8, maybe a bit of history is nice to keep? 🤷

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
