### PR TITLE
Use full path for `instance_eval` in `Bundler::DSL#eval_gemfile`

### DIFF
--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -46,7 +46,7 @@ module Bundler
       @gemfile = expanded_gemfile_path
       @gemfiles << expanded_gemfile_path
       contents ||= Bundler.read_file(@gemfile.to_s)
-      instance_eval(contents, gemfile.to_s, 1)
+      instance_eval(contents, @gemfile.to_s, 1)
     rescue Exception => e # rubocop:disable Lint/RescueException
       message = "There was an error " \
         "#{e.is_a?(GemfileEvalError) ? "evaluating" : "parsing"} " \

--- a/bundler/spec/bundler/dsl_spec.rb
+++ b/bundler/spec/bundler/dsl_spec.rb
@@ -134,6 +134,17 @@ RSpec.describe Bundler::Dsl do
       expect { subject.eval_gemfile("Gemfile") }.
         to raise_error(Bundler::GemfileError, /There was an error evaluating `Gemfile`: ruby_version must match the :engine_version for MRI/)
     end
+
+    it "populates __dir__ and __FILE__ correctly" do
+      abs_path = source_root.join("../fragment.rb").to_s
+      expect(Bundler).to receive(:read_file).with(abs_path).and_return(<<~RUBY)
+        @fragment_dir = __dir__
+        @fragment_file = __FILE__
+      RUBY
+      subject.eval_gemfile("../fragment.rb")
+      expect(subject.instance_variable_get(:@fragment_dir)).to eq(source_root.dirname.to_s)
+      expect(subject.instance_variable_get(:@fragment_file)).to eq(abs_path)
+    end
   end
 
   describe "#gem" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When using `eval_gemfile("../gemfile_prefix.rb")` with a Gemfile that's not in the current directory, `__dir__` and `__FILE__`
end up being `".."` and `"gemfile_prefix.rb"` respectively, which is not usable from within gemfile_prefix.rb in order to find other relative files, since `Dir.pwd` is not the Gemfile's directory.

## What is your fix for the problem, implemented in this PR?

`eval_gemfile` already calculates the absolute path to the gemfile fragment; just pass that to `instance_eval`. This makes it behave the same wrt `__dir__` and `__FILE__` as `require_relative`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
