### PR TITLE
Changelogs for RubyGems 3.5.3 and Bundler 2.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.5.3 / 2023-12-22
+
+## Enhancements:
+
+* Installs bundler 2.5.3 as a default gem.
+
 # 3.5.2 / 2023-12-21
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.5.3 (December 22, 2023)
+
+## Bug fixes:
+
+  - Fix incorrect error when Gemfile overrides a gemspec development dependency [#7319](https://github.com/rubygems/rubygems/pull/7319)
+
 # 2.5.2 (December 21, 2023)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.5.3 and Bundler 2.5.3 into master.