### PR TITLE
Warn if RubyGems version explicitly set in gemspec does not match running version

### DIFF
--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -518,7 +518,6 @@ module Spec
 
         if options[:rubygems_version]
           @spec.rubygems_version = options[:rubygems_version]
-          def @spec.mark_version; end
 
           def @spec.validate(*); end
         end

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -294,7 +294,6 @@ class Gem::Package
 
     Gem.load_yaml
 
-    @spec.mark_version
     @spec.validate true, strict_validation unless skip_validation
 
     setup_signer(

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -194,7 +194,7 @@ class Gem::Specification < Gem::BasicSpecification
   NOT_FOUND = Struct.new(:to_spec, :this).new # :nodoc:
 
   # Tracking removed method calls to warn users during build time.
-  REMOVED_METHODS = [:rubyforge_project=].freeze # :nodoc:
+  REMOVED_METHODS = [:rubyforge_project=, :mark_version].freeze # :nodoc:
   def removed_method_calls
     @removed_method_calls ||= []
   end
@@ -1874,8 +1874,6 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   def encode_with(coder) # :nodoc:
-    mark_version
-
     coder.add "name", @name
     coder.add "version", @version
     platform = case @original_platform
@@ -2168,13 +2166,6 @@ class Gem::Specification < Gem::BasicSpecification
     @ri_dir        = nil
     @spec_dir      = nil
     @spec_file     = nil
-  end
-
-  ##
-  # Sets the rubygems_version to the current RubyGems version.
-
-  def mark_version
-    @rubygems_version = Gem::VERSION
   end
 
   ##
@@ -2494,7 +2485,6 @@ class Gem::Specification < Gem::BasicSpecification
   # still have their default values are omitted.
 
   def to_ruby
-    mark_version
     result = []
     result << "# -*- encoding: utf-8 -*-"
     result << "#{Gem::StubSpecification::PREFIX}#{name} #{version} #{platform} #{raw_require_paths.join("\0")}"

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -274,7 +274,9 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
 
     return if rubygems_version == Gem::VERSION
 
-    error "expected RubyGems version #{Gem::VERSION}, was #{rubygems_version}"
+    warning "expected RubyGems version #{Gem::VERSION}, was #{rubygems_version}"
+
+    @specification.rubygems_version = Gem::VERSION
   end
 
   def validate_required_attributes

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1281,7 +1281,6 @@ class TestGem < Gem::TestCase
   def test_self_try_activate_missing_extensions
     spec = util_spec "ext", "1" do |s|
       s.extensions = %w[ext/extconf.rb]
-      s.mark_version
       s.installed_by_version = v("2.2")
     end
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -56,7 +56,6 @@ end
       s.add_dependency "jabber4r", "> 0.0.0"
       s.add_dependency "pqa", ["> 0.4", "<= 0.6"]
 
-      s.mark_version
       s.files = %w[lib/code.rb]
     end
   end
@@ -69,7 +68,6 @@ end
       s.license = "MIT"
       s.platform = platform
 
-      s.mark_version
       s.files = %w[lib/code.rb]
       s.installed_by_version = v("2.2")
     end
@@ -96,7 +94,6 @@ end
       s.requirements << "A working computer"
       s.license = "MIT"
 
-      s.mark_version
       s.files = %w[lib/code.rb]
     end
 
@@ -3187,7 +3184,7 @@ or set it to nil if you don't want to specify a license.
   end
 
   def test_removed_methods
-    assert_equal Gem::Specification::REMOVED_METHODS, [:rubyforge_project=]
+    assert_equal Gem::Specification::REMOVED_METHODS, [:rubyforge_project=, :mark_version]
   end
 
   def test_validate_removed_rubyforge_project
@@ -3480,12 +3477,17 @@ Did you mean 'Ruby'?
     util_setup_validate
 
     @a1.rubygems_version = "3"
-    e = assert_raise Gem::InvalidSpecificationException do
+
+    use_ui @ui do
       @a1.validate
     end
 
-    assert_equal "expected RubyGems version #{Gem::VERSION}, was 3",
-                 e.message
+    expected = <<~EXPECTED
+      #{w}:  expected RubyGems version #{Gem::VERSION}, was 3
+      #{w}:  See https://guides.rubygems.org/specification-reference/ for help
+    EXPECTED
+
+    assert_equal expected, @ui.error
   end
 
   def test_validate_specification_version


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This gets in the middle if we ever start allowing to build as if using a different RubyGems version than the one being run.

This could be useful to make `gem rebuild` a little more usable, and it's already done by Bundler specs which already make this method a noop when they need this.

I'm not sure forcefully setting this, even if user explicitly specified something else is helpful.

## What is your fix for the problem, implemented in this PR?

Since this could potentially prevent gems explicitly setting a constant RubyGems version from building, I changed the error of incorrect RubyGems version from a hard error to a warning, since it will start happening in those cases if we stop overwriting the version.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
