### PR TITLE
Avoid to fail with race condition

### DIFF
--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -421,7 +421,7 @@ module Spec
         build_path = @context.tmp + full_name
         bundler_path = build_path + "#{full_name}.gem"
 
-        Dir.mkdir build_path
+        Dir.mkdir build_path unless File.directory?(build_path)
 
         @context.shipped_files.each do |shipped_file|
           target_shipped_file = shipped_file

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -421,7 +421,7 @@ module Spec
         build_path = @context.tmp + full_name
         bundler_path = build_path + "#{full_name}.gem"
 
-        Dir.mkdir build_path unless File.directory?(build_path)
+        FileUtils.mkdir_p build_path
 
         @context.shipped_files.each do |shipped_file|
           target_shipped_file = shipped_file


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I got test fails sometimes with the following error.

```
An error occurred in a `before(:suite)` hook.
Failure/Error: Dir.mkdir build_path

Errno::EEXIST:
  File exists @ dir_s_mkdir - /Users/hsbt/Documents/github.com/ruby/ruby/tmp/5/bundler-2.6.0.dev
# ./spec/bundler/support/builders.rb:424:in 'Dir.mkdir'
# ./spec/bundler/support/builders.rb:424:in 'Spec::Builders::BundlerBuilder#_build'
# ./spec/bundler/support/helpers.rb:330:in 'Spec::Helpers#with_built_bundler'
# ./spec/bundler/support/helpers.rb:310:in 'block (2 levels) in Spec::Helpers#system_gems'
# ./spec/bundler/support/helpers.rb:306:in 'block in Spec::Helpers#system_gems'
# ./spec/bundler/support/helpers.rb:339:in 'block in Spec::Helpers#with_gem_path_as'
# ./spec/bundler/support/helpers.rb:353:in 'Spec::Helpers#without_env_side_effects'
# ./spec/bundler/support/helpers.rb:334:in 'Spec::Helpers#with_gem_path_as'
# ./spec/bundler/support/helpers.rb:304:in 'Spec::Helpers#system_gems'
# ./spec/bundler/spec_helper.rb:91:in 'block (2 levels) in <top (required)>'


Finished in 0.19038 seconds (files took 0.3191 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples
```

## What is your fix for the problem, implemented in this PR?

I added simple check for directory existence.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
