### PR TITLE
Changelogs for RubyGems 3.5.2 and Bundler 2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 3.5.2 / 2023-12-21
+
+## Enhancements:
+
+* Support dynamic library loading with extension .so or .o. Pull request
+  [#7241](https://github.com/rubygems/rubygems/pull/7241) by hogelog
+* Installs bundler 2.5.2 as a default gem.
+
+## Performance:
+
+* Replace `object_id` comparison with identity Hash. Pull request
+  [#7303](https://github.com/rubygems/rubygems/pull/7303) by amomchilov
+* Use IO.copy_stream when reading, writing. Pull request
+  [#6958](https://github.com/rubygems/rubygems/pull/6958) by martinemde
+
 # 3.5.1 / 2023-12-15
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 2.5.2 (December 21, 2023)
+
+## Enhancements:
+
+  - Avoid vendored thor gem polluting the global namespace [#7305](https://github.com/rubygems/rubygems/pull/7305)
+
+## Bug fixes:
+
+  - Fix `bundle update --bundler` when latest version does not support current ruby [#7310](https://github.com/rubygems/rubygems/pull/7310)
+  - Fix incorrect lockfiles being generated in some situations [#7307](https://github.com/rubygems/rubygems/pull/7307)
+  - Fix incorrect re-resolve messages [#7306](https://github.com/rubygems/rubygems/pull/7306)
+
 # 2.5.1 (December 15, 2023)
 
 ## Bug fixes:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.5.2 and Bundler 2.5.2 into master.