### PR TITLE
Add `--glob` flag to `bundle add`

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -347,6 +347,7 @@ module Bundler
     method_option "github", type: :string
     method_option "branch", type: :string
     method_option "ref", type: :string
+    method_option "glob", type: :string
     method_option "skip-install", type: :boolean, banner: "Adds gem to the Gemfile but does not install it"
     method_option "optimistic", type: :boolean, banner: "Adds optimistic declaration of version to gem"
     method_option "strict", type: :boolean, banner: "Adds strict declaration of version to gem"

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -347,7 +347,7 @@ module Bundler
     method_option "github", type: :string
     method_option "branch", type: :string
     method_option "ref", type: :string
-    method_option "glob", type: :string
+    method_option "glob", type: :string, banner: "The location of a dependency's .gemspec, expanded within Ruby (single quotes recommended)"
     method_option "skip-install", type: :boolean, banner: "Adds gem to the Gemfile but does not install it"
     method_option "optimistic", type: :boolean, banner: "Adds optimistic declaration of version to gem"
     method_option "strict", type: :boolean, banner: "Adds strict declaration of version to gem"

--- a/bundler/lib/bundler/dependency.rb
+++ b/bundler/lib/bundler/dependency.rb
@@ -7,7 +7,7 @@ require_relative "rubygems_ext"
 module Bundler
   class Dependency < Gem::Dependency
     attr_reader :autorequire
