### PR TITLE
Add missing resolv, timeout, and net-protocol licenses

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -438,6 +438,7 @@ lib/rubygems/net-http/lib/net/http/response.rb
 lib/rubygems/net-http/lib/net/http/responses.rb
 lib/rubygems/net-http/lib/net/http/status.rb
 lib/rubygems/net-http/lib/net/https.rb
+lib/rubygems/net-protocol/LICENSE.txt
 lib/rubygems/net-protocol/lib/net/protocol.rb
 lib/rubygems/net/http.rb
 lib/rubygems/openssl.rb
@@ -480,6 +481,7 @@ lib/rubygems/request_set/lockfile.rb
 lib/rubygems/request_set/lockfile/parser.rb
 lib/rubygems/request_set/lockfile/tokenizer.rb
 lib/rubygems/requirement.rb
+lib/rubygems/resolv/LICENSE.txt
 lib/rubygems/resolv/lib/resolv.rb
 lib/rubygems/resolver.rb
 lib/rubygems/resolver/activation_request.rb
@@ -562,6 +564,7 @@ lib/rubygems/ssl_certs/rubygems.org/GlobalSignRootCA_R3.pem
 lib/rubygems/stub_specification.rb
 lib/rubygems/text.rb
 lib/rubygems/timeout.rb
+lib/rubygems/timeout/LICENSE.txt
 lib/rubygems/timeout/lib/timeout.rb
 lib/rubygems/tsort.rb
 lib/rubygems/tsort/.document

--- a/Rakefile
+++ b/Rakefile
@@ -213,7 +213,7 @@ if File.exist?("tool/automatiek.rake")
         subsublib.namespace = "Timeout"
         subsublib.prefix = "Gem"
         subsublib.vendor_lib = "lib/rubygems/timeout"
-        subsublib.license_path = "License.txt"
+        subsublib.license_path = "LICENSE.txt"
       end
     end
 
@@ -240,7 +240,7 @@ if File.exist?("tool/automatiek.rake")
         subsublib.namespace = "Net"
         subsublib.prefix = "Gem"
         subsublib.vendor_lib = "lib/rubygems/net-protocol"
-        subsublib.license_path = "License.txt"
+        subsublib.license_path = "LICENSE.txt"
 
         subsublib.dependency("timeout") do |ssslib|
           ssslib.version = "v0.4.1"
@@ -248,7 +248,7 @@ if File.exist?("tool/automatiek.rake")
           ssslib.namespace = "Timeout"
           ssslib.prefix = "Gem"
           ssslib.vendor_lib = "lib/rubygems/timeout"
-          ssslib.license_path = "License.txt"
+          ssslib.license_path = "LICENSE.txt"
         end
       end
 
@@ -258,7 +258,7 @@ if File.exist?("tool/automatiek.rake")
         subsublib.namespace = "Timeout"
         subsublib.prefix = "Gem"
         subsublib.vendor_lib = "lib/rubygems/timeout"
-        subsublib.license_path = "License.txt"
+        subsublib.license_path = "LICENSE.txt"
       end
 
       sublib.dependency("resolv") do |subsublib|
@@ -267,7 +267,7 @@ if File.exist?("tool/automatiek.rake")
         subsublib.namespace = "Resolv"
         subsublib.prefix = "Gem"
         subsublib.vendor_lib = "lib/rubygems/resolv"
-        subsublib.license_path = "License.txt"
+        subsublib.license_path = "LICENSE.txt"
 
         subsublib.dependency("timeout") do |ssslib|
           ssslib.version = "v0.4.1"
@@ -275,7 +275,7 @@ if File.exist?("tool/automatiek.rake")
           ssslib.namespace = "Timeout"
           ssslib.prefix = "Gem"
           ssslib.vendor_lib = "lib/rubygems/timeout"
-          ssslib.license_path = "License.txt"
+          ssslib.license_path = "LICENSE.txt"
         end
       end
     end

--- a/lib/rubygems/net-protocol/LICENSE.txt
+++ b/lib/rubygems/net-protocol/LICENSE.txt
@@ -1,0 +1,22 @@
+Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/lib/rubygems/resolv/LICENSE.txt
+++ b/lib/rubygems/resolv/LICENSE.txt
@@ -1,0 +1,22 @@
+Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/lib/rubygems/timeout/LICENSE.txt
+++ b/lib/rubygems/timeout/LICENSE.txt
@@ -1,0 +1,22 @@
+Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/tool/automatiek/gem.rb
+++ b/tool/automatiek/gem.rb
@@ -115,10 +115,17 @@ module Automatiek
     end
 
     def clean
-      files = Dir.glob("#{vendor_lib}/*", File::FNM_DOTMATCH).reject do |f|
+      all_files = Dir.glob("#{vendor_lib}/*", File::FNM_DOTMATCH)
+
+      unless all_files.include?("#{vendor_lib}/#{license_path}")
+        raise "#{license_path} was not found in gem #{gem_name}. The gem includes the following files:\n  * #{all_files.join("\n  * ")}"
+      end
+
+      files = all_files.reject do |f|
         basename = f.split("/").last
         allowlist.include? basename
       end
+
       FileUtils.rm_r files
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I made typos when specifying licenses for timeout and resolv at #6793.

## What is your fix for the problem, implemented in this PR?

Fix typos.

NOTE: I know it's not ideal that we currently have to specify the same info every time a vendored gem appears as a subdependency, but I did not care much about it since this is just support code to help us vendor the gems. 

Closes #7260.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
