### PR TITLE
Default to gmake for BSD and Solaris

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -27,7 +27,15 @@ class Gem::Ext::Builder
     # try to find make program from Ruby configure arguments first
     RbConfig::CONFIG["configure_args"] =~ /with-make-prog\=(\w+)/
     make_program_name = ENV["MAKE"] || ENV["make"] || $1
-    make_program_name ||= RUBY_PLATFORM.include?("mswin") ? "nmake" : "make"
+    make_program_name ||=
+      case RUBY_PLATFORM
+      when /mswin/
+        "nmake"
+      when /(bsd|solaris)/
+        "gmake"
+      else
+        "make"
+      end
     make_program = Shellwords.split(make_program_name)
 
     # The installation of the bundled gems is failed when DESTDIR is empty in mswin platform.


### PR DESCRIPTION
The BSD `make` is not compatible with many directives in GNU make. For FreeBSD and Solaris systems, default to `gmake` so that native gem builds work without having to specify `MAKE=gmake` in the environment.

Relates to:
* https://github.com/oxidize-rb/rb-sys/issues/299
* https://github.com/redis/hiredis-rb/issues/23

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