-    attr_reader :groups, :platforms, :gemfile, :path, :git, :github, :branch, :ref
+    attr_reader :groups, :platforms, :gemfile, :path, :git, :github, :branch, :ref, :glob
 
     ALL_RUBY_VERSIONS = (18..27).to_a.concat((30..34).to_a).freeze
     PLATFORM_MAP = {
@@ -39,6 +39,7 @@ module Bundler
       @github         = options["github"]
       @branch         = options["branch"]
       @ref            = options["ref"]
+      @glob           = options["glob"]
       @platforms      = Array(options["platforms"])
       @env            = options["env"]
       @should_include = options.fetch("should_include", true)

--- a/bundler/lib/bundler/injector.rb
+++ b/bundler/lib/bundler/injector.rb
@@ -120,9 +120,10 @@ module Bundler
         github = ", :github => \"#{d.github}\"" unless d.github.nil?
         branch = ", :branch => \"#{d.branch}\"" unless d.branch.nil?
         ref = ", :ref => \"#{d.ref}\"" unless d.ref.nil?
+        glob = ", :glob => \"#{d.glob}\"" unless d.glob.nil?
         require_path = ", :require => #{convert_autorequire(d.autorequire)}" unless d.autorequire.nil?
 
-        %(gem #{name}#{requirement}#{group}#{source}#{path}#{git}#{github}#{branch}#{ref}#{require_path})
+        %(gem #{name}#{requirement}#{group}#{source}#{path}#{git}#{github}#{branch}#{ref}#{glob}#{require_path})
       end.join("\n")
     end
 

--- a/bundler/spec/commands/add_spec.rb
+++ b/bundler/spec/commands/add_spec.rb
@@ -175,6 +175,61 @@ RSpec.describe "bundle add" do
     end
   end
 
+  describe "with --git and --glob" do
+    it "adds dependency with specified git source" do
+      bundle "add foo --git=#{lib_path("foo-2.0")} --glob=./*.gemspec"
+
+      expect(bundled_app_gemfile.read).to match(%r{gem "foo", "~> 2.0", :git => "#{lib_path("foo-2.0")}", :glob => "\./\*\.gemspec"})
+      expect(the_bundle).to include_gems "foo 2.0"
+    end
+  end
+
+  describe "with --git and --branch and --glob" do
+    before do
+      update_git "foo", "2.0", branch: "test"
+    end
+
+    it "adds dependency with specified git source and branch" do
+      bundle "add foo --git=#{lib_path("foo-2.0")} --branch=test --glob=./*.gemspec"
+
+      expect(bundled_app_gemfile.read).to match(%r{gem "foo", "~> 2.0", :git => "#{lib_path("foo-2.0")}", :branch => "test", :glob => "\./\*\.gemspec"})
+      expect(the_bundle).to include_gems "foo 2.0"
+    end
+  end
+
+  describe "with --git and --ref and --glob" do
+    it "adds dependency with specified git source and branch" do
+      bundle "add foo --git=#{lib_path("foo-2.0")} --ref=#{revision_for(lib_path("foo-2.0"))} --glob=./*.gemspec"
+
+      expect(bundled_app_gemfile.read).to match(%r{gem "foo", "~> 2\.0", :git => "#{lib_path("foo-2.0")}", :ref => "#{revision_for(lib_path("foo-2.0"))}", :glob => "\./\*\.gemspec"})
+      expect(the_bundle).to include_gems "foo 2.0"
+    end
+  end
+
+  describe "with --github and --glob" do
+    it "adds dependency with specified github source", :realworld do
+      bundle "add rake --github=ruby/rake --glob=./*.gemspec"
+
+      expect(bundled_app_gemfile.read).to match(%r{gem "rake", "~> 13\.\d+", :github => "ruby\/rake", :glob => "\.\/\*\.gemspec"})
+    end
+  end
+
+  describe "with --github and --branch --and glob" do
+    it "adds dependency with specified github source and branch", :realworld do
+      bundle "add rake --github=ruby/rake --branch=master --glob=./*.gemspec"
+
+      expect(bundled_app_gemfile.read).to match(%r{gem "rake", "~> 13\.\d+", :github => "ruby\/rake", :branch => "master", :glob => "\.\/\*\.gemspec"})
+    end
+  end
+
+  describe "with --github and --ref and --glob" do
+    it "adds dependency with specified github source and ref", :realworld do
+      bundle "add rake --github=ruby/rake --ref=5c60da8 --glob=./*.gemspec"
+
+      expect(bundled_app_gemfile.read).to match(%r{gem "rake", "~> 13\.\d+", :github => "ruby\/rake", :ref => "5c60da8", :glob => "\.\/\*\.gemspec"})
+    end
+  end
+
   describe "with --skip-install" do
     it "adds gem to Gemfile but is not installed" do
       bundle "add foo --skip-install --version=2.0"

--- a/bundler/spec/commands/add_spec.rb
+++ b/bundler/spec/commands/add_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe "bundle add" do
 
   describe "with --git and --glob" do
     it "adds dependency with specified git source" do
-      bundle "add foo --git=#{lib_path("foo-2.0")} --glob=./*.gemspec"
+      bundle "add foo --git=#{lib_path("foo-2.0")} --glob='./*.gemspec'"
 
       expect(bundled_app_gemfile.read).to match(%r{gem "foo", "~> 2.0", :git => "#{lib_path("foo-2.0")}", :glob => "\./\*\.gemspec"})
       expect(the_bundle).to include_gems "foo 2.0"
@@ -190,7 +190,7 @@ RSpec.describe "bundle add" do
     end
 
     it "adds dependency with specified git source and branch" do
-      bundle "add foo --git=#{lib_path("foo-2.0")} --branch=test --glob=./*.gemspec"
+      bundle "add foo --git=#{lib_path("foo-2.0")} --branch=test --glob='./*.gemspec'"
 
       expect(bundled_app_gemfile.read).to match(%r{gem "foo", "~> 2.0", :git => "#{lib_path("foo-2.0")}", :branch => "test", :glob => "\./\*\.gemspec"})
       expect(the_bundle).to include_gems "foo 2.0"
@@ -199,7 +199,7 @@ RSpec.describe "bundle add" do
 
   describe "with --git and --ref and --glob" do
     it "adds dependency with specified git source and branch" do
-      bundle "add foo --git=#{lib_path("foo-2.0")} --ref=#{revision_for(lib_path("foo-2.0"))} --glob=./*.gemspec"
+      bundle "add foo --git=#{lib_path("foo-2.0")} --ref=#{revision_for(lib_path("foo-2.0"))} --glob='./*.gemspec'"
 
       expect(bundled_app_gemfile.read).to match(%r{gem "foo", "~> 2\.0", :git => "#{lib_path("foo-2.0")}", :ref => "#{revision_for(lib_path("foo-2.0"))}", :glob => "\./\*\.gemspec"})
       expect(the_bundle).to include_gems "foo 2.0"
@@ -208,7 +208,7 @@ RSpec.describe "bundle add" do
 
   describe "with --github and --glob" do
     it "adds dependency with specified github source", :realworld do
-      bundle "add rake --github=ruby/rake --glob=./*.gemspec"
+      bundle "add rake --github=ruby/rake --glob='./*.gemspec'"
 
       expect(bundled_app_gemfile.read).to match(%r{gem "rake", "~> 13\.\d+", :github => "ruby\/rake", :glob => "\.\/\*\.gemspec"})
     end
@@ -216,7 +216,7 @@ RSpec.describe "bundle add" do
 
   describe "with --github and --branch --and glob" do
     it "adds dependency with specified github source and branch", :realworld do
-      bundle "add rake --github=ruby/rake --branch=master --glob=./*.gemspec"
+      bundle "add rake --github=ruby/rake --branch=master --glob='./*.gemspec'"
 
       expect(bundled_app_gemfile.read).to match(%r{gem "rake", "~> 13\.\d+", :github => "ruby\/rake", :branch => "master", :glob => "\.\/\*\.gemspec"})
     end
@@ -224,7 +224,7 @@ RSpec.describe "bundle add" do
 
   describe "with --github and --ref and --glob" do
     it "adds dependency with specified github source and ref", :realworld do
-      bundle "add rake --github=ruby/rake --ref=5c60da8 --glob=./*.gemspec"
+      bundle "add rake --github=ruby/rake --ref=5c60da8 --glob='./*.gemspec'"
 
       expect(bundled_app_gemfile.read).to match(%r{gem "rake", "~> 13\.\d+", :github => "ruby\/rake", :ref => "5c60da8", :glob => "\.\/\*\.gemspec"})
     end


### PR DESCRIPTION
Bundler online documentation says that if the gem is located within a subdirectory of a git repository, you can use the `:glob` option to specify the location of its .gemspec, [docs](https://bundler.io/guides/git.html)

`gem 'cf-copilot', git: 'https://github.com/cloudfoundry/copilot', glob: 'sdk/ruby/*.gemspec'`

This change allows for equivalent functionality from the bundler CLI

`bundle add cf-copilot --git=https://github.com/cloudfoundry/copilot --glob='sdk/ruby/*.gemspec'`

## What was the end-user or developer problem that led to this PR?

I'm working on some projects that require gems from remote git sources, and sometimes these projects don't specify the `.gemspec` file at the root of the repo. Instead of manually editing the `Gemfile`, I'd like to use bundler's CLI where possible.

## What is your fix for the problem, implemented in this PR?

My fix is to pass-through the `glob` option from `Bundler::CLI#add(*gems)`, to `Bundler::Dependency#glob` to be used in `Bundler::Injector#build_gem_lines()`

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
