### PR TITLE
Pend tests for gem permission with Travis

### DIFF
--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -513,6 +513,7 @@ class TestGemPackage < Gem::Package::TarTestCase
 
   def test_extract_file_permissions
     pend "chmod not supported" if Gem.win_platform?
+    pend "Travis CI enable writable permission to group" if ENV['TRAVIS']
 
     gem_with_long_permissions = File.expand_path("packages/Bluebie-legs-0.6.2.gem", __dir__)
 
@@ -528,6 +529,7 @@ class TestGemPackage < Gem::Package::TarTestCase
 
   def test_extract_file_umask_global_permissions
     pend "chmod not supported" if Gem.win_platform?
+    pend "Travis CI enable writable permission to group" if ENV['TRAVIS']
 
     package = Gem::Package.new @gem
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

https://github.com/rubygems/rubygems/pull/7300 break test with Travis CI.

## What is your fix for the problem, implemented in this PR?

I simply skip them with Travis CI. I'm not sure why Travis add write permission to group. 

This commit from https://github.com/ruby/ruby/pull/9603.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
