### PR TITLE
Allow string keys with gemrc

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -210,6 +210,17 @@ class Gem::ConfigFile
       @hash = @hash.merge environment_config
     end
 
+    @hash.transform_keys! do |k|
+      # gemhome and gempath are not working with symbol keys
+      if %w[backtrace bulk_threshold verbose update_sources cert_expiration_length_days
+            install_extension_in_lib ipv4_fallback_enabled sources disable_default_gem_server
+            ssl_verify_mode ssl_ca_cert ssl_client_cert].include?(k)
+        k.to_sym
+      else
+        k
+      end
+    end
+
     # HACK: these override command-line args, which is bad
     @backtrace                   = @hash[:backtrace]                   if @hash.key? :backtrace
     @bulk_threshold              = @hash[:bulk_threshold]              if @hash.key? :bulk_threshold

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -213,19 +213,20 @@ class Gem::ConfigFile
     # HACK: these override command-line args, which is bad
     @backtrace                   = @hash[:backtrace]                   if @hash.key? :backtrace
     @bulk_threshold              = @hash[:bulk_threshold]              if @hash.key? :bulk_threshold
-    @home                        = @hash[:gemhome]                     if @hash.key? :gemhome
-    @path                        = @hash[:gempath]                     if @hash.key? :gempath
-    @update_sources              = @hash[:update_sources]              if @hash.key? :update_sources
     @verbose                     = @hash[:verbose]                     if @hash.key? :verbose
-    @disable_default_gem_server  = @hash[:disable_default_gem_server]  if @hash.key? :disable_default_gem_server
-    @sources                     = @hash[:sources]                     if @hash.key? :sources
+    @update_sources              = @hash[:update_sources]              if @hash.key? :update_sources
+    # TODO: We should handle concurrent_downloads same as other options
     @cert_expiration_length_days = @hash[:cert_expiration_length_days] if @hash.key? :cert_expiration_length_days
     @install_extension_in_lib    = @hash[:install_extension_in_lib]    if @hash.key? :install_extension_in_lib
     @ipv4_fallback_enabled       = @hash[:ipv4_fallback_enabled]       if @hash.key? :ipv4_fallback_enabled
 
-    @ssl_verify_mode  = @hash[:ssl_verify_mode]  if @hash.key? :ssl_verify_mode
-    @ssl_ca_cert      = @hash[:ssl_ca_cert]      if @hash.key? :ssl_ca_cert
-    @ssl_client_cert  = @hash[:ssl_client_cert]  if @hash.key? :ssl_client_cert
+    @home                        = @hash[:gemhome]                     if @hash.key? :gemhome
+    @path                        = @hash[:gempath]                     if @hash.key? :gempath
+    @sources                     = @hash[:sources]                     if @hash.key? :sources
+    @disable_default_gem_server  = @hash[:disable_default_gem_server]  if @hash.key? :disable_default_gem_server
+    @ssl_verify_mode             = @hash[:ssl_verify_mode]             if @hash.key? :ssl_verify_mode
+    @ssl_ca_cert                 = @hash[:ssl_ca_cert]                 if @hash.key? :ssl_ca_cert
+    @ssl_client_cert             = @hash[:ssl_client_cert]             if @hash.key? :ssl_client_cert
 
     @api_keys         = nil
     @rubygems_api_key = nil

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -487,6 +487,16 @@ if you believe they were disclosed to a third party.
     end
   end
 
+  def test_accept_string_key
+    File.open @temp_conf, "w" do |fp|
+      fp.puts "verbose: false"
+    end
+
+    util_config_file
+
+    assert_equal false, @cfg.verbose
+  end
+
   def test_load_ssl_verify_mode_from_config
     File.open @temp_conf, "w" do |fp|
       fp.puts ":ssl_verify_mode: 1"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I sometimes confused why it's not working correctly with the following `gemrc`.

```
gem: "--no-document"
verbose: false
```

The correct case is `:verbose:` for that key. It's not useful for users.

## What is your fix for the problem, implemented in this PR?

I convert them to symbol keys if specified at gemrc.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
