### PR TITLE
Make `gem update --system` respect ruby version constraints

### DIFF
--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -282,7 +282,7 @@ command to remove old versions.
     check_oldest_rubygems version
 
     installed_gems = Gem::Specification.find_all_by_name "rubygems-update", requirement
-    installed_gems = update_gem("rubygems-update", version) if installed_gems.empty? || installed_gems.first.version != version
+    installed_gems = update_gem("rubygems-update", requirement) if installed_gems.empty? || installed_gems.first.version != version
     return if installed_gems.empty?
 
     install_rubygems installed_gems.first

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -294,9 +294,7 @@ command to remove old versions.
     args << "--prefix" << Gem.prefix if Gem.prefix
     args << "--no-document" unless options[:document].include?("rdoc") || options[:document].include?("ri")
     args << "--no-format-executable" if options[:no_format_executable]
-    args << "--previous-version" << Gem::VERSION if
-      options[:system] == true ||
-      Gem::Version.new(options[:system]) >= Gem::Version.new(2)
+    args << "--previous-version" << Gem::VERSION
     args
   end
 

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -130,6 +130,34 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
     assert_empty err
   end
 
+  def test_execute_system_when_latest_does_not_support_your_ruby_but_previous_one_does
+    spec_fetcher do |fetcher|
+      fetcher.download "rubygems-update", 9 do |s|
+        s.files = %w[setup.rb]
+        s.required_ruby_version = "> 9"
+      end
+
+      fetcher.download "rubygems-update", 8 do |s|
+        s.files = %w[setup.rb]
+      end
+    end
+
+    @cmd.options[:args]          = []
+    @cmd.options[:system]        = true
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    err = @ui.error.split "\n"
+    assert_empty err
+
+    out = @ui.output.split "\n"
+    assert_equal "Installing RubyGems 8", out.shift
+    assert_equal "RubyGems system software updated", out.shift
+    assert_empty out
+  end
+
   def test_execute_system_multiple
     spec_fetcher do |fetcher|
       fetcher.download "rubygems-update", 8 do |s|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I thought `gem update --system` used the same `gem install` logic under the hood, so after `gem install` was fixed to respect ruby version constraints, it would also respect them.

However, that's not the case.

## What is your fix for the problem, implemented in this PR?

Remove code to resolve `rubygems-update` version manually, and instead let the resolver do its job.

Fixes #7329.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
