### PR TITLE
Clear generated files recursively

### DIFF
--- a/bundler/spec/install/global_cache_spec.rb
+++ b/bundler/spec/install/global_cache_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe "global gem caching" do
       R
       expect(out).to eq "VERY_SIMPLE_BINARY_IN_C\nVERY_SIMPLE_GIT_BINARY_IN_C"
 
-      FileUtils.rm Dir[home(".bundle", "cache", "extensions", "**", "*binary_c*")]
+      FileUtils.rm_rf Dir[home(".bundle", "cache", "extensions", "**", "*binary_c*")]
 
       gem_binary_cache.join("very_simple_binary_c.rb").open("w") {|f| f << "puts File.basename(__FILE__)" }
       git_binary_cache.join("very_simple_git_binary_c.rb").open("w") {|f| f << "puts File.basename(__FILE__)" }


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

On macOS, `dsymutil` utility splits debug info into .dSYM directory. Glob list of `.bundle/cache/extensions/**/*binary_c*` includes that directory but `FileUtils.rm` fails to unlink a directory.

https://github.com/ruby/ruby/actions/runs/8149918901/job/22275331688#step:11:3000
```
       Operation not permitted @ apply2files - /Users/runner/work/ruby/ruby/src/tmp/2/home/.bundle/cache/extensions/arm64-darwin-22/ruby/3.4.0+0/3b02a1011c53518f911ab3a9e8c6c608/very_simple_binary-1.0/very_simple_binary_c.bundle.dSYM
     # ./lib/fileutils.rb:2332:in 'File.unlink'
     # ./lib/fileutils.rb:2332:in 'block in FileUtils::Entry_#remove_file'
     # ./lib/fileutils.rb:2337:in 'FileUtils::Entry_#platform_support'
     # ./lib/fileutils.rb:2331:in 'FileUtils::Entry_#remove_file'
     # ./lib/fileutils.rb:1475:in 'FileUtils.remove_file'
     # ./lib/fileutils.rb:1223:in 'block in FileUtils.rm'
     # ./lib/fileutils.rb:1222:in 'FileUtils.rm'
     # ./spec/bundler/install/global_cache_spec.rb:235:in 'block (3 levels) in <top (required)>'
```

## What is your fix for the problem, implemented in this PR?

Just clean recursively with `FileUtils.rm_rf` instead of `FileUtils.rm`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
