### PR TITLE
Make tests play with upstream Ruby tests

### DIFF
--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -541,38 +541,38 @@ class TestGemRequire < Gem::TestCase
   end
 
   def test_default_gem_with_unresolved_gems_depending_on_it
-    net_http_old = util_spec "net-http", "0.1.1", nil, "lib/net/http.rb"
-    install_gem net_http_old
+    my_http_old = util_spec "my-http", "0.1.1", nil, "lib/my/http.rb"
+    install_gem my_http_old
 
-    net_http_default = new_default_spec "net-http", "0.3.0", nil, "net/http.rb"
-    install_default_gems net_http_default
+    my_http_default = new_default_spec "my-http", "0.3.0", nil, "my/http.rb"
+    install_default_gems my_http_default
 
-    faraday_1 = util_spec "faraday", "1", { "net-http" => ">= 0" }
+    faraday_1 = util_spec "faraday", "1", { "my-http" => ">= 0" }
     install_gem faraday_1
 
-    faraday_2 = util_spec "faraday", "2", { "net-http" => ">= 0" }
+    faraday_2 = util_spec "faraday", "2", { "my-http" => ">= 0" }
     install_gem faraday_2
 
     chef = util_spec "chef", "1", { "faraday" => [">= 1", "< 3"] }, "lib/chef.rb"
     install_gem chef
 
     assert_require "chef"
-    assert_require "net/http"
+    assert_require "my/http"
   end
 
   def test_default_gem_required_circulary_with_unresolved_gems_depending_on_it
-    net_http_old = util_spec "net-http", "0.1.1", nil, "lib/net/http.rb"
-    install_gem net_http_old
+    my_http_old = util_spec "my-http", "0.1.1", nil, "lib/my/http.rb"
+    install_gem my_http_old
 
-    net_http_default = new_default_spec "net-http", "0.3.0", nil, "net/http.rb"
-    net_http_default_path = File.join(@tempdir, "default_gems", "lib", "net/http.rb")
-    install_default_gems net_http_default
-    File.write(net_http_default_path, 'require "net/http"')
+    my_http_default = new_default_spec "my-http", "0.3.0", nil, "my/http.rb"
+    my_http_default_path = File.join(@tempdir, "default_gems", "lib", "my/http.rb")
+    install_default_gems my_http_default
+    File.write(my_http_default_path, 'require "my/http"')
 
-    faraday_1 = util_spec "faraday", "1", { "net-http" => ">= 0" }
+    faraday_1 = util_spec "faraday", "1", { "my-http" => ">= 0" }
     install_gem faraday_1
 
-    faraday_2 = util_spec "faraday", "2", { "net-http" => ">= 0" }
+    faraday_2 = util_spec "faraday", "2", { "my-http" => ">= 0" }
     install_gem faraday_2
 
     chef = util_spec "chef", "1", { "faraday" => [">= 1", "< 3"] }, "lib/chef.rb"
@@ -581,7 +581,7 @@ class TestGemRequire < Gem::TestCase
     assert_require "chef"
 
     out, err = capture_output do
-      assert_require "net/http"
+      assert_require "my/http"
     end
 
     assert_empty out


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

CI broke in https://github.com/ruby/ruby/pull/9604 because if any Ruby tests run `require 'net/http'`, they will pollute the `$LOADED_FEATURES` for the RubyGems tests. We can fix this by renaming the test default gem from `net-http` to `my-http`. 

See https://github.com/rubygems/rubygems/pull/7379#issuecomment-1901241299 for more details.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
