### PR TITLE
Fix `ruby setup.rb` leaving traces in source folder

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -116,7 +116,7 @@ jobs:
         run: ruby setup.rb
         shell: bash
       - name: Check installation didn't modify any source controlled files
-        run: git diff --exit-code
+        run: git add . && git diff --cached --exit-code
         shell: bash
       - name: Check we can install a Gemfile with git sources
         run: bundle init && bundle add fileutils --git https://github.com/ruby/fileutils

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -395,12 +395,6 @@ By default, this RubyGems will install gem as:
         each {|default_gem| rm_r File.join(bundler_spec.gems_dir, default_gem) }
     end
 
-    bundler_bin_dir = new_bundler_spec.bin_dir
-    mkdir_p bundler_bin_dir, mode: 0o755
-    bundler_spec.executables.each do |e|
-      cp File.join("bundler", new_bundler_spec.bindir, e), File.join(bundler_bin_dir, e)
-    end
-
     require_relative "../installer"
 
     Dir.chdir("bundler") do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

As a last sanity check for the gems I'm about to release, I normally release using the version I'm about to release, by running `ruby setup.rb` from the source repo before running the release tasks.

When running that to do some testing prior to the release, I found that `ruby setup.rb` is leaving a `gems/` folder with bundler executables inside in the source of the repo.

Everything seems installed fine though, I think because it's the `Gem::Installer` below that actually installs the bundler executables.
  
## What is your fix for the problem, implemented in this PR?

Remove the bad codes.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
