### PR TITLE
Fix incorrect `bundle update --bundler` message

### DIFF
--- a/bundler/lib/bundler/self_manager.rb
+++ b/bundler/lib/bundler/self_manager.rb
@@ -113,7 +113,7 @@ module Bundler
     end
 
     def local_specs
-      @local_specs ||= Bundler::Source::Rubygems.new("allow_local" => true).specs.select {|spec| spec.name == "bundler" }
+      @local_specs ||= Bundler::Source::Rubygems.new("allow_local" => true, "allow_cached" => true).specs.select {|spec| spec.name == "bundler" }
     end
 
     def remote_specs

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -17,7 +17,7 @@ module Bundler
         @remotes = []
         @dependency_names = []
         @allow_remote = false
-        @allow_cached = false
+        @allow_cached = options["allow_cached"] || false
         @allow_local = options["allow_local"] || false
         @checksum_store = Checksum::Store.new
 
@@ -133,7 +133,7 @@ module Bundler
           # sources, and large_idx.merge! small_idx is way faster than
           # small_idx.merge! large_idx.
           index = @allow_remote ? remote_specs.dup : Index.new
-          index.merge!(cached_specs) if @allow_cached || @allow_remote
+          index.merge!(cached_specs) if @allow_cached
           index.merge!(installed_specs) if @allow_local
           index
         end

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -9,7 +9,7 @@ module Bundler
       :metadata_source
 
     def global_rubygems_source
-      @global_rubygems_source ||= rubygems_aggregate_class.new("allow_local" => true)
+      @global_rubygems_source ||= rubygems_aggregate_class.new("allow_local" => true, "allow_cached" => true)
     end
 
     def initialize
@@ -174,7 +174,7 @@ module Bundler
       replacement_source = replacement_sources.find {|s| s == global_rubygems_source }
       return global_rubygems_source unless replacement_source
 
-      replacement_source.local!
+      replacement_source.cached!
       replacement_source
     end
 

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -885,7 +885,7 @@ RSpec.describe "bundle exec" do
       let(:exit_code) { Bundler::GemNotFound.new.status_code }
       let(:expected) { "" }
       let(:expected_err) { <<-EOS.strip }
-Could not find gem 'rack (= 2)' in locally installed gems.
+Could not find gem 'rack (= 2)' in cached gems or installed locally.
 
 The source contains the following gems matching 'rack':
   * rack-0.9.1
@@ -915,7 +915,7 @@ Run `bundle install` to install missing gems.
       let(:exit_code) { Bundler::GemNotFound.new.status_code }
       let(:expected) { "" }
       let(:expected_err) { <<-EOS.strip }
-Could not find gem 'rack (= 2)' in locally installed gems.
+Could not find gem 'rack (= 2)' in cached gems or installed locally.
 
 The source contains the following gems matching 'rack':
   * rack-1.0.0

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe "bundle lock" do
   it "does not fetch remote specs when using the --local option" do
     bundle "lock --update --local", raise_on_error: false
 
-    expect(err).to match(/locally installed gems/)
+    expect(err).to match(/cached gems or installed locally/)
   end
 
   it "does not fetch remote checksums with --local" do
@@ -1211,7 +1211,7 @@ RSpec.describe "bundle lock" do
       Because rails >= 7.0.4 depends on railties = 7.0.4
         and rails < 7.0.4 depends on railties = 7.0.3.1,
         railties = 7.0.3.1 OR = 7.0.4 is required.
-      So, because railties = 7.0.3.1 OR = 7.0.4 could not be found in rubygems repository #{file_uri_for(gem_repo4)}/ or installed locally,
+      So, because railties = 7.0.3.1 OR = 7.0.4 could not be found in rubygems repository #{file_uri_for(gem_repo4)}/, cached gems or installed locally,
         version solving has failed.
     ERR
   end
@@ -1322,7 +1322,7 @@ RSpec.describe "bundle lock" do
       Thus, rails >= 7.0.2.3, < 7.0.4 cannot be used.
       And because rails >= 7.0.4 depends on activemodel = 7.0.4,
         rails >= 7.0.2.3 requires activemodel = 7.0.4.
