### PR TITLE
fix Gem::Dependency#to_spec returning nil when prerelease is the only…

### DIFF
--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -328,9 +328,9 @@ class Gem::Dependency
     return active if active
 
     unless prerelease?
-      # Move prereleases to the end of the list for >= 0 requirements
+      # Consider prereleases only as a fallback
       pre, matches = matches.partition {|spec| spec.version.prerelease? }
-      matches += pre if requirement == Gem::Requirement.default || matches.empty?
+      matches = pre if matches.empty?
     end
 
     matches.first

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -330,7 +330,7 @@ class Gem::Dependency
     unless prerelease?
       # Move prereleases to the end of the list for >= 0 requirements
       pre, matches = matches.partition {|spec| spec.version.prerelease? }
-      matches += pre if requirement == Gem::Requirement.default
+      matches += pre if requirement == Gem::Requirement.default || matches.empty?
     end
 
     matches.first

--- a/test/rubygems/test_gem_dependency.rb
+++ b/test/rubygems/test_gem_dependency.rb
@@ -394,6 +394,16 @@ class TestGemDependency < Gem::TestCase
     assert_match "Could not find 'b' (= 2.0) among 1 total gem(s)", e.message
   end
 
+  def test_to_spec_with_only_prereleases
+    a_2_a_1 = util_spec "a", "2.a1"
+    a_2_a_2 = util_spec "a", "2.a2"
+    install_specs a_2_a_1, a_2_a_2
+
+    a_dep = dep "a", ">= 1"
+
+    assert_equal a_2_a_2, a_dep.to_spec
+  end
+
   def test_identity
     assert_equal dep("a", "= 1").identity, :released
     assert_equal dep("a", "= 1.a").identity, :complete

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3801,6 +3801,13 @@ end
     assert Gem::Specification.find_by_name "q"
   end
 
+  def test_find_by_name_with_only_prereleases_with_requirements
+    q = util_spec "q", "2.a"
+    install_specs q
+
+    assert Gem::Specification.find_by_name "q", ">= 1"
+  end
+
   def test_find_by_name_prerelease
     b = util_spec "b", "2.a"
 

--- a/test/rubygems/test_kernel.rb
+++ b/test/rubygems/test_kernel.rb
@@ -52,10 +52,20 @@ class TestGemKernel < Gem::TestCase
     assert_equal 1, $:.count {|p| p.include?("a-1/lib") }
   end
 
-  def test_gem_prerelease
+  def test_gem_prerelease_is_the_only_available
     quick_gem "d", "1.1.a"
-    refute gem("d", ">= 1"),   "release requirement must not load prerelease"
-    assert gem("d", ">= 1.a"), "prerelease requirement may load prerelease"
+
+    assert gem("d", ">= 1"), "release requirement may load prerelease when sole option"
+    assert $:.one? {|p| p.include?("1.1.a/lib") }
+  end
+
+  def test_release_favored_over_prerelease
+    quick_gem "d", "1.1.a"
+    quick_gem "d", "1.2"
+    gem("d", ">= 1")
+
+    refute $:.any? {|p| p.include?("1.1.a/lib") }
+    assert $:.one? {|p| p.include?("1.2/lib") }
   end
 
   def test_gem_env_req

--- a/test/rubygems/test_kernel.rb
+++ b/test/rubygems/test_kernel.rb
@@ -56,7 +56,7 @@ class TestGemKernel < Gem::TestCase
     quick_gem "d", "1.1.a"
 
     assert gem("d", ">= 1"), "release requirement may load prerelease when sole option"
-    assert $:.one? {|p| p.include?("1.1.a/lib") }
+    assert $:.one? {|p| p.include?("/d-1.1.a/lib") }
   end
 
   def test_release_favored_over_prerelease
@@ -64,8 +64,8 @@ class TestGemKernel < Gem::TestCase
     quick_gem "d", "1.2"
     gem("d", ">= 1")
 
-    refute $:.any? {|p| p.include?("1.1.a/lib") }
-    assert $:.one? {|p| p.include?("1.2/lib") }
+    refute $:.any? {|p| p.include?("/d-1.1.a/lib") }
+    assert $:.one? {|p| p.include?("/d-1.2/lib") }
   end
 
   def test_gem_env_req


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Gem `ruby-lsp` calls `Gem::Dependency#to_spec` expecting it can't return `nil`. That caused the lsp to break because sometimes `nil` is actually being returned.

Some PRs were/are open to handle the issue on their side ([see ruby-lsp PR for more details](https://github.com/Shopify/ruby-lsp/pull/1326)), but that prompt me to investigate if there was a problem in the Bundler.

A [comment](https://github.com/Shopify/ruby-lsp/issues/1141#issuecomment-1781812598) there pointed me to [this line of code](https://github.com/rubygems/rubygems/blob/0a69ce21ca3e8bfbc3ff7a6cec6d36ba2c434128/lib/rubygems/dependency.rb#L333).

I found PR #1755 with a similar problem in the past and that stated `#to_spec` must not return `nil`.

The issue with the lsp happened for this bundle setup:

```ruby
source 'https://rubygems.org'

git_source(:github) { |repo| "https://github.com/#{repo}.git" }

ruby '3.3.0'

gem 'rails', '~> 7.1.2'
gem 'validates_timeliness', '>= 6.0.1'
```

Calling `#to_spec` for `<Bundler::Dependency type=:runtime name="validates_timeliness" requirements=">= 6.0.1">`  returns `nil` (see `ruby-lsp` PR linked above for reproducing steps).

Because of Rails dependencies, validates_timeliness can't resolve to 6.0.1. The next available versions for it are 7.0.0.beta1 and 7.0.0.beta2, only prereleases.

This is - to my understanding (be aware this is my first contribution here) - where the problem happens:

```ruby
  def to_spec
    matches = to_specs.compact

    active = matches.find(&:activated?)
    return active if active

    unless prerelease?
      # Move prereleases to the end of the list for >= 0 requirements
      pre, matches = matches.partition {|spec| spec.version.prerelease? }
      matches += pre if requirement == Gem::Requirement.default
    end

    matches.first
  end
```

This moves all matches (all prereleases) to variable `pre`:

```ruby
pre, matches = matches.partition {|spec| spec.version.prerelease? }
```

Because there is a requirement, this prevents adding them to `matches` again, leaving matches empty:
```ruby
matches += pre if requirement == Gem::Requirement.default
```

## What is your fix for the problem, implemented in this PR?

I honestly don't quite get why we want only change the order `if requirement == Gem::Requirement.default`.

The solution was to simply add `matches.empty?` to the condition.

```ruby
matches += pre if requirement == Gem::Requirement.default || matches.empty?
```

## Failing Test

The fix I tried broke `/test/rubygems/test_kernel.rb:57`.

```ruby
def test_gem_prerelease
    quick_gem "d", "1.1.a"
    refute gem("d", ">= 1"),   "release requirement must not load prerelease"
    assert gem("d", ">= 1.a"), "prerelease requirement may load prerelease"
end
```

That prompt me to question wether `#to_spec` should indeed never return `nil`. It also prompt me to think if a release requirement loading a prerelease is the actual expected behaviour (I opened #7427 for it).

So before moving on, I thought it was a good idea to ask, because maybe I am looking for a fix on the wrong place.

On the other hand, If the expected behavior is to indeed load the prerelease if it's the only available version, is this test wrong?

I'm most likely missing some context here.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)