### PR TITLE
Revert "Simplify how extensions are built"

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -19,14 +19,7 @@ class Gem::Ext::Builder
     $1.downcase
   end
 
-  def self.make(dest_path, results, make_dir = Dir.pwd, targets_or_sitedir = ["clean", "", "install"], old_targets = ["clean", "", "install"])
-    if !targets_or_sitedir.is_a?(Array)
-      verbose { "sitedir parameter to Gem::Ext::Builder.make is getting ignored. sitearchdir and sitelibdir are now always set to the first argument passed to this method. Please stop passing this parameter" }
-      targets = old_targets
-    else
-      targets = targets_or_sitedir
-    end
-
+  def self.make(dest_path, results, make_dir = Dir.pwd, sitedir = nil, targets = ["clean", "", "install"])
     unless File.exist? File.join(make_dir, "Makefile")
       raise Gem::InstallError, "Makefile not found"
     end
@@ -42,8 +35,10 @@ class Gem::Ext::Builder
 
     env = [destdir]
 
-    env << format("sitearchdir=%s", dest_path)
-    env << format("sitelibdir=%s", dest_path)
+    if sitedir
+      env << format("sitearchdir=%s", sitedir)
+      env << format("sitelibdir=%s", sitedir)
+    end
 
     targets.each do |target|
       # Pass DESTDIR via command line to override what's in MAKEFLAGS

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -9,6 +9,15 @@
 class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
   def self.build(extension, dest_path, results, args=[], lib_dir=nil, extension_dir=Dir.pwd)
     require "fileutils"
+    require "tempfile"
+
+    tmp_dest = Dir.mktmpdir(".gem.", extension_dir)
+
+    # Some versions of `mktmpdir` return absolute paths, which will break make
+    # if the paths contain spaces.
+    #
+    # As such, we convert to a relative path.
+    tmp_dest_relative = get_relative_path(tmp_dest.clone, extension_dir)
 
     destdir = ENV["DESTDIR"]
 
@@ -30,31 +39,35 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
 
       ENV["DESTDIR"] = nil
 
-      rel_dest_path = get_relative_path(dest_path, extension_dir)
-      make rel_dest_path, results, extension_dir
+      make dest_path, results, extension_dir, tmp_dest_relative
+
+      full_tmp_dest = File.join(extension_dir, tmp_dest_relative)
 
       # TODO: remove in RubyGems 4
       if Gem.install_extension_in_lib && lib_dir
         FileUtils.mkdir_p lib_dir
-        entries = Dir.entries(dest_path) - %w[. ..]
-        entries = entries.map {|entry| File.join dest_path, entry }
+        entries = Dir.entries(full_tmp_dest) - %w[. ..]
+        entries = entries.map {|entry| File.join full_tmp_dest, entry }
         FileUtils.cp_r entries, lib_dir, remove_destination: true
       end
 
-      make dest_path, results, extension_dir, ["clean"]
+      FileUtils::Entry_.new(full_tmp_dest).traverse do |ent|
+        destent = ent.class.new(dest_path, ent.rel)
+        destent.exist? || FileUtils.mv(ent.path, destent.path)
+      end
+
+      make dest_path, results, extension_dir, tmp_dest_relative, ["clean"]
     ensure
       ENV["DESTDIR"] = destdir
     end
 
     results
+  ensure
+    FileUtils.rm_rf tmp_dest if tmp_dest
   end
 
   def self.get_relative_path(path, base)
-    path.split("/").zip(base.split("/")).inject(String.new) do |result, (path_component, base_component)|
-      next result if path_component == base_component
-      result.prepend("../") if base_component
-      result.concat("#{path_component}/") if path_component
-      result
-    end
+    path[0..base.length - 1] = "." if path.start_with?(base)
+    path
   end
 end

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -48,9 +48,9 @@ install:
 
     results = results.join("\n").b
 
-    assert_match(/DESTDIR\\=#{ENV["DESTDIR"]} sitearchdir\\=#{@dest_path} sitelibdir\\=#{@dest_path} clean$/, results)
-    assert_match(/DESTDIR\\=#{ENV["DESTDIR"]} sitearchdir\\=#{@dest_path} sitelibdir\\=#{@dest_path}$/, results)
-    assert_match(/DESTDIR\\=#{ENV["DESTDIR"]} sitearchdir\\=#{@dest_path} sitelibdir\\=#{@dest_path} install/, results)
+    assert_match(/DESTDIR\\=#{ENV["DESTDIR"]} clean$/,   results)
+    assert_match(/DESTDIR\\=#{ENV["DESTDIR"]}$/,         results)
+    assert_match(/DESTDIR\\=#{ENV["DESTDIR"]} install$/, results)
 
     unless results.include?("nmake")
       assert_match(/^clean: destination$/,   results)
@@ -77,9 +77,9 @@ install:
 
     results = results.join("\n").b
 
-    assert_match(/DESTDIR\\=#{ENV["DESTDIR"]} sitearchdir\\=#{@dest_path} sitelibdir\\=#{@dest_path} clean$/, results)
-    assert_match(/DESTDIR\\=#{ENV["DESTDIR"]} sitearchdir\\=#{@dest_path} sitelibdir\\=#{@dest_path}$/, results)
-    assert_match(/DESTDIR\\=#{ENV["DESTDIR"]} sitearchdir\\=#{@dest_path} sitelibdir\\=#{@dest_path} install$/, results)
+    assert_match(/DESTDIR\\=#{ENV["DESTDIR"]} clean$/,   results)
+    assert_match(/DESTDIR\\=#{ENV["DESTDIR"]}$/,         results)
+    assert_match(/DESTDIR\\=#{ENV["DESTDIR"]} install$/, results)
   end
 
   def test_custom_make_with_options


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

After #6137, #7450 was brought up that brings some extra complexity to the original PR, making it unclear whether changes are worth it.

## What is your fix for the problem, implemented in this PR?

When in doubt, better not to change anything.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
