### PR TITLE
Update rake to 13.1.0 in tools/bundler/*_gems.rb

### DIFF
--- a/.github/workflows/realworld-bundler.yml
+++ b/.github/workflows/realworld-bundler.yml
@@ -115,4 +115,4 @@ jobs:
         with:
           path: ./bundler/spec/support/artifice/used_vcr_cassettes
       - name: Check unused cassettes
-        run: bin/rake dev:rake spec:realworld:check_unused_cassettes
+        run: bin/rake spec:realworld:check_unused_cassettes

--- a/Rakefile
+++ b/Rakefile
@@ -586,9 +586,6 @@ task :spec do
 end
 
 namespace :dev do
-  desc "Ensure the rake version we use for development is installed"
-  task :rake
-
   desc "Ensure dev dependencies are installed"
   task :deps do
     Spec::Rubygems.dev_setup

--- a/bin/rake
+++ b/bin/rake
@@ -3,7 +3,7 @@
 
 require_relative "../bundler/spec/support/rubygems_ext"
 
-if ["dev:rake", "dev:deps", "dev:frozen_deps", "spec:deps", "spec:parallel_deps"].include?(ARGV[0])
+if ["dev:deps", "dev:frozen_deps", "spec:deps", "spec:parallel_deps"].include?(ARGV[0])
   Spec::Rubygems.gem_load_and_possibly_install("rake", "rake")
 else
   Spec::Rubygems.gem_load("rake", "rake")

--- a/tool/bundler/dev_gems.rb.lock
+++ b/tool/bundler/dev_gems.rb.lock
@@ -22,7 +22,7 @@ GEM
     power_assert (2.0.3)
     racc (1.7.3)
     racc (1.7.3-java)
-    rake (13.0.6)
+    rake (13.1.0)
     rb_sys (0.9.79)
     rexml (3.2.6)
     rspec (3.12.0)
@@ -88,7 +88,7 @@ CHECKSUMS
   power_assert (2.0.3) sha256=cd5e13c267370427c9804ce6a57925d6030613e341cb48e02eec1f3c772d4cf8
   racc (1.7.3) sha256=b785ab8a30ec43bce073c51dbbe791fd27000f68d1c996c95da98bf685316905
   racc (1.7.3-java) sha256=b2ad737e788cfa083263ce7c9290644bb0f2c691908249eb4f6eb48ed2815dbf
-  rake (13.0.6) sha256=5ce4bf5037b4196c24ac62834d8db1ce175470391026bd9e557d669beeb19097
+  rake (13.1.0) sha256=be6a3e1aa7f66e6c65fa57555234eb75ce4cf4ada077658449207205474199c6
   rb_sys (0.9.79) sha256=d5dcd6bbdcab27c3f1a7dfb44cbdc2d2941e2b7774cf0d860853382be52357e3
   rexml (3.2.6) sha256=e0669a2d4e9f109951cb1fde723d8acd285425d81594a2ea929304af50282816
   rspec (3.12.0) sha256=ccc41799a43509dc0be84070e3f0410ac95cbd480ae7b6c245543eb64162399c

--- a/tool/bundler/rubocop_gems.rb.lock
+++ b/tool/bundler/rubocop_gems.rb.lock
@@ -14,7 +14,7 @@ GEM
     racc (1.7.1)
     racc (1.7.1-java)
     rainbow (3.1.1)
-    rake (13.0.6)
+    rake (13.1.0)
     rake-compiler (1.2.3)
       rake
     rb_sys (0.9.79)
@@ -87,7 +87,7 @@ CHECKSUMS
   racc (1.7.1) sha256=af64124836fdd3c00e830703d7f873ea5deabde923f37006a39f5a5e0da16387
   racc (1.7.1-java) sha256=eaa5cd10ace36a5c5a139e699875a45fa1dfd7d5df8432ffd6243962c6b24ef0
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
-  rake (13.0.6) sha256=5ce4bf5037b4196c24ac62834d8db1ce175470391026bd9e557d669beeb19097
+  rake (13.1.0) sha256=be6a3e1aa7f66e6c65fa57555234eb75ce4cf4ada077658449207205474199c6
   rake-compiler (1.2.3) sha256=994a53efb3374b8960de536ea1cbdff9a0d36bfe4fd4f409d73a26e60993d085
   rb_sys (0.9.79) sha256=d5dcd6bbdcab27c3f1a7dfb44cbdc2d2941e2b7774cf0d860853382be52357e3
   regexp_parser (2.8.1) sha256=83f63e2bfae3db38f988c66f114485140ff1791321fd827480bc75aa42cacb8c

--- a/tool/bundler/standard_gems.rb.lock
+++ b/tool/bundler/standard_gems.rb.lock
@@ -16,7 +16,7 @@ GEM
     racc (1.7.1)
     racc (1.7.1-java)
     rainbow (3.1.1)
-    rake (13.0.6)
+    rake (13.1.0)
     rake-compiler (1.2.3)
       rake
     rb_sys (0.9.79)
@@ -105,7 +105,7 @@ CHECKSUMS
   racc (1.7.1) sha256=af64124836fdd3c00e830703d7f873ea5deabde923f37006a39f5a5e0da16387
   racc (1.7.1-java) sha256=eaa5cd10ace36a5c5a139e699875a45fa1dfd7d5df8432ffd6243962c6b24ef0
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
-  rake (13.0.6) sha256=5ce4bf5037b4196c24ac62834d8db1ce175470391026bd9e557d669beeb19097
+  rake (13.1.0) sha256=be6a3e1aa7f66e6c65fa57555234eb75ce4cf4ada077658449207205474199c6
   rake-compiler (1.2.3) sha256=994a53efb3374b8960de536ea1cbdff9a0d36bfe4fd4f409d73a26e60993d085
   rb_sys (0.9.79) sha256=d5dcd6bbdcab27c3f1a7dfb44cbdc2d2941e2b7774cf0d860853382be52357e3
   regexp_parser (2.8.1) sha256=83f63e2bfae3db38f988c66f114485140ff1791321fd827480bc75aa42cacb8c


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Both #7246 and #7247 deal with updating rake, which is apparently not as straightforward as it would seem.

## What is your fix for the problem, implemented in this PR?

Update rake in dev exclusively.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
