### PR TITLE
Changelogs for RubyGems 3.5.1 and Bundler 2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.5.1 / 2023-12-15
+
+## Enhancements:
+
+* Installs bundler 2.5.1 as a default gem.
+
 # 3.5.0 / 2023-12-15
 
 ## Security:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 2.5.1 (December 15, 2023)
+
+## Bug fixes:
+
+  - Fix `ruby` Gemfile DSL with `file:` parameter no longer working [#7288](https://github.com/rubygems/rubygems/pull/7288)
+
+## Performance:
+
+  - Save array allocation for every dependency in Gemfile [#7270](https://github.com/rubygems/rubygems/pull/7270)
+
 # 2.5.0 (December 15, 2023)
 
 ## Breaking changes:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.5.1 and Bundler 2.5.1 into master.