### PR TITLE
Reset `Gem.state_file` along with `Gem.state_home`

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -76,6 +76,8 @@ class Gem::TestCase < Test::Unit::TestCase
 
   attr_accessor :uri # :nodoc:
 
+  @@tempdirs = []
+
   def assert_activate(expected, *specs)
     specs.each do |spec|
       case spec
@@ -287,7 +289,8 @@ class Gem::TestCase < Test::Unit::TestCase
 
     FileUtils.mkdir_p @tmp
 
-    @tempdir = Dir.mktmpdir("test_rubygems_", @tmp)
+    @tempdir = Dir.mktmpdir(method_name.to_s, @tmp)
+    @@tempdirs << @tempdir
 
     ENV["GEM_VENDOR"] = nil
     ENV["GEMRC"] = nil
@@ -354,6 +357,7 @@ class Gem::TestCase < Test::Unit::TestCase
     Gem.instance_variable_set :@config_home, nil
     Gem.instance_variable_set :@data_home, nil
     Gem.instance_variable_set :@state_home, @statehome
+    Gem.instance_variable_set :@state_file, nil
     Gem.instance_variable_set :@gemdeps, nil
     Gem.instance_variable_set :@env_requirements_by_name, nil
     Gem.send :remove_instance_variable, :@ruby_version if
@@ -470,6 +474,8 @@ class Gem::TestCase < Test::Unit::TestCase
     end
 
     @back_ui.close
+
+    assert_empty @@tempdirs.select {|tempdir| File.exist?(tempdir) }
   end
 
   def credential_setup


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Every time run a test, a temporary directory remains under `tmp` created in the source directory.

## What is your fix for the problem, implemented in this PR?

Reset `Gem.state_file` along with `Gem.state_home` in `Gem::TestCase#setup`.
As `Gem.state_file` is placed under `Gem.state_home` directory, when the latter is reset, also the former should be reset.
If left unreset, the file for a previously run test will be re-created and will not be deleted.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
