### PR TITLE
Drop two TODOs from specification.rb

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1003,8 +1003,6 @@ class Gem::Specification < Gem::BasicSpecification
   def self.find_all_by_name(name, *requirements)
     requirements = Gem::Requirement.default if requirements.empty?
 
-    # TODO: maybe try: find_all { |s| spec === dep }
-
     Gem::Dependency.new(name, *requirements).matching_specs
   end
 
@@ -1021,8 +1019,6 @@ class Gem::Specification < Gem::BasicSpecification
 
   def self.find_by_name(name, *requirements)
     requirements = Gem::Requirement.default if requirements.empty?
-
-    # TODO: maybe try: find { |s| spec === dep }
 
     Gem::Dependency.new(name, *requirements).to_spec
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

There are many TODOs in a project.

These were introduced 13 years ago, in a documentation update. Perhaps we can let the TODOs go, without taking any action?

Perhaps we gain clarity and lose nothing?


## What is your fix for the problem, implemented in this PR?

- Looked in git blame, it was 13 y ago
- Remove these two TODOs that I inspected

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
