### PR TITLE
Fix `ruby` Gemfile DSL with `file:` parameter no longer working

### DIFF
--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -20,7 +20,7 @@ module Bundler
 
     GITHUB_PULL_REQUEST_URL = %r{\Ahttps://github\.com/([A-Za-z0-9_\-\.]+/[A-Za-z0-9_\-\.]+)/pull/(\d+)\z}
 
-    attr_reader :gemspecs
+    attr_reader :gemspecs, :gemfile
     attr_accessor :dependencies
 
     def initialize

--- a/bundler/spec/install/gemfile/ruby_spec.rb
+++ b/bundler/spec/install/gemfile/ruby_spec.rb
@@ -120,4 +120,38 @@ RSpec.describe "ruby requirement" do
 
     expect(err).to include("There was an error parsing") # i.e. DSL error, not error template
   end
+
+  it "allows picking up ruby version from a file" do
+    create_file ".ruby-version", Gem.ruby_version.to_s
+
+    install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
+      ruby file: ".ruby-version"
+      gem "rack"
+    G
+
+    expect(lockfile).to include("RUBY VERSION")
+  end
+
+  it "reads the ruby version file from the right folder when nested Gemfiles are involved" do
+    create_file ".ruby-version", Gem.ruby_version.to_s
+
+    gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
+      ruby file: ".ruby-version"
+      gem "rack"
+    G
+
+    nested_dir = bundled_app(".ruby-lsp")
+
+    FileUtils.mkdir nested_dir
+
+    create_file ".ruby-lsp/Gemfile", <<-G
+      eval_gemfile(File.expand_path("../Gemfile", __dir__))
+    G
+
+    bundle "install", dir: nested_dir
+
+    expect(bundled_app(".ruby-lsp/Gemfile.lock").read).to include("RUBY VERSION")
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The `ruby` DSL is not working properly in Bundler 2.5.

## What is your fix for the problem, implemented in this PR?

Add the missing `attr_reader` and cover the simple case and the one reported at #7219 with realworld specs.

Fixes #7286.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
