### PR TITLE
Resolve `ruby file: ".ruby-version"` relative to containing Gemfile

### DIFF
--- a/bundler/lib/bundler/ruby_dsl.rb
+++ b/bundler/lib/bundler/ruby_dsl.rb
@@ -32,8 +32,10 @@ module Bundler
     #     ruby   2.5.1# close comment and extra spaces doesn't confuse
     #
     # Intentionally does not support `3.2.1@gemset` since rvm recommends using .ruby-gemset instead
+    #
+    # Loads the file relative to the dirname of the Gemfile itself.
     def normalize_ruby_file(filename)
-      file_content = Bundler.read_file(Bundler.root.join(filename))
+      file_content = Bundler.read_file(gemfile.dirname.join(filename))
       # match "ruby-3.2.2" or "ruby   3.2.2" capturing version string up to the first space or comment
       if /^ruby(-|\s+)([^\s#]+)/.match(file_content)
         $2


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

As pointed out in #7219 When Bundler.root is not the same as the Gemfile's dirname, the ruby-version file path is evaluated incorrectly.

Fixes #7219
Also will help Shopify/vscode-ruby-lsp#922 since that's where the bug originally arose.

## What is your fix for the problem, implemented in this PR?

Resolves path in `ruby file: "path"` relative to the Gemfile that is being evaluated.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
