### PR TITLE
Explicily lock turbo_tests to 2.2.0 in Gemfile

### DIFF
--- a/tool/bundler/dev_gems.rb
+++ b/tool/bundler/dev_gems.rb
@@ -7,7 +7,7 @@ gem "rake", "~> 13.1"
 gem "rb_sys"
 
 gem "webrick", "~> 1.6"
-gem "turbo_tests", "~> 2.1"
+gem "turbo_tests", "= 2.2.0"
 gem "parallel_tests", "< 3.9.0"
 gem "parallel", "~> 1.19"
 gem "rspec-core", "~> 3.12"

--- a/tool/bundler/dev_gems.rb.lock
+++ b/tool/bundler/dev_gems.rb.lock
@@ -80,7 +80,7 @@ DEPENDENCIES
   rspec-expectations (~> 3.12)
   rspec-mocks (~> 3.12)
   test-unit (~> 3.0)
-  turbo_tests (~> 2.1)
+  turbo_tests (= 2.2.0)
   uri (~> 0.13.0)
   webrick (~> 1.6)
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Ruby-core CI is having issues with turbo_tests 2.2.1. This version adds json as a dependency and the `bundle install` command ruby-core uses is not able to compile it for some reason.

I was not able to reproduce the issue locally, so this needs more investigation.

## What is your fix for the problem, implemented in this PR?

We're already locked to 2.2.0, but ruby-core does not use a lockfile so we need to lock explicitly in the Gemfile for now.

This ports https://github.com/ruby/ruby/commit/d60b2caa95b01f37d35db9ef8be1d035d14b408d, but corrects the last working version (it's 2.2.0, not 2.1.0), and adds lockfile changes.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
