### PR TITLE
Revert treating default gems as regular gems

### DIFF
--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -469,7 +469,7 @@ module Bundler
     end
 
     def all_specs
-      Gem::Specification.stubs.reject(&:default_gem?).map do |stub|
+      Gem::Specification.stubs.map do |stub|
         StubSpecification.from_stub(stub)
       end
     end

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -225,7 +225,11 @@ module Bundler
         cached_path = cached_path(spec)
         if cached_path.nil?
           remote_spec = remote_specs.search(spec).first
-          cached_path = fetch_gem(remote_spec)
+          if remote_spec
+            cached_path = fetch_gem(remote_spec)
+          else
+            Bundler.ui.warn "#{spec.full_name} is built in to Ruby, and can't be cached because your Gemfile doesn't have any sources that contain it."
+          end
         end
         cached_path
       end

--- a/bundler/spec/cache/gems_spec.rb
+++ b/bundler/spec/cache/gems_spec.rb
@@ -102,8 +102,8 @@ RSpec.describe "bundle cache" do
 
     it "uses builtin gems when installing to system gems" do
       bundle "config set path.system true"
-      install_gemfile %(source "#{file_uri_for(gem_repo2)}"; gem 'json', '#{default_json_version}'), verbose: true
-      expect(out).to include("Installing json #{default_json_version}")
+      install_gemfile %(source "#{file_uri_for(gem_repo1)}"; gem 'json', '#{default_json_version}'), verbose: true
+      expect(out).to include("Using json #{default_json_version}")
     end
 
     it "caches remote and builtin gems" do
@@ -142,6 +142,19 @@ RSpec.describe "bundle cache" do
 
       bundle "install --local"
       expect(the_bundle).to include_gems("builtin_gem_2 1.0.2")
+    end
+
+    it "errors if the builtin gem isn't available to cache" do
+      bundle "config set path.system true"
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem 'json', '#{default_json_version}'
+      G
+
+      bundle :cache, raise_on_error: false
+      expect(exitstatus).to_not eq(0)
+      expect(err).to include("json-#{default_json_version} is built in to Ruby, and can't be cached")
     end
   end
 

--- a/bundler/spec/commands/open_spec.rb
+++ b/bundler/spec/commands/open_spec.rb
@@ -164,6 +164,7 @@ RSpec.describe "bundle open" do
 
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
+        gem "json"
       G
     end
 

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1281,10 +1281,6 @@ end
 
   describe "with gemified standard libraries" do
     it "does not load Digest", :ruby_repo do
-      build_repo2 do
-        build_gem "digest"
-      end
-
       build_git "bar", gemspec: false do |s|
         s.write "lib/bar/version.rb", %(BAR_VERSION = '1.0')
         s.write "bar.gemspec", <<-G
@@ -1303,7 +1299,7 @@ end
       end
 
       gemfile <<-G
-        source "#{file_uri_for(gem_repo2)}"
+        source "#{file_uri_for(gem_repo1)}"
         gem "bar", :git => "#{lib_path("bar-1.0")}"
       G
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I merged #7242 recently but on second thought I think there's probably a better compatibility story here. We can make default gems be installed and cached by default, but still use them when missing during `Bundler.setup`, possibly with a warning that advices to rebundle so that the default gem is included with the rest of the bundle.

## What is your fix for the problem, implemented in this PR?

I don't have time to work on the above now, so I'd like to revert the PR for now to make it for a smoother release.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
