### PR TITLE
Respect global umask when writing regular files

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -454,7 +454,7 @@ EOM
 
         if entry.file?
           File.open(destination, "wb") {|out| copy_stream(entry, out) }
-          FileUtils.chmod file_mode(entry.header.mode), destination
+          FileUtils.chmod file_mode(entry.header.mode) & ~File.umask, destination
         end
 
         verbose destination

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -133,7 +133,7 @@ class TestGem < Gem::TestCase
 
   def test_self_install_permissions_umask_077
     umask = File.umask(0o077)
-    assert_self_install_permissions
+    assert_self_install_permissions(data_mode: 0o600)
   ensure
     File.umask(umask)
   end
@@ -151,12 +151,12 @@ class TestGem < Gem::TestCase
     Gem::Installer.exec_format = nil
   end
 
-  def assert_self_install_permissions(format_executable: false)
+  def assert_self_install_permissions(format_executable: false, data_mode: 0o640)
     mask = Gem.win_platform? ? 0o700 : 0o777
     options = {
       dir_mode: 0o500,
       prog_mode: Gem.win_platform? ? 0o410 : 0o510,
-      data_mode: 0o640,
+      data_mode: data_mode,
       wrappers: true,
       format_executable: format_executable,
     }


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

RubyGems does not respect global umask when writing regular files.

## What is your fix for the problem, implemented in this PR?

Always apply the default umask when writing.

This tries a more focused alternative to #7300, that hopefully plays nice with ruby/ruby CI.
 
## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
