### PR TITLE
Fix resolver error message when it runs out of versions due to `--strict --patch` filtering out everything

### DIFF
--- a/bundler/lib/bundler/gem_version_promoter.rb
+++ b/bundler/lib/bundler/gem_version_promoter.rb
@@ -45,13 +45,12 @@ module Bundler
 
     # Given a Resolver::Package and an Array of Specifications of available
     # versions for a gem, this method will return the Array of Specifications
-    # sorted (and possibly truncated if strict is true) in an order to give
-    # preference to the current level (:major, :minor or :patch) when resolution
-    # is deciding what versions best resolve all dependencies in the bundle.
+    # sorted in an order to give preference to the current level (:major, :minor
+    # or :patch) when resolution is deciding what versions best resolve all
+    # dependencies in the bundle.
     # @param package [Resolver::Package] The package being resolved.
     # @param specs [Specification] An array of Specifications for the package.
-    # @return [Specification] A new instance of the Specification Array sorted and
-    #    possibly filtered.
+    # @return [Specification] A new instance of the Specification Array sorted.
     def sort_versions(package, specs)
       locked_version = package.locked_version
 
@@ -94,6 +93,15 @@ module Bundler
       pre == true
     end
 
+    # Given a Resolver::Package and an Array of Specifications of available
+    # versions for a gem, this method will truncate the Array if strict
+    # is true. That means filtering out downgrades from the version currently
+    # locked, and filtering out upgrades that go past the selected level (major,
+    # minor, or patch).
+    # @param package [Resolver::Package] The package being resolved.
+    # @param specs [Specification] An array of Specifications for the package.
+    # @return [Specification] A new instance of the Specification Array
+    #   truncated.
     def filter_versions(package, specs)
       return specs unless strict
 

--- a/bundler/lib/bundler/gem_version_promoter.rb
+++ b/bundler/lib/bundler/gem_version_promoter.rb
@@ -59,20 +59,20 @@ module Bundler
           a_pre = a.prerelease?
           b_pre = b.prerelease?
 
-          next -1 if a_pre && !b_pre
-          next  1 if b_pre && !a_pre
+          next 1 if a_pre && !b_pre
+          next -1 if b_pre && !a_pre
         end
 
         if major? || locked_version.nil?
-          a <=> b
+          b <=> a
         elsif either_version_older_than_locked?(a, b, locked_version)
-          a <=> b
+          b <=> a
         elsif segments_do_not_match?(a, b, :major)
-          b <=> a
-        elsif !minor? && segments_do_not_match?(a, b, :minor)
-          b <=> a
-        else
           a <=> b
+        elsif !minor? && segments_do_not_match?(a, b, :minor)
+          a <=> b
+        else
+          b <=> a
         end
       end
       post_sort(result, package.unlock?, locked_version)
@@ -137,13 +137,13 @@ module Bundler
       if unlock || locked_version.nil?
         result
       else
-        move_version_to_end(result, locked_version)
+        move_version_to_beginning(result, locked_version)
       end
     end
 
-    def move_version_to_end(result, version)
+    def move_version_to_beginning(result, version)
       move, keep = result.partition {|s| s.version.to_s == version.to_s }
-      keep.concat(move)
+      move.concat(keep)
     end
   end
 end

--- a/bundler/lib/bundler/gem_version_promoter.rb
+++ b/bundler/lib/bundler/gem_version_promoter.rb
@@ -53,7 +53,7 @@ module Bundler
     # @return [Specification] A new instance of the Specification Array sorted and
     #    possibly filtered.
     def sort_versions(package, specs)
-      specs = filter_dep_specs(specs, package) if strict
+      specs = filter_versions(package, specs)
 
       sort_dep_specs(specs, package)
     end
@@ -73,9 +73,9 @@ module Bundler
       pre == true
     end
 
-    private
+    def filter_versions(package, specs)
+      return specs unless strict
 
-    def filter_dep_specs(specs, package)
       locked_version = package.locked_version
       return specs if locked_version.nil? || major?
 
@@ -88,6 +88,8 @@ module Bundler
         all_match && gsv >= locked_version
       end
     end
+
+    private
 
     def sort_dep_specs(specs, package)
       locked_version = package.locked_version

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -275,7 +275,7 @@ module Bundler
         groups
       end
 
-      sort_versions_by_preferred(package, versions)
+      @gem_version_promoter.filter_versions(package, versions)
     end
 
     def source_for(name)

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -51,24 +51,20 @@ module Bundler
       end
 
       @sorted_versions = Hash.new do |candidates, package|
-        candidates[package] = if package.root?
-          [root_version]
-        else
-          all_versions_for(package).sort
-        end
+        candidates[package] = all_versions_for(package).sort
       end
