### PR TITLE
Fix Sinatra warning during specs

### DIFF
--- a/tool/bundler/release_gems.rb.lock
+++ b/tool/bundler/release_gems.rb.lock
@@ -4,7 +4,7 @@ GEM
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     aws-eventstream (1.3.0)
-    aws-partitions (1.864.0)
+    aws-partitions (1.867.0)
     aws-sdk-core (3.190.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)
@@ -58,7 +58,7 @@ DEPENDENCIES
 CHECKSUMS
   addressable (2.8.6) sha256=798f6af3556641a7619bad1dce04cdb6eb44b0216a991b0396ea7339276f2b47
   aws-eventstream (1.3.0) sha256=f1434cc03ab2248756eb02cfa45e900e59a061d7fbdc4a9fd82a5dd23d796d3f
-  aws-partitions (1.864.0) sha256=5ae21437336e9baf1cd53f0c09a4ae5ae4e8a6cdd421477c11c9ff011768c19a
+  aws-partitions (1.867.0) sha256=5e3b154fbff890bec3a7c6e656eaf3e2c3be36dd4a3554ca977bf2168eb4bd22
   aws-sdk-core (3.190.0) sha256=a3455fb3fc1691dd5331282ff16cb0b2ef136a5b63ed68b77e9fda447ea7cfa6
   aws-sdk-kms (1.74.0) sha256=b2537b21d051f6112c3bd71d2b60783435d08b152c2873d4593af93f539059c7
   aws-sdk-s3 (1.141.0) sha256=cadb88497af6736e86a4a1fc8eb42333fb27ae85901686334252c50862bdd02e

--- a/tool/bundler/test_gems.rb
+++ b/tool/bundler/test_gems.rb
@@ -2,11 +2,11 @@
 
 source "https://rubygems.org"
 
-gem "rack", "2.0.8"
+gem "rack", "~> 2.0"
 gem "webrick", "1.7.0"
 gem "rack-test", "~> 1.1"
 gem "compact_index", "~> 0.15.0"
-gem "sinatra", "~> 2.0"
+gem "sinatra", "~> 3.0"
 gem "rake", "~> 13.1"
 gem "builder", "~> 3.2"
 gem "rb_sys"

--- a/tool/bundler/test_gems.rb.lock
+++ b/tool/bundler/test_gems.rb.lock
@@ -3,11 +3,11 @@ GEM
   specs:
     builder (3.2.4)
     compact_index (0.15.0)
-    mustermann (1.1.2)
+    mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
-    rack (2.0.8)
-    rack-protection (2.0.8.1)
-      rack
+    rack (2.2.8)
+    rack-protection (3.1.0)
+      rack (~> 2.2, >= 2.2.4)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rake (13.1.0)
@@ -15,10 +15,10 @@ GEM
     ruby2_keywords (0.0.5)
     rubygems-generate_index (1.1.2)
       compact_index (~> 0.15.0)
-    sinatra (2.0.8.1)
-      mustermann (~> 1.0)
-      rack (~> 2.0)
-      rack-protection (= 2.0.8.1)
+    sinatra (3.1.0)
+      mustermann (~> 3.0)
+      rack (~> 2.2, >= 2.2.4)
+      rack-protection (= 3.1.0)
       tilt (~> 2.0)
     tilt (2.3.0)
     webrick (1.7.0)
@@ -37,26 +37,26 @@ PLATFORMS
 DEPENDENCIES
   builder (~> 3.2)
   compact_index (~> 0.15.0)
-  rack (= 2.0.8)
+  rack (~> 2.0)
   rack-test (~> 1.1)
   rake (~> 13.1)
   rb_sys
   rubygems-generate_index (~> 1.1)
-  sinatra (~> 2.0)
+  sinatra (~> 3.0)
   webrick (= 1.7.0)
 
 CHECKSUMS
   builder (3.2.4) sha256=99caf08af60c8d7f3a6b004029c4c3c0bdaebced6c949165fe98f1db27fbbc10
   compact_index (0.15.0) sha256=5c6c404afca8928a7d9f4dde9524f6e1610db17e675330803055db282da84a8b
-  mustermann (1.1.2) sha256=7b64de2f39ae6b623b6d4f7d2ced10d3442817ca9bb6200cf7bff3b9f6447b7e
-  rack (2.0.8) sha256=f98171fb30e104950abe1e9fb97c177d8bb5643dd649bc2ed837864eb596a0c5
-  rack-protection (2.0.8.1) sha256=d187dee7708ca93301854127e81b2675b60af86ab53532f9735087ecd649d2ff
+  mustermann (3.0.0) sha256=6d3569aa3c3b2f048c60626f48d9b2d561cc8d2ef269296943b03da181c08b67
+  rack (2.2.8) sha256=7b83a1f1304a8f5554c67bc83632d29ecd2ed1daeb88d276b7898533fde22d97
+  rack-protection (3.1.0) sha256=f9bc997fa87ab5fe3eb5d9d00e2a6222df3f9b8e6e9d610909ea3fc6203a5f77
   rack-test (1.1.0) sha256=154161f40f162b1c009a655b7b0c5de3a3102cc6d7d2e94b64e1f46ace800866
   rake (13.1.0) sha256=be6a3e1aa7f66e6c65fa57555234eb75ce4cf4ada077658449207205474199c6
   rb_sys (0.9.83) sha256=0ed80df79aa08b942af731d93a676f2d885428267f2fbf138f9b6b7809c6455e
   ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
   rubygems-generate_index (1.1.2) sha256=b5cfafe811b18bc45780b4cccc92593cf3115d2c8ea2a9f93a253eb9b2a8b955
-  sinatra (2.0.8.1) sha256=b8845f060fde0157940172a4d006b757f3ba6a5ea36326c7c9352c25391c3e66
+  sinatra (3.1.0) sha256=e89e7352a9e5cacf89d52ad4e47acc4e25b5cda7b87747a3ad01eaeb2d0ba400
   tilt (2.3.0) sha256=82dd903d61213c63679d28e404ee8e10d1b0fdf5270f1ad0898ec314cc3e745c
   webrick (1.7.0) sha256=87e9b8e39947b7925338a5eb55427b11ce1f2b25a3645770ec9f39d8ebdb8cb4
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Some specs now print the following warning:

```
/path/to/bundler/tmp/1/gems/base/ruby/3.2.0/gems/sinatra-2.0.8.1/lib/sinatra/base.rb:902: warning: constant Tilt::Cache is deprecated
```
## What is your fix for the problem, implemented in this PR?

Updating sinatra to latest & greatest fixes it.

Update other deps too since at it.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
