### PR TITLE
feature: deep copy requirements in Gem::Specification and Gem::Requirement

### DIFF
--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -284,6 +284,11 @@ class Gem::Requirement
   def _tilde_requirements
     @_tilde_requirements ||= _sorted_requirements.select {|r| r.first == "~>" }
   end
+
+  def initialize_copy(other) # :nodoc:
+    @requirements = other.requirements.dup
+    super
+  end
 end
 
 class Gem::Version

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2075,7 +2075,8 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   ##
-  # Duplicates array_attributes from +other_spec+ so state isn't shared.
+  # Duplicates Array and Gem::Requirement attributes from +other_spec+ so state isn't shared.
+  #
 
   def initialize_copy(other_spec)
     self.class.array_attributes.each do |name|
@@ -2097,6 +2098,9 @@ class Gem::Specification < Gem::BasicSpecification
         raise e
       end
     end
+
+    @required_ruby_version = other_spec.required_ruby_version.dup
+    @required_rubygems_version = other_spec.required_rubygems_version.dup
   end
 
   def base_dir

--- a/test/rubygems/test_gem_requirement.rb
+++ b/test/rubygems/test_gem_requirement.rb
@@ -12,6 +12,14 @@ class TestGemRequirement < Gem::TestCase
     assert_equal [[">=", v(1)], ["<", v(2)]], r.requirements
   end
 
+  def test_initialize_copy
+    r = req("= 1.2")
+    r2 = r.dup
+
+    assert_equal r.requirements, r2.requirements
+    refute_same r.requirements, r2.requirements
+  end
+
   def test_equals2
     r = req "= 1.2"
     assert_equal r, r.dup

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1194,10 +1194,13 @@ dependencies: []
     assert_same spec.bindir, dup_spec.bindir
 
     assert_equal ">= 0", spec.required_ruby_version.to_s
-    assert_same spec.required_ruby_version, dup_spec.required_ruby_version
+    assert_equal spec.required_ruby_version, dup_spec.required_ruby_version
+    refute_same spec.required_ruby_version, dup_spec.required_ruby_version
 
     assert_equal ">= 0", spec.required_rubygems_version.to_s
-    assert_same spec.required_rubygems_version,
+    assert_equal spec.required_rubygems_version,
+                 dup_spec.required_rubygems_version
+    refute_same spec.required_rubygems_version,
                 dup_spec.required_rubygems_version
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

While drafting https://github.com/rake-compiler/rake-compiler/pull/236, I needed to modify the `required_rubygems_version` of a `Gem::Specification` that was a copy of the original.

While doing so, I discovered two things:

- modifying the `required_rubygems_version` of a `Gem::Specification` copy also mutates the original's
- modifying the requirements of a `Gem::Requirements` copy also mutates the original's

That is:

```ruby
requirement2 = requirement.dup

# this modifies original `requirement`
requirement2.concat([">= 3.3.22"])
```

and

```ruby
spec2 = spec.dup

# this modifies original `spec`'s `required_rubygems_version`
spec2.required_rubygems_version.concat([">= 3.3.22"])
```

This was confusing and led to more complex code and tests.


## What is your fix for the problem, implemented in this PR?

This PR implements what I believe to be the common-sense behavior of "copy" for these classes to avoid accidental mutation of the originals:

- deep-copies the `Gem::Requirement` attributes of a `Gem::Specification`
- deep-copies the `@requirements` attribute of a `Gem::Requirement`

With this new behavior, my use case described above can be solved by:

```ruby
spec2 = spec.dup
spec2.required_rubygems_version.concat([">= 3.3.22"])
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
