### PR TITLE
Refactor setting ENV and ruby flags when shelling out during specs

### DIFF
--- a/bundler/lib/bundler/self_manager.rb
+++ b/bundler/lib/bundler/self_manager.rb
@@ -70,24 +70,9 @@ module Bundler
       configured_gem_home = ENV["GEM_HOME"]
       configured_gem_path = ENV["GEM_PATH"]
 
-      # Bundler specs need some stuff to be required before Bundler starts
-      # running, for example, for faking the compact index API. However, these
-      # flags are lost when we reexec to a different version of Bundler. In the
-      # future, we may be able to properly reconstruct the original Ruby
-      # invocation (see https://bugs.ruby-lang.org/issues/6648), but for now
-      # there's no way to do it, so we need to be explicit about how to re-exec.
-      # This may be a feature end users request at some point, but maybe by that
-      # time, we have builtin tools to do. So for now, we use an undocumented
-      # ENV variable only for our specs.
-      bundler_spec_original_cmd = ENV["BUNDLER_SPEC_ORIGINAL_CMD"]
-      if bundler_spec_original_cmd
-        require "shellwords"
-        cmd = [*Shellwords.shellsplit(bundler_spec_original_cmd), *ARGV]
-      else
-        argv0 = File.exist?($PROGRAM_NAME) ? $PROGRAM_NAME : Process.argv0
-        cmd = [argv0, *ARGV]
-        cmd.unshift(Gem.ruby) unless File.executable?(argv0)
-      end
+      argv0 = File.exist?($PROGRAM_NAME) ? $PROGRAM_NAME : Process.argv0
+      cmd = [argv0, *ARGV]
+      cmd.unshift(Gem.ruby) unless File.executable?(argv0)
 
       Bundler.with_original_env do
         Kernel.exec(

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe "bundle exec" do
       end
 
       it "uses version provided by ruby" do
-        bundle "exec erb --version", artifice: nil
+        bundle "exec erb --version"
 
         expect(stdboth).to eq(default_erb_version)
       end
@@ -227,7 +227,7 @@ RSpec.describe "bundle exec" do
       end
 
       it "uses version specified" do
-        bundle "exec erb --version", artifice: nil
+        bundle "exec erb --version"
 
         expect(stdboth).to eq(specified_erb_version)
       end
@@ -254,7 +254,7 @@ RSpec.describe "bundle exec" do
       end
 
       it "uses resolved version" do
-        bundle "exec erb --version", artifice: nil
+        bundle "exec erb --version"
 
         expect(stdboth).to eq(indirect_erb_version)
       end
@@ -583,7 +583,7 @@ RSpec.describe "bundle exec" do
     G
 
     bundle "config set auto_install 1"
-    bundle "exec myrackup"
+    bundle "exec myrackup", artifice: "compact_index"
     expect(out).to include("Installing foo 1.0")
   end
 
@@ -598,7 +598,7 @@ RSpec.describe "bundle exec" do
     G
 
     bundle "config set auto_install 1"
-    bundle "exec foo"
+    bundle "exec foo", artifice: "compact_index"
     expect(out).to include("Fetching myrack 0.9.1")
     expect(out).to include("Fetching #{lib_path("foo-1.0")}")
     expect(out.lines).to end_with("1.0")
@@ -625,7 +625,7 @@ RSpec.describe "bundle exec" do
       gem "fastlane"
     G
 
-    bundle "exec fastlane"
+    bundle "exec fastlane", artifice: "compact_index"
     expect(out).to include("Installing optparse 999.999.999")
     expect(out).to include("2.192.0")
   end
@@ -1250,9 +1250,9 @@ RSpec.describe "bundle exec" do
 
         env = { "PATH" => path }
         aggregate_failures do
-          expect(bundle("exec #{file}", artifice: nil, env: env)).to eq(default_openssl_version)
-          expect(bundle("exec bundle exec #{file}", artifice: nil, env: env)).to eq(default_openssl_version)
-          expect(bundle("exec ruby #{file}", artifice: nil, env: env)).to eq(default_openssl_version)
+          expect(bundle("exec #{file}", env: env)).to eq(default_openssl_version)
+          expect(bundle("exec bundle exec #{file}", env: env)).to eq(default_openssl_version)
+          expect(bundle("exec ruby #{file}", env: env)).to eq(default_openssl_version)
           expect(run(file.read, artifice: nil, env: env)).to eq(default_openssl_version)
         end
 

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -1558,7 +1558,7 @@ RSpec.describe "bundle update --bundler" do
     G
     lockfile lockfile.sub(/(^\s*)#{Bundler::VERSION}($)/, "2.99.9")
 
-    bundle :update, bundler: true, verbose: true, preserve_ruby_flags: true, env: { "BUNDLER_4_MODE" => nil }
+    bundle :update, bundler: true, verbose: true, env: { "BUNDLER_4_MODE" => nil }
 
     expect(out).to include("Updating bundler to 999.0.0")
     expect(out).to include("Running `bundle update --bundler \"> 0.a\" --verbose` with bundler 999.0.0")

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -742,7 +742,7 @@ RSpec.describe "compact index api" do
         gem "myrack"
       G
 
-      bundle :install, env: { "RUBYOPT" => opt_add("-I#{bundled_app("broken_ssl")}", ENV["RUBYOPT"]) }, raise_on_error: false, artifice: nil
+      bundle :install, env: { "RUBYOPT" => "-I#{bundled_app("broken_ssl")}" }, raise_on_error: false, artifice: nil
       expect(err).to include("recompile Ruby").and include("cannot load such file")
     end
   end

--- a/bundler/spec/install/gems/dependency_api_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_spec.rb
@@ -712,7 +712,7 @@ RSpec.describe "gemcutter's dependency API" do
         gem "myrack"
       G
 
-      bundle :install, artifice: "fail", env: { "RUBYOPT" => opt_add("-I#{bundled_app("broken_ssl")}", ENV["RUBYOPT"]) }, raise_on_error: false
+      bundle :install, artifice: "fail", env: { "RUBYOPT" => "-I#{bundled_app("broken_ssl")}" }, raise_on_error: false
       expect(err).to include("recompile Ruby").and include("cannot load such file")
     end
   end

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe "the lockfile format" do
          #{version}
     L
 
-    install_gemfile <<-G, verbose: true, preserve_ruby_flags: true, env: { "BUNDLER_4_MODE" => nil }
+    install_gemfile <<-G, verbose: true, env: { "BUNDLER_4_MODE" => nil }
       source "https://gem.repo4"
 
       gem "myrack"

--- a/bundler/spec/runtime/env_helpers_spec.rb
+++ b/bundler/spec/runtime/env_helpers_spec.rb
@@ -62,9 +62,6 @@ RSpec.describe "env helpers" do
     end
 
     it "removes variables that bundler added", :ruby_repo do
-      # Simulate bundler has not yet been loaded
-      ENV.replace(ENV.to_hash.delete_if {|k, _v| k.start_with?(Bundler::EnvironmentPreserver::BUNDLER_PREFIX) })
-
       original = ruby('puts ENV.to_a.map {|e| e.join("=") }.sort.join("\n")', artifice: "fail")
       create_file("source.rb", <<-RUBY)
         puts Bundler.original_env.to_a.map {|e| e.join("=") }.sort.join("\n")

--- a/bundler/spec/runtime/requiring_spec.rb
+++ b/bundler/spec/runtime/requiring_spec.rb
@@ -2,13 +2,13 @@
 
 RSpec.describe "Requiring bundler" do
   it "takes care of requiring rubygems when entrypoint is bundler/setup" do
-    sys_exec("#{Gem.ruby} -I#{lib_dir} -rbundler/setup -e'puts true'", env: { "RUBYOPT" => opt_add("--disable=gems", ENV["RUBYOPT"]) })
+    sys_exec("#{Gem.ruby} -I#{lib_dir} -rbundler/setup -e'puts true'", env: { "RUBYOPT" => "--disable=gems" })
 
     expect(stdboth).to eq("true")
   end
 
   it "takes care of requiring rubygems when requiring just bundler" do
-    sys_exec("#{Gem.ruby} -I#{lib_dir} -rbundler -e'puts true'", env: { "RUBYOPT" => opt_add("--disable=gems", ENV["RUBYOPT"]) })
+    sys_exec("#{Gem.ruby} -I#{lib_dir} -rbundler -e'puts true'", env: { "RUBYOPT" => "--disable=gems" })
 
     expect(stdboth).to eq("true")
   end

--- a/bundler/spec/runtime/self_management_spec.rb
+++ b/bundler/spec/runtime/self_management_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Self management" do
       lockfile_bundled_with(previous_minor)
 
       bundle "config set --local path.system true"
-      bundle "install", preserve_ruby_flags: true
+      bundle "install"
       expect(out).to include("Bundler #{current_version} is running, but your lockfile was generated with #{previous_minor}. Installing Bundler #{previous_minor} and restarting using that version.")
 
       # It uninstalls the older system bundler
@@ -70,7 +70,7 @@ RSpec.describe "Self management" do
       lockfile_bundled_with(previous_minor)
 
       bundle "config set --local path vendor/bundle"
-      bundle "install", preserve_ruby_flags: true
+      bundle "install"
       expect(out).to include("Bundler #{current_version} is running, but your lockfile was generated with #{previous_minor}. Installing Bundler #{previous_minor} and restarting using that version.")
       expect(vendored_gems("gems/bundler-#{previous_minor}")).to exist
 
@@ -107,7 +107,7 @@ RSpec.describe "Self management" do
       lockfile_bundled_with(previous_minor)
 
       bundle "config set --local deployment true"
-      bundle "install", preserve_ruby_flags: true
+      bundle "install"
       expect(out).to include("Bundler #{current_version} is running, but your lockfile was generated with #{previous_minor}. Installing Bundler #{previous_minor} and restarting using that version.")
       expect(vendored_gems("gems/bundler-#{previous_minor}")).to exist
 
@@ -162,7 +162,7 @@ RSpec.describe "Self management" do
       lockfile_bundled_with(current_version)
 
       bundle "config set --local version #{previous_minor}"
-      bundle "install", preserve_ruby_flags: true
+      bundle "install"
       expect(out).to include("Bundler #{current_version} is running, but your configuration was #{previous_minor}. Installing Bundler #{previous_minor} and restarting using that version.")
 
       bundle "-v"

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1464,7 +1464,7 @@ end
         install_gemfile "source 'https://gem.repo1'"
         create_file("script.rb", "#!/usr/bin/env ruby\n\n#{code}")
         FileUtils.chmod(0o777, bundled_app("script.rb"))
-        bundle "exec ./script.rb", artifice: nil, env: { "RUBYOPT" => activation_warning_hack_rubyopt }
+        bundle "exec ./script.rb", env: { "RUBYOPT" => activation_warning_hack_rubyopt }
         expect(out).to eq("{}")
       end
 

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -84,6 +84,10 @@ RSpec.configure do |config|
 
     require_relative "support/rubygems_ext"
     Spec::Rubygems.test_setup
+
+    # Simulate bundler has not yet been loaded
+    ENV.replace(ENV.to_hash.delete_if {|k, _v| k.start_with?(Bundler::EnvironmentPreserver::BUNDLER_PREFIX) })
+
     ENV["BUNDLER_SPEC_RUN"] = "true"
     ENV["BUNDLE_USER_CONFIG"] = ENV["BUNDLE_USER_CACHE"] = ENV["BUNDLE_USER_PLUGIN"] = nil
     ENV["BUNDLE_APP_CONFIG"] = nil

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -83,7 +83,7 @@ module Spec
       load_path << custom_load_path if custom_load_path
 
       build_ruby_options = { load_path: load_path, requires: requires, env: env }
-      build_ruby_options.merge!(artifice: options.delete(:artifice)) if options.key?(:artifice)
+      build_ruby_options.merge!(artifice: options.delete(:artifice)) if options.key?(:artifice) || cmd.start_with?("exec")
 
       match_source(cmd)
 

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -71,7 +71,6 @@ module Spec
       bundle_bin ||= installed_bindir.join("bundle")
 
       env = options.delete(:env) || {}
-      preserve_ruby_flags = options.delete(:preserve_ruby_flags)
 
       requires = options.delete(:requires) || []
 
@@ -102,7 +101,6 @@ module Spec
       end.join
 
       cmd = "#{Gem.ruby} #{bundle_bin} #{cmd}#{args}"
-      env["BUNDLER_SPEC_ORIGINAL_CMD"] = "#{Gem.ruby} #{bundle_bin}" if preserve_ruby_flags
       sys_exec(cmd, { env: env, dir: dir, raise_on_error: raise_on_error }, &block)
     end
 

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -172,7 +172,7 @@ module Spec
         requires << "#{Path.spec_dir}/support/artifice/#{artifice}.rb"
       end
 
-      requires << "#{Path.spec_dir}/support/hax.rb"
+      requires << hax
 
       require_option = requires.map {|r| "-r#{r}" }
 
@@ -186,7 +186,7 @@ module Spec
 
     def gem_command(command, options = {})
       env = options[:env] || {}
-      env["RUBYOPT"] = opt_add(opt_add("-r#{spec_dir}/support/hax.rb", env["RUBYOPT"]), ENV["RUBYOPT"])
+      env["RUBYOPT"] = opt_add(opt_add("-r#{hax}", env["RUBYOPT"]), ENV["RUBYOPT"])
       options[:env] = env
 
       # Sometimes `gem install` commands hang at dns resolution, which has a

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -75,6 +75,10 @@ module Spec
       @man_dir ||= lib_dir.join("bundler/man")
     end
 
+    def hax
+      @hax ||= spec_dir.join("support/hax.rb")
+    end
+
     def tracked_files
       @tracked_files ||= git_ls_files(tracked_files_glob)
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Setting ENV and ruby flags when shelling out during specs is quite messy.

## What is your fix for the problem, implemented in this PR?

Use `ENV` consistently. This way it's more clear to understand what's going on and since we don't use any ruby CLI flags, we can test restarts more reliably without the workaround we were using previously.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
