### PR TITLE
Store Checksum::Store indexed by spec.lock_name

### DIFF
--- a/bundler/lib/bundler/errors.rb
+++ b/bundler/lib/bundler/errors.rb
@@ -53,8 +53,8 @@ module Bundler
   class MarshalError < StandardError; end
 
   class ChecksumMismatchError < SecurityError
-    def initialize(name_tuple, existing, checksum)
-      @name_tuple = name_tuple
+    def initialize(lock_name, existing, checksum)
+      @lock_name = lock_name
       @existing = existing
       @checksum = checksum
     end
@@ -62,9 +62,9 @@ module Bundler
     def message
       <<~MESSAGE
         Bundler found mismatched checksums. This is a potential security risk.
-          #{@name_tuple.lock_name} #{@existing.to_lock}
+          #{@lock_name} #{@existing.to_lock}
             from #{@existing.sources.join("\n    and ")}
-          #{@name_tuple.lock_name} #{@checksum.to_lock}
+          #{@lock_name} #{@checksum.to_lock}
             from #{@checksum.sources.join("\n    and ")}
 
         #{mismatch_resolution_instructions}


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

There's too many crashes on hashing the NameTuple.

## What is your fix for the problem, implemented in this PR?

Use `lock_name` as the index in the checksum store.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
