### PR TITLE
Remove no longer necessary code

### DIFF
--- a/lib/rubygems/commands/rdoc_command.rb
+++ b/lib/rubygems/commands/rdoc_command.rb
@@ -84,14 +84,7 @@ Use --overwrite to force rebuilding of documentation.
         FileUtils.rm_rf File.join(spec.doc_dir, "rdoc")
       end
 
-      begin
-        doc.generate
-      rescue Errno::ENOENT => e
-        match = e.message.include?(" - ")
-        alert_error "Unable to document #{spec.full_name}, " \
-                    " #{match.post_match} is missing, skipping"
-        terminate_interaction 1 if specs.length == 1
-      end
+      doc.generate
     end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

#7371 introduced a potential `NoMethodError` in the `gem rdoc` command. See https://github.com/rubygems/rubygems/pull/7371/commits/34df962cf4bb4d5de508e0b57e2cf9ca73fe3f78#r1449105511.

## What is your fix for the problem, implemented in this PR?

I _believe_ this code is no longer necessary.

It was introduced a long time ago at e6e3c79d1269d34b92802799d7c004df83cad2cf. I guess "pseudo gems" meant default gems, and indeed passing a default gem to `gem rdoc` does not seem to generate any documentation nor log messages, however, it does not cause this rescue to be triggered, so I think `rdoc` must be swallowing whatever error internally.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
