### PR TITLE
Rename wrapper file for vendored molinillo

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -480,7 +480,6 @@ lib/rubygems/resolver/installer_set.rb
 lib/rubygems/resolver/local_specification.rb
 lib/rubygems/resolver/lock_set.rb
 lib/rubygems/resolver/lock_specification.rb
-lib/rubygems/resolver/molinillo.rb
 lib/rubygems/resolver/requirement_list.rb
 lib/rubygems/resolver/set.rb
 lib/rubygems/resolver/source_set.rb
@@ -608,6 +607,7 @@ lib/rubygems/vendor/uri/lib/uri/rfc3986_parser.rb
 lib/rubygems/vendor/uri/lib/uri/version.rb
 lib/rubygems/vendor/uri/lib/uri/ws.rb
 lib/rubygems/vendor/uri/lib/uri/wss.rb
+lib/rubygems/vendored_molinillo.rb
 lib/rubygems/version.rb
 lib/rubygems/version_option.rb
 lib/rubygems/yaml_serializer.rb

--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -11,7 +11,7 @@ require_relative "util/list"
 # all the requirements.
 
 class Gem::Resolver
-  require_relative "resolver/molinillo"
+  require_relative "vendored_molinillo"
 
   ##
   # If the DEBUG_RESOLVER environment variable is set then debugging mode is

--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -167,7 +167,7 @@ class Gem::Resolver
     reqs
   end
 
-  include Molinillo::UI
+  include Gem::Molinillo::UI
 
   def output
     @output ||= debug? ? $stdout : File.open(IO::NULL, "w")
@@ -177,14 +177,14 @@ class Gem::Resolver
     DEBUG_RESOLVER
   end
 
-  include Molinillo::SpecificationProvider
+  include Gem::Molinillo::SpecificationProvider
 
   ##
   # Proceed with resolution! Returns an array of ActivationRequest objects.
 
   def resolve
-    Molinillo::Resolver.new(self, self).resolve(@needed.map {|d| DependencyRequest.new d, nil }).tsort.map(&:payload).compact
-  rescue Molinillo::VersionConflict => e
+    Gem::Molinillo::Resolver.new(self, self).resolve(@needed.map {|d| DependencyRequest.new d, nil }).tsort.map(&:payload).compact
+  rescue Gem::Molinillo::VersionConflict => e
     conflict = e.conflicts.values.first
     raise Gem::DependencyResolutionError, Conflict.new(conflict.requirement_trees.first.first, conflict.existing, conflict.requirement)
   ensure

--- a/lib/rubygems/resolver/molinillo.rb
+++ b/lib/rubygems/resolver/molinillo.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-require_relative "../vendor/molinillo/lib/molinillo"

--- a/lib/rubygems/vendor/molinillo/lib/molinillo.rb
+++ b/lib/rubygems/vendor/molinillo/lib/molinillo.rb
@@ -6,6 +6,6 @@ require_relative 'molinillo/resolver'
 require_relative 'molinillo/modules/ui'
 require_relative 'molinillo/modules/specification_provider'
 
-# Gem::Resolver::Molinillo is a generic dependency resolution algorithm.
-module Gem::Resolver::Molinillo
+# Gem::Molinillo is a generic dependency resolution algorithm.
+module Gem::Molinillo
 end

--- a/lib/rubygems/vendor/molinillo/lib/molinillo/delegates/resolution_state.rb
+++ b/lib/rubygems/vendor/molinillo/lib/molinillo/delegates/resolution_state.rb
@@ -1,55 +1,55 @@
 # frozen_string_literal: true
 
-module Gem::Resolver::Molinillo
+module Gem::Molinillo
   # @!visibility private
   module Delegates
-    # Delegates all {Gem::Resolver::Molinillo::ResolutionState} methods to a `#state` property.
+    # Delegates all {Gem::Molinillo::ResolutionState} methods to a `#state` property.
     module ResolutionState
-      # (see Gem::Resolver::Molinillo::ResolutionState#name)
+      # (see Gem::Molinillo::ResolutionState#name)
       def name
