### PR TITLE
Improve gem login scope selection

### DIFF
--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -306,7 +306,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
     ENV["RUBYGEMS_HOST"] = @fetcher.host
     Gem::RemoteFetcher.fetcher = @fetcher
 
-    @sign_in_ui = Gem::MockGemUi.new("#{email}\n#{password}\n\n\n\n\n\n\n\n\n" + extra_input)
+    @sign_in_ui = Gem::MockGemUi.new("#{email}\n#{password}\n\n\n" + extra_input)
 
     use_ui @sign_in_ui do
       if args.length > 0


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?
Gem login api scopes is confusing and difficult as show_dashboard permission invalidates the rest.
More details in issue https://github.com/rubygems/rubygems/issues/7238
<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?
Enhance scope selection by prompting first exclusively scopes and message about when one of those is selected (other scopes will be disabled). updated prompt:

```
Enter your RubyGems.org credentials.
Don't have an account yet? Create one at https://rubygems.org/sign_up
   Email:   [redacted]
Password:   [redacted]

API Key name [redacted]:   test
The default access scope is:
  index_rubygems: y

Do you want to customise scopes? [yN]  y
show_dashboard [yN]  y
You selected show_dashboard, which must be enabled exclusively. Other scopes will be disabled.
Is this fine? (type no for selecting other scopes) [Yn]  y
...
```
<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
