### PR TITLE
WEBrick:Utils::TimeoutHandler is always provided after webrick gem

### DIFF
--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -1129,8 +1129,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
       @ssl_server_thread.kill.join
       @ssl_server_thread = nil
     end
-    utils = WEBrick::Utils # TimeoutHandler is since 1.9
-    utils::TimeoutHandler.terminate if defined?(utils::TimeoutHandler.terminate)
+    WEBrick::Utils::TimeoutHandler.terminate
   end
 
   def normal_server_port


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`WEBrick:Utils::TimeoutHandler` is always provide from webrick gem.

## What is your fix for the problem, implemented in this PR?

Removed needless condition.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
