### PR TITLE
Fix installing plugins via relative paths

### DIFF
--- a/bundler/lib/bundler/plugin/installer.rb
+++ b/bundler/lib/bundler/plugin/installer.rb
@@ -77,7 +77,7 @@ module Bundler
 
       def install_path(names, version, path)
         source_list = SourceList.new
-        source = source_list.add_path_source({ "path" => path })
+        source = source_list.add_path_source({ "path" => path, "root_path" => SharedHelpers.pwd })
 
         install_all_sources(names, version, source_list, source)
       end

--- a/bundler/lib/bundler/plugin/installer/path.rb
+++ b/bundler/lib/bundler/plugin/installer/path.rb
@@ -5,7 +5,7 @@ module Bundler
     class Installer
       class Path < Bundler::Source::Path
         def root
-          Plugin.root
+          SharedHelpers.in_bundle? ? Bundler.root : Plugin.root
         end
 
         def generate_bin(spec, disable_extensions = false)

--- a/bundler/spec/plugins/install_spec.rb
+++ b/bundler/spec/plugins/install_spec.rb
@@ -212,14 +212,42 @@ RSpec.describe "bundler plugin install" do
     end
   end
 
-  it "installs from a path source" do
-    build_lib "path_plugin" do |s|
-      s.write "plugins.rb"
-    end
-    bundle "plugin install path_plugin --path #{lib_path("path_plugin-1.0")}"
+  context "path plugins" do
+    it "installs from a path source" do
+      build_lib "path_plugin" do |s|
+        s.write "plugins.rb"
+      end
+      bundle "plugin install path_plugin --path #{lib_path("path_plugin-1.0")}"
 
-    expect(out).to include("Installed plugin path_plugin")
-    plugin_should_be_installed("path_plugin")
+      expect(out).to include("Installed plugin path_plugin")
+      plugin_should_be_installed("path_plugin")
+    end
+
+    it "installs from a relative path source" do
+      build_lib "path_plugin" do |s|
+        s.write "plugins.rb"
+      end
+      path = lib_path("path_plugin-1.0").relative_path_from(bundled_app)
+      bundle "plugin install path_plugin --path #{path}"
+
+      expect(out).to include("Installed plugin path_plugin")
+      plugin_should_be_installed("path_plugin")
+    end
+
+    it "installs from a relative path source when inside an app" do
+      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+      gemfile ""
+
+      build_lib "ga-plugin" do |s|
+        s.write "plugins.rb"
+      end
+
+      path = lib_path("ga-plugin-1.0").relative_path_from(bundled_app)
+      bundle "plugin install ga-plugin --path #{path}"
+
+      plugin_should_be_installed("ga-plugin")
+      expect(local_plugin_gem("foo-1.0")).not_to be_directory
+    end
   end
 
   context "Gemfile eval" do
@@ -285,6 +313,21 @@ RSpec.describe "bundler plugin install" do
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
         plugin 'ga-plugin', :path => "#{lib_path("ga-plugin-1.0")}"
+      G
+
+      expect(out).to include("Installed plugin ga-plugin")
+      plugin_should_be_installed("ga-plugin")
+    end
+
+    it "accepts relative path sources" do
+      build_lib "ga-plugin" do |s|
+        s.write "plugins.rb"
+      end
+
+      path = lib_path("ga-plugin-1.0").relative_path_from(bundled_app)
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        plugin 'ga-plugin', :path => "#{path}"
       G
 
       expect(out).to include("Installed plugin ga-plugin")


### PR DESCRIPTION
This affected both CLI and Gemfile installs. It fixes a regression caused by #6960.

## What was the end-user or developer problem that led to this PR?

```
% bundle plugin install --path vendor/gems/bundler-multilock 
The path `/Users/cody/src/canvas-lms/.bundle/plugin/vendor/gems/bundler-multilock` does not exist.
```

## What is your fix for the problem, implemented in this PR?

 * Explicitly pass Dir.pwd as the root when installing a plugin from the CLI
 * Make sure that Bundler::Plugin::Source::Path#root still returns Bundler.root if we're within a bundle
 * Still return Plugin.root when we're not in the bundle (actual value doesn't matter; we just can't call Bundler.root when not in a bundle -- but the first bullet point will make the path calculation not actually use this value)

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
