### PR TITLE
Changelogs for RubyGems 3.5.5 and Bundler 2.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# 3.5.5 / 2024-01-18
+
+## Enhancements:
+
+* Installs bundler 2.5.5 as a default gem.
+
+## Bug fixes:
+
+* Fix `require` activation conflicts when requiring default gems under
+  some situations. Pull request
+  [#7379](https://github.com/rubygems/rubygems/pull/7379) by
+  deivid-rodriguez
+* Use cache_home instead of data_home in default_spec_cache_dir. Pull
+  request [#7331](https://github.com/rubygems/rubygems/pull/7331) by mrkn
+
+## Documentation:
+
+* Use squiggly heredocs in `Gem::Specification#description` documentation,
+  so it doesn't add leading whitespace. Pull request
+  [#7373](https://github.com/rubygems/rubygems/pull/7373) by bravehager
+
 # 3.5.4 / 2024-01-04
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 2.5.5 (January 18, 2024)
+
+## Bug fixes:
+
+  - Fix development dependency not being added if introduced by two gemspecs [#7358](https://github.com/rubygems/rubygems/pull/7358)
+  - Fix ETag quoting regression in If-None-Match header of compact index request [#7352](https://github.com/rubygems/rubygems/pull/7352)
+
+## Documentation:
+
+  - Refer to underscores as underscores [#7364](https://github.com/rubygems/rubygems/pull/7364)
+
 # 2.5.4 (January 4, 2024)
 
 ## Bug fixes:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.5.5 and Bundler 2.5.5 into master.