### PR TITLE
Fix incorrect lockfiles being generated in some situations

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -726,12 +726,10 @@ module Bundler
       invalid = []
 
       @locked_specs.each do |s|
-        s.dependencies.each do |dep|
-          next if dep.name == "bundler"
+        validation = @locked_specs.validate_deps(s)
 
-          missing << s unless @locked_specs.names.include?(dep.name)
-          invalid << s if @locked_specs.none? {|spec| dep.matches_spec?(spec) }
-        end
+        missing << s if validation == :missing
+        invalid << s if validation == :invalid
       end
 
       if missing.any?

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -722,7 +722,6 @@ module Bundler
       @locked_spec_with_invalid_deps = nil
       @locked_spec_with_missing_deps = nil
 
-      locked_names = @locked_specs.map(&:name)
       missing = []
       invalid = []
 
@@ -730,7 +729,7 @@ module Bundler
         s.dependencies.each do |dep|
           next if dep.name == "bundler"
 
-          missing << s unless locked_names.include?(dep.name)
+          missing << s unless @locked_specs.names.include?(dep.name)
           invalid << s if @locked_specs.none? {|spec| dep.matches_spec?(spec) }
         end
       end

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -10,6 +10,8 @@ module Bundler
     attr_reader :name, :version, :platform
     attr_accessor :source, :remote, :force_ruby_platform, :dependencies, :required_ruby_version, :required_rubygems_version
 
+    alias_method :runtime_dependencies, :dependencies
+
     def self.from_spec(s)
       lazy_spec = new(s.name, s.version, s.platform, s.source)
       lazy_spec.dependencies = s.dependencies

--- a/bundler/lib/bundler/remote_specification.rb
+++ b/bundler/lib/bundler/remote_specification.rb
@@ -88,6 +88,10 @@ module Bundler
       end
     end
 
+    def runtime_dependencies
+      dependencies.select(&:runtime?)
+    end
+
     def git_version
       return unless loaded_from && source.is_a?(Bundler::Source::Git)
       " #{source.revision[0..6]}"

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -193,6 +193,10 @@ module Bundler
       sorted.each(&b)
     end
 
+    def names
+      lookup.keys
+    end
+
     private
 
     def sorted

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -167,7 +167,7 @@ module Bundler
     end
 
     def what_required(spec)
-      unless req = find {|s| s.dependencies.any? {|d| d.type == :runtime && d.name == spec.name } }
+      unless req = find {|s| s.runtime_dependencies.any? {|d| d.name == spec.name } }
         return [spec]
       end
       what_required(req) << spec

--- a/bundler/spec/support/artifice/helpers/compact_index.rb
+++ b/bundler/spec/support/artifice/helpers/compact_index.rb
@@ -77,7 +77,7 @@ class CompactIndexAPI < Endpoint
 
         specs.group_by(&:name).map do |name, versions|
           gem_versions = versions.map do |spec|
-            deps = spec.dependencies.select {|d| d.type == :runtime }.map do |d|
+            deps = spec.runtime_dependencies.map do |d|
               reqs = d.requirement.requirements.map {|r| r.join(" ") }.join(", ")
               CompactIndex::Dependency.new(d.name, reqs)
             end

--- a/bundler/spec/support/artifice/helpers/endpoint.rb
+++ b/bundler/spec/support/artifice/helpers/endpoint.rb
@@ -72,7 +72,7 @@ class Endpoint < Sinatra::Base
           name: spec.name,
           number: spec.version.version,
           platform: spec.platform.to_s,
-          dependencies: spec.dependencies.select {|dep| dep.type == :runtime }.map do |dep|
+          dependencies: spec.runtime_dependencies.map do |dep|
             [dep.name, dep.requirement.requirements.map {|a| a.join(" ") }.join(", ")]
           end,
         }


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since https://github.com/rubygems/rubygems/commit/5f24f06bc5d17c2e942f08ece1b7386f5dc5234f, Bundler will automatically complete the resolution it found with extra platforms that are also valid for the resolution that was initially found.

However, if one of the platform specific gems being added brings extra dependencies, the new resolution will never be invalid since we'll be missing the extra dependency.

## What is your fix for the problem, implemented in this PR?

This PR fixes the issue by avoiding the addition of platforms and platform specific gems in the above situation.

Closes #7304.

Builds on top of #7306.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
