### PR TITLE
Changelogs for RubyGems 3.5.0 and Bundler 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,100 @@
+# 3.5.0 / 2023-12-15
+
+## Security:
+
+* Replace `Marshal.load` with a fully-checked safe gemspec loader. Pull
+  request [#6896](https://github.com/rubygems/rubygems/pull/6896) by
+  segiddins
+
+## Breaking changes:
+
+* Drop ruby 2.6 and 2.7 support. Pull request
+  [#7116](https://github.com/rubygems/rubygems/pull/7116) by
+  deivid-rodriguez
+* Release package no longer includes test files. Pull request
+  [#6781](https://github.com/rubygems/rubygems/pull/6781) by hsbt
+* Hide `Gem::MockGemUi` from users. Pull request
+  [#6623](https://github.com/rubygems/rubygems/pull/6623) by hsbt
+* Deprecated `Gem.datadir` has been removed. Pull request
+  [#6469](https://github.com/rubygems/rubygems/pull/6469) by hsbt
+
+## Deprecations:
+
+* Deprecate `Gem::Platform.match?`. Pull request
+  [#6783](https://github.com/rubygems/rubygems/pull/6783) by hsbt
+* Deprecate `Gem::List`. Pull request
+  [#6311](https://github.com/rubygems/rubygems/pull/6311) by segiddins
+
+## Features:
+
+* The `generate_index` command can now generate compact index files and
+  lives as an external `rubygems-generate_index` gem. Pull request
+  [#7085](https://github.com/rubygems/rubygems/pull/7085) by segiddins
+* Make `gem install` fallback to user installation directory if default
+  gem home is not writable. Pull request
+  [#5327](https://github.com/rubygems/rubygems/pull/5327) by duckinator
+* Leverage ruby feature to warn when requiring default gems from stdlib
+  that will be turned into bundled gems in the future. Pull request
+  [#6840](https://github.com/rubygems/rubygems/pull/6840) by hsbt
+
+## Performance:
+
+* Use match? when regexp match data is unused. Pull request
+  [#7263](https://github.com/rubygems/rubygems/pull/7263) by segiddins
+* Fewer allocations in gem installation. Pull request
+  [#6975](https://github.com/rubygems/rubygems/pull/6975) by segiddins
+* Optimize allocations in `Gem::Version`. Pull request
+  [#6970](https://github.com/rubygems/rubygems/pull/6970) by segiddins
+
+## Enhancements:
+
+* Warn for duplicate meta data links when building gems. Pull request
+  [#7213](https://github.com/rubygems/rubygems/pull/7213) by etherbob
+* Vendor `net-http`, `net-protocol`, `resolv`, and `timeout` to reduce
+  conflicts between Gemfile gems and internal dependencies. Pull request
+  [#6793](https://github.com/rubygems/rubygems/pull/6793) by
+  deivid-rodriguez
+* Remove non-transparent requirement added to prerelease gems. Pull
+  request [#7226](https://github.com/rubygems/rubygems/pull/7226) by
+  deivid-rodriguez
+* Stream output from ext builds when --verbose. Pull request
+  [#7240](https://github.com/rubygems/rubygems/pull/7240) by osyoyu
+* Add missing services to CI detection and make it consistent between
+  RubyGems and Bundler. Pull request
+  [#7205](https://github.com/rubygems/rubygems/pull/7205) by nevinera
+* Update generate licenses template to not freeze regexps. Pull request
+  [#7154](https://github.com/rubygems/rubygems/pull/7154) by
+  github-actions[bot]
+* Don't check `LIBRUBY_RELATIVE` in truffleruby to signal a bash prelude
+  in rubygems binstubs. Pull request
+  [#7156](https://github.com/rubygems/rubygems/pull/7156) by
+  deivid-rodriguez
+* Update SPDX list and warn on deprecated identifiers. Pull request
+  [#6926](https://github.com/rubygems/rubygems/pull/6926) by simi
+* Simplify extended `require` to potentially fix some deadlocks. Pull
+  request [#6827](https://github.com/rubygems/rubygems/pull/6827) by nobu
+* Small refactors for `Gem::Resolver`. Pull request
+  [#6766](https://github.com/rubygems/rubygems/pull/6766) by hsbt
+* Use double-quotes instead of single-quotes consistently in warnings.
+  Pull request [#6550](https://github.com/rubygems/rubygems/pull/6550) by
+  hsbt
+* Add debug message for `nil` version gemspec. Pull request
+  [#6436](https://github.com/rubygems/rubygems/pull/6436) by hsbt
+* Installs bundler 2.5.0 as a default gem.
+
+## Bug fixes:
+
+* Fix installing from source with same default bundler version already
+  installed. Pull request
+  [#7244](https://github.com/rubygems/rubygems/pull/7244) by
+  deivid-rodriguez
+
+## Documentation:
+
+* Improve comment explaining the necessity of `write_default_spec` method.
+  Pull request [#6563](https://github.com/rubygems/rubygems/pull/6563) by
+  voxik
+
 # 3.4.22 / 2023-11-09
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,55 @@
+# 2.5.0 (December 15, 2023)
+
+## Breaking changes:
+
+  - Drop ruby 2.6 and 2.7 support [#7116](https://github.com/rubygems/rubygems/pull/7116)
+  - The `:mswin`, `:mswin64`, `:mingw`, and `:x64_mingw` Gemfile `platform` values are soft-deprecated and aliased to `:windows` [#6391](https://github.com/rubygems/rubygems/pull/6391)
+
+## Features:
+
+  - Leverage ruby feature to warn when requiring default gems not included in the bundle that will be turned into bundled gems in the future [#6831](https://github.com/rubygems/rubygems/pull/6831)
+  - Introduce `bundle config set version` feature to choose the version of Bundler that should be used and potentially disable using the `lockfile` version by setting it to `system` [#6817](https://github.com/rubygems/rubygems/pull/6817)
+
+## Performance:
+
+  - Use match? when regexp match data is unused [#7263](https://github.com/rubygems/rubygems/pull/7263)
+  - Avoid some allocations when evaluating `ruby` Gemfile DSL [#7251](https://github.com/rubygems/rubygems/pull/7251)
+  - Reduce array allocations when loading definition [#7199](https://github.com/rubygems/rubygems/pull/7199)
+  - Avoid re-compiling static regexp in a loop [#7198](https://github.com/rubygems/rubygems/pull/7198)
+  - Reduce allocations when installing gems with bundler [#6977](https://github.com/rubygems/rubygems/pull/6977)
+  - Use a shared connection pool for fetching gems [#7079](https://github.com/rubygems/rubygems/pull/7079)
+  - Reduce allocations when parsing compact index [#6971](https://github.com/rubygems/rubygems/pull/6971)
+
+## Enhancements:
+
+  - Add 3.4 as a supported ruby version in Gemfile DSL [#7264](https://github.com/rubygems/rubygems/pull/7264)
+  - Improve install advice when some gems are not found [#7265](https://github.com/rubygems/rubygems/pull/7265)
+  - Vendor `net-http`, `net-protocol`, `resolv`, and `timeout` to reduce conflicts between Gemfile gems and internal dependencies [#6793](https://github.com/rubygems/rubygems/pull/6793)
+  - Allow `bundle pristine` to run in parallel [#6927](https://github.com/rubygems/rubygems/pull/6927)
+  - Make `bundle lock` always touch the lockfile in non-frozen mode [#7220](https://github.com/rubygems/rubygems/pull/7220)
+  - Use `Minitest::TestTask` in a template file for `minitest` [#7234](https://github.com/rubygems/rubygems/pull/7234)
+  - Add missing services to CI detection and make it consistent between RubyGems and Bundler [#7205](https://github.com/rubygems/rubygems/pull/7205)
+  - Allow auto-install to install missing git gems [#7197](https://github.com/rubygems/rubygems/pull/7197)
+  - Stop remembering cli flags like `--jobs` or `--retry` in configuration [#7191](https://github.com/rubygems/rubygems/pull/7191)
+  - Simplify remembered flags deprecation message [#7189](https://github.com/rubygems/rubygems/pull/7189)
+  - Make sure to `require "rubygems"` explicitly [#7139](https://github.com/rubygems/rubygems/pull/7139)
+  - Handle development dependencies duplicated in gemspec vs Gemfile [#6014](https://github.com/rubygems/rubygems/pull/6014)
+  - Make lockfiles generated on macOS include a lock for Linux by default [#5700](https://github.com/rubygems/rubygems/pull/5700)
+  - Only add a dummy bundler spec to the metadata source when necessary [#4443](https://github.com/rubygems/rubygems/pull/4443)
+
+## Bug fixes:
+
+  - Resolve `ruby file: ".ruby-version"` relative to containing Gemfile [#7250](https://github.com/rubygems/rubygems/pull/7250)
+  - Implement opaque ETag in Compact Index to avoid falling back to old index in servers with different etag implementations [#7122](https://github.com/rubygems/rubygems/pull/7122)
+  - Fix `bundle install --system` deprecation advice [#7190](https://github.com/rubygems/rubygems/pull/7190)
+  - Fix invalid platform removal missing adjacent platforms [#7170](https://github.com/rubygems/rubygems/pull/7170)
+
+## Documentation:
+
+  - Add missing --prefer-local to Synopsis in bundle-install.1.ronn [#7194](https://github.com/rubygems/rubygems/pull/7194)
+  - Update GitHub organization of Standard Ruby in `bundle gem` output and generated configuration [#6818](https://github.com/rubygems/rubygems/pull/6818)
+  - Replace "prior to" with "immediately after" in `bundle gem` generated README file [#6338](https://github.com/rubygems/rubygems/pull/6338)
+
 # 2.4.22 (November 9, 2023)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.5.0 and Bundler 2.5.0 into master.