### PR TITLE
Remove reference to file that no longer exists

### DIFF
--- a/.github/workflows/system-rubygems-bundler.yml
+++ b/.github/workflows/system-rubygems-bundler.yml
@@ -5,7 +5,6 @@ on:
     paths:
       - bundler/**
       - .github/workflows/system-rubygems-bundler.yml
-      - .rubocop_bundler.yml
 
   push:
     branches:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I found a reference to a file that no longer exists.

## What is your fix for the problem, implemented in this PR?

I removed the reference instead of moving it to `.rubocop.yml` because I don't think it ever made us. 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