+
+      @sorted_versions[root] = [root_version]
 
       root_dependencies = prepare_dependencies(@requirements, @packages)
 
       @cached_dependencies = Hash.new do |dependencies, package|
-        dependencies[package] = if package.root?
-          { root_version => root_dependencies }
-        else
-          Hash.new do |versions, version|
-            versions[version] = to_dependency_hash(version.dependencies.reject {|d| d.name == package.name }, @packages)
-          end
+        dependencies[package] = Hash.new do |versions, version|
+          versions[version] = to_dependency_hash(version.dependencies.reject {|d| d.name == package.name }, @packages)
         end
       end
+
+      @cached_dependencies[root] = { root_version => root_dependencies }
 
       logger = Bundler::UI::Shell.new
       logger.level = debug? ? "debug" : "warn"

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -158,7 +158,7 @@ module Bundler
     def versions_for(package, range=VersionRange.any)
       versions = range.select_versions(@sorted_versions[package])
 
-      sort_versions(package, versions)
+      sort_versions_by_preferred(package, versions)
     end
 
     def no_versions_incompatibility_for(package, unsatisfied_term)
@@ -275,7 +275,7 @@ module Bundler
         groups
       end
 
-      sort_versions(package, versions)
+      sort_versions_by_preferred(package, versions)
     end
 
     def source_for(name)
@@ -357,7 +357,7 @@ module Bundler
       requirement.satisfied_by?(spec.version) || spec.source.is_a?(Source::Gemspec)
     end
 
-    def sort_versions(package, versions)
+    def sort_versions_by_preferred(package, versions)
       if versions.size > 1
         @gem_version_promoter.sort_versions(package, versions).reverse
       else

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -158,7 +158,13 @@ module Bundler
     def versions_for(package, range=VersionRange.any)
       versions = range.select_versions(@sorted_versions[package])
 
-      sort_versions_by_preferred(package, versions)
+      # Conditional avoids (among other things) calling
+      # sort_versions_by_preferred with the root package
+      if versions.size > 1
+        sort_versions_by_preferred(package, versions)
+      else
+        versions
+      end
     end
 
     def no_versions_incompatibility_for(package, unsatisfied_term)
@@ -358,11 +364,7 @@ module Bundler
     end
 
     def sort_versions_by_preferred(package, versions)
-      if versions.size > 1
-        @gem_version_promoter.sort_versions(package, versions)
-      else
-        versions
-      end
+      @gem_version_promoter.sort_versions(package, versions)
     end
 
     def repository_for(package)

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -359,7 +359,7 @@ module Bundler
 
     def sort_versions_by_preferred(package, versions)
       if versions.size > 1
-        @gem_version_promoter.sort_versions(package, versions).reverse
+        @gem_version_promoter.sort_versions(package, versions)
       else
         versions
       end

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -156,7 +156,7 @@ module Bundler
     end
 
     def versions_for(package, range=VersionRange.any)
-      versions = range.select_versions(@sorted_versions[package])
+      versions = select_sorted_versions(package, range)
 
       # Conditional avoids (among other things) calling
       # sort_versions_by_preferred with the root package
@@ -381,11 +381,12 @@ module Bundler
 
         next [dep_package, dep_constraint] if name == "bundler"
 
-        versions = versions_for(dep_package, dep_constraint.range)
+        dep_range = dep_constraint.range
+        versions = select_sorted_versions(dep_package, dep_range)
         if versions.empty? && dep_package.ignores_prereleases?
           @sorted_versions.delete(dep_package)
           dep_package.consider_prereleases!
-          versions = versions_for(dep_package, dep_constraint.range)
+          versions = select_sorted_versions(dep_package, dep_range)
         end
         next [dep_package, dep_constraint] unless versions.empty?
 
@@ -393,6 +394,10 @@ module Bundler
 
         raise_not_found!(dep_package)
       end.compact.to_h
+    end
+
+    def select_sorted_versions(package, range)
+      range.select_versions(@sorted_versions[package])
     end
 
     def other_specs_matching_message(specs, requirement)

--- a/bundler/lib/bundler/resolver/candidate.rb
+++ b/bundler/lib/bundler/resolver/candidate.rb
@@ -15,7 +15,7 @@ module Bundler
     # considered separately.
     #
     # Some candidates may also keep some information explicitly about the
-    # package the refer to. These candidates are referred to as "canonical" and
+    # package they refer to. These candidates are referred to as "canonical" and
     # are used when materializing resolution results back into RubyGems
     # specifications that can be installed, written to lock files, and so on.
     #

--- a/bundler/spec/bundler/gem_version_promoter_spec.rb
+++ b/bundler/spec/bundler/gem_version_promoter_spec.rb
@@ -58,18 +58,18 @@ RSpec.describe Bundler::GemVersionPromoter do
       context "when level is minor" do
         before { gvp.level = :minor }
 
