### PR TITLE
include MatchMetadata in Bundler::LazySpecification

### DIFF
--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -4,6 +4,7 @@ require_relative "force_platform"
 
 module Bundler
   class LazySpecification
+    include MatchMetadata
     include MatchPlatform
     include ForcePlatform
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

My bundler plugin manually resolves a definition, and is running into this error:

```
NoMethodError: undefined method `matches_current_metadata?' for #<Bundler::LazySpecification:0x0000000119c344b0 @name="sqlite3", @version=#<Gem::Version "1.6.9">, @dependencies=[], @required_ruby_version=#<Gem::Requirement:0x0000000119c34460 @requirements=[[">=", #<Gem::Version "0">]]>, @required_rubygems_version=#<Gem::Requirement:0x0000000119c34320 @requirements=[[">=", #<Gem::Version "0">]]>, @platform=#<Gem::Platform:0x0000000119c34640 @cpu="aarch64", @os="linux", @version=nil>, @source=#<Bundler::Source::Rubygems:0x24300 locally installed gems>, @force_ruby_platform=false, @full_name="sqlite3-1.6.9-aarch64-linux">

          s.matches_current_metadata? && valid_dependencies?(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/spec_set.rb:212:in `block (2 levels) in complete_platform'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/spec_set.rb:211:in `each'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/spec_set.rb:211:in `find'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/spec_set.rb:211:in `block in complete_platform'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/spec_set.rb:208:in `each'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/spec_set.rb:208:in `all?'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/spec_set.rb:208:in `complete_platform'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/spec_set.rb:76:in `block in complete_platforms!'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/spec_set.rb:75:in `each'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/spec_set.rb:75:in `complete_platforms!'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/definition.rb:605:in `start_resolution'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/definition.rb:311:in `resolve'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/definition.rb:170:in `resolve_with_cache!'
         /Users/cody/src/bundler-multilock/lib/bundler/multilock.rb:464:in `write_lockfile'
          /Users/cody/src/bundler-multilock/lib/bundler/multilock.rb:265:in `block (3 levels) in after_install_all'
          /Users/cody/.rubies/ruby-3.1.3/lib/ruby/3.1.0/tempfile.rb:358:in `create'
          /Users/cody/src/bundler-multilock/lib/bundler/multilock.rb:261:in `block (2 levels) in after_install_all'
          /Users/cody/src/bundler-multilock/lib/bundler/multilock.rb:158:in `each'
          /Users/cody/src/bundler-multilock/lib/bundler/multilock.rb:158:in `block in after_install_all'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/settings.rb:158:in `temporary'
          /Users/cody/src/bundler-multilock/lib/bundler/multilock.rb:157:in `after_install_all'
          /Users/cody/src/bundler-multilock/plugins.rb:24:in `block in <top (required)>'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/plugin.rb:233:in `block in hook'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/plugin.rb:233:in `each'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/plugin.rb:233:in `hook'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/installer.rb:24:in `install'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/cli/update.rb:79:in `run'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/cli.rb:277:in `block in update'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/settings.rb:158:in `temporary'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/cli.rb:276:in `update'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/vendor/thor/lib/thor/command.rb:28:in `run'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/vendor/thor/lib/thor.rb:527:in `dispatch'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/cli.rb:34:in `dispatch'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/vendor/thor/lib/thor/base.rb:584:in `start'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/cli.rb:28:in `start'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/exe/bundle:28:in `block in <top (required)>'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
          /Users/cody/.gem/ruby/3.1.3/gems/bundler-2.5.4/exe/bundle:20:in `<top (required)>'
          /Users/cody/src/canvas-lms/bin/bundle:131:in `load'
          /Users/cody/src/canvas-lms/bin/bundle:131:in `<main>'
```

## What is your fix for the problem, implemented in this PR?

Make sure the method is available on LazySpecification, not just Gem::Specification.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