-        current_state = state || Gem::Resolver::Molinillo::ResolutionState.empty
+        current_state = state || Gem::Molinillo::ResolutionState.empty
         current_state.name
       end
 
-      # (see Gem::Resolver::Molinillo::ResolutionState#requirements)
+      # (see Gem::Molinillo::ResolutionState#requirements)
       def requirements
-        current_state = state || Gem::Resolver::Molinillo::ResolutionState.empty
+        current_state = state || Gem::Molinillo::ResolutionState.empty
         current_state.requirements
       end
 
-      # (see Gem::Resolver::Molinillo::ResolutionState#activated)
+      # (see Gem::Molinillo::ResolutionState#activated)
       def activated
-        current_state = state || Gem::Resolver::Molinillo::ResolutionState.empty
+        current_state = state || Gem::Molinillo::ResolutionState.empty
         current_state.activated
       end
 
-      # (see Gem::Resolver::Molinillo::ResolutionState#requirement)
+      # (see Gem::Molinillo::ResolutionState#requirement)
       def requirement
-        current_state = state || Gem::Resolver::Molinillo::ResolutionState.empty
+        current_state = state || Gem::Molinillo::ResolutionState.empty
         current_state.requirement
       end
 
-      # (see Gem::Resolver::Molinillo::ResolutionState#possibilities)
+      # (see Gem::Molinillo::ResolutionState#possibilities)
       def possibilities
-        current_state = state || Gem::Resolver::Molinillo::ResolutionState.empty
+        current_state = state || Gem::Molinillo::ResolutionState.empty
         current_state.possibilities
       end
 
-      # (see Gem::Resolver::Molinillo::ResolutionState#depth)
+      # (see Gem::Molinillo::ResolutionState#depth)
       def depth
-        current_state = state || Gem::Resolver::Molinillo::ResolutionState.empty
+        current_state = state || Gem::Molinillo::ResolutionState.empty
         current_state.depth
       end
 
-      # (see Gem::Resolver::Molinillo::ResolutionState#conflicts)
+      # (see Gem::Molinillo::ResolutionState#conflicts)
       def conflicts
-        current_state = state || Gem::Resolver::Molinillo::ResolutionState.empty
+        current_state = state || Gem::Molinillo::ResolutionState.empty
         current_state.conflicts
       end
 
-      # (see Gem::Resolver::Molinillo::ResolutionState#unused_unwind_options)
+      # (see Gem::Molinillo::ResolutionState#unused_unwind_options)
       def unused_unwind_options
-        current_state = state || Gem::Resolver::Molinillo::ResolutionState.empty
+        current_state = state || Gem::Molinillo::ResolutionState.empty
         current_state.unused_unwind_options
       end
     end

--- a/lib/rubygems/vendor/molinillo/lib/molinillo/delegates/specification_provider.rb
+++ b/lib/rubygems/vendor/molinillo/lib/molinillo/delegates/specification_provider.rb
@@ -1,67 +1,67 @@
 # frozen_string_literal: true
 
-module Gem::Resolver::Molinillo
+module Gem::Molinillo
   module Delegates
-    # Delegates all {Gem::Resolver::Molinillo::SpecificationProvider} methods to a
+    # Delegates all {Gem::Molinillo::SpecificationProvider} methods to a
     # `#specification_provider` property.
     module SpecificationProvider
-      # (see Gem::Resolver::Molinillo::SpecificationProvider#search_for)
+      # (see Gem::Molinillo::SpecificationProvider#search_for)
       def search_for(dependency)
         with_no_such_dependency_error_handling do
           specification_provider.search_for(dependency)
         end
       end
 
-      # (see Gem::Resolver::Molinillo::SpecificationProvider#dependencies_for)
+      # (see Gem::Molinillo::SpecificationProvider#dependencies_for)
       def dependencies_for(specification)
         with_no_such_dependency_error_handling do
           specification_provider.dependencies_for(specification)
         end
       end
 
-      # (see Gem::Resolver::Molinillo::SpecificationProvider#requirement_satisfied_by?)
+      # (see Gem::Molinillo::SpecificationProvider#requirement_satisfied_by?)
       def requirement_satisfied_by?(requirement, activated, spec)
         with_no_such_dependency_error_handling do
           specification_provider.requirement_satisfied_by?(requirement, activated, spec)
         end
       end
 
