### PR TITLE
Improve command suggestion when gems are missing

### DIFF
--- a/bundler/lib/bundler/setup.rb
+++ b/bundler/lib/bundler/setup.rb
@@ -12,7 +12,9 @@ if Bundler::SharedHelpers.in_bundle?
       Bundler.ui.error e.message
       Bundler.ui.warn e.backtrace.join("\n") if ENV["DEBUG"]
       if e.is_a?(Bundler::GemNotFound)
-        suggested_bundle = Gem.loaded_specs["bundler"] ? "bundle" : Bundler::SharedHelpers.bundle_bin_path
+        default_bundle = Gem.bin_path("bundler", "bundle")
+        current_bundle = Bundler::SharedHelpers.bundle_bin_path
+        suggested_bundle = default_bundle == current_bundle ? "bundle" : current_bundle
         suggested_cmd = "#{suggested_bundle} install"
         original_gemfile = Bundler.original_env["BUNDLE_GEMFILE"]
         suggested_cmd += " --gemfile #{original_gemfile}" if original_gemfile


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Previous attempt to use a full path when the running version is different than the one that would be activated by default are different was not correct.

This is because if this error happens in a `bundle exec` context, the `Gem.loaded_specs` is cleared because we're in an exec'd process, so will be always using a full path in these cases.


## What is your fix for the problem, implemented in this PR?

This alternative approach should do what I was expecting: compare the path that a rubugems binstub will resolve to with the executable path of the current instance, and only recommend a full path when they are not identical.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
