### PR TITLE
Remove Travis related code from `bundle gem` completely

### DIFF
--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -32,7 +32,6 @@ module Bundler
 
       validate_ext_name if @extension
       validate_rust_builder_rubygems_version if @extension == "rust"
-      travis_removal_info
     end
 
     def run
@@ -446,19 +445,6 @@ module Bundler
 
     def standard_version
       "1.3"
-    end
-
-    # TODO: remove at next minor release
-    def travis_removal_info
-      if options[:ci] == "travis"
-        Bundler.ui.error "Support for Travis CI was removed from gem skeleton generator."
-        exit 1
-      end
-
-      if Bundler.settings["gem.ci"] == "travis"
-        Bundler.ui.error "Support for Travis CI was removed from gem skeleton generator, but it is present in bundle config. Please configure another provider using `bundle config set gem.ci SERVICE` (where SERVICE is one of github/gitlab/circle) or unset configuration using `bundle config unset gem.ci`."
-        exit 1
-      end
     end
 
     def validate_rust_builder_rubygems_version

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -932,24 +932,6 @@ RSpec.describe "bundle gem" do
       end
     end
 
-    context "--ci set to travis" do
-      it "generates a GitHub Actions config file" do
-        bundle "gem #{gem_name} --ci=travis", raise_on_error: false
-        expect(err).to include("Support for Travis CI was removed from gem skeleton generator.")
-
-        expect(bundled_app("#{gem_name}/.travis.yml")).to_not exist
-      end
-    end
-
-    context "--ci set to travis" do
-      it "generates a GitHub Actions config file" do
-        bundle "gem #{gem_name} --ci=travis", raise_on_error: false
-        expect(err).to include("Support for Travis CI was removed from gem skeleton generator.")
-
-        expect(bundled_app("#{gem_name}/.travis.yml")).to_not exist
-      end
-    end
-
     context "--ci set to github" do
       it "generates a GitHub Actions config file" do
         bundle "gem #{gem_name} --ci=github"
@@ -997,18 +979,6 @@ RSpec.describe "bundle gem" do
         expect(bundled_app("#{gem_name}/.github/workflows/main.yml")).to_not exist
         expect(bundled_app("#{gem_name}/.gitlab-ci.yml")).to_not exist
         expect(bundled_app("#{gem_name}/.circleci/config.yml")).to_not exist
-      end
-    end
-
-    context "gem.ci setting set to travis" do
-      it "errors with friendly message" do
-        bundle "config set gem.ci travis"
-        bundle "gem #{gem_name}", raise_on_error: false
-
-        expect(err).to include("Support for Travis CI was removed from gem skeleton generator,")
-        expect(err).to include("bundle config unset gem.ci")
-
-        expect(bundled_app("#{gem_name}/.travis.yml")).to_not exist
       end
     end
 

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -31,7 +31,6 @@ class TestGemCommandsSetupCommand < Gem::TestCase
       bundler/lib/bundler/man/gemfile.5
       bundler/lib/bundler/man/gemfile.5.ronn
       bundler/lib/bundler/templates/.circleci/config.yml
-      bundler/lib/bundler/templates/.travis.yml
     ]
 
     create_dummy_files(filelist)
@@ -178,7 +177,6 @@ class TestGemCommandsSetupCommand < Gem::TestCase
       assert_path_exist File.join(dir, "bundler/b.rb")
 
       assert_path_exist File.join(dir, "bundler/templates/.circleci/config.yml")
-      assert_path_exist File.join(dir, "bundler/templates/.travis.yml")
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This is just internal code clean-up.

## What is your fix for the problem, implemented in this PR?

I removed `travis_removal_info`.

`travis_removal_info` is added by https://github.com/rubygems/rubygems/pull/6150, at [v2.4.0](https://github.com/rubygems/rubygems/blob/0a69ce21ca3e8bfbc3ff7a6cec6d36ba2c434128/bundler/CHANGELOG.md#breaking-changes-1). According to the comment, it's supposed to be removed at bundler v2.5.0 but it still exists.


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
