### PR TITLE
Fix incorrect error when Gemfile overrides a gemspec development dependency

### DIFF
--- a/bundler/lib/bundler/dependency.rb
+++ b/bundler/lib/bundler/dependency.rb
@@ -68,6 +68,10 @@ module Bundler
       @should_include && current_env? && current_platform?
     end
 
+    def gemspec_dev_dep?
+      type == :development
+    end
+
     def current_env?
       return true unless @env
       if @env.is_a?(Hash)

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -108,11 +108,16 @@ module Bundler
         if current.requirement != dep.requirement
           current_requirement_open = current.requirements_list.include?(">= 0")
 
-          if current.gemspec_dev_dep?
-            unless current_requirement_open || dep.gemspec_dev_dep?
-              Bundler.ui.warn "A gemspec development dependency (#{dep.name}, #{current.requirement}) is being overridden by a Gemfile dependency (#{dep.name}, #{dep.requirement}).\n" \
-                              "This behaviour may change in the future. Please remove either of them, or make sure they both have the same requirement\n" \
+          gemspec_dep = [dep, current].find(&:gemspec_dev_dep?)
+          if gemspec_dep
+            gemfile_dep = [dep, current].find(&:runtime?)
+
+            unless current_requirement_open
+              Bundler.ui.warn "A gemspec development dependency (#{gemspec_dep.name}, #{gemspec_dep.requirement}) is being overridden by a Gemfile dependency (#{gemfile_dep.name}, #{gemfile_dep.requirement}).\n" \
+                              "This behaviour may change in the future. Please remove either of them, or make sure they both have the same requirement\n"
             end
+
+            return if dep.gemspec_dev_dep?
           else
             update_prompt = ""
 

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -103,13 +103,13 @@ module Bundler
       # if there's already a dependency with this name we try to prefer one
       if current = @dependencies.find {|d| d.name == dep.name }
         # Always prefer the dependency from the Gemfile
-        deleted_dep = @dependencies.delete(current) if current.type == :development
+        @dependencies.delete(current) if current.gemspec_dev_dep?
 
         if current.requirement != dep.requirement
           current_requirement_open = current.requirements_list.include?(">= 0")
 
-          if current.type == :development
-            unless current_requirement_open || dep.type == :development
+          if current.gemspec_dev_dep?
+            unless current_requirement_open || dep.gemspec_dev_dep?
               Bundler.ui.warn "A gemspec development dependency (#{dep.name}, #{current.requirement}) is being overridden by a Gemfile dependency (#{dep.name}, #{dep.requirement}).\n" \
                               "This behaviour may change in the future. Please remove either of them, or make sure they both have the same requirement\n" \
             end
@@ -130,8 +130,8 @@ module Bundler
                            "You specified: #{current.name} (#{current.requirement}) and #{dep.name} (#{dep.requirement})" \
                            "#{update_prompt}"
           end
-        elsif current.type == :development || dep.type == :development
-          return if deleted_dep.nil?
+        elsif current.gemspec_dev_dep? || dep.gemspec_dev_dep?
+          return if dep.gemspec_dev_dep?
         elsif current.source != dep.source
           raise GemfileError, "You cannot specify the same gem twice coming from different sources.\n" \
                           "You specified that #{dep.name} (#{dep.requirement}) should come from " \


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We added a warning when gemspec development dependencies are being overridden, but it was incorrect in certain situations and causing a hard error.

## What is your fix for the problem, implemented in this PR?

Properly account of the potential different parsing order between Gemfile and gemspec development dependencies.

Fixes https://github.com/rubygems/rubygems/pull/6014#issuecomment-1865266444.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
