### PR TITLE
Change gem login message to clear up that username can be also used

### DIFF
--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -130,8 +130,8 @@ module Gem::GemcutterUtilities
 
     say "The existing key doesn't have access of #{scope} on #{pretty_host}. Please sign in to update access."
 
-    email    = ask "   Email: "
-    password = ask_for_password "Password: "
+    email    = ask "Username/email: "
+    password = ask_for_password "      Password: "
 
     response = rubygems_api_request(:put, "api/v1/api_key",
                                     sign_in_host, scope: scope) do |request|

--- a/test/rubygems/test_gem_commands_owner_command.rb
+++ b/test/rubygems/test_gem_commands_owner_command.rb
@@ -471,7 +471,7 @@ EOF
 
     access_notice = "The existing key doesn't have access of remove_owner on RubyGems.org. Please sign in to update access."
     assert_match access_notice, @stub_ui.output
-    assert_match "Email:", @stub_ui.output
+    assert_match "Username/email:", @stub_ui.output
     assert_match "Password:", @stub_ui.output
     assert_match "Added remove_owner scope to the existing API key", @stub_ui.output
     assert_match response_success, @stub_ui.output
@@ -495,7 +495,7 @@ EOF
 
     access_notice = "The existing key doesn't have access of add_owner on RubyGems.org. Please sign in to update access."
     assert_match access_notice, @stub_ui.output
-    assert_match "Email:", @stub_ui.output
+    assert_match "Username/email:", @stub_ui.output
     assert_match "Password:", @stub_ui.output
     assert_match "Added add_owner scope to the existing API key", @stub_ui.output
     assert_match response_success, @stub_ui.output

--- a/test/rubygems/test_gem_commands_push_command.rb
+++ b/test/rubygems/test_gem_commands_push_command.rb
@@ -547,7 +547,7 @@ class TestGemCommandsPushCommand < Gem::TestCase
     access_notice = "The existing key doesn't have access of push_rubygem on https://rubygems.example. Please sign in to update access."
     assert_match mfa_notice, @ui.output
     assert_match access_notice, @ui.output
-    assert_match "Email:", @ui.output
+    assert_match "Username/email:", @ui.output
     assert_match "Password:", @ui.output
     assert_match "Added push_rubygem scope to the existing API key", @ui.output
     assert_match response_success, @ui.output
@@ -588,7 +588,7 @@ class TestGemCommandsPushCommand < Gem::TestCase
     mfa_notice = "You have enabled multi-factor authentication. Please enter OTP code."
     assert_match mfa_notice, @ui.output
     assert_match "Enter your https://rubygems.example credentials.", @ui.output
-    assert_match "Email:", @ui.output
+    assert_match "Username/email:", @ui.output
     assert_match "Password:", @ui.output
     assert_match "Signed in with API key:", @ui.output
     assert_match response_success, @ui.output

--- a/test/rubygems/test_gem_commands_yank_command.rb
+++ b/test/rubygems/test_gem_commands_yank_command.rb
@@ -291,7 +291,7 @@ class TestGemCommandsYankCommand < Gem::TestCase
 
     access_notice = "The existing key doesn't have access of yank_rubygem on http://example. Please sign in to update access."
     assert_match access_notice, @ui.output
-    assert_match "Email:", @ui.output
+    assert_match "Username/email:", @ui.output
     assert_match "Password:", @ui.output
     assert_match "Added yank_rubygem scope to the existing API key", @ui.output
     assert_match response_success, @ui.output


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Right now login question looks like this:
```
Enter your RubyGems.org credentials.
Don't have an account yet? Create one at https://rubygems.org/sign_up
   Email:   VitaliySerov
Password:  
```

But according to my try it also support login via username, not only via email

## What is your fix for the problem, implemented in this PR?

Change wording

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
