### PR TITLE
Backport https://bugs.ruby-lang.org/issues/16495

### DIFF
--- a/bundler/spec/bundler/bundler_spec.rb
+++ b/bundler/spec/bundler/bundler_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Bundler do
   describe "#load_marshal" do
     it "is a private method and raises an error" do
       data = Marshal.dump(Bundler)
-      expect { Bundler.load_marshal(data) }.to raise_error(NoMethodError, /private method `load_marshal' called/)
+      expect { Bundler.load_marshal(data) }.to raise_error(NoMethodError, /private method [`']load_marshal' called/)
     end
 
     it "loads any data" do

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -831,8 +831,7 @@ RSpec.describe "bundle exec" do
       let(:executable) { super() << "\nraise 'ERROR'" }
       let(:exit_code) { 1 }
       let(:expected_err) do
-        "bundler: failed to load command: #{path} (#{path})" \
-        "\n#{path}:10:in `<top (required)>': ERROR (RuntimeError)"
+        /\Abundler: failed to load command: #{Regexp.quote(path.to_s)} \(#{Regexp.quote(path.to_s)}\)\n#{Regexp.quote(path.to_s)}:10:in [`']<top \(required\)>': ERROR \(RuntimeError\)/
       end
 
       it "runs like a normally executed executable" do
@@ -840,7 +839,7 @@ RSpec.describe "bundle exec" do
 
         subject
         expect(exitstatus).to eq(exit_code)
-        expect(err).to start_with(expected_err)
+        expect(err).to match(expected_err)
         expect(out).to eq(expected)
       end
     end

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1532,7 +1532,7 @@ end
       RUBY
 
       expect(last_command.stdboth).not_to include "FAIL"
-      expect(err).to include "private method `require'"
+      expect(err).to match /private method [`']require'/
     end
 
     it "memoizes initial set of specs when requiring bundler/setup, so that even if further code mutates dependencies, Bundler.definition.specs is not affected" do

--- a/test/rubygems/test_rubygems.rb
+++ b/test/rubygems/test_rubygems.rb
@@ -17,7 +17,7 @@ class GemTest < Gem::TestCase
 
     output = Gem::Util.popen(*ruby_with_rubygems_and_fake_operating_system_in_load_path(path), "-e", "'require \"rubygems\"'", { err: [:child, :out] }).strip
     assert !$?.success?
-    assert_includes output, "undefined local variable or method `intentionally_not_implemented_method'"
+    assert_includes output, "undefined local variable or method 'intentionally_not_implemented_method'"
     assert_includes output, "Loading the #{operating_system_rb_at(path)} file caused an error. " \
     "This file is owned by your OS, not by rubygems upstream. " \
     "Please find out which OS package this file belongs to and follow the guidelines from your OS to report " \


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

See https://bugs.ruby-lang.org/issues/16495

Ruby core changed inconsistent quotes for Ruby 3.4.

## What is your fix for the problem, implemented in this PR?

I backport these changes from `ruby/ruby` repo.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
