### PR TITLE
Fix resolution when different platform specific gems have different dependencies

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -312,10 +312,6 @@ module Bundler
       end
     end
 
-    def should_complete_platforms?
-      !lockfile_exists? && generic_local_platform_is_ruby? && !Bundler.settings[:force_ruby_platform]
-    end
-
     def spec_git_paths
       sources.git_sources.map {|s| File.realpath(s.path) if File.exist?(s.path) }.compact
     end
@@ -516,6 +512,10 @@ module Bundler
     end
 
     private
+
+    def should_complete_platforms?
+      !lockfile_exists? && generic_local_platform_is_ruby? && !Bundler.settings[:force_ruby_platform]
+    end
 
     def lockfile_exists?
       lockfile && File.exist?(lockfile)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -602,6 +602,8 @@ module Bundler
       @resolved_bundler_version = result.find {|spec| spec.name == "bundler" }&.version
       @platforms = result.add_extra_platforms!(platforms) if should_add_extra_platforms?
 
+      result.complete_platforms!(platforms)
+
       SpecSet.new(result.for(dependencies, false, @platforms))
     end
 

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -513,7 +513,7 @@ module Bundler
 
     private
 
-    def should_complete_platforms?
+    def should_add_extra_platforms?
       !lockfile_exists? && generic_local_platform_is_ruby? && !Bundler.settings[:force_ruby_platform]
     end
 
@@ -600,7 +600,7 @@ module Bundler
       result = SpecSet.new(resolver.start)
 
       @resolved_bundler_version = result.find {|spec| spec.name == "bundler" }&.version
-      @platforms = result.complete_platforms!(platforms) if should_complete_platforms?
+      @platforms = result.add_extra_platforms!(platforms) if should_add_extra_platforms?
 
       SpecSet.new(result.for(dependencies, false, @platforms))
     end

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -71,6 +71,12 @@ module Bundler
       platforms
     end
 
+    def complete_platforms!(platforms)
+      platforms.each do |platform|
+        complete_platform(platform)
+      end
+    end
+
     def validate_deps(s)
       s.runtime_dependencies.each do |dep|
         next if dep.name == "bundler"

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -52,7 +52,7 @@ module Bundler
       specs.uniq
     end
 
-    def complete_platforms!(platforms)
+    def add_extra_platforms!(platforms)
       return platforms.concat([Gem::Platform::RUBY]).uniq if @specs.empty?
 
       new_platforms = @specs.flat_map {|spec| spec.source.specs.search([spec.name, spec.version]).map(&:platform) }.uniq.select do |platform|

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -86,8 +86,7 @@ module Bundler
       less_specific_platform = new_platforms.find {|platform| platform != Gem::Platform::RUBY && platform === Bundler.local_platform }
       platforms.delete(Bundler.local_platform) if less_specific_platform
 
-      @sorted = nil
-      @lookup = nil
+      reset!
 
       platforms
     end
@@ -110,14 +109,14 @@ module Bundler
 
     def []=(key, value)
       @specs << value
-      @lookup = nil
-      @sorted = nil
+
+      reset!
     end
 
     def delete(specs)
       specs.each {|spec| @specs.delete(spec) }
-      @lookup = nil
-      @sorted = nil
+
+      reset!
     end
 
     def sort!
@@ -175,8 +174,8 @@ module Bundler
 
     def delete_by_name(name)
       @specs.reject! {|spec| spec.name == name }
-      @lookup = nil
-      @sorted = nil
+
+      reset!
     end
 
     def what_required(spec)
@@ -211,6 +210,11 @@ module Bundler
     end
 
     private
+
+    def reset!
+      @sorted = nil
+      @lookup = nil
+    end
 
     def valid_dependencies?(s)
       validate_deps(s) == :valid

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -68,8 +68,6 @@ module Bundler
       less_specific_platform = new_platforms.find {|platform| platform != Gem::Platform::RUBY && platform === Bundler.local_platform }
       platforms.delete(Bundler.local_platform) if less_specific_platform
 
-      reset!
-
       platforms
     end
 
@@ -209,14 +207,18 @@ module Bundler
         end
 
         if platform_spec
-          new_specs << LazySpecification.from_spec(platform_spec)
+          new_specs << LazySpecification.from_spec(platform_spec) unless specs.include?(platform_spec)
           true
         else
           false
         end
       end
 
