### PR TITLE
Remove no longer necessary `ruby/setup-ruby-pkgs` action

### DIFF
--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -49,14 +49,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby.value }}
           bundler: none
-        if: matrix.os.name != 'Windows'
-      - name: Setup ruby (Windows)
-        uses: ruby/setup-ruby-pkgs@c7f324bc4a9434f2ce3e55fa1cc19e41daecb231 # v1.33.1
-        with:
-          ruby-version: ${{ matrix.ruby.value }}
-          bundler: none
-          mingw: clang
-        if: matrix.os.name == 'Windows'
       - name: Configure bindgen
         shell: pwsh
         run: |


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

RubyGems CI on Windows is broken.

## What is your fix for the problem, implemented in this PR?

Stop using `ruby/setup-ruby-pkgs`. I was only added as a [workaround](https://github.com/rubygems/rubygems/pull/5175#discussion_r794873977) originally but it seems no longer necessary.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
