### PR TITLE
Support Ruby 3.4

### DIFF
--- a/bundler/spec/support/artifice/endpoint_500.rb
+++ b/bundler/spec/support/artifice/endpoint_500.rb
@@ -2,7 +2,7 @@
 
 require_relative "../path"
 
-$LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gem_path.join("gems/{mustermann,rack,tilt,sinatra,ruby2_keywords}-*/lib")].map(&:to_s))
+$LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gem_path.join("gems/{mustermann,rack,tilt,sinatra,ruby2_keywords,base64}-*/lib")].map(&:to_s))
 
 require "sinatra/base"
 

--- a/bundler/spec/support/artifice/helpers/endpoint.rb
+++ b/bundler/spec/support/artifice/helpers/endpoint.rb
@@ -2,7 +2,7 @@
 
 require_relative "../../path"
 
-$LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gem_path.join("gems/{mustermann,rack,tilt,sinatra,ruby2_keywords}-*/lib")].map(&:to_s))
+$LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gem_path.join("gems/{mustermann,rack,tilt,sinatra,ruby2_keywords,base64}-*/lib")].map(&:to_s))
 
 require "sinatra/base"
 

--- a/bundler/spec/support/artifice/windows.rb
+++ b/bundler/spec/support/artifice/windows.rb
@@ -2,7 +2,7 @@
 
 require_relative "../path"
 
-$LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gem_path.join("gems/{mustermann,rack,tilt,sinatra,ruby2_keywords}-*/lib")].map(&:to_s))
+$LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gem_path.join("gems/{mustermann,rack,tilt,sinatra,ruby2_keywords,base64}-*/lib")].map(&:to_s))
 
 require "sinatra/base"
 

--- a/tool/bundler/test_gems.rb
+++ b/tool/bundler/test_gems.rb
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "rack", "~> 2.0"
+gem "base64"
 gem "webrick", "1.7.0"
 gem "rack-test", "~> 1.1"
 gem "compact_index", "~> 0.15.0"

--- a/tool/bundler/test_gems.rb.lock
+++ b/tool/bundler/test_gems.rb.lock
@@ -37,6 +37,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  base64
   builder (~> 3.2)
   compact_index (~> 0.15.0)
   rack (~> 2.0)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I extracted `base64` as bundled gems from `ruby/ruby` repository. After that, CI of rubygems may be failed with some examples.

## What is your fix for the problem, implemented in this PR?

I added `base64` to test dependency.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
