### PR TITLE
Add missing ostruct require until upstream fixes it

### DIFF
--- a/bundler/bin/parallel_rspec
+++ b/bundler/bin/parallel_rspec
@@ -4,6 +4,8 @@
 require_relative "../spec/support/rubygems_ext"
 
 require_relative "../spec/support/switch_rubygems"
+
+require "ostruct" # Backfill missing require in turbo_tests. Remove when added upstream
 require "turbo_tests"
 
 if RUBY_PLATFORM.match?(/mingw|mswin/)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

json dropped its dependency on ostruct in ruby-core. That surfaced that turbo_tests was using ostruct without requiring it first, since it was their json dependency actually doing that.

That broke our daily bundler specs. 

## What is your fix for the problem, implemented in this PR?

Add the missing require ourselves, for now.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
