### PR TITLE
Add Ruby 3.3 on Windows to CI

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -47,6 +47,7 @@ jobs:
           - { os: { name: Windows, value: windows-2022 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.0, value: 3.0.6 }, timeout: 150 }
           - { os: { name: Windows, value: windows-2022 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.4 }, timeout: 150 }
           - { os: { name: Windows, value: windows-2022 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.2, value: 3.2.2 }, timeout: 150 }
+          - { os: { name: Windows, value: windows-2022 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.3, value: 3.3.0 }, timeout: 150 }
 
     env:
       RGV: ..

--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -98,6 +98,7 @@ jobs:
         ruby:
           - { name: "3.1", value: 3.1.4 } # Rails 7
           - { name: "3.2", value: 3.2.2 } # Rails 7
+          - { name: "3.3", value: 3.3.0 } # Rails 7
           - { name: jruby-9.4, value: jruby-9.4.2.0, rails-args: "--skip-webpack-install" } # Rails 6
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -42,10 +42,6 @@ jobs:
           - os: { name: Windows, value: windows-2022 }
             ruby: { name: mswin, value: mswin }
 
-        exclude:
-          - os: { name: Windows, value: windows-2022 }
-            ruby: { name: "3.3", value: 3.3.0 }
-
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Setup ruby (Ubuntu/macOS)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Ruby 3.3 is now available on Windows.

## What is your fix for the problem, implemented in this PR?

Test against that.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
