### PR TITLE
Use cache_home instead of data_home in default_spec_cache_dir

### DIFF
--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -24,7 +24,7 @@ module Gem
     default_spec_cache_dir = File.join Gem.user_home, ".gem", "specs"
 
     unless File.exist?(default_spec_cache_dir)
-      default_spec_cache_dir = File.join Gem.data_home, "gem", "specs"
+      default_spec_cache_dir = File.join Gem.cache_home, "gem", "specs"
     end
 
     default_spec_cache_dir


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

This isn't a pragmatic problem for end-users and developers.
I found just an inconsistency in using XDG's directories.

## What is your fix for the problem, implemented in this PR?

Replace the base directory of `default_spec_cache_dir` from `Gem.data_dir` to `Gem.cache_dir`.
I guess `Gem.cache_dir` is appropriate for the base dir of `default_spec_cache_dir`.

## Make sure the following tasks are checked

I don't think we need to add any new tests for this change.

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)