### PR TITLE
Make sure --no-user-install is respected for auto user installation

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -682,7 +682,7 @@ class Gem::Installer
       if @build_root.nil?
         if options[:user_install]
           @gem_home = Gem.user_dir
-        elsif !ENV.key?("GEM_HOME") && (File.exist?(Gem.dir) && !File.writable?(Gem.dir))
+        elsif options[:user_install].nil? && !ENV.key?("GEM_HOME") && (File.exist?(Gem.dir) && !File.writable?(Gem.dir))
           say "Defaulting to user installation because default installation directory (#{Gem.dir}) is not writable."
           @gem_home = Gem.user_dir
         end

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -680,6 +680,10 @@ class Gem::Installer
     unless @gem_home
       # `--build-root` overrides `--user-install` and auto-user-install
       if @build_root.nil?
+        # Please note that `options[:user_install]` might have three states:
+        # * `true`: `--user-install`
+        # * `false`: `--no-user-install` and
+        # * `nil`: option was not specified
         if options[:user_install]
           @gem_home = Gem.user_dir
         elsif options[:user_install].nil? && !ENV.key?("GEM_HOME") && (File.exist?(Gem.dir) && !File.writable?(Gem.dir))

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1987,8 +1987,9 @@ end
 
     FileUtils.chmod 0o000, @gemhome
 
-    use_ui(@ui) { Gem::Installer.at @gem }
+    installer = use_ui(@ui) { Gem::Installer.at @gem }
 
+    assert_equal Gem.user_dir, installer.gem_home
     assert_equal "Defaulting to user installation because default installation directory (#{@gemhome}) is not writable.", @ui.output.strip
   ensure
     FileUtils.chmod 0o755, @gemhome

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1995,6 +1995,27 @@ end
     ENV["GEM_HOME"] = orig_gem_home
   end
 
+  def test_process_options_does_not_fallback_to_user_install_when_gem_home_not_writable_and_no_user_install
+    if Process.uid.zero?
+      pend("skipped in root privilege")
+      return
+    end
+
+    orig_gem_home = ENV.delete("GEM_HOME")
+
+    @gem = setup_base_gem
+
+    FileUtils.chmod 0o000, @gemhome
+
+    installer = use_ui(@ui) { Gem::Installer.at @gem, user_install: false }
+
+    assert_equal @gemhome, installer.gem_home
+    assert_empty @ui.output.strip
+  ensure
+    FileUtils.chmod 0o755, @gemhome
+    ENV["GEM_HOME"] = orig_gem_home
+  end
+
   def test_shebang_arguments
     load_relative "no" do
       installer = setup_base_installer


### PR DESCRIPTION
The `options[:user_install]` might have three states:
* `true`: `--user-install`
* `false`: `--no-user-install` and
* `nil`: option was not specified

However, this had not been respected previously and the `false` and `nil` were treated the same. This could lead to auto user installation despite `--no-user-install` being specified on the command line.

Fixes #7237

BTW I have added explicit comment about the 3 states. It is kept in separate commit in case somebody considers that redundant.