### PR TITLE
Update documentation to use squiggly heredoc

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -301,7 +301,7 @@ class Gem::Specification < Gem::BasicSpecification
   #
   # Usage:
   #
-  #   spec.description = <<-EOF
+  #   spec.description = <<~EOF
   #     Rake is a Make-like program implemented in Ruby. Tasks and
   #     dependencies are specified in standard Ruby syntax.
   #   EOF


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Using a non-squiggly heredoc adds leading whitespace in the gem description. [rubygems.org](https://rubygems.org/) seems to handle this fine (by relying on HTML ignoring it), but in other contexts it can make it difficult to render the text (e.g. [in an editor using an LSP](https://github.com/Shopify/ruby-lsp/pull/1279)).

(also see https://github.com/rubygems/guides/pull/352)

## What is your fix for the problem, implemented in this PR?

Use a squiggly heredoc in the specification documentation.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
