### PR TITLE
Improve install advice when some gems are not found

### DIFF
--- a/bundler/lib/bundler/setup.rb
+++ b/bundler/lib/bundler/setup.rb
@@ -12,7 +12,8 @@ if Bundler::SharedHelpers.in_bundle?
       Bundler.ui.error e.message
       Bundler.ui.warn e.backtrace.join("\n") if ENV["DEBUG"]
       if e.is_a?(Bundler::GemNotFound)
-        suggested_cmd = "bundle install"
+        suggested_bundle = Gem.loaded_specs["bundler"] ? "bundle" : Bundler::SharedHelpers.bundle_bin_path
+        suggested_cmd = "#{suggested_bundle} install"
         original_gemfile = Bundler.original_env["BUNDLE_GEMFILE"]
         suggested_cmd += " --gemfile #{original_gemfile}" if original_gemfile
         Bundler.ui.warn "Run `#{suggested_cmd}` to install missing gems."

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -304,6 +304,13 @@ module Bundler
     public :set_env
 
     def set_bundle_variables
+      Bundler::SharedHelpers.set_env "BUNDLE_BIN_PATH", bundle_bin_path
+      Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", find_gemfile.to_s
+      Bundler::SharedHelpers.set_env "BUNDLER_VERSION", Bundler::VERSION
+      Bundler::SharedHelpers.set_env "BUNDLER_SETUP", File.expand_path("setup", __dir__)
+    end
+
+    def bundle_bin_path
       # bundler exe & lib folders have same root folder, typical gem installation
       exe_file = File.expand_path("../../exe/bundle", __dir__)
 
@@ -313,11 +320,9 @@ module Bundler
       # bundler is a default gem, exe path is separate
       exe_file = Bundler.rubygems.bin_path("bundler", "bundle", VERSION) unless File.exist?(exe_file)
 
-      Bundler::SharedHelpers.set_env "BUNDLE_BIN_PATH", exe_file
-      Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", find_gemfile.to_s
-      Bundler::SharedHelpers.set_env "BUNDLER_VERSION", Bundler::VERSION
-      Bundler::SharedHelpers.set_env "BUNDLER_SETUP", File.expand_path("setup", __dir__)
+      exe_file
     end
+    public :bundle_bin_path
 
     def set_path
       validate_bundle_path


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This problem is quite specific to our dev environment, but I guess the fix could be handy for other situations.

After merging [a change](https://github.com/rubygems/rubygems/pull/7242) to treat default gems as regular gems, I get this when trying to run `rubocop` on our repo:

```
$ bin/rubocop  --only Performance/RegexpMatch
Could not find json-2.6.3 in locally installed gems
Run `bundle install --gemfile /Users/deivid/code/rubygems/rubygems/tool/bundler/lint_gems.rb` to install missing gems.
```

However, when running the suggested command, nothing changes and I still get the same error:

```
$ bundle install --gemfile /Users/deivid/code/rubygems/rubygems/tool/bundler/lint_gems.rb
Using ast 2.4.2
Using bundler 2.4.10
Using json 2.6.3
Using parallel 1.23.0
Using racc 1.7.1
Using parser 3.2.2.3
Using rainbow 3.1.1
Using regexp_parser 2.8.1
Using rexml 3.2.5
Using rubocop-ast 1.29.0
Using ruby-progressbar 1.13.0
Using unicode-display_width 2.4.2
Using rubocop 1.52.1
Using rubocop-performance 1.14.2
Bundle complete! 2 Gemfile dependencies, 14 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.

$ bin/rubocop  --only Performance/RegexpMatch
Could not find json-2.6.3 in locally installed gems
Run `bundle install --gemfile /Users/deivid/code/rubygems/rubygems/tool/bundler/lint_gems.rb` to install missing gems.
```

The problem is that our `bin/rubocop` script uses the development version of Bundler (which has the change causing the problem), but the advice recommands the default version of Bundler, which does not yet have the change.

## What is your fix for the problem, implemented in this PR?

This commit changes the advice to recommend to use the same version of Bundler that run into the problem in the first place.
    
So in the above situation you now get:
    
```
$ bin/rubocop  --only Performance/RegexpMatch
Could not find json-2.6.3 in locally installed gems
Run `/Users/deivid/code/rubygems/rubygems/bundler/exe/bundle install --gemfile /Users/deivid/code/rubygems/rubygems/tool/bundler/lint_gems.rb` to install missing gems.
```
    
And running that fixes the problem:
    
```
$ /Users/deivid//rubygems/rubygems/bundler/exe/bundle install --gemfile /Users/deivid/code/rubygems/rubygems/tool/bundler/lint_gems.rb
Fetching gem metadata from https://rubygems.org/.........
Fetching json 2.6.3
Installing json 2.6.3 with native extensions
Bundle complete! 2 Gemfile dependencies, 14 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
```
## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
