### PR TITLE
Fix some flaky test failures on Windows

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -62,12 +62,12 @@ jobs:
       - name: Install graphviz (Ubuntu)
         run: sudo apt-get install graphviz -y
         if: matrix.bundler.value == '' && matrix.os.name == 'Ubuntu'
-      - name: Prepare dependencies
-        run: |
-          bin/rake spec:parallel_deps
       - name: Replace version
         run: BUNDLER_SPEC_SUB_VERSION=${{ matrix.bundler.value }} bin/rake override_version
         if: matrix.bundler.value != ''
+      - name: Prepare dependencies
+        run: |
+          bin/rake spec:parallel_deps
       - name: Run Test
         run: |
           bin/parallel_rspec

--- a/.github/workflows/realworld-bundler.yml
+++ b/.github/workflows/realworld-bundler.yml
@@ -49,11 +49,11 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby.value }}
           bundler: none
-      - name: Prepare dependencies
-        run: bin/rake spec:deps
       - name: Replace version
         run: BUNDLER_SPEC_SUB_VERSION=${{ matrix.bundler.value }} bin/rake override_version
         if: matrix.bundler.value != ''
+      - name: Prepare dependencies
+        run: bin/rake spec:deps
       - name: Run Test
         run: bin/rake spec:realworld
       - name: Upload used cassettes as artifact
@@ -85,11 +85,11 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby.value }}
           bundler: none
-      - name: Prepare dependencies
-        run: bin/rake spec:deps
       - name: Replace version
         run: BUNDLER_SPEC_SUB_VERSION=${{ matrix.bundler.value }} bin/rake override_version
         if: matrix.bundler.value != ''
+      - name: Prepare dependencies
+        run: bin/rake spec:deps
       - name: Run Test
         run: bin/rake spec:realworld
       - name: Upload used cassettes as artifact

--- a/.github/workflows/system-rubygems-bundler.yml
+++ b/.github/workflows/system-rubygems-bundler.yml
@@ -47,12 +47,12 @@ jobs:
       - name: Install graphviz
         run: sudo apt-get install graphviz -y
         if: matrix.bundler.value == ''
-      - name: Prepare dependencies
-        run: |
-          bin/rake spec:parallel_deps
       - name: Replace version
         run: BUNDLER_SPEC_SUB_VERSION=${{ matrix.bundler.value }} bin/rake override_version
         if: matrix.bundler.value != ''
+      - name: Prepare dependencies
+        run: |
+          bin/rake spec:parallel_deps
       - name: Run Test
         run: |
           bin/parallel_rspec

--- a/Rakefile
+++ b/Rakefile
@@ -532,12 +532,16 @@ end
 namespace :spec do
   desc "Ensure spec dependencies are installed"
   task deps: "dev:deps" do
-    Spec::Rubygems.install_test_deps
+    chdir("bundler") do
+      Spec::Rubygems.install_test_deps
+    end
   end
 
   desc "Ensure spec dependencies for running in parallel are installed"
   task parallel_deps: "dev:deps" do
-    Spec::Rubygems.install_parallel_test_deps
+    chdir("bundler") do
+      Spec::Rubygems.install_parallel_test_deps
+    end
   end
 
   desc "Run all specs"

--- a/bin/rake
+++ b/bin/rake
@@ -3,7 +3,7 @@
 
 require_relative "../bundler/spec/support/rubygems_ext"
 
-if ["setup", "dev:deps", "dev:frozen_deps", "spec:deps", "spec:parallel_deps"].include?(ARGV[0])
+if ["setup", "dev:deps", "dev:frozen_deps", "override_version", "spec:deps", "spec:parallel_deps"].include?(ARGV[0])
   Spec::Rubygems.gem_load_and_possibly_install("rake", "rake")
 else
   Spec::Rubygems.gem_load("rake", "rake")

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -87,11 +87,10 @@ RSpec.configure do |config|
     # Don't wrap output in tests
     ENV["THOR_COLUMNS"] = "10000"
 
