### PR TITLE
Rename `backport` labels

### DIFF
--- a/.changelog.yml
+++ b/.changelog.yml
@@ -21,7 +21,7 @@ changelog_label_mapping:
   "rubygems: enhancement": "## Enhancements:"
   "rubygems: bug fix": "## Bug fixes:"
   "rubygems: documentation": "## Documentation:"
-  "rubygems: backport": null
+  "rubygems: skip changelog": null
 
 patch_level_labels:
   - "rubygems: security"
@@ -30,4 +30,4 @@ patch_level_labels:
   - "rubygems: bug fix"
   - "rubygems: performance"
   - "rubygems: documentation"
-  - "rubygems: backport"
+  - "rubygems: skip changelog"

--- a/POLICIES.md
+++ b/POLICIES.md
@@ -79,11 +79,11 @@ changelog.
 If PRs don't have a proper label, they won't be backported to patch releases.
 
 If you want a PR to be backported to a patch level release, but don't want to
-include it in the changelog, you can use the special `rubygems: backport` and
-`bundler: backport` labels. For example, this is useful when backporting a PR
-generates conflicts that are solved by backporting another PR with no user
-visible changes. You can use these special labels to also backport the other PR
-and not get any conflicts.
+include it in the changelog, you can use the special `rubygems: skip changelog`
+and `bundler: skip changelog` labels. For example, this is useful when
+backporting a PR generates conflicts that are solved by backporting another PR
+with no user visible changes. You can use these special labels to also backport
+the other PR and not get any conflicts.
 
 ### Steps for patch releases
 

--- a/bundler/.changelog.yml
+++ b/bundler/.changelog.yml
@@ -15,7 +15,7 @@ changelog_label_mapping:
   "bundler: enhancement": "## Enhancements:"
   "bundler: bug fix": "## Bug fixes:"
   "bundler: documentation": "## Documentation:"
-  "bundler: backport": null
+  "bundler: skip changelog": null
 
 patch_level_labels:
   - "bundler: security"
@@ -24,4 +24,4 @@ patch_level_labels:
   - "bundler: bug fix"
   - "bundler: performance"
   - "bundler: documentation"
-  - "bundler: backport"
+  - "bundler: skip changelog"

--- a/bundler/doc/playbooks/MERGING_A_PR.md
+++ b/bundler/doc/playbooks/MERGING_A_PR.md
@@ -30,8 +30,8 @@ release, make sure the following information is accurate:
   file.
 
   If for some reason you need a PR to be backported to a stable branch, but it
-  doesn't have any user visible changes, apply the "bundler: backport" label to
-  it so that our release scripts know about that.
+  doesn't have any user visible changes, apply the "bundler: skip changelog"
+  label to it so that our release scripts know about that.
 
 Finally, don't forget to review the changes in detail. Make sure you try them
 locally if they are not trivial and make sure you request changes and ask as


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I think "backport" is a confusing name because not only PRs with this label get backported, also PRs with other labels like `rubygems: bug fix`, or `rubygems: enhancement` get backported.

## What is your fix for the problem, implemented in this PR?

This commit uses alternative labels with names that better represents the purpose.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
