### PR TITLE
Add `/vendor/bundle/` to `gitignore.tt`

### DIFF
--- a/bundler/lib/bundler/templates/newgem/gitignore.tt
+++ b/bundler/lib/bundler/templates/newgem/gitignore.tt
@@ -1,4 +1,5 @@
 /.bundle/
+/vendor/bundle/
 /.yardoc
 /_yardoc/
 /coverage/


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

When contributing to (or authoring) open source gems, it's not uncommon to configure bundler to use `vendor/bundle` as the local gem directory. However, I've noticed that most gems do not have this path ignored in `.gitignore` by default, resulting in installed dependencies showing up as changed files unless `vendor/bundle` is `gitignore`'d.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Add `/vendor/bundle` to `.gitignore.tt` so new gems ignore locally installed dependencies by default. This already exists in [Github's Ruby `.gitignore` template](https://github.com/github/gitignore/blob/4488915eec0b3a45b5c63ead28f286819c0917de/Ruby.gitignore#L43).

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
