### PR TITLE
Changelogs for RubyGems 3.5.7 and Bundler 2.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+# 3.5.7 / 2024-03-20
+
+## Enhancements:
+
+* Warn on empty or open required_ruby_version specification attribute.
+  Pull request [#5010](https://github.com/rubygems/rubygems/pull/5010) by
+  simi
+* Control whether YAML aliases are enabled in Gem::SafeYAML.safe_load via
+  attribute. Pull request
+  [#7464](https://github.com/rubygems/rubygems/pull/7464) by segiddins
+* Update SPDX license list as of 2024-02-08. Pull request
+  [#7468](https://github.com/rubygems/rubygems/pull/7468) by
+  github-actions[bot]
+* Installs bundler 2.5.7 as a default gem.
+
+## Bug fixes:
+
+* Allow prerelease activation (even if requirement is not explicit about
+  it) when it's the only possibility. Pull request
+  [#7428](https://github.com/rubygems/rubygems/pull/7428) by kimesf
+
+## Documentation:
+
+* Fix a typo. Pull request
+  [#7505](https://github.com/rubygems/rubygems/pull/7505) by hsbt
+* Use https instead of http in documentation links. Pull request
+  [#7481](https://github.com/rubygems/rubygems/pull/7481) by hsbt
+
 # 3.5.6 / 2024-02-06
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 2.5.7 (March 20, 2024)
+
+## Deprecations:
+
+  - Deprecate `bundle plugin install --local-git=` [#7048](https://github.com/rubygems/rubygems/pull/7048)
+
+## Enhancements:
+
+  - Ignore commented out keys in config file [#7514](https://github.com/rubygems/rubygems/pull/7514)
+  - Fix exclusion of `.gemspec` file itself in `bundle gem` generated gemspec file [#7488](https://github.com/rubygems/rubygems/pull/7488)
+  - Remove redundant configs from `bundle gem` generated rubocop configuration [#7478](https://github.com/rubygems/rubygems/pull/7478)
+  - Add `gitlab:` git source shorthand [#7449](https://github.com/rubygems/rubygems/pull/7449)
+  - Use full path for `instance_eval` in `Bundler::DSL#eval_gemfile` [#7471](https://github.com/rubygems/rubygems/pull/7471)
+
+## Documentation:
+
+  - Use https instead of http in documentation links [#7481](https://github.com/rubygems/rubygems/pull/7481)
+
 # 2.5.6 (February 6, 2024)
 
 ## Deprecations:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.5.7 and Bundler 2.5.7 into master.