### PR TITLE
Fix: vendor_gem takes a block

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1363,12 +1363,12 @@ Also, a list:
   #
   # Yields the +specification+ to the block, if given
 
-  def vendor_gem(name = "a", version = 1)
+  def vendor_gem(name = "a", version = 1, &block)
     directory = File.join "vendor", name
 
     FileUtils.mkdir_p directory
 
-    save_gemspec name, version, directory
+    save_gemspec name, version, directory, &block
   end
 
   ##

--- a/test/rubygems/test_gem_request_set.rb
+++ b/test/rubygems/test_gem_request_set.rb
@@ -450,7 +450,7 @@ ruby "0"
 
   def test_resolve_vendor
     a_name, _, a_directory = vendor_gem "a", 1 do |s|
-      s.add_dependency "b", "~> 2.0"
+      s.add_dependency "b", "~> 2"
     end
 
     b_name, _, b_directory = vendor_gem "b", 2

--- a/test/rubygems/test_gem_request_set.rb
+++ b/test/rubygems/test_gem_request_set.rb
@@ -449,11 +449,11 @@ ruby "0"
   end
 
   def test_resolve_vendor
-    a_name, _, a_directory = vendor_gem "a", 1 do |s|
-      s.add_dependency "b", "~> 2"
+    a_name, _, a_directory = vendor_gem "a", "1.0" do |s|
+      s.add_dependency "b", "~> 2.0"
     end
 
-    b_name, _, b_directory = vendor_gem "b", 2
+    b_name, _, b_directory = vendor_gem "b", "2.0"
 
     rs = Gem::RequestSet.new
 
@@ -475,7 +475,7 @@ ruby "0"
 
     names = res.map(&:full_name).sort
 
-    assert_equal ["a-1", "b-2"], names
+    assert_equal ["a-1.0", "b-2.0"], names
 
     assert_equal [Gem::Resolver::BestSet, Gem::Resolver::GitSet, Gem::Resolver::VendorSet, Gem::Resolver::SourceSet],
                  rs.sets.map(&:class)


### PR DESCRIPTION

## What was the end-user or developer problem that led to this PR?

Fixes #7493

## What is your fix for the problem, implemented in this PR?

Pass the block through vendor_gem to save_gemspec.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
