### PR TITLE
Remove redundant rubocop configs

### DIFF
--- a/bundler/lib/bundler/templates/newgem/rubocop.yml.tt
+++ b/bundler/lib/bundler/templates/newgem/rubocop.yml.tt
@@ -2,12 +2,7 @@ AllCops:
   TargetRubyVersion: <%= ::Gem::Version.new(config[:required_ruby_version]).segments[0..1].join(".") %>
 
 Style/StringLiterals:
-  Enabled: true
   EnforcedStyle: double_quotes
 
 Style/StringLiteralsInInterpolation:
-  Enabled: true
   EnforcedStyle: double_quotes
-
-Layout/LineLength:
-  Max: 120


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->
When creating a new gem with `bundle gem`, the specified rubocop version is `"~> 1.21"`, which already has several of the configs values set:

- The default `Max` value of `LineLength` has been 120 since [v0.84.0](https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md#changes-80)
- `Style/StringLiterals` and `Style/StringLiteralsInInterpolation` have been enabled by default for even [longer](https://github.com/rubocop/rubocop/pull/6293/files#diff-3653213e3a153018a75cc7b2536b1d0217a6d8d75188d71cf45441812f789698R3986)

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

I've removed the redundant config settings.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
