### PR TITLE
Allow `extconf.rb` to cancel building the extension

### DIFF
--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -37,6 +37,10 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
         end
       end
 
+      if File.exist?(File.join(extension_dir, "gem.build_skipped"))
+        return ["Skipping the extension build"]
+      end
+
       ENV["DESTDIR"] = nil
 
       make dest_path, results, extension_dir, tmp_dest_relative

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1416,6 +1416,27 @@ dependencies: []
     assert_path_not_exist spec.extension_dir
   end
 
+  def test_extconf_skip_build
+    ext_spec
+
+    assert_path_not_exist @ext.extension_dir, "sanity check"
+    refute_empty @ext.extensions, "sanity check"
+
+    extconf_rb = File.join @ext.gem_dir, @ext.extensions.first
+    FileUtils.mkdir_p File.dirname extconf_rb
+
+    File.open extconf_rb, "w" do |f|
+      f.write <<-'RUBY'
+        File.write("gem.build_skipped", "")
+        File.write("Makefile", "syntax-error")
+      RUBY
+    end
+
+    @ext.build_extensions
+
+    assert_path_exist @ext.extension_dir
+  end
+
   def test_build_extensions_error
     pend "extensions don't quite work on jruby" if Gem.java_platform?
     ext_spec


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/20152

There are various gems that ship with a native extension as a way to speedup part of the gem, but also ship with a pure Ruby version of these methods as a fallback. So they only want to compile the extension if the platform supports it, and if not, just fallback Ruby implementation.

Right now users rely on one of two hacks to do this. Either they create an empty Makefile, but then still depend on make being available and it feels very hacky, or they publish platform specific packages without any extension in them.

Examples include `bootnsap`, `erb`, `hiredis-client`, `ddtrace`, `prism`.

This changes attempt to make this use case a first class citizen by checking if the `extconf.rb` did generate a `gem.build_skipped` file. If it did, `make` isn't invoked at all.
