### PR TITLE
Changelogs for RubyGems 3.5.4 and Bundler 2.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 3.5.4 / 2024-01-03
+
+## Enhancements:
+
+* Always avoid "Updating rubygems-update" message. Pull request
+  [#7335](https://github.com/rubygems/rubygems/pull/7335) by
+  deivid-rodriguez
+* Installs bundler 2.5.4 as a default gem.
+
+## Bug fixes:
+
+* Make `gem update --system` respect ruby version constraints. Pull
+  request [#7334](https://github.com/rubygems/rubygems/pull/7334) by
+  deivid-rodriguez
+
 # 3.5.3 / 2023-12-22
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.5.4 (January 3, 2024)
+
+## Bug fixes:
+
+  - Fix resolution when different platform specific gems have different dependencies [#7324](https://github.com/rubygems/rubygems/pull/7324)
+
 # 2.5.3 (December 22, 2023)
 
 ## Bug fixes:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.5.4 and Bundler 2.5.4 into master.