### PR TITLE
Fix daily CI

### DIFF
--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -1380,7 +1380,7 @@ RSpec.describe "bundle update --bundler" do
       build_bundler "999.0.0"
     end
 
-    install_gemfile <<-G
+    install_gemfile <<-G, artifice: nil, env: { "BUNDLER_IGNORE_DEFAULT_GEM" => "true" }
       source "#{file_uri_for(gem_repo4)}"
       gem "rack"
     G


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Another place where `artifice` usage was making the copy of vendored http in ruby-core be loaded instead of the one under test.

## What is your fix for the problem, implemented in this PR?

Remove unnecessary artifice usage.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
