### PR TITLE
Removed redundant block for test helper

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -105,7 +105,7 @@ class Gem::TestCase < Test::Unit::TestCase
     refute File.directory?(path), msg
   end
 
-  # https://github.com/seattlerb/minitest/blob/21d9e804b63c619f602f3f4ece6c71b48974707a/lib/minitest/assertions.rb#L546
+  # Originally copied from minitest/assertions.rb
   def capture_subprocess_io
     require "tempfile"
 

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -122,7 +122,7 @@ class Gem::TestCase < Test::Unit::TestCase
     $stdout.rewind
     $stderr.rewind
 
-    return captured_stdout.read, captured_stderr.read
+    [captured_stdout.read, captured_stderr.read]
   ensure
     $stdout.reopen orig_stdout
     $stderr.reopen orig_stderr

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -105,39 +105,32 @@ class Gem::TestCase < Test::Unit::TestCase
     refute File.directory?(path), msg
   end
 
-  # https://github.com/seattlerb/minitest/blob/21d9e804b63c619f602f3f4ece6c71b48974707a/lib/minitest/assertions.rb#L188
-  def _synchronize
-    yield
-  end
-
   # https://github.com/seattlerb/minitest/blob/21d9e804b63c619f602f3f4ece6c71b48974707a/lib/minitest/assertions.rb#L546
   def capture_subprocess_io
-    _synchronize do
-      require "tempfile"
+    require "tempfile"
 
-      captured_stdout = Tempfile.new("out")
-      captured_stderr = Tempfile.new("err")
+    captured_stdout = Tempfile.new("out")
+    captured_stderr = Tempfile.new("err")
 
-      orig_stdout = $stdout.dup
-      orig_stderr = $stderr.dup
-      $stdout.reopen captured_stdout
-      $stderr.reopen captured_stderr
+    orig_stdout = $stdout.dup
+    orig_stderr = $stderr.dup
+    $stdout.reopen captured_stdout
+    $stderr.reopen captured_stderr
 
-      yield
+    yield
 
-      $stdout.rewind
-      $stderr.rewind
+    $stdout.rewind
+    $stderr.rewind
 
-      return captured_stdout.read, captured_stderr.read
-    ensure
-      $stdout.reopen orig_stdout
-      $stderr.reopen orig_stderr
+    return captured_stdout.read, captured_stderr.read
+  ensure
+    $stdout.reopen orig_stdout
+    $stderr.reopen orig_stderr
 
-      orig_stdout.close
-      orig_stderr.close
-      captured_stdout.close!
-      captured_stderr.close!
-    end
+    orig_stdout.close
+    orig_stderr.close
+    captured_stdout.close!
+    captured_stderr.close!
   end
 
   ##


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

There is no problem. This is only cosmetic.

## What is your fix for the problem, implemented in this PR?

Removed redundant block on `test/rubygems/helper.rb`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
