### PR TITLE
Make bin/rubocop resolve config relative to itself

### DIFF
--- a/bin/rubocop
+++ b/bin/rubocop
@@ -7,6 +7,6 @@ ENV["BUNDLE_GEMFILE"] = File.expand_path("../tool/bundler/lint_gems.rb", __dir__
 require "bundler/setup"
 
 # explicit rubocop config increases performance slightly while avoiding config confusion.
-ARGV.unshift("--config", ".rubocop.yml")
+ARGV.unshift("--config", File.expand_path("../.rubocop.yml", __dir__))
 
 load Gem.bin_path("rubocop", "rubocop")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Running `../bin/rubocop` from the bundler dir fails to find the config.

## What is your fix for the problem, implemented in this PR?

Resolve the config file properly.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