-        it "removes downgrades and major upgrades" do
+        it "sorts highest minor within same major in last position" do
           versions = sorted_versions(candidates: %w[0.2.0 0.3.0 0.3.1 0.9.0 1.0.0 2.0.1 2.1.0], current: "0.3.0")
-          expect(versions).to eq %w[0.3.0 0.3.1 0.9.0]
+          expect(versions).to eq %w[0.2.0 2.0.1 2.1.0 1.0.0 0.3.0 0.3.1 0.9.0]
         end
       end
 
       context "when level is patch" do
         before { gvp.level = :patch }
 
-        it "removes downgrades and major and minor upgrades" do
+        it "sorts highest patch within same minor in last position" do
           versions = sorted_versions(candidates: %w[0.2.0 0.3.0 0.3.1 0.9.0 1.0.0 2.0.1 2.1.0], current: "0.3.0")
-          expect(versions).to eq %w[0.3.0 0.3.1]
+          expect(versions).to eq %w[0.2.0 2.1.0 2.0.1 1.0.0 0.9.0 0.3.0 0.3.1]
         end
       end
     end

--- a/bundler/spec/bundler/gem_version_promoter_spec.rb
+++ b/bundler/spec/bundler/gem_version_promoter_spec.rb
@@ -33,13 +33,13 @@ RSpec.describe Bundler::GemVersionPromoter do
 
     it "numerically sorts versions" do
       versions = sorted_versions(candidates: %w[1.7.7 1.7.8 1.7.9 1.7.15 1.8.0], current: "1.7.8")
-      expect(versions).to eq %w[1.7.7 1.7.8 1.7.9 1.7.15 1.8.0]
+      expect(versions).to eq %w[1.8.0 1.7.15 1.7.9 1.7.8 1.7.7]
     end
 
     context "with no options" do
       it "defaults to level=:major, strict=false, pre=false" do
         versions = sorted_versions(candidates: %w[0.2.0 0.3.0 0.3.1 0.9.0 1.0.0 2.0.1 2.1.0], current: "0.3.0")
-        expect(versions).to eq %w[0.2.0 0.3.0 0.3.1 0.9.0 1.0.0 2.0.1 2.1.0]
+        expect(versions).to eq %w[2.1.0 2.0.1 1.0.0 0.9.0 0.3.1 0.3.0 0.2.0]
       end
     end
 
@@ -51,25 +51,25 @@ RSpec.describe Bundler::GemVersionPromoter do
 
         it "keeps downgrades" do
           versions = sorted_versions(candidates: %w[0.2.0 0.3.0 0.3.1 0.9.0 1.0.0 2.0.1 2.1.0], current: "0.3.0")
-          expect(versions).to eq %w[0.2.0 0.3.0 0.3.1 0.9.0 1.0.0 2.0.1 2.1.0]
+          expect(versions).to eq %w[2.1.0 2.0.1 1.0.0 0.9.0 0.3.1 0.3.0 0.2.0]
         end
       end
 
       context "when level is minor" do
         before { gvp.level = :minor }
 
-        it "sorts highest minor within same major in last position" do
+        it "sorts highest minor within same major in first position" do
           versions = sorted_versions(candidates: %w[0.2.0 0.3.0 0.3.1 0.9.0 1.0.0 2.0.1 2.1.0], current: "0.3.0")
-          expect(versions).to eq %w[0.2.0 2.0.1 2.1.0 1.0.0 0.3.0 0.3.1 0.9.0]
+          expect(versions).to eq %w[0.9.0 0.3.1 0.3.0 1.0.0 2.1.0 2.0.1 0.2.0]
         end
       end
 
       context "when level is patch" do
         before { gvp.level = :patch }
 
-        it "sorts highest patch within same minor in last position" do
+        it "sorts highest patch within same minor in first position" do
           versions = sorted_versions(candidates: %w[0.2.0 0.3.0 0.3.1 0.9.0 1.0.0 2.0.1 2.1.0], current: "0.3.0")
-          expect(versions).to eq %w[0.2.0 2.1.0 2.0.1 1.0.0 0.9.0 0.3.0 0.3.1]
+          expect(versions).to eq %w[0.3.1 0.3.0 0.9.0 1.0.0 2.0.1 2.1.0 0.2.0]
         end
       end
     end
@@ -82,25 +82,25 @@ RSpec.describe Bundler::GemVersionPromoter do
 
         it "orders by version" do
           versions = sorted_versions(candidates: %w[0.2.0 0.3.0 0.3.1 0.9.0 1.0.0 2.0.1 2.1.0], current: "0.3.0")
