### PR TITLE
Fix Bundler daily CI

### DIFF
--- a/bundler/spec/runtime/self_management_spec.rb
+++ b/bundler/spec/runtime/self_management_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Self management", rubygems: ">= 3.3.0.dev", realworld: true do
       expect(out).to include("Bundler #{Bundler::VERSION} is running, but your lockfile was generated with #{previous_minor}. Installing Bundler #{previous_minor} and restarting using that version.")
 
       # It uninstalls the older system bundler
-      bundle "clean --force"
+      bundle "clean --force", artifice: nil
       expect(out).to eq("Removing bundler (#{Bundler::VERSION})")
 
       # App now uses locked version


### PR DESCRIPTION



## What was the end-user or developer problem that led to this PR?

Daily Bundler CI (which probably got fixed after we added 3.0.0-rc1 to our regular CI), got broken again after new vendored libraries landed into ruby-core.

A default Bundler copy with vendored net-http is causing a Bundler spec to end up loading that copy instead of the copy of Bundler under test. 

## What is your fix for the problem, implemented in this PR?

This is because of vcr, but we don't really need vcr in the command that's failing, so I avoided loading it.
 
## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