-      # (see Gem::Resolver::Molinillo::SpecificationProvider#dependencies_equal?)
+      # (see Gem::Molinillo::SpecificationProvider#dependencies_equal?)
       def dependencies_equal?(dependencies, other_dependencies)
         with_no_such_dependency_error_handling do
           specification_provider.dependencies_equal?(dependencies, other_dependencies)
         end
       end
 
-      # (see Gem::Resolver::Molinillo::SpecificationProvider#name_for)
+      # (see Gem::Molinillo::SpecificationProvider#name_for)
       def name_for(dependency)
         with_no_such_dependency_error_handling do
           specification_provider.name_for(dependency)
         end
       end
 
-      # (see Gem::Resolver::Molinillo::SpecificationProvider#name_for_explicit_dependency_source)
+      # (see Gem::Molinillo::SpecificationProvider#name_for_explicit_dependency_source)
       def name_for_explicit_dependency_source
         with_no_such_dependency_error_handling do
           specification_provider.name_for_explicit_dependency_source
         end
       end
 
-      # (see Gem::Resolver::Molinillo::SpecificationProvider#name_for_locking_dependency_source)
+      # (see Gem::Molinillo::SpecificationProvider#name_for_locking_dependency_source)
       def name_for_locking_dependency_source
         with_no_such_dependency_error_handling do
           specification_provider.name_for_locking_dependency_source
         end
       end
 
-      # (see Gem::Resolver::Molinillo::SpecificationProvider#sort_dependencies)
+      # (see Gem::Molinillo::SpecificationProvider#sort_dependencies)
       def sort_dependencies(dependencies, activated, conflicts)
         with_no_such_dependency_error_handling do
           specification_provider.sort_dependencies(dependencies, activated, conflicts)
         end
       end
 
-      # (see Gem::Resolver::Molinillo::SpecificationProvider#allow_missing?)
+      # (see Gem::Molinillo::SpecificationProvider#allow_missing?)
       def allow_missing?(dependency)
         with_no_such_dependency_error_handling do
           specification_provider.allow_missing?(dependency)

--- a/lib/rubygems/vendor/molinillo/lib/molinillo/dependency_graph.rb
+++ b/lib/rubygems/vendor/molinillo/lib/molinillo/dependency_graph.rb
@@ -5,7 +5,7 @@ require_relative '../../../../tsort'
 require_relative 'dependency_graph/log'
 require_relative 'dependency_graph/vertex'
 
-module Gem::Resolver::Molinillo
+module Gem::Molinillo
   # A directed acyclic graph that is tuned to hold named dependencies
   class DependencyGraph
     include Enumerable

--- a/lib/rubygems/vendor/molinillo/lib/molinillo/dependency_graph/action.rb
+++ b/lib/rubygems/vendor/molinillo/lib/molinillo/dependency_graph/action.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Gem::Resolver::Molinillo
+module Gem::Molinillo
   class DependencyGraph
     # An action that modifies a {DependencyGraph} that is reversible.
     # @abstract

--- a/lib/rubygems/vendor/molinillo/lib/molinillo/dependency_graph/add_edge_no_circular.rb
+++ b/lib/rubygems/vendor/molinillo/lib/molinillo/dependency_graph/add_edge_no_circular.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'action'
-module Gem::Resolver::Molinillo
+module Gem::Molinillo
   class DependencyGraph
     # @!visibility private
     # (see DependencyGraph#add_edge_no_circular)

--- a/lib/rubygems/vendor/molinillo/lib/molinillo/dependency_graph/add_vertex.rb
+++ b/lib/rubygems/vendor/molinillo/lib/molinillo/dependency_graph/add_vertex.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'action'
-module Gem::Resolver::Molinillo
+module Gem::Molinillo
   class DependencyGraph
     # @!visibility private
     # (see DependencyGraph#add_vertex)