-          expect(versions).to eq %w[0.2.0 0.3.0 0.3.1 0.9.0 1.0.0 2.0.1 2.1.0]
+          expect(versions).to eq %w[2.1.0 2.0.1 1.0.0 0.9.0 0.3.1 0.3.0 0.2.0]
         end
       end
 
       context "when level is minor" do
         before { gvp.level = :minor }
 
-        it "favors downgrades, then upgrades by major descending, minor ascending, patch ascending" do
+        it "favors minor upgrades, then patch upgrades, then major upgrades, then downgrades" do
           versions = sorted_versions(candidates: %w[0.2.0 0.3.0 0.3.1 0.9.0 1.0.0 2.0.1 2.1.0], current: "0.3.0")
-          expect(versions).to eq %w[0.2.0 2.0.1 2.1.0 1.0.0 0.3.0 0.3.1 0.9.0]
+          expect(versions).to eq %w[0.9.0 0.3.1 0.3.0 1.0.0 2.1.0 2.0.1 0.2.0]
         end
       end
 
       context "when level is patch" do
         before { gvp.level = :patch }
 
-        it "favors downgrades, then upgrades by major descending, minor descending, patch ascending" do
+        it "favors patch upgrades, then minor upgrades, then major upgrades, then downgrades" do
           versions = sorted_versions(candidates: %w[0.2.0 0.3.0 0.3.1 0.9.0 1.0.0 2.0.1 2.1.0], current: "0.3.0")
-          expect(versions).to eq %w[0.2.0 2.1.0 2.0.1 1.0.0 0.9.0 0.3.0 0.3.1]
+          expect(versions).to eq %w[0.3.1 0.3.0 0.9.0 1.0.0 2.0.1 2.1.0 0.2.0]
         end
       end
     end
@@ -110,7 +110,7 @@ RSpec.describe Bundler::GemVersionPromoter do
 
       it "sorts regardless of prerelease status" do
         versions = sorted_versions(candidates: %w[1.7.7.pre 1.8.0 1.8.1.pre 1.8.1 2.0.0.pre 2.0.0], current: "1.8.0")
-        expect(versions).to eq %w[1.7.7.pre 1.8.0 1.8.1.pre 1.8.1 2.0.0.pre 2.0.0]
+        expect(versions).to eq %w[2.0.0 2.0.0.pre 1.8.1 1.8.1.pre 1.8.0 1.7.7.pre]
       end
     end
 
@@ -119,16 +119,16 @@ RSpec.describe Bundler::GemVersionPromoter do
 
       it "deprioritizes prerelease gems" do
         versions = sorted_versions(candidates: %w[1.7.7.pre 1.8.0 1.8.1.pre 1.8.1 2.0.0.pre 2.0.0], current: "1.8.0")
-        expect(versions).to eq %w[1.7.7.pre 1.8.1.pre 2.0.0.pre 1.8.0 1.8.1 2.0.0]
+        expect(versions).to eq %w[2.0.0 1.8.1 1.8.0 2.0.0.pre 1.8.1.pre 1.7.7.pre]
       end
     end
 
     context "when locking and not major" do
       before { gvp.level = :minor }
 
-      it "keeps the current version last" do
+      it "keeps the current version first" do
         versions = sorted_versions(candidates: %w[0.2.0 0.3.0 0.3.1 0.9.0 1.0.0 2.1.0 2.0.1], current: "0.3.0", locked: ["bar"])
-        expect(versions.last).to eq("0.3.0")
+        expect(versions.first).to eq("0.3.0")
       end
     end
   end

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -392,6 +392,22 @@ RSpec.describe "bundle lock" do
       expect(the_bundle.locked_gems.specs.map(&:full_name)).to eq(%w[foo-1.5.0 bar-2.1.1 qux-1.1.0].sort)
     end
 
+    it "shows proper error when Gemfile changes forbid patch upgrades, and --patch --strict is given" do
+      # force next minor via Gemfile
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo4)}"
+        gem 'foo', '1.5.0'
+        gem 'qux'
+      G
+
+      bundle "lock --update foo --patch --strict", raise_on_error: false
+
+      expect(err).to include(
+        "foo is locked to 1.4.3, while Gemfile is requesting foo (= 1.5.0). " \
+        "--strict --patch was specified, but there are no patch level upgrades from 1.4.3 satisfying foo (= 1.5.0), so version solving has failed"
+      )
+    end
+
     context "pre" do
       it "defaults to major" do
         bundle "lock --update --pre"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In some resolver edge cases, we end up giving a confusing error message.

## What is your fix for the problem, implemented in this PR?

Refactor the resolver to detect the situation and give a better error. While figuring things out, I also included several resolver improvements like avoiding version sorting when not necessary, and sorting in descending order directly instead of sorting in ascending order and then reversing.

Fixes #7369.
Supersedes #7376.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
