### PR TITLE
Bump `required_ruby_version` to be used in `bundle gem` template

### DIFF
--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -437,7 +437,7 @@ module Bundler
     end
 
     def required_ruby_version
-      "2.6.0"
+      "3.0.0"
     end
 
     def rubocop_version


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

`bundle gem` command generates `.gemspec`, `rubocop.yml` and `standard.yml` with outdated Ruby version 2.6.0. As a gem creator, I expect the version should be any supported one.


## What is your fix for the problem, implemented in this PR?

I just bumped `required_ruby_version` to 3.0.0 that is still supported.

I think it's reasonable since 2.6 and 2.7 are EOL and bundler dropped their support by https://github.com/rubygems/rubygems/pull/7116.



## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