--- a/lib/rubygems/vendor/molinillo/lib/molinillo/dependency_graph/delete_edge.rb
+++ b/lib/rubygems/vendor/molinillo/lib/molinillo/dependency_graph/delete_edge.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'action'
-module Gem::Resolver::Molinillo
+module Gem::Molinillo
   class DependencyGraph
     # @!visibility private
     # (see DependencyGraph#delete_edge)

--- a/lib/rubygems/vendor/molinillo/lib/molinillo/dependency_graph/detach_vertex_named.rb
+++ b/lib/rubygems/vendor/molinillo/lib/molinillo/dependency_graph/detach_vertex_named.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'action'
-module Gem::Resolver::Molinillo
+module Gem::Molinillo
   class DependencyGraph
     # @!visibility private
     # @see DependencyGraph#detach_vertex_named

--- a/lib/rubygems/vendor/molinillo/lib/molinillo/dependency_graph/log.rb
+++ b/lib/rubygems/vendor/molinillo/lib/molinillo/dependency_graph/log.rb
@@ -7,7 +7,7 @@ require_relative 'detach_vertex_named'
 require_relative 'set_payload'
 require_relative 'tag'
 
-module Gem::Resolver::Molinillo
+module Gem::Molinillo
   class DependencyGraph
     # A log for dependency graph actions
     class Log

--- a/lib/rubygems/vendor/molinillo/lib/molinillo/dependency_graph/set_payload.rb
+++ b/lib/rubygems/vendor/molinillo/lib/molinillo/dependency_graph/set_payload.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'action'
-module Gem::Resolver::Molinillo
+module Gem::Molinillo
   class DependencyGraph
     # @!visibility private
     # @see DependencyGraph#set_payload

--- a/lib/rubygems/vendor/molinillo/lib/molinillo/dependency_graph/tag.rb
+++ b/lib/rubygems/vendor/molinillo/lib/molinillo/dependency_graph/tag.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'action'
-module Gem::Resolver::Molinillo
+module Gem::Molinillo
   class DependencyGraph
     # @!visibility private
     # @see DependencyGraph#tag

--- a/lib/rubygems/vendor/molinillo/lib/molinillo/dependency_graph/vertex.rb
+++ b/lib/rubygems/vendor/molinillo/lib/molinillo/dependency_graph/vertex.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Gem::Resolver::Molinillo
+module Gem::Molinillo
   class DependencyGraph
     # A vertex in a {DependencyGraph} that encapsulates a {#name} and a
     # {#payload}

--- a/lib/rubygems/vendor/molinillo/lib/molinillo/errors.rb
+++ b/lib/rubygems/vendor/molinillo/lib/molinillo/errors.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Gem::Resolver::Molinillo
+module Gem::Molinillo
   # An error that occurred during the resolution process
   class ResolverError < StandardError; end
 

--- a/lib/rubygems/vendor/molinillo/lib/molinillo/gem_metadata.rb
+++ b/lib/rubygems/vendor/molinillo/lib/molinillo/gem_metadata.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Gem::Resolver::Molinillo
-  # The version of Gem::Resolver::Molinillo.
+module Gem::Molinillo
+  # The version of Gem::Molinillo.
   VERSION = '0.8.0'.freeze
 end

--- a/lib/rubygems/vendor/molinillo/lib/molinillo/modules/specification_provider.rb
+++ b/lib/rubygems/vendor/molinillo/lib/molinillo/modules/specification_provider.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-module Gem::Resolver::Molinillo
+module Gem::Molinillo
   # Provides information about specifications and dependencies to the resolver,
   # allowing the {Resolver} class to remain generic while still providing power
   # and flexibility.
   #
-  # This module contains the methods that users of Gem::Resolver::Molinillo must to implement,
+  # This module contains the methods that users of Gem::Molinillo must to implement,
   # using knowledge of their own model classes.
   module SpecificationProvider
     # Search for the specifications that match the given dependency.

--- a/lib/rubygems/vendor/molinillo/lib/molinillo/modules/ui.rb
+++ b/lib/rubygems/vendor/molinillo/lib/molinillo/modules/ui.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Gem::Resolver::Molinillo
+module Gem::Molinillo
   # Conveys information about the resolution process to a user.
   module UI
     # The {IO} object that should be used to print output. `STDOUT`, by default.

