### PR TITLE
Improve validation of `bundle plugin install` options

### DIFF
--- a/bundler/lib/bundler/plugin/installer.rb
+++ b/bundler/lib/bundler/plugin/installer.rb
@@ -43,10 +43,23 @@ module Bundler
         if options.key?(:git) && options.key?(:local_git)
           raise InvalidOption, "Remote and local plugin git sources can't be both specified"
         end
+
         # back-compat; local_git is an alias for git
         if options.key?(:local_git)
           Bundler::SharedHelpers.major_deprecation(2, "--local_git is deprecated, use --git")
           options[:git] = options.delete(:local_git)
+        end
+
+        if (options.keys & [:source, :git]).length > 1
+          raise InvalidOption, "Only one of --source, or --git may be specified"
+        end
+
+        if (options.key?(:branch) || options.key?(:ref)) && !options.key?(:git)
+          raise InvalidOption, "--#{options.key?(:branch) ? "branch" : "ref"} can only be used with git sources"
+        end
+
+        if options.key?(:branch) && options.key?(:ref)
+          raise InvalidOption, "--branch and --ref can't be both specified"
         end
       end
 

--- a/bundler/spec/plugins/install_spec.rb
+++ b/bundler/spec/plugins/install_spec.rb
@@ -92,16 +92,18 @@ RSpec.describe "bundler plugin install" do
     expect(out).to include("Using foo 1.1")
   end
 
-  it "installs when --branch specified" do
-    bundle "plugin install foo --branch main --source #{file_uri_for(gem_repo2)}"
+  it "raises an error when when --branch specified" do
+    bundle "plugin install foo --branch main --source #{file_uri_for(gem_repo2)}", raise_on_error: false
 
-    expect(out).to include("Installed plugin foo")
+    expect(out).not_to include("Installed plugin foo")
+
+    expect(err).to include("--branch can only be used with git sources")
   end
 
-  it "installs when --ref specified" do
-    bundle "plugin install foo --ref v1.2.3 --source #{file_uri_for(gem_repo2)}"
+  it "raises an error when --ref specified" do
+    bundle "plugin install foo --ref v1.2.3 --source #{file_uri_for(gem_repo2)}", raise_on_error: false
 
-    expect(out).to include("Installed plugin foo")
+    expect(err).to include("--ref can only be used with git sources")
   end
 
   it "raises error when both --branch and --ref options are specified" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes incorrect flag combinations are allowed by `bundle plugin install`, causing ambiguous behavior.

## What is your fix for the problem, implemented in this PR?

Ensure only one source type is specified, and ensure options that are only relevant to git sources are only specified with git.

Extracted from #6960.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
