### PR TITLE
Ignore commented out keys in config file

### DIFF
--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -492,16 +492,19 @@ module Bundler
         valid_file = file.exist? && !file.size.zero?
         return {} unless valid_file
         serializer_class.load(file.read).inject({}) do |config, (k, v)|
-          if k.include?("-")
-            Bundler.ui.warn "Your #{file} config includes `#{k}`, which contains the dash character (`-`).\n" \
-              "This is deprecated, because configuration through `ENV` should be possible, but `ENV` keys cannot include dashes.\n" \
-              "Please edit #{file} and replace any dashes in configuration keys with a triple underscore (`___`)."
+          unless k.start_with?("#")
+            if k.include?("-")
+              Bundler.ui.warn "Your #{file} config includes `#{k}`, which contains the dash character (`-`).\n" \
+                "This is deprecated, because configuration through `ENV` should be possible, but `ENV` keys cannot include dashes.\n" \
+                "Please edit #{file} and replace any dashes in configuration keys with a triple underscore (`___`)."
 
-            # string hash keys are frozen
-            k = k.gsub("-", "___")
+              # string hash keys are frozen
+              k = k.gsub("-", "___")
+            end
+
+            config[k] = v
           end
 
-          config[k] = v
           config
         end
       end

--- a/bundler/spec/bundler/settings_spec.rb
+++ b/bundler/spec/bundler/settings_spec.rb
@@ -319,6 +319,15 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
       expect(settings["mirror.https://rubygems.org/"]).to eq("http://rubygems-mirror.org")
     end
 
+    it "ignores commented out keys" do
+      create_file bundled_app(".bundle/config"), <<~C
+        # BUNDLE_MY-PERSONAL-SERVER__ORG: my-personal-server.org
+      C
+
+      expect(Bundler.ui).not_to receive(:warn)
+      expect(settings.all).to be_empty
+    end
+
     it "converts older keys with dashes" do
       config("BUNDLE_MY-PERSONAL-SERVER__ORG" => "my-personal-server.org")
       expect(Bundler.ui).to receive(:warn).with(


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes Bundler will print warnings about configuration settings that are commented out.

## What is your fix for the problem, implemented in this PR?

Ignore commented out keys when parsing config.

Fixes #7511.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