-    extend(Spec::Helpers)
-    system_gems :bundler, path: pristine_system_gem_path
-  end
+    Spec::Helpers.install_dev_bundler unless ENV["CI"]
 
-  config.before :all do
+    extend(Spec::Builders)
+
     check_test_gems!
 
     build_repo1

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -5,6 +5,11 @@ require "shellwords"
 
 module Spec
   module Builders
+    def self.extended(mod)
+      mod.extend Path
+      mod.extend Helpers
+    end
+
     def self.constantize(name)
       name.delete("-").upcase
     end
@@ -22,7 +27,7 @@ module Spec
     end
 
     def build_repo1
-      rake_path = Dir["#{Path.base_system_gems}/**/rake*.gem"].first
+      rake_path = Dir["#{base_system_gems}/**/rake*.gem"].first
 
       build_repo gem_repo1 do
         FileUtils.cp rake_path, "#{gem_repo1}/gems/"
@@ -240,12 +245,12 @@ module Spec
     end
 
     def check_test_gems!
-      rake_path = Dir["#{Path.base_system_gems}/**/rake*.gem"].first
+      rake_path = Dir["#{base_system_gems}/**/rake*.gem"].first
 
       if rake_path.nil?
-        FileUtils.rm_rf(Path.base_system_gems)
+        FileUtils.rm_rf(base_system_gems)
         Spec::Rubygems.install_test_deps
-        rake_path = Dir["#{Path.base_system_gems}/**/rake*.gem"].first
+        rake_path = Dir["#{base_system_gems}/**/rake*.gem"].first
       end
 
       if rake_path.nil?
@@ -261,9 +266,9 @@ module Spec
       @_build_path = "#{path}/gems"
       @_build_repo = File.basename(path)
       yield
-      with_gem_path_as Path.base_system_gem_path do
-        Dir[Spec::Path.base_system_gem_path.join("gems/rubygems-generate_index*/lib")].first ||
-          raise("Could not find rubygems-generate_index lib directory in #{Spec::Path.base_system_gem_path}")
+      with_gem_path_as base_system_gem_path do
+        Dir[base_system_gem_path.join("gems/rubygems-generate_index*/lib")].first ||
+          raise("Could not find rubygems-generate_index lib directory in #{base_system_gem_path}")
 
         command = "generate_index"
         command += " --no-compact" if !build_compact_index && gem_command(command + " --help").include?("--[no-]compact")

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -11,6 +11,12 @@ module Spec
     include Spec::Options
     include Spec::Subprocess
 
+    def self.extended(mod)
+      mod.extend Spec::Path
+      mod.extend Spec::Options
+      mod.extend Spec::Subprocess
+    end
+
     def reset!
       Dir.glob("#{tmp}/{gems/*,*}", File::FNM_DOTMATCH).each do |dir|
         next if %w[base base_system remote1 rubocop standard gems rubygems . ..].include?(File.basename(dir))
@@ -301,6 +307,12 @@ module Spec
       end
     end
 
+    def self.install_dev_bundler
+      extend self
+
+      system_gems :bundler, path: pristine_system_gem_path
+    end
+
     def install_gem(path, install_dir, default = false)
       raise "OMG `#{path}` does not exist!" unless File.exist?(path)
 
@@ -311,6 +323,8 @@ module Spec
     end
 
     def with_built_bundler(version = nil, &block)
+      require_relative "builders"
+
       Builders::BundlerBuilder.new(self, "bundler", version)._build(&block)
     end
 

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -75,9 +75,15 @@ module Spec
     end
 
     def install_test_deps
+      Gem.clear_paths
+
       install_gems(test_gemfile, Path.base_system_gems.to_s)
       install_gems(rubocop_gemfile, Path.rubocop_gems.to_s)
       install_gems(standard_gemfile, Path.standard_gems.to_s)
+
+      # For some reason, doing this here crashes on JRuby + Windows. So defer to
+      # when the test suite is running in that case.
+      Helpers.install_dev_bundler unless Gem.win_platform? && RUBY_ENGINE == "jruby"
     end
 
     def check_source_control_changes(success_message:, error_message:)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

