### PR TITLE
Remove tip on how to disable documentation generation

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -222,9 +222,6 @@ By default, this RubyGems will install gem as:
         say "  gem server"
         say "and then peruse beautifully formatted documentation for your gems"
         say "with your web browser."
-        say "If you do not wish to install this documentation in the future, use the"
-        say "--no-document flag, or set it as the default in your ~/.gemrc file. See"
-        say "'gem help env' for details."
         say
       end
 
@@ -234,9 +231,6 @@ By default, this RubyGems will install gem as:
         say "  ri Classname"
         say "  ri Classname.class_method"
         say "  ri Classname#instance_method"
-        say "If you do not wish to install this documentation in the future, use the"
-        say "--no-document flag, or set it as the default in your ~/.gemrc file. See"
-        say "'gem help env' for details."
         say
       end
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We should be encouraging more Ruby documentation, and having a very visible guide on how to disable documentation generation is counterproductive.

## What is your fix for the problem, implemented in this PR?

Removed the suggestion on how to disable documentation generation during gem install.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
