### PR TITLE
Use https instead of http

### DIFF
--- a/bundler/lib/bundler/man/bundle-add.1
+++ b/bundler/lib/bundler/man/bundle-add.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-ADD" "1" "December 2023" ""
+.TH "BUNDLE\-ADD" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-add\fR \- Add gem to the Gemfile and run bundle install
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-binstubs.1
+++ b/bundler/lib/bundler/man/bundle-binstubs.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-BINSTUBS" "1" "December 2023" ""
+.TH "BUNDLE\-BINSTUBS" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-binstubs\fR \- Install the binstubs of the listed gems
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-cache.1
+++ b/bundler/lib/bundler/man/bundle-cache.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-CACHE" "1" "December 2023" ""
+.TH "BUNDLE\-CACHE" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-cache\fR \- Package your needed \fB\.gem\fR files into your application
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-check.1
+++ b/bundler/lib/bundler/man/bundle-check.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-CHECK" "1" "December 2023" ""
+.TH "BUNDLE\-CHECK" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-check\fR \- Verifies if dependencies are satisfied by installed gems
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-clean.1
+++ b/bundler/lib/bundler/man/bundle-clean.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-CLEAN" "1" "December 2023" ""
+.TH "BUNDLE\-CLEAN" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-clean\fR \- Cleans up unused gems in your bundler directory
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-CONFIG" "1" "December 2023" ""
+.TH "BUNDLE\-CONFIG" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-config\fR \- Set bundler configuration options
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-console.1
+++ b/bundler/lib/bundler/man/bundle-console.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-CONSOLE" "1" "December 2023" ""
+.TH "BUNDLE\-CONSOLE" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-console\fR \- Deprecated way to open an IRB session with the bundle pre\-loaded
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-doctor.1
+++ b/bundler/lib/bundler/man/bundle-doctor.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-DOCTOR" "1" "December 2023" ""
+.TH "BUNDLE\-DOCTOR" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-doctor\fR \- Checks the bundle for common problems
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-exec.1
+++ b/bundler/lib/bundler/man/bundle-exec.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-EXEC" "1" "December 2023" ""
+.TH "BUNDLE\-EXEC" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-exec\fR \- Execute a command in the context of the bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-gem.1
+++ b/bundler/lib/bundler/man/bundle-gem.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-GEM" "1" "December 2023" ""
+.TH "BUNDLE\-GEM" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-gem\fR \- Generate a project skeleton for creating a rubygem
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-help.1
+++ b/bundler/lib/bundler/man/bundle-help.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-HELP" "1" "December 2023" ""
+.TH "BUNDLE\-HELP" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-help\fR \- Displays detailed help for each subcommand
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-info.1
+++ b/bundler/lib/bundler/man/bundle-info.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-INFO" "1" "December 2023" ""
+.TH "BUNDLE\-INFO" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-info\fR \- Show information for the given gem in your bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-init.1
+++ b/bundler/lib/bundler/man/bundle-init.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-INIT" "1" "December 2023" ""
+.TH "BUNDLE\-INIT" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-init\fR \- Generates a Gemfile into the current working directory
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-inject.1
+++ b/bundler/lib/bundler/man/bundle-inject.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-INJECT" "1" "December 2023" ""
+.TH "BUNDLE\-INJECT" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-inject\fR \- Add named gem(s) with version requirements to Gemfile
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-install.1
+++ b/bundler/lib/bundler/man/bundle-install.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-INSTALL" "1" "December 2023" ""
+.TH "BUNDLE\-INSTALL" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-install\fR \- Install the dependencies specified in your Gemfile
 .SH "SYNOPSIS"
@@ -208,8 +208,8 @@ To explicitly update \fBactionpack\fR, including its dependencies which other ge
 \fBSummary\fR: In general, after making a change to the Gemfile(5) , you should first try to run \fBbundle install\fR, which will guarantee that no other gem in the Gemfile(5) is impacted by the change\. If that does not work, run bundle update(1) \fIbundle\-update\.1\.html\fR\.
 .SH "SEE ALSO"
 .IP "\(bu" 4
-Gem install docs \fIhttp://guides\.rubygems\.org/rubygems\-basics/#installing\-gems\fR
+Gem install docs \fIhttps://guides\.rubygems\.org/rubygems\-basics/#installing\-gems\fR
 .IP "\(bu" 4
-Rubygems signing docs \fIhttp://guides\.rubygems\.org/security/\fR
+Rubygems signing docs \fIhttps://guides\.rubygems\.org/security/\fR
 .IP "" 0
 

--- a/bundler/lib/bundler/man/bundle-install.1.ronn
+++ b/bundler/lib/bundler/man/bundle-install.1.ronn
@@ -379,5 +379,5 @@ does not work, run [bundle update(1)](bundle-update.1.html).
 
 ## SEE ALSO
 
