### PR TITLE
Make sure `bundle update <specific_gems>` can always update to the latest resolvable version of each requested gem

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -227,7 +227,6 @@ module Bundler
       @resolver = nil
       @resolution_packages = nil
       @specs = nil
-      @gem_version_promoter = nil
 
       Bundler.ui.debug "The definition is missing dependencies, failed to resolve & materialize locally (#{e})"
       true

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -252,6 +252,128 @@ RSpec.describe "bundle lock" do
     expect(read_lockfile).to eq(remove_checksums_from_lockfile(@lockfile, "(2.3.2)", "(#{rake_version})"))
   end
 
+  it "updates specific gems using --update, even if that requires unlocking other top level gems" do
+    build_repo4 do
+      build_gem "prism", "0.15.1"
+      build_gem "prism", "0.24.0"
+
+      build_gem "ruby-lsp", "0.12.0" do |s|
+        s.add_dependency "prism", "< 0.24.0"
+      end
+
+      build_gem "ruby-lsp", "0.16.1" do |s|
+        s.add_dependency "prism", ">= 0.24.0"
+      end
+
+      build_gem "tapioca", "0.11.10" do |s|
+        s.add_dependency "prism", "< 0.24.0"
+      end
+
+      build_gem "tapioca", "0.13.1" do |s|
+        s.add_dependency "prism", ">= 0.24.0"
+      end
+    end
+
+    gemfile <<~G
+      source "#{file_uri_for(gem_repo4)}"
+
+      gem "tapioca"
+      gem "ruby-lsp"
+    G
+
+    lockfile <<~L
+      GEM
+        remote: #{file_uri_for(gem_repo4)}
+        specs:
+          prism (0.15.1)
+          ruby-lsp (0.12.0)
+            prism (< 0.24.0)
+          tapioca (0.11.10)
+            prism (< 0.24.0)
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        ruby-lsp
+        tapioca
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    bundle "lock --update tapioca --verbose"
+
+    expect(lockfile).to include("tapioca (0.13.1)")
+  end
+
+  it "updates specific gems using --update, even if that requires unlocking other top level gems, but only as few as possible" do
+    build_repo4 do
+      build_gem "prism", "0.15.1"
+      build_gem "prism", "0.24.0"
+
+      build_gem "ruby-lsp", "0.12.0" do |s|
+        s.add_dependency "prism", "< 0.24.0"
+      end
+
+      build_gem "ruby-lsp", "0.16.1" do |s|
+        s.add_dependency "prism", ">= 0.24.0"
+      end
+
+      build_gem "tapioca", "0.11.10" do |s|
+        s.add_dependency "prism", "< 0.24.0"
+      end
+
+      build_gem "tapioca", "0.13.1" do |s|
+        s.add_dependency "prism", ">= 0.24.0"
+      end
+
+      build_gem "other-prism-dependent", "1.0.0" do |s|
+        s.add_dependency "prism", ">= 0.15.1"
+      end
+
+      build_gem "other-prism-dependent", "1.1.0" do |s|
+        s.add_dependency "prism", ">= 0.15.1"
+      end
+    end
+
+    gemfile <<~G
+      source "#{file_uri_for(gem_repo4)}"
+
+      gem "tapioca"
+      gem "ruby-lsp"
+      gem "other-prism-dependent"
+    G
+
+    lockfile <<~L
+      GEM
+        remote: #{file_uri_for(gem_repo4)}
+        specs:
+          other-prism-dependent (1.0.0)
+            prism (>= 0.15.1)
+          prism (0.15.1)
+          ruby-lsp (0.12.0)
+            prism (< 0.24.0)
+          tapioca (0.11.10)
+            prism (< 0.24.0)
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        ruby-lsp
+        tapioca
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    bundle "lock --update tapioca"
+
+    expect(lockfile).to include("tapioca (0.13.1)")
+    expect(lockfile).to include("other-prism-dependent (1.0.0)")
+  end
+
   it "preserves unknown checksum algorithms" do
     lockfile @lockfile.gsub(/(sha256=[a-f0-9]+)$/, "constant=true,\\1,xyz=123")
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes `bundle update foo` won't actually update foo, even if a clean `bundle install` will resolve to a higher version of foo than the one currently locked.

The problem is that other locked dependencies may be setting some constraints on dependencies of foo, preventing it from being upgraded. These locked dependencies are not present on a clean `bundle install`.

## What is your fix for the problem, implemented in this PR?

My fix is, if `bundle update foo` is requested, and initial try did not update foo, try unlocking other gems, even if they are not dependencies of foo. Keep doing this until foo updates, or it's not possible to unlock more gems.

Fixes https://github.com/rubygems/rubygems/issues/3310.
Fixes https://github.com/rubygems/rubygems/issues/5463.
Fixes https://github.com/rubygems/rubygems/issues/7176.

Supersedes https://github.com/rubygems/rubygems/pull/5520.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
