### PR TITLE
[commands/rebuild] Remove unused DATE_FORMAT constant.

### DIFF
--- a/lib/rubygems/commands/rebuild_command.rb
+++ b/lib/rubygems/commands/rebuild_command.rb
@@ -10,8 +10,6 @@ require_relative "../package"
 class Gem::Commands::RebuildCommand < Gem::Command
   include Gem::GemspecHelpers
 
-  DATE_FORMAT = "%Y-%m-%d %H:%M:%S.%N Z"
-
   def initialize
     super "rebuild", "Attempt to reproduce a build of a gem."
 


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

I accidentally added an unused constant in a previous PR.

## What is your fix for the problem, implemented in this PR?

I removed the unused constant.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
