### PR TITLE
Test that regular gems don't shadow default gems

### DIFF
--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -489,6 +489,17 @@ class TestGemRequire < Gem::TestCase
     assert_equal %w[default-3.0], loaded_spec_names
   end
 
+  def test_normal_gem_does_not_shadow_default_gem
+    default_gem_spec = new_default_spec("foo", "2.0", nil, "foo.rb")
+    install_default_gems(default_gem_spec)
+
+    normal_gem_spec = util_spec("fake-foo", "3.0", nil, "lib/foo.rb")
+    install_specs(normal_gem_spec)
+
+    assert_require "foo"
+    assert_equal %w[foo-2.0], loaded_spec_names
+  end
+
   def test_normal_gems_with_overridden_load_error_message
     normal_gem_spec = util_spec("normal", "3.0", nil, "lib/normal/gem.rb")
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Just increasing code coverage.

## What is your fix for the problem, implemented in this PR?

Add a test that checks that regular gems don't get activated if the feature is included in a default gem.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