-      So, because activemodel = 7.0.4 could not be found in rubygems repository #{file_uri_for(gem_repo4)}/ or installed locally
+      So, because activemodel = 7.0.4 could not be found in rubygems repository #{file_uri_for(gem_repo4)}/, cached gems or installed locally
         and Gemfile depends on rails >= 7.0.2.3,
         version solving has failed.
     ERR

--- a/bundler/spec/commands/post_bundle_message_spec.rb
+++ b/bundler/spec/commands/post_bundle_message_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe "post bundle message" do
           gem "not-a-gem", :group => :development
         G
         expect(err).to include <<-EOS.strip
-Could not find gem 'not-a-gem' in rubygems repository #{file_uri_for(gem_repo1)}/ or installed locally.
+Could not find gem 'not-a-gem' in rubygems repository #{file_uri_for(gem_repo1)}/, cached gems or installed locally.
         EOS
       end
 

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -929,7 +929,7 @@ RSpec.describe "bundle install with git sources" do
         gem "has_submodule"
       end
     G
-    expect(err).to match(%r{submodule >= 0 could not be found in rubygems repository #{file_uri_for(gem_repo1)}/ or installed locally})
+    expect(err).to match(%r{submodule >= 0 could not be found in rubygems repository #{file_uri_for(gem_repo1)}/, cached gems or installed locally})
 
     expect(the_bundle).not_to include_gems "has_submodule 1.0"
   end

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -520,7 +520,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
       it "fails" do
         bundle :install, artifice: "compact_index", raise_on_error: false
-        expect(err).to include("Could not find gem 'private_gem_1' in rubygems repository https://gem.repo2/ or installed locally.")
+        expect(err).to include("Could not find gem 'private_gem_1' in rubygems repository https://gem.repo2/, cached gems or installed locally.")
       end
     end
 
@@ -611,7 +611,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
             Could not find compatible versions
 
             Because every version of depends_on_rack depends on rack >= 0
-              and rack >= 0 could not be found in rubygems repository https://gem.repo2/ or installed locally,
+              and rack >= 0 could not be found in rubygems repository https://gem.repo2/, cached gems or installed locally,
               depends_on_rack cannot be used.
             So, because Gemfile depends on depends_on_rack >= 0,
               version solving has failed.

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -395,7 +395,7 @@ RSpec.describe "bundle install with specific platforms" do
     G
 
     error_message = <<~ERROR.strip
-      Could not find gem 'sorbet-static (= 0.5.6433)' with platform 'arm64-darwin-21' in rubygems repository #{file_uri_for(gem_repo4)}/ or installed locally.
+      Could not find gem 'sorbet-static (= 0.5.6433)' with platform 'arm64-darwin-21' in rubygems repository #{file_uri_for(gem_repo4)}/, cached gems or installed locally.
 
       The source contains the following gems matching 'sorbet-static (= 0.5.6433)':
         * sorbet-static-0.5.6433-universal-darwin-20
@@ -434,7 +434,7 @@ RSpec.describe "bundle install with specific platforms" do
       Could not find compatible versions
 
       Because every version of sorbet depends on sorbet-static = 0.5.6433
-        and sorbet-static = 0.5.6433 could not be found in rubygems repository #{file_uri_for(gem_repo4)}/ or installed locally for any resolution platforms (arm64-darwin-21),
+        and sorbet-static = 0.5.6433 could not be found in rubygems repository #{file_uri_for(gem_repo4)}/, cached gems or installed locally for any resolution platforms (arm64-darwin-21),
         sorbet cannot be used.
       So, because Gemfile depends on sorbet = 0.5.6433,
         version solving has failed.
@@ -473,7 +473,7 @@ RSpec.describe "bundle install with specific platforms" do
     bundle "lock", raise_on_error: false, env: { "BUNDLE_FORCE_RUBY_PLATFORM" => "true" }
 
     expect(err).to include <<~ERROR.rstrip
-      Could not find gem 'sorbet-static (= 0.5.9889)' with platform 'ruby' in rubygems repository #{file_uri_for(gem_repo4)}/ or installed locally.
+      Could not find gem 'sorbet-static (= 0.5.9889)' with platform 'ruby' in rubygems repository #{file_uri_for(gem_repo4)}/, cached gems or installed locally.
 
       The source contains the following gems matching 'sorbet-static (= 0.5.9889)':
         * sorbet-static-0.5.9889-#{Gem::Platform.local}

--- a/bundler/spec/install/gems/flex_spec.rb
+++ b/bundler/spec/install/gems/flex_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe "bundle flex_install" do
         Could not find compatible versions
 
         Because rack-obama >= 2.0 depends on rack = 1.2
-          and rack = 1.2 could not be found in rubygems repository #{file_uri_for(gem_repo2)}/ or installed locally,
+          and rack = 1.2 could not be found in rubygems repository #{file_uri_for(gem_repo2)}/, cached gems or installed locally,
           rack-obama >= 2.0 cannot be used.
         So, because Gemfile depends on rack-obama = 2.0,
           version solving has failed.

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -434,7 +434,7 @@ RSpec.describe "bundle install with install-time dependencies" do
           end
 
           nice_error = <<~E.strip
-            Could not find gems matching 'sorbet-static (= 0.5.10554)' valid for all resolution platforms (arm64-darwin-21, aarch64-linux) in rubygems repository #{file_uri_for(gem_repo4)}/ or installed locally.
+            Could not find gems matching 'sorbet-static (= 0.5.10554)' valid for all resolution platforms (arm64-darwin-21, aarch64-linux) in rubygems repository #{file_uri_for(gem_repo4)}/, cached gems or installed locally.
 
             The source contains the following gems matching 'sorbet-static (= 0.5.10554)':
               * sorbet-static-0.5.10554-universal-darwin-21
@@ -490,7 +490,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
         it "raises a proper error" do
           nice_error = <<~E.strip
-            Could not find gems matching 'sorbet-static' valid for all resolution platforms (arm-linux, x86_64-linux) in rubygems repository #{file_uri_for(gem_repo4)}/ or installed locally.
+            Could not find gems matching 'sorbet-static' valid for all resolution platforms (arm-linux, x86_64-linux) in rubygems repository #{file_uri_for(gem_repo4)}/, cached gems or installed locally.
 
             The source contains the following gems matching 'sorbet-static':
               * sorbet-static-0.5.10696-x86_64-linux

--- a/bundler/spec/install/yanked_spec.rb
+++ b/bundler/spec/install/yanked_spec.rb
@@ -188,7 +188,7 @@ RSpec.context "when using gem before installing" do
 
     bundle :list, raise_on_error: false
 
-    expect(err).to include("Could not find rack-0.9.1 in locally installed gems")
+    expect(err).to include("Could not find rack-0.9.1 in cached gems or installed locally")
     expect(err).to_not include("Your bundle is locked to rack (0.9.1) from")
     expect(err).to_not include("If you haven't changed sources, that means the author of rack (0.9.1) has removed it.")
     expect(err).to_not include("You'll need to update your bundle to a different version of rack (0.9.1) that hasn't been removed in order to install.")
@@ -197,7 +197,7 @@ RSpec.context "when using gem before installing" do
     lockfile lockfile.gsub(/PLATFORMS\n  #{lockfile_platforms}/m, "PLATFORMS\n  #{lockfile_platforms("ruby")}")
 
     bundle :list, raise_on_error: false
-    expect(err).to include("Could not find rack-0.9.1 in locally installed gems")
+    expect(err).to include("Could not find rack-0.9.1 in cached gems or installed locally")
   end
 
   it "does not suggest the author has yanked the gem when using more than one gem, but shows all gems that couldn't be found in the source" do
@@ -224,7 +224,7 @@ RSpec.context "when using gem before installing" do
 
     bundle :list, raise_on_error: false
 
-    expect(err).to include("Could not find rack-0.9.1, rack_middleware-1.0 in locally installed gems")
+    expect(err).to include("Could not find rack-0.9.1, rack_middleware-1.0 in cached gems or installed locally")
     expect(err).to include("Install missing gems with `bundle install`.")
     expect(err).to_not include("Your bundle is locked to rack (0.9.1) from")
     expect(err).to_not include("If you haven't changed sources, that means the author of rack (0.9.1) has removed it.")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler prints an incorrect "Updating bundler to..." message in presence of a local application cache.

## What is your fix for the problem, implemented in this PR?

Make sure cached gems are not incorrectly included when fetching remote gems.

Fixes #7477.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
