### PR TITLE
Get rid of too long paths

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -289,8 +289,8 @@ class Gem::TestCase < Test::Unit::TestCase
 
     FileUtils.mkdir_p @tmp
 
-    @tempdir = Dir.mktmpdir(method_name.to_s, @tmp)
-    @@tempdirs << @tempdir
+    @tempdir = Dir.mktmpdir("test_rubygems_", @tmp)
+    @@tempdirs << [method_name, @tempdir]
 
     ENV["GEM_VENDOR"] = nil
     ENV["GEMRC"] = nil
@@ -475,7 +475,13 @@ class Gem::TestCase < Test::Unit::TestCase
 
     @back_ui.close
 
-    assert_empty @@tempdirs.select {|tempdir| File.exist?(tempdir) }
+    ghosts = @@tempdirs.filter_map do |test_name, tempdir|
+      if File.exist?(tempdir)
+        FileUtils.rm_rf(tempdir)
+        test_name
+      end
+    end
+    assert_empty ghosts
   end
 
   def credential_setup

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -290,7 +290,6 @@ class Gem::TestCase < Test::Unit::TestCase
     FileUtils.mkdir_p @tmp
 
     @tempdir = Dir.mktmpdir("test_rubygems_", @tmp)
-    @@tempdirs << [method_name, @tempdir]
 
     ENV["GEM_VENDOR"] = nil
     ENV["GEMRC"] = nil
@@ -475,12 +474,11 @@ class Gem::TestCase < Test::Unit::TestCase
 
     @back_ui.close
 
+    refute_directory_exists @tempdir, "may be still in use"
     ghosts = @@tempdirs.filter_map do |test_name, tempdir|
-      if File.exist?(tempdir)
-        FileUtils.rm_rf(tempdir)
-        test_name
-      end
+      test_name if File.exist?(tempdir)
     end
+    @@tempdirs << [method_name, @tempdir]
     assert_empty ghosts
   end
 

--- a/test/rubygems/test_gem_ext_cargo_builder.rb
+++ b/test/rubygems/test_gem_ext_cargo_builder.rb
@@ -152,12 +152,16 @@ class TestGemExtCargoBuilder < Gem::TestCase
     require "fiddle"
     dylib_handle = Fiddle.dlopen bundle
     assert_nothing_raised { dylib_handle[name] }
+  ensure
+    dylib_handle&.close
   end
 
   def refute_ffi_handle(bundle, name)
     require "fiddle"
     dylib_handle = Fiddle.dlopen bundle
     assert_raise { dylib_handle[name] }
+  ensure
+    dylib_handle&.close
   end
 
   def replace_in_rust_file(name, from, to)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This is a fix-up of #7483.

Test method names in Rubygems are often very long, and the path under the temporary directory generated from them can easily exceed system limits.

## What is your fix for the problem, implemented in this PR?

Even without including the method name in the path name, by saving the method and path name pair, it is possible to find the method from the remaining path name.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
