### PR TITLE
Add .ruby-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.rbc
 *.swp
+.ruby-version
 .DS_Store
 /.idea
 /.rdoc


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The [discussion](https://github.com/rubygems/rubygems/discussions/7074) about `.ruby-version` made me realize one of the minor annoyances with this repo is that it doesn't auto-switch to the ruby I want to use for development.

## What is your fix for the problem, implemented in this PR?

Allow `.ruby-version` to exist, ignored by git, so that chruby and the like can switch automatically but not have it impact anything besides local dev.

The only reason not to do this is if we thought it would encourage some bad behavior. Personally I always switch to the same ruby for working or rubygems anyway, or use the default. This just makes it automatic if you choose to do so, and doesn't require your default to be the same as what you use for rubygems development.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