-      @specs.concat(new_specs.uniq) if valid_platform
+      if valid_platform && new_specs.any?
+        @specs.concat(new_specs)
+
+        reset!
+      end
 
       valid_platform
     end

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -55,29 +55,11 @@ module Bundler
     def add_extra_platforms!(platforms)
       return platforms.concat([Gem::Platform::RUBY]).uniq if @specs.empty?
 
-      new_platforms = @specs.flat_map {|spec| spec.source.specs.search([spec.name, spec.version]).map(&:platform) }.uniq.select do |platform|
+      new_platforms = all_platforms.select do |platform|
         next if platforms.include?(platform)
         next unless GemHelpers.generic(platform) == Gem::Platform::RUBY
 
-        new_specs = []
-
-        valid_platform = lookup.all? do |_, specs|
-          spec = specs.first
-          matching_specs = spec.source.specs.search([spec.name, spec.version])
-          platform_spec = GemHelpers.select_best_platform_match(matching_specs, platform).find do |s|
-            s.matches_current_metadata? && valid_dependencies?(s)
-          end
-
-          if platform_spec
-            new_specs << LazySpecification.from_spec(platform_spec)
-            true
-          else
-            false
-          end
-        end
-        next unless valid_platform
-
-        @specs.concat(new_specs.uniq)
+        complete_platform(platform)
       end
       return platforms if new_platforms.empty?
 
@@ -214,6 +196,33 @@ module Bundler
     def reset!
       @sorted = nil
       @lookup = nil
+    end
+
+    def complete_platform(platform)
+      new_specs = []
+
+      valid_platform = lookup.all? do |_, specs|
+        spec = specs.first
+        matching_specs = spec.source.specs.search([spec.name, spec.version])
+        platform_spec = GemHelpers.select_best_platform_match(matching_specs, platform).find do |s|
+          s.matches_current_metadata? && valid_dependencies?(s)
+        end
+
+        if platform_spec
+          new_specs << LazySpecification.from_spec(platform_spec)
+          true
+        else
+          false
+        end
+      end
+
+      @specs.concat(new_specs.uniq) if valid_platform
+
+      valid_platform
+    end
+
+    def all_platforms
+      @specs.flat_map {|spec| spec.source.specs.search([spec.name, spec.version]).map(&:platform) }.uniq
     end
 
     def valid_dependencies?(s)

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -86,7 +86,7 @@ module Spec
         puts success_message
         puts
       else
-        system("git status --porcelain")
+        system("git diff")
 
         puts
         puts error_message

--- a/tool/bundler/dev_gems.rb.lock
+++ b/tool/bundler/dev_gems.rb.lock
@@ -11,6 +11,8 @@ GEM
     nokogiri (1.15.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nokogiri (1.15.5-java)
+      racc (~> 1.4)
     nronn (0.11.1)
       kramdown (~> 2.1)
       kramdown-parser-gfm (>= 1.0.1, < 1.2)
@@ -81,6 +83,7 @@ CHECKSUMS
   mini_portile2 (2.8.5) sha256=7a37db8ae758086c3c3ac3a59c036704d331e965d5e106635e4a42d6e66089ce
   mustache (1.1.1) sha256=90891fdd50b53919ca334c8c1031eada1215e78d226d5795e523d6123a2717d0
   nokogiri (1.15.5) sha256=22448ca35dbcbdcec60dbe25ccf452b685a5436c28f21b2fec2e20917aba9100
+  nokogiri (1.15.5-java) sha256=5f87e71aaeb4f7479b94698737a0aacea77836b4805c7433b655e9565bd56cfe
   nronn (0.11.1) sha256=60305c7a42dcaf6bdd33210993a7e38087520717561da101bea1df7197546369
   parallel (1.23.0) sha256=27154713ad6ef32fa3dcb7788a721d6c07bca77e72443b4c6080a14145288c49
   parallel_tests (3.8.1) sha256=c781c0910be3b489411f24e3a3397d57f481d6ee4eb27dba2a1cd4b8a0967f06


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If two platform specific variants of the same gem version have different dependencies, our resolver may fallback to picking only the RUBY variant. However, _some_ platform specific gems may still be compatible with the resolution.

## What is your fix for the problem, implemented in this PR?

Do one pass after resolution completing platforms specific gems that may be compatible.

Fixes #7321.
 
## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
