### PR TITLE
Fix some flaky test failures on Windows

### DIFF
--- a/bundler/spec/support/command_execution.rb
+++ b/bundler/spec/support/command_execution.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Spec
-  CommandExecution = Struct.new(:command, :working_directory, :exitstatus, :stdout, :stderr) do
+  CommandExecution = Struct.new(:command, :working_directory, :exitstatus, :original_stdout, :original_stderr) do
     def to_s
       "$ #{command}"
     end
@@ -9,6 +9,19 @@ module Spec
 
     def stdboth
       @stdboth ||= [stderr, stdout].join("\n").strip
+    end
+
+    def stdout
+      original_stdout
+    end
+
+    # Can be removed once/if https://github.com/oneclick/rubyinstaller2/pull/369 is resolved
+    def stderr
+      return original_stderr unless Gem.win_platform?
+
+      original_stderr.split("\n").reject do |l|
+        l.include?("operating_system_defaults")
+      end.join("\n")
     end
 
     def to_s_verbose

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -193,8 +193,8 @@ module Spec
 
         stdout_read_thread = Thread.new { stdout.read }
         stderr_read_thread = Thread.new { stderr.read }
-        command_execution.stdout = stdout_read_thread.value.strip
-        command_execution.stderr = stderr_read_thread.value.strip
+        command_execution.original_stdout = stdout_read_thread.value.strip
+        command_execution.original_stderr = stderr_read_thread.value.strip
 
         status = wait_thr.value
         command_execution.exitstatus = if status.exited?


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Some specs assert empty output, but sometimes they print warnings about redefinition warnings. 

## What is your fix for the problem, implemented in this PR?

Ignore those until they are fixed [upstream](https://github.com/oneclick/rubyinstaller2/pull/369).

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
