### PR TITLE
Suppress warning during test runner.

### DIFF
--- a/test/rubygems/test_gem_package_task.rb
+++ b/test/rubygems/test_gem_package_task.rb
@@ -9,10 +9,6 @@ rescue LoadError => e
   raise unless e.path == "rake/packagetask"
 end
 
-unless defined?(Rake::PackageTask)
-  warn "Skipping Gem::PackageTask tests.  rake not found."
-end
-
 class TestGemPackageTask < Gem::TestCase
   def test_gem_package
     original_rake_fileutils_verbosity = RakeFileUtils.verbose_flag


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

ruby core repository explicitly removed this test file at https://github.com/ruby/ruby/commit/c945a849cb2c5fcdfa546e501f35bf8f834c8d7e for avoid to show warning.

In my opinion, we should remove `--exclude='rubygems/test_gem_package_task\.rb'` option. This is harmful to specify test file in common Makefile.

## What is your fix for the problem, implemented in this PR?

I removed this warning. ruby core explicitly removed `rake` as bundled gems from `$LOAD_PATH` at https://github.com/ruby/ruby/commit/5bf75c20a2098e626d0dd65708a35c46039c5310. 

`rubygems/test_gem_package_task.rb` is not runnable with above policy.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
