### PR TITLE
Ensure that the lockfile mtime is not altered on frozen install

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -343,7 +343,8 @@ module Bundler
       preserve_unknown_sections ||= !updating_major && (Bundler.frozen_bundle? || !(unlocking? || @unlocking_bundler))
 
       if file && File.exist?(file) && lockfiles_equal?(@lockfile_contents, contents, preserve_unknown_sections)
-        SharedHelpers.filesystem_access(file) {|p| FileUtils.touch(p) }
+        return if Bundler.frozen_bundle?
+        SharedHelpers.filesystem_access(file) { FileUtils.touch(file) }
         return
       end
 

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -237,7 +237,9 @@ RSpec.describe "install in deployment or frozen mode" do
 
     it "installs gems by default to vendor/bundle" do
       bundle "config set deployment true"
-      bundle "install"
+      expect do
+        bundle "install"
+      end.not_to change { bundled_app_lock.mtime }
       expect(out).to include("vendor/bundle")
     end
 
@@ -256,11 +258,15 @@ RSpec.describe "install in deployment or frozen mode" do
 
     it "works with the `frozen` setting" do
       bundle "config set frozen true"
-      bundle "install"
+      expect do
+        bundle "install"
+      end.not_to change { bundled_app_lock.mtime }
     end
 
     it "works with BUNDLE_FROZEN if you didn't change anything" do
-      bundle :install, env: { "BUNDLE_FROZEN" => "true" }
+      expect do
+        bundle :install, env: { "BUNDLE_FROZEN" => "true" }
+      end.not_to change { bundled_app_lock.mtime }
     end
 
     it "explodes with the `deployment` setting if you make a change and don't check in the lockfile" do

--- a/bundler/spec/install/gemfile/lockfile_spec.rb
+++ b/bundler/spec/install/gemfile/lockfile_spec.rb
@@ -11,6 +11,11 @@ RSpec.describe "bundle install with a lockfile present" do
     install_gemfile(gf)
   end
 
+  it "touches the lockfile on install even when nothing has changed" do
+    subject
+    expect { bundle :install }.to change { bundled_app_lock.mtime }
+  end
+
   context "gemfile evaluation" do
     let(:gf) { super() + "\n\n File.open('evals', 'a') {|f| f << %(1\n) } unless ENV['BUNDLER_SPEC_NO_APPEND']" }
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Follow up on #7220 to ensure that frozen Gemfile.lock is not touched.
 
## What is your fix for the problem, implemented in this PR?

Check frozen setting before touching the lockfile.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
