### PR TITLE
Clear `RUBY_CODESIGN` env var while running tests

### DIFF
--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -38,6 +38,10 @@ module Spec
       FileUtils.mkdir_p(Path.tmpdir)
 
       ENV["HOME"] = Path.home.to_s
+      # Remove "RUBY_CODESIGN", which is used by mkmf-generated Makefile to
+      # sign extension bundles on macOS, to avoid trying to find the specified key
+      # from the fake $HOME/Library/Keychains directory.
+      ENV.delete "RUBY_CODESIGN"
       ENV["TMPDIR"] = Path.tmpdir.to_s
 
       require "rubygems/user_interaction"

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -351,6 +351,10 @@ class Gem::TestCase < Test::Unit::TestCase
     Dir.chdir @tempdir
 
     ENV["HOME"] = @userhome
+    # Remove "RUBY_CODESIGN", which is used by mkmf-generated Makefile to
+    # sign extension bundles on macOS, to avoid trying to find the specified key
+    # from the fake $HOME/Library/Keychains directory.
+    ENV.delete "RUBY_CODESIGN"
     Gem.instance_variable_set :@config_file, nil
     Gem.instance_variable_set :@user_home, nil
     Gem.instance_variable_set :@config_home, nil


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The `RUBY_CODESIGN` environment variable is used by mkmf-generated Makefile to sign extension bundles on macOS. The variable specifies a key identifier to use for signing given by the user. However, the key is usually stored in `$HOME/Library/Keychains` directory, and the test suite creates a fake `$HOME` directory. This causes the test suite to try to find the specified key from the fake home directory, which results in a failure.

```
$ ruby --version
ruby 3.4.0dev (2024-03-04T03:33:00Z master 2d8788e90c) [arm64-darwin22]
$ env RUBY_CODESIGN="Apple Development: Yuta Saito (XXXXXXXX)" ./bin/rspec ./spec/commands/clean_spec.rb:845
...
       rm -f very_simple_git_binary_c.bundle
       clang -dynamic -bundle -o very_simple_git_binary_c.bundle very_simple_git_binary.o -L. -L/Users/katei/.rbenv/versions/master/lib -L. -fstack-protector-strong -Wl,-undefined,dynamic_lookup -bundle_loader '/Users/katei/.rbenv/versions/master/bin/ruby' -arch arm64  -lpthread
       dsymutil very_simple_git_binary_c.bundle 2>/dev/null; { test -z 'Apple Development: Yuta Saito (XXXXXXXX)' || codesign -s 'Apple Development: Yuta Saito (XXXXXXXX)' -f very_simple_git_binary_c.bundle; }
       Apple Development: Yuta Saito (XXXXXXXX): no identity found
       make: *** [very_simple_git_binary_c.bundle] Error 1

       make failed, exit code 2
```

Recently, we fixed mkmf to perform codesign for extension libraries properly (https://github.com/ruby/ruby/pull/10149) and it revealed this issue.

## What is your fix for the problem, implemented in this PR?

Clear developer specified `RUBY_CODESIGN` from the `ENV` to avoid pointing a key identifier that is valid with unmodified `$HOME` but invalid with faked `$HOME`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
