### PR TITLE
Allow FormatError to take either String or Gem for source

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -59,7 +59,7 @@ class Gem::Package
 
     def initialize(message, source = nil)
       if source
-        @path = source.path
+        @path = source.is_a?(String) ? source : source.path
 
         message += " in #{path}" if path
       end


### PR DESCRIPTION

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Most of the calls to `FormatError.new` pass `@gem` for the second argument, which has a `path` method.

But in one case—on package.rb:691 in `verify_gz`, the `source` argument is a `String`.

So if there's ever a GZip decode error when attempting to read the contents of the `data.tar.gz` file, instead of reporting the underlying GZip error (which might be something like "unexpected end of file"), we would report instead a NoMethodError coming from package.rb

```
Exception while verifying sorbet-0.5.11301.gem
ERROR:  While executing gem ... (NoMethodError)
    undefined method `path' for "data.tar.gz":String

        @path = source.path
                      ^^^^^
```



## What is your fix for the problem, implemented in this PR?

There are two ways to fix this:

1. Make `FormatError#initialize` aware of the fact that `source` might sometimes be a `String`
2. Make the call to `FormatError.new` in `verify_gz` pass `@gem` instead of `entry.full_name`.

I've chosen 1 because I think it's more useful to see "unexpected end of file in data.tar.gz" instead of "unexpected end of file in sorbet-0.5.11301.gem." The end of file **is actually** in data.tar.gz, not in the gem file itself, which was decoded successfully.


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

I have tested this by forcibly untar'ing, corrupting, and re-tar'ing a `*.gem` file. Without this change, I see the NoMethodError on that tar file. With this change, I see the underlying gzip library's error. I've attached the tar file that I used for this test.
[test-case.tar.gz](https://github.com/rubygems/rubygems/files/14750347/test-case.tar.gz)

To reproduce:

```
tar xf test-case.tar.gz
gem push sorbet-0.5.11301.gem
```
