### PR TITLE
Fix incorrect re-resolve messages

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -496,7 +496,15 @@ module Bundler
     private :sources
 
     def nothing_changed?
-      !@source_changes && !@dependency_changes && !@new_platform && !@path_changes && !@local_changes && !@missing_lockfile_dep && !@unlocking_bundler && !@invalid_lockfile_dep
+      !@source_changes &&
+        !@dependency_changes &&
+        !@new_platform &&
+        !@path_changes &&
+        !@local_changes &&
+        !@missing_lockfile_dep &&
+        !@unlocking_bundler &&
+        !@locked_spec_with_missing_deps &&
+        !@locked_spec_with_invalid_deps
     end
 
     def no_resolve_needed?
@@ -653,7 +661,8 @@ module Bundler
         [@local_changes, "the gemspecs for git local gems changed"],
         [@missing_lockfile_dep, "your lock file is missing \"#{@missing_lockfile_dep}\""],
         [@unlocking_bundler, "an update to the version of Bundler itself was requested"],
-        [@invalid_lockfile_dep, "your lock file has an invalid dependency \"#{@invalid_lockfile_dep}\""],
+        [@locked_spec_with_missing_deps, "your lock file includes \"#{@locked_spec_with_missing_deps}\" but not some of its dependencies"],
+        [@locked_spec_with_invalid_deps, "your lockfile does not satisfy dependencies of \"#{@locked_spec_with_invalid_deps}\""],
       ].select(&:first).map(&:last).join(", ")
     end
 
@@ -708,8 +717,10 @@ module Bundler
     end
 
     def check_lockfile
-      @invalid_lockfile_dep = nil
       @missing_lockfile_dep = nil
+
+      @locked_spec_with_invalid_deps = nil
+      @locked_spec_with_missing_deps = nil
 
       locked_names = @locked_specs.map(&:name)
       missing = []
@@ -727,7 +738,7 @@ module Bundler
       if missing.any?
         @locked_specs.delete(missing)
 
-        @missing_lockfile_dep = missing.first.name
+        @locked_spec_with_missing_deps = missing.first.name
       elsif !@dependency_changes
         @missing_lockfile_dep = current_dependencies.find do |d|
           @locked_specs[d.name].empty? && d.name != "bundler"
@@ -737,7 +748,7 @@ module Bundler
       if invalid.any?
         @locked_specs.delete(invalid)
 
-        @invalid_lockfile_dep = invalid.first.name
+        @locked_spec_with_invalid_deps = invalid.first.name
       end
     end
 

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -121,10 +121,7 @@ RSpec.describe Bundler::Definition do
         gem "foo", :path => "#{lib_path("foo")}"
       G
 
-      bundle :check, env: { "DEBUG" => "1" }
-
-      expect(out).to match(/using resolution from the lockfile/)
-      expect(lockfile).to eq <<~G
+      expected_lockfile = <<~G
         PATH
           remote: #{lib_path("foo")}
           specs:
@@ -145,6 +142,13 @@ RSpec.describe Bundler::Definition do
         BUNDLED WITH
            #{Bundler::VERSION}
       G
+
+      expect(lockfile).to eq(expected_lockfile)
+
+      bundle :check, env: { "DEBUG" => "1" }
+
+      expect(out).to match(/using resolution from the lockfile/)
+      expect(lockfile).to eq(expected_lockfile)
     end
 
     it "for a locked gem for another platform" do

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -1603,7 +1603,7 @@ RSpec.describe "the lockfile format" do
     L
 
     bundle "install --verbose"
-    expect(out).to include("re-resolving dependencies because your lock file is missing \"minitest-bisect\"")
+    expect(out).to include("re-resolving dependencies because your lock file includes \"minitest-bisect\" but not some of its dependencies")
 
     expect(lockfile).to eq <<~L
       GEM


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes bundler prints a message about re-resolving because of a gem it's missing from the lockfile, but it's one of its dependencies that's actually missing.

## What is your fix for the problem, implemented in this PR?

Print a correct message when this happens.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