-* [Gem install docs](http://guides.rubygems.org/rubygems-basics/#installing-gems)
-* [Rubygems signing docs](http://guides.rubygems.org/security/)
+* [Gem install docs](https://guides.rubygems.org/rubygems-basics/#installing-gems)
+* [Rubygems signing docs](https://guides.rubygems.org/security/)

--- a/bundler/lib/bundler/man/bundle-list.1
+++ b/bundler/lib/bundler/man/bundle-list.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-LIST" "1" "December 2023" ""
+.TH "BUNDLE\-LIST" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-list\fR \- List all the gems in the bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-lock.1
+++ b/bundler/lib/bundler/man/bundle-lock.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-LOCK" "1" "December 2023" ""
+.TH "BUNDLE\-LOCK" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-lock\fR \- Creates / Updates a lockfile without installing
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-open.1
+++ b/bundler/lib/bundler/man/bundle-open.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-OPEN" "1" "December 2023" ""
+.TH "BUNDLE\-OPEN" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-open\fR \- Opens the source directory for a gem in your bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-outdated.1
+++ b/bundler/lib/bundler/man/bundle-outdated.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-OUTDATED" "1" "December 2023" ""
+.TH "BUNDLE\-OUTDATED" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-outdated\fR \- List installed gems with newer versions available
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-platform.1
+++ b/bundler/lib/bundler/man/bundle-platform.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-PLATFORM" "1" "December 2023" ""
+.TH "BUNDLE\-PLATFORM" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-platform\fR \- Displays platform compatibility information
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-plugin.1
+++ b/bundler/lib/bundler/man/bundle-plugin.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-PLUGIN" "1" "December 2023" ""
+.TH "BUNDLE\-PLUGIN" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-plugin\fR \- Manage Bundler plugins
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-pristine.1
+++ b/bundler/lib/bundler/man/bundle-pristine.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-PRISTINE" "1" "December 2023" ""
+.TH "BUNDLE\-PRISTINE" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-pristine\fR \- Restores installed gems to their pristine condition
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-remove.1
+++ b/bundler/lib/bundler/man/bundle-remove.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-REMOVE" "1" "December 2023" ""
+.TH "BUNDLE\-REMOVE" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-remove\fR \- Removes gems from the Gemfile
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-show.1
+++ b/bundler/lib/bundler/man/bundle-show.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-SHOW" "1" "December 2023" ""
+.TH "BUNDLE\-SHOW" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-show\fR \- Shows all the gems in your bundle, or the path to a gem
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-update.1
+++ b/bundler/lib/bundler/man/bundle-update.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-UPDATE" "1" "December 2023" ""
+.TH "BUNDLE\-UPDATE" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-update\fR \- Update your gems to the latest available versions
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-version.1
+++ b/bundler/lib/bundler/man/bundle-version.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-VERSION" "1" "December 2023" ""
+.TH "BUNDLE\-VERSION" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-version\fR \- Prints Bundler version information
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-viz.1
+++ b/bundler/lib/bundler/man/bundle-viz.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE\-VIZ" "1" "December 2023" ""
+.TH "BUNDLE\-VIZ" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\-viz\fR \- Generates a visual dependency graph for your Gemfile
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle.1
+++ b/bundler/lib/bundler/man/bundle.1
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "BUNDLE" "1" "December 2023" ""
+.TH "BUNDLE" "1" "February 2024" ""
 .SH "NAME"
 \fBbundle\fR \- Ruby Dependency Management
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/gemfile.5
+++ b/bundler/lib/bundler/man/gemfile.5
@@ -1,6 +1,6 @@
 .\" generated with nRonn/v0.11.1
 .\" https://github.com/n-ronn/nronn/tree/0.11.1
-.TH "GEMFILE" "5" "December 2023" ""
+.TH "GEMFILE" "5" "February 2024" ""
 .SH "NAME"
 \fBGemfile\fR \- A format for describing gem dependencies for Ruby programs
 .SH "SYNOPSIS"
@@ -72,7 +72,7 @@ A Ruby engine is an implementation of the Ruby language\.
 .IP "\(bu" 4
 For background: the reference or original implementation of the Ruby programming language is called Matz's Ruby Interpreter \fIhttps://en\.wikipedia\.org/wiki/Ruby_MRI\fR, or MRI for short\. This is named after Ruby creator Yukihiro Matsumoto, also known as Matz\. MRI is also known as CRuby, because it is written in C\. MRI is the most widely used Ruby engine\.
 .IP "\(bu" 4
-Other implementations \fIhttps://www\.ruby\-lang\.org/en/about/\fR of Ruby exist\. Some of the more well\-known implementations include JRuby \fIhttp://jruby\.org/\fR and TruffleRuby \fIhttps://www\.graalvm\.org/ruby/\fR\. Rubinius is an alternative implementation of Ruby written in Ruby\. JRuby is an implementation of Ruby on the JVM, short for Java Virtual Machine\. TruffleRuby is a Ruby implementation on the GraalVM, a language toolkit built on the JVM\.
+Other implementations \fIhttps://www\.ruby\-lang\.org/en/about/\fR of Ruby exist\. Some of the more well\-known implementations include JRuby \fIhttps://www\.jruby\.org/\fR and TruffleRuby \fIhttps://www\.graalvm\.org/ruby/\fR\. Rubinius is an alternative implementation of Ruby written in Ruby\. JRuby is an implementation of Ruby on the JVM, short for Java Virtual Machine\. TruffleRuby is a Ruby implementation on the GraalVM, a language toolkit built on the JVM\.
 .IP "" 0
 .SS "ENGINE VERSION"
 Each application \fImay\fR specify a Ruby engine version\. If an engine version is specified, an engine \fImust\fR also be specified\. If the engine is "ruby" the engine version specified \fImust\fR match the Ruby version\.
@@ -449,7 +449,7 @@ end
 .fi
 .IP "" 0
 .SH "GEMSPEC"
-The \fB\.gemspec\fR \fIhttp://guides\.rubygems\.org/specification\-reference/\fR file is where you provide metadata about your gem to Rubygems\. Some required Gemspec attributes include the name, description, and homepage of your gem\. This is also where you specify the dependencies your gem needs to run\.
+The \fB\.gemspec\fR \fIhttps://guides\.rubygems\.org/specification\-reference/\fR file is where you provide metadata about your gem to Rubygems\. Some required Gemspec attributes include the name, description, and homepage of your gem\. This is also where you specify the dependencies your gem needs to run\.
 .P
 If you wish to use Bundler to help install dependencies for a gem while it is being developed, use the \fBgemspec\fR method to pull in the dependencies listed in the \fB\.gemspec\fR file\.
 .P

--- a/bundler/lib/bundler/man/gemfile.5.ronn
+++ b/bundler/lib/bundler/man/gemfile.5.ronn
@@ -96,7 +96,7 @@ What exactly is an Engine?
 
   - [Other implementations](https://www.ruby-lang.org/en/about/) of Ruby exist.
     Some of the more well-known implementations include
-    [JRuby](http://jruby.org/) and [TruffleRuby](https://www.graalvm.org/ruby/).
+    [JRuby](https://www.jruby.org/) and [TruffleRuby](https://www.graalvm.org/ruby/).
     Rubinius is an alternative implementation of Ruby written in Ruby.
     JRuby is an implementation of Ruby on the JVM, short for Java Virtual Machine.
     TruffleRuby is a Ruby implementation on the GraalVM, a language toolkit built on the JVM.
@@ -509,7 +509,7 @@ software is installed or some other conditions are met.
 
 ## GEMSPEC
 
-The [`.gemspec`](http://guides.rubygems.org/specification-reference/) file is where
+The [`.gemspec`](https://guides.rubygems.org/specification-reference/) file is where
  you provide metadata about your gem to Rubygems. Some required Gemspec
  attributes include the name, description, and homepage of your gem. This is
  also where you specify the dependencies your gem needs to run.

--- a/lib/rubygems/commands/help_command.rb
+++ b/lib/rubygems/commands/help_command.rb
@@ -59,7 +59,7 @@ multiple environments.  The RubyGems implementation is designed to be
 compatible with Bundler's Gemfile format.  You can see additional
 documentation on the format at:
 
-  http://bundler.io
+  https://bundler.io
 
 RubyGems automatically looks for these gem dependencies files:
 
@@ -172,7 +172,7 @@ and #platforms methods:
 See the bundler Gemfile manual page for a list of platforms supported in a gem
 dependencies file.:
 
-  http://bundler.io/v1.6/man/gemfile.5.html
+  https://bundler.io/v2.5/man/gemfile.5.html
 
 Ruby Version and Engine Dependency
 ==================================

--- a/lib/rubygems/security.rb
+++ b/lib/rubygems/security.rb
@@ -323,7 +323,7 @@ require_relative "openssl"
 # == Original author
 #
 # Paul Duncan <pabs@pablotron.org>
-# http://pablotron.org/
+# https://pablotron.org/
 
 module Gem::Security
   ##

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -341,7 +341,7 @@ class Gem::Specification < Gem::BasicSpecification
   # https://opensource.org/licenses/ approved.
   #
   # The most commonly used OSI-approved licenses are MIT and Apache-2.0.
-  # GitHub also provides a license picker at http://choosealicense.com/.
+  # GitHub also provides a license picker at https://choosealicense.com/.
   #
   # You can also use a custom license file along with your gemspec and specify
   # a LicenseRef-<idstring>, where idstring is the name of the file containing


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I found some of http urls from RubyGems and Bundler. They are redirected https. We have no reason why to use http for them.

## What is your fix for the problem, implemented in this PR?

I replaced them with https and fixed some of dead links.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