There's a longstanding flaky CI failure on Windows that reads like this:

```
4 processes for 172 specs, ~ 43 specs per process

Randomized with seed 26551


An error occurred in a `before(:suite)` hook.
Failure/Error: FileUtils.cp shipped_file, target_shipped_file, preserve: true

Errno::EACCES:
  Permission denied - read
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/3.3.0/fileutils.rb:2280:in `copy_stream'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/3.3.0/fileutils.rb:2280:in `block (2 levels) in copy_file'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/3.3.0/fileutils.rb:2279:in `open'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/3.3.0/fileutils.rb:2279:in `block in copy_file'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/3.3.0/fileutils.rb:2278:in `open'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/3.3.0/fileutils.rb:2278:in `copy_file'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/3.3.0/fileutils.rb:1078:in `copy_file'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/3.3.0/fileutils.rb:877:in `block in cp'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/3.3.0/fileutils.rb:2469:in `block in fu_each_src_dest'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/3.3.0/fileutils.rb:2485:in `fu_each_src_dest0'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/3.3.0/fileutils.rb:2467:in `fu_each_src_dest'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/3.3.0/fileutils.rb:876:in `cp'
# ./spec/support/builders.rb:432:in `block in _build'
# ./spec/support/builders.rb:426:in `each'
# ./spec/support/builders.rb:426:in `_build'
# ./spec/support/helpers.rb:280:in `with_built_bundler'
# ./spec/support/helpers.rb:260:in `block (2 levels) in system_gems'
# ./spec/support/helpers.rb:256:in `each'
# ./spec/support/helpers.rb:256:in `block in system_gems'
# ./spec/support/helpers.rb:289:in `block in with_gem_path_as'
# ./spec/support/helpers.rb:303:in `without_env_side_effects'
# ./spec/support/helpers.rb:284:in `with_gem_path_as'
# ./spec/support/helpers.rb:254:in `system_gems'
# ./spec/spec_helper.rb:91:in `block (2 levels) in <top (required)>'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/example.rb:457:in `instance_exec'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/example.rb:457:in `instance_exec'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/hooks.rb:365:in `run'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/configuration.rb:2185:in `block in run_suite_hooks'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/configuration.rb:2183:in `each'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/configuration.rb:2183:in `run_suite_hooks'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/configuration.rb:2090:in `with_suite_hooks'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/runner.rb:116:in `block in run_specs'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/reporter.rb:74:in `report'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/runner.rb:115:in `run_specs'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/runner.rb:89:in `run'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/runner.rb:71:in `run'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/runner.rb:45:in `invoke'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/exe/rspec:4:in `<top (required)>'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/bin/rspec:25:in `load'
# C:/hostedtoolcache/windows/Ruby/3.3.1/x64/bin/rspec:25:in `<main>'
*...*.......................................................................................................*.................*...............................................................................................................................................*...................................................................................................................................................................................................................................................................................................................................................................................................................................................*........................................**...............****.........*....................****.......***************.******.**.*.*.*.*.*.*.*.*.*.*.*.*.*.*.*.*.*...........*............*.............*........**.*..**..*..***.**..*.*.*...............*......................................................................................................................................................................................................................................................................................................................................................*.......................................................................................................................................*............................**..............*........................................*...............*..................................................*.......*............*....................................*...........................................................*.......*.......*.......*.......................*................................*...*...................................................*.................*.......*......*....*...........*.......................*...............................................................................................................................................................................................................................................................................*............*......*...........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
```

See for example https://github.com/rubygems/rubygems/actions/runs/9663003543/job/26654152938.
 
## What is your fix for the problem, implemented in this PR?

My diagnosis is that when starting the parallelized test suite, multiple processes copy source files necessary to build bundler to its own folder in `tmp/`. On Windows, this can apparently result in permission errors, I guess because the file is in use by another process.

As a workaround, I changed building bundler in CI to happen just once at `bin/rake spec:deps` time, not on the fly when running specs.

I expect this to make this error not happen again.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
