### PR TITLE
Add `gitlab:` git source shorthand

### DIFF
--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -19,6 +19,7 @@ module Bundler
                     platform platforms type source install_if gemfile force_ruby_platform].freeze
 
     GITHUB_PULL_REQUEST_URL = %r{\Ahttps://github\.com/([A-Za-z0-9_\-\.]+/[A-Za-z0-9_\-\.]+)/pull/(\d+)\z}
+    GITLAB_MERGE_REQUEST_URL = %r{\Ahttps://gitlab\.com/([A-Za-z0-9_\-\./]+)/-/merge_requests/(\d+)\z}
 
     attr_reader :gemspecs, :gemfile
     attr_accessor :dependencies
@@ -307,6 +308,20 @@ module Bundler
         user_name, repo_name = repo_name.split("/")
         repo_name ||= user_name
         "https://#{user_name}@bitbucket.org/#{user_name}/#{repo_name}.git"
+      end
+
+      git_source(:gitlab) do |repo_name|
+        if repo_name =~ GITLAB_MERGE_REQUEST_URL
+          {
+            "git" => "https://gitlab.com/#{$1}.git",
+            "branch" => nil,
+            "ref" => "refs/merge-requests/#{$2}/head",
+            "tag" => nil,
+          }
+        else
+          repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+          "https://gitlab.com/#{repo_name}.git"
+        end
       end
     end
 


### PR DESCRIPTION
First off, thank you for considering this Pull Request! I appreciate your time.

## What was the end-user or developer problem that led to this PR?

In #7210, I noted the existence of the `github:` and `bitbucket:` shorthands for installing gems from Git sources. I proposed adding two new providers, `gitlab:` and `codeberg:`, for the notable Git services [Gitlab](https://gitlab.com) and [Codeberg](https://codeberg.org). The proposal to add Gitlab was accepted.

The changes proposed in this PR would provide a small quality-of-life improvement for users with Ruby dependencies whose source repositories exist somewhere other than GitHub.

Resolves #7210.

## What is your fix for the problem, implemented in this PR?

This PR adds `gitlab:` shorthand with similar functionality to the existing `github:` shorthand:

```ruby
gem "gitlab-sdk", gitlab: "gitlab-org/analytics-section/product-analytics/gl-application-sdk-rb"
```

Merge Request URLs are also supported for each new shorthand:

```ruby
gem "gitlab-sdk", gitlab: "https://gitlab.com/gitlab-org/analytics-section/product-analytics/gl-application-sdk-rb/-/merge_requests/27"
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
