### PR TITLE
Fix development dependency not being added if introduced by two gemspecs

### DIFF
--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -102,9 +102,6 @@ module Bundler
 
       # if there's already a dependency with this name we try to prefer one
       if current = @dependencies.find {|d| d.name == dep.name }
-        # Always prefer the dependency from the Gemfile
-        @dependencies.delete(current) if current.gemspec_dev_dep?
-
         if current.requirement != dep.requirement
           current_requirement_open = current.requirements_list.include?(">= 0")
 
@@ -116,8 +113,6 @@ module Bundler
               Bundler.ui.warn "A gemspec development dependency (#{gemspec_dep.name}, #{gemspec_dep.requirement}) is being overridden by a Gemfile dependency (#{gemfile_dep.name}, #{gemfile_dep.requirement}).\n" \
                               "This behaviour may change in the future. Please remove either of them, or make sure they both have the same requirement\n"
             end
-
-            return if dep.gemspec_dev_dep?
           else
             update_prompt = ""
 
@@ -135,8 +130,13 @@ module Bundler
                            "You specified: #{current.name} (#{current.requirement}) and #{dep.name} (#{dep.requirement})" \
                            "#{update_prompt}"
           end
-        elsif current.gemspec_dev_dep? || dep.gemspec_dev_dep?
-          return if dep.gemspec_dev_dep?
+        end
+
+        # Always prefer the dependency from the Gemfile
+        if current.gemspec_dev_dep?
+          @dependencies.delete(current)
+        elsif dep.gemspec_dev_dep?
+          return
         elsif current.source != dep.source
           raise GemfileError, "You cannot specify the same gem twice coming from different sources.\n" \
                           "You specified that #{dep.name} (#{dep.requirement}) should come from " \


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If two gemspecs add the same development dependency with the same requirement, the dependency was being silently ignored.

## What is your fix for the problem, implemented in this PR?

Fix the logic to consider the dependency.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
