### PR TITLE
Bump uri version used in development

### DIFF
--- a/tool/bundler/dev_gems.rb
+++ b/tool/bundler/dev_gems.rb
@@ -13,7 +13,7 @@ gem "parallel", "~> 1.19"
 gem "rspec-core", "~> 3.12"
 gem "rspec-expectations", "~> 3.12"
 gem "rspec-mocks", "~> 3.12"
-gem "uri", "~> 0.12.0"
+gem "uri", "~> 0.13.0"
 
 group :doc do
   gem "nronn", "~> 0.11.1", platform: :ruby

--- a/tool/bundler/dev_gems.rb.lock
+++ b/tool/bundler/dev_gems.rb.lock
@@ -53,7 +53,7 @@ GEM
     turbo_tests (2.2.0)
       parallel_tests (>= 3.3.0, < 5)
       rspec (>= 3.10)
-    uri (0.12.2)
+    uri (0.13.0)
     webrick (1.8.1)
 
 PLATFORMS
@@ -81,7 +81,7 @@ DEPENDENCIES
   rspec-mocks (~> 3.12)
   test-unit (~> 3.0)
   turbo_tests (~> 2.1)
-  uri (~> 0.12.0)
+  uri (~> 0.13.0)
   webrick (~> 1.6)
 
 CHECKSUMS
@@ -112,7 +112,7 @@ CHECKSUMS
   rspec-support (3.12.1) sha256=f969b85d0068ff97bc47c9d6fc2bca9706d73406f2b4e5d3b346443d8734c8cf
   test-unit (3.6.1) sha256=0aa5c45910725d44e38d0340b31fab3ea8bfac02b11f7201d0ca2a978d52600b
   turbo_tests (2.2.0) sha256=1fc08defd07aef5329c35f69b08827eb66daddf642dcf40adc426543fabbfdcc
-  uri (0.12.2) sha256=be79bd8017858c9fc36c78765c69e92b6a7e049ea6a83364909476ad1b4b4439
+  uri (0.13.0) sha256=26553c2a9399762e1e8bebd4444b4361c4b21298cf1c864b22eeabc9c4998f24
   webrick (1.8.1) sha256=19411ec6912911fd3df13559110127ea2badd0c035f7762873f58afc803e158f
 
 BUNDLED WITH


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Just run into the following issue while preparing releases:

```
$ rake "prepare_release[3.5.5]"
Bundle complete! 3 Gemfile dependencies, 17 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
rake aborted!
Gem::LoadError: can't activate uri-0.12.2, already activated uri-0.13.0 (Gem::LoadError)
<internal:/Users/deivid/.asdf/installs/ruby/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:98:in `each'
<internal:/Users/deivid/.asdf/installs/ruby/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:98:in `block in require'
<internal:/Users/deivid/.asdf/installs/ruby/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:39:in `synchronize'
<internal:/Users/deivid/.asdf/installs/ruby/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:39:in `require'
<internal:/Users/deivid/.asdf/installs/ruby/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
<internal:/Users/deivid/.asdf/installs/ruby/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
<internal:/Users/deivid/.asdf/installs/ruby/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
<internal:/Users/deivid/.asdf/installs/ruby/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
<internal:/Users/deivid/.asdf/installs/ruby/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
<internal:/Users/deivid/.asdf/installs/ruby/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
<internal:/Users/deivid/.asdf/installs/ruby/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
<internal:/Users/deivid/.asdf/installs/ruby/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
<internal:/Users/deivid/.asdf/installs/ruby/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:132:in `require'
<internal:/Users/deivid/.asdf/installs/ruby/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:132:in `rescue in require'
<internal:/Users/deivid/.asdf/installs/ruby/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:126:in `require'
/Users/deivid/code/rubygems/rubygems/tool/release.rb:9:in `gh_client'
/Users/deivid/code/rubygems/rubygems/tool/release.rb:290:in `scan_unreleased_pull_requests'
/Users/deivid/code/rubygems/rubygems/tool/release.rb:286:in `unreleased_pull_requests'
/Users/deivid/code/rubygems/rubygems/tool/release.rb:177:in `prepare!'
/Users/deivid/code/rubygems/rubygems/Rakefile:177:in `block in <top (required)>'

Caused by:
LoadError: cannot load such file -- octokit (LoadError)
<internal:/Users/deivid/.asdf/installs/ruby/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
<internal:/Users/deivid/.asdf/installs/ruby/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:127:in `require'
/Users/deivid/code/rubygems/rubygems/tool/release.rb:9:in `gh_client'
/Users/deivid/code/rubygems/rubygems/tool/release.rb:290:in `scan_unreleased_pull_requests'
/Users/deivid/code/rubygems/rubygems/tool/release.rb:286:in `unreleased_pull_requests'
/Users/deivid/code/rubygems/rubygems/tool/release.rb:177:in `prepare!'
/Users/deivid/code/rubygems/rubygems/Rakefile:177:in `block in <top (required)>'
Tasks: TOP => prepare_release
(See full trace by running task with --trace)
```

We got that reported somewhere else and I'll be looking into fixing the issue, but a quick workaround would be to bump the version of uri used for development.

## What is your fix for the problem, implemented in this PR?

Bump uri.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
