### PR TITLE
Honor a specified path as the temporary diretory if given

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -285,9 +285,12 @@ class Gem::TestCase < Test::Unit::TestCase
   def setup
     @orig_hooks = {}
     @orig_env = ENV.to_hash
-    @tmp = File.expand_path("../../tmp", __dir__)
 
-    FileUtils.mkdir_p @tmp
+    top_srcdir = __dir__ + "/../.."
+    @tmp = File.expand_path(ENV.fetch("GEM_TEST_TMPDIR", "tmp"), top_srcdir)
+
+    FileUtils.mkdir_p(@tmp, mode: 0o700) # =rwx
+    @tmp = File.realpath(@tmp)
 
     @tempdir = Dir.mktmpdir("test_rubygems_", @tmp)
 


### PR DESCRIPTION
## The problem

Currently the tests are executed in the fixed name directory "tmp" under the top source directory.  However it makes the tests fail when the source path contains symlinks.  Or unable to even start if the top source directory is read-only, e.g., remote-mounting in read-only mode from virtual machines.

Also, with the fixed directory, there is no way to avoid `pend` in `TestGemPackage#test_extract_symlink_parent_doesnt_delete_user_dir`.

## The fix

Instead of creating the fixed name directory, this PR allows to use a different path given with the environment variable "GEM_TEST_TMPDIR". The default path is, as well as the current behavior, "tmp" from the top source directory.

### Caveat

It is the caller's responsibility to make the directory safe (owned, world unwritable, or sticky) when setting the environment variable.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
