### PR TITLE
Let `Bundler.with_original_env` properly restore env variables originally empty

### DIFF
--- a/bundler/lib/bundler/environment_preserver.rb
+++ b/bundler/lib/bundler/environment_preserver.rb
@@ -58,7 +58,7 @@ module Bundler
       env = @original.clone
       @keys.each do |key|
         value = env[key]
-        if !value.nil? && !value.empty?
+        if !value.nil?
           env[@prefix + key] ||= value
         elsif value.nil?
           env[@prefix + key] ||= INTENTIONALLY_NIL
@@ -72,7 +72,7 @@ module Bundler
       env = @original.clone
       @keys.each do |key|
         value_original = env[@prefix + key]
-        next if value_original.nil? || value_original.empty?
+        next if value_original.nil?
         if value_original == INTENTIONALLY_NIL
           env.delete(key)
         else

--- a/bundler/lib/bundler/environment_preserver.rb
+++ b/bundler/lib/bundler/environment_preserver.rb
@@ -60,7 +60,7 @@ module Bundler
         value = env[key]
         if !value.nil?
           env[@prefix + key] ||= value
-        elsif value.nil?
+        else
           env[@prefix + key] ||= INTENTIONALLY_NIL
         end
       end

--- a/bundler/spec/bundler/environment_preserver_spec.rb
+++ b/bundler/spec/bundler/environment_preserver_spec.rb
@@ -27,8 +27,12 @@ RSpec.describe Bundler::EnvironmentPreserver do
     context "when a key is empty" do
       let(:env) { { "foo" => "" } }
 
-      it "should not create backup entries" do
-        expect(subject).not_to have_key "BUNDLER_ORIG_foo"
+      it "should keep the original entry" do
+        expect(subject["foo"]).to be_empty
+      end
+
+      it "should still create backup entries" do
+        expect(subject).to have_key "BUNDLER_ORIG_foo"
       end
     end
 
@@ -71,8 +75,12 @@ RSpec.describe Bundler::EnvironmentPreserver do
     context "when the original key is empty" do
       let(:env) { { "foo" => "my-foo", "BUNDLER_ORIG_foo" => "" } }
 
-      it "should keep the current value" do
-        expect(subject["foo"]).to eq("my-foo")
+      it "should restore the original value" do
+        expect(subject["foo"]).to be_empty
+      end
+
+      it "should delete the backup value" do
+        expect(subject.key?("BUNDLER_ORIG_foo")).to eq(false)
       end
     end
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Our `Bundler.with_original_env` helper does not properly restore empty ENV variables.

## What is your fix for the problem, implemented in this PR?

Just trying CI to tell me if there's a specific reason for it.

See https://github.com/rubygems/rubygems/issues/7365.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
