### PR TITLE
Fix resolver to properly intersect Arrays of `Gem::Resolver::Activation` objects

### DIFF
--- a/lib/rubygems/resolver/spec_specification.rb
+++ b/lib/rubygems/resolver/spec_specification.rb
@@ -66,4 +66,11 @@ class Gem::Resolver::SpecSpecification < Gem::Resolver::Specification
   def version
     spec.version
   end
+
+  ##
+  # The hash value for this specification.
+
+  def hash
+    spec.hash
+  end
 end

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1367,12 +1367,12 @@ Also, a list:
   #
   # Yields the +specification+ to the block, if given
 
-  def vendor_gem(name = "a", version = 1)
+  def vendor_gem(name = "a", version = 1, &block)
     directory = File.join "vendor", name
 
     FileUtils.mkdir_p directory
 
-    save_gemspec name, version, directory
+    save_gemspec name, version, directory, &block
   end
 
   ##


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Iterating on #7494. I think the issue is that:

* Resolver uses `Array#&` [here](https://github.com/rubygems/rubygems/blob/59bc67f40d6f98fb823d2356e5c2835a82a39447/lib/rubygems/vendor/molinillo/lib/molinillo/resolution.rb#L709), which compares items using `eql?`.
* `eql?` also needs an implementation of `hash` that guarantees that two equal objects return the same hash.
* The objects that are compared by the resolver are `Gem::Resolver::ActivationRequest` objects which implement `eql?` and `hash` [like this](https://github.com/rubygems/rubygems/blob/59bc67f40d6f98fb823d2356e5c2835a82a39447/lib/rubygems/resolver/activation_request.rb#L38-L45).
* In particular `hash` delegates to `@spec.hash`, which is usually a `Gem::Resolver::SpecSpecification` which does not override `hash` itself.

I think the above causes incorrect array intersection in JRuby & Truffleruby (I'd say it just works by chance in CRuby).

## What is your fix for the problem, implemented in this PR?

My attempted fix is to implement `Gem::Resolver::SpecSpecification#hash`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
