### PR TITLE
Fix musl platform not being added to the lockfile

### DIFF
--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -65,7 +65,7 @@ module Bundler
 
       platforms.concat(new_platforms)
 
-      less_specific_platform = new_platforms.find {|platform| platform != Gem::Platform::RUBY && platform === Bundler.local_platform }
+      less_specific_platform = new_platforms.find {|platform| platform != Gem::Platform::RUBY && Bundler.local_platform === platform }
       platforms.delete(Bundler.local_platform) if less_specific_platform
 
       platforms


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since Bundler 2.5.0, we automatically lock all possible "RUBY" platforms (not windows, not java) where the resolve we found for the current platform is also valid.

I added some code though to avoid locking too many platforms in darwin, where no platform specific gems for each darwin version are release, so it's enough to lock `x86_64-darwin` rather than the exact running platform (things like `x86_64-darwin-19`).

However, this code had a bug where the current platform would also be incorrectly removed when it's `x86_64-linux-musl`.

## What is your fix for the problem, implemented in this PR?

Musl support in RubyGems introduced an exception in `Gem::Platform#===` commutativity and turns out the order should be the opposite to the one I was using to not get this case wrong.

Fixes #7432.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
