### PR TITLE
Replace `object_id` comparison with identity Hash

### DIFF
--- a/lib/rubygems/request.rb
+++ b/lib/rubygems/request.rb
@@ -30,7 +30,7 @@ class Gem::Request
     @uri = uri
     @request_class = request_class
     @last_modified = last_modified
-    @requests = Hash.new 0
+    @requests = Hash.new(0).compare_by_identity
     @user_agent = user_agent
 
     @connection_pool = pool
@@ -196,7 +196,7 @@ class Gem::Request
     bad_response = false
 
     begin
-      @requests[connection.object_id] += 1
+      @requests[connection] += 1
 
       verbose "#{request.method} #{Gem::Uri.redact(@uri)}"
 
@@ -247,7 +247,7 @@ class Gem::Request
     rescue EOFError, Gem::Timeout::Error,
            Errno::ECONNABORTED, Errno::ECONNRESET, Errno::EPIPE
 
-      requests = @requests[connection.object_id]
+      requests = @requests[connection]
       verbose "connection reset after #{requests} requests, retrying"
 
       raise Gem::RemoteFetcher::FetchError.new("too many connection resets", @uri) if retried
@@ -267,7 +267,7 @@ class Gem::Request
   # Resets HTTP connection +connection+.
 
   def reset(connection)
-    @requests.delete connection.object_id
+    @requests.delete connection
 
     connection.finish
     connection.start


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Found this while auditing uses of `object_id` in `ruby/ruby`. Pulled out from ruby/ruby#9276

## What is your fix for the problem, implemented in this PR?

Replace a `Hash` keyed by `object_id`s with an identity Hash. See `Hash#compare_by_identity`](https://ruby-doc.org/3.2.2/Hash.html#method-i-compare_by_identity), which has the same semantics, but is faster and doesn't trigger allocation of IDs for these objects.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] ~Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes~
- [x] Write code to solve the problem
- [ x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
