### PR TITLE
(Wrong) fix for `bundle lock` edge case

### DIFF
--- a/bundler/lib/bundler/resolver/package.rb
+++ b/bundler/lib/bundler/resolver/package.rb
@@ -18,10 +18,19 @@ module Bundler
       def initialize(name, platforms, locked_specs:, unlock:, prerelease: false, dependency: nil)
         @name = name
         @platforms = platforms
-        @locked_version = locked_specs[name].first&.version
         @unlock = unlock
-        @dependency = dependency || Dependency.new(name, @locked_version)
         @top_level = !dependency.nil?
+
+        locked_spec = locked_specs[name].first
+
+        if @top_level
+          @locked_version = locked_spec.version if locked_spec && dependency.matches_spec?(locked_spec)
+          @dependency = dependency
+        else
+          @locked_version = locked_spec&.version
+          @dependency = Dependency.new(name, @locked_version)
+        end
+
         @prerelease = @dependency.prerelease? || @locked_version&.prerelease? || prerelease ? :consider_first : :ignore
       end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The problem is #7369. However, after further thought I don't think this is a good solution and we should only aim to provide a better error message here.

## What is your fix for the problem, implemented in this PR?

Bring lockfile up to date when `bundle lock --update foo --patch --strict` is given with an out of date lockfile.

I don't think we want to do that, really.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
