### PR TITLE
Changelogs for RubyGems 3.5.8 and Bundler 2.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+# 3.5.8 / 2024-04-11
+
+## Security:
+
+* Respect global umask when writing regular files. Pull request
+  [#7518](https://github.com/rubygems/rubygems/pull/7518) by
+  deivid-rodriguez
+
+## Enhancements:
+
+* Allow string keys with gemrc. Pull request
+  [#7543](https://github.com/rubygems/rubygems/pull/7543) by hsbt
+* [Experimental] Add "gem rebuild" command. Pull request
+  [#4913](https://github.com/rubygems/rubygems/pull/4913) by duckinator
+* Installs bundler 2.5.8 as a default gem.
+
+## Bug fixes:
+
+* Fix NoMethodError crash when building errors about corrupt package
+  files. Pull request
+  [#7539](https://github.com/rubygems/rubygems/pull/7539) by jez
+* Fix resolver to properly intersect Arrays of `Gem::Resolver::Activation`
+  objects. Pull request
+  [#7537](https://github.com/rubygems/rubygems/pull/7537) by
+  deivid-rodriguez
+
 # 3.5.7 / 2024-03-22
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 2.5.8 (April 11, 2024)
+
+## Enhancements:
+
+  - Allow installing plugins from path via CLI [#6960](https://github.com/rubygems/rubygems/pull/6960)
+  - Improve validation of `bundle plugin install` options [#7529](https://github.com/rubygems/rubygems/pull/7529)
+
+## Bug fixes:
+
+  - Fix resolver error message when it runs out of versions due to `--strict --patch` filtering out everything [#7527](https://github.com/rubygems/rubygems/pull/7527)
+  - Fix incorrect `bundle update --bundler` message [#7516](https://github.com/rubygems/rubygems/pull/7516)
+
 # 2.5.7 (March 22, 2024)
 
 ## Deprecations:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.5.8 and Bundler 2.5.8 into master.