### PR TITLE
Remove no longer needed gem installation during spec

### DIFF
--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -603,9 +603,6 @@ RSpec.describe "bundler/inline#gemfile" do
 
     realworld_system_gems "timeout uri" # this spec uses net/http which requires these default gems
 
-    # on prerelease rubies, a required_rubygems_version constraint is added by RubyGems to the resolution, causing Molinillo to load the `set` gem
-    realworld_system_gems "set --version 1.0.3" if Gem.ruby_version.prerelease?
-
     script <<-RUBY, dir: tmp("path_without_gemfile"), env: { "BUNDLER_GEM_DEFAULT_DIR" => system_gem_path.to_s }
       require "bundler/inline"
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Reading the comment reminded me that this can be removed after #7226.

## What is your fix for the problem, implemented in this PR?

Remove what's not needed.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
