### PR TITLE
Add 3.4 as a supported ruby version in Gemfile DSL

### DIFF
--- a/bundler/lib/bundler/dependency.rb
+++ b/bundler/lib/bundler/dependency.rb
@@ -9,7 +9,7 @@ module Bundler
     attr_reader :autorequire
     attr_reader :groups, :platforms, :gemfile, :path, :git, :github, :branch, :ref
 
-    ALL_RUBY_VERSIONS = ((18..27).to_a + (30..33).to_a).freeze
+    ALL_RUBY_VERSIONS = (18..27).to_a.concat((30..34).to_a).freeze
     PLATFORM_MAP = {
       ruby: [Gem::Platform::RUBY, ALL_RUBY_VERSIONS],
       mri: [Gem::Platform::RUBY, ALL_RUBY_VERSIONS],

--- a/bundler/spec/bundler/dependency_spec.rb
+++ b/bundler/spec/bundler/dependency_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe Bundler::Dependency do
         ruby_31: Gem::Platform::RUBY,
         ruby_32: Gem::Platform::RUBY,
         ruby_33: Gem::Platform::RUBY,
+        ruby_34: Gem::Platform::RUBY,
         mri: Gem::Platform::RUBY,
         mri_18: Gem::Platform::RUBY,
         mri_19: Gem::Platform::RUBY,
@@ -70,6 +71,7 @@ RSpec.describe Bundler::Dependency do
         mri_31: Gem::Platform::RUBY,
         mri_32: Gem::Platform::RUBY,
         mri_33: Gem::Platform::RUBY,
+        mri_34: Gem::Platform::RUBY,
         rbx: Gem::Platform::RUBY,
         truffleruby: Gem::Platform::RUBY,
         jruby: Gem::Platform::JAVA,
@@ -89,7 +91,8 @@ RSpec.describe Bundler::Dependency do
         windows_30: Gem::Platform::WINDOWS,
         windows_31: Gem::Platform::WINDOWS,
         windows_32: Gem::Platform::WINDOWS,
-        windows_33: Gem::Platform::WINDOWS }
+        windows_33: Gem::Platform::WINDOWS,
+        windows_34: Gem::Platform::WINDOWS }
     end
 
     let(:deprecated) do
@@ -108,6 +111,7 @@ RSpec.describe Bundler::Dependency do
         mswin_31: Gem::Platform::MSWIN,
         mswin_32: Gem::Platform::MSWIN,
         mswin_33: Gem::Platform::MSWIN,
+        mswin_34: Gem::Platform::MSWIN,
         mswin64: Gem::Platform::MSWIN64,
         mswin64_19: Gem::Platform::MSWIN64,
         mswin64_20: Gem::Platform::MSWIN64,
@@ -122,6 +126,7 @@ RSpec.describe Bundler::Dependency do
         mswin64_31: Gem::Platform::MSWIN64,
         mswin64_32: Gem::Platform::MSWIN64,
         mswin64_33: Gem::Platform::MSWIN64,
+        mswin64_34: Gem::Platform::MSWIN64,
         mingw: Gem::Platform::MINGW,
         mingw_18: Gem::Platform::MINGW,
         mingw_19: Gem::Platform::MINGW,
@@ -137,6 +142,7 @@ RSpec.describe Bundler::Dependency do
         mingw_31: Gem::Platform::MINGW,
         mingw_32: Gem::Platform::MINGW,
         mingw_33: Gem::Platform::MINGW,
+        mingw_34: Gem::Platform::MINGW,
         x64_mingw: Gem::Platform::X64_MINGW,
         x64_mingw_20: Gem::Platform::X64_MINGW,
         x64_mingw_21: Gem::Platform::X64_MINGW,
@@ -149,7 +155,8 @@ RSpec.describe Bundler::Dependency do
         x64_mingw_30: Gem::Platform::X64_MINGW,
         x64_mingw_31: Gem::Platform::X64_MINGW,
         x64_mingw_32: Gem::Platform::X64_MINGW,
-        x64_mingw_33: Gem::Platform::X64_MINGW }
+        x64_mingw_33: Gem::Platform::X64_MINGW,
+        x64_mingw_34: Gem::Platform::X64_MINGW }
     end
     # rubocop:enable Naming/VariableNumber
 


### PR DESCRIPTION
Since ruby trunk will be 3.4 very soon

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)