### PR TITLE
Use www.rfc-editor.org for RFC text

### DIFF
--- a/bundler/spec/bundler/digest_spec.rb
+++ b/bundler/spec/bundler/digest_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Bundler::Digest do
     it "is compatible with stdlib" do
       random_strings = ["foo", "skfjsdlkfjsdf", "3924m", "ldskfj"]
 
-      # https://datatracker.ietf.org/doc/html/rfc3174#section-7.3
+      # https://www.rfc-editor.org/rfc/rfc3174#section-7.3
       rfc3174_test_cases = ["abc", "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", "a", "01234567" * 8]
 
       (random_strings + rfc3174_test_cases).each do |payload|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Backport from https://github.com/ruby/ruby/pull/10391

We should use `www.rfc-editor.org` for RFC text.

## What is your fix for the problem, implemented in this PR?

I update docs in bundler example.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