--- a/lib/rubygems/vendor/molinillo/lib/molinillo/resolution.rb
+++ b/lib/rubygems/vendor/molinillo/lib/molinillo/resolution.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Gem::Resolver::Molinillo
+module Gem::Molinillo
   class Resolver
     # A specific resolution from a given {Resolver}
     class Resolution
@@ -244,8 +244,8 @@ module Gem::Resolver::Molinillo
       require_relative 'delegates/resolution_state'
       require_relative 'delegates/specification_provider'
 
-      include Gem::Resolver::Molinillo::Delegates::ResolutionState
-      include Gem::Resolver::Molinillo::Delegates::SpecificationProvider
+      include Gem::Molinillo::Delegates::ResolutionState
+      include Gem::Molinillo::Delegates::SpecificationProvider
 
       # Processes the topmost available {RequirementState} on the stack
       # @return [void]

--- a/lib/rubygems/vendor/molinillo/lib/molinillo/resolver.rb
+++ b/lib/rubygems/vendor/molinillo/lib/molinillo/resolver.rb
@@ -2,7 +2,7 @@
 
 require_relative 'dependency_graph'
 
-module Gem::Resolver::Molinillo
+module Gem::Molinillo
   # This class encapsulates a dependency resolver.
   # The resolver is responsible for determining which set of dependencies to
   # activate, with feedback from the {#specification_provider}

--- a/lib/rubygems/vendor/molinillo/lib/molinillo/state.rb
+++ b/lib/rubygems/vendor/molinillo/lib/molinillo/state.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Gem::Resolver::Molinillo
+module Gem::Molinillo
   # A state that a {Resolution} can be in
   # @attr [String] name the name of the current requirement
   # @attr [Array<Object>] requirements currently unsatisfied requirements

--- a/lib/rubygems/vendored_molinillo.rb
+++ b/lib/rubygems/vendored_molinillo.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative "vendor/molinillo/lib/molinillo"

--- a/tool/automatiek/vendor.rb
+++ b/tool/automatiek/vendor.rb
@@ -79,7 +79,7 @@ ignore = ["bundler"]
 
 vendored_gems = [
   # RubyGems
-  VendoredGem.new(name: "molinillo", namespace: "Molinillo", prefix: "Gem::Resolver", vendor_lib: "lib/rubygems/vendor/molinillo", license_path: "LICENSE", extra_dependencies: %w[tsort/lib/rubygems/vendor/tsort], patch_name: "molinillo-master.patch"),
+  VendoredGem.new(name: "molinillo", namespace: "Molinillo", prefix: "Gem", vendor_lib: "lib/rubygems/vendor/molinillo", license_path: "LICENSE", extra_dependencies: %w[tsort/lib/rubygems/vendor/tsort], patch_name: "molinillo-master.patch"),
   VendoredGem.new(name: "net-http", namespace: "Net", prefix: "Gem", vendor_lib: "lib/rubygems/vendor/net-http", license_path: "LICENSE.txt", extra_dependencies: %w[net-protocol resolv timeout uri/lib/rubygems/vendor/uri], skip_dependencies: %w[uri], patch_name: "net-http-v0.4.0.patch"),
   VendoredGem.new(name: "net-http-persistent", namespace: "Net::HTTP::Persistent", prefix: "Gem", vendor_lib: "bundler/lib/bundler/vendor/net-http-persistent", license_path: "README.rdoc", extra_dependencies: %w[net-http uri/lib/rubygems/vendor/uri], patch_name: "net-http-persistent-v4.0.2.patch"),
   VendoredGem.new(name: "net-protocol", namespace: "Net", prefix: "Gem", vendor_lib: "lib/rubygems/vendor/net-protocol", license_path: "LICENSE.txt"),


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The current `molinillo` loads to `Gem::Resolver::Molinillo` namespace. It's inconsistency with https://github.com/rubygems/rubygems/pull/7433 changes.

## What is your fix for the problem, implemented in this PR?

I renamed `Gem::Resolver::Molinillo` to `Gem::Molinillo` and resolved related code.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
