### PR TITLE
Don't upcase Windows ENV before backing it up

### DIFF
--- a/bundler/lib/bundler/environment_preserver.rb
+++ b/bundler/lib/bundler/environment_preserver.rb
@@ -39,18 +39,7 @@ module Bundler
 
     # Replaces `ENV` with the bundler environment variables backed up
     def replace_with_backup
-      unless Gem.win_platform?
-        ENV.replace(backup)
-        return
-      end
-
-      # Fallback logic for Windows below to workaround
-      # https://bugs.ruby-lang.org/issues/16798. Can be dropped once all
-      # supported rubies include the fix for that.
-
-      ENV.clear
-
-      backup.each {|k, v| ENV[k] = v }
+      ENV.replace(backup)
     end
 
     # @return [Hash]

--- a/bundler/lib/bundler/environment_preserver.rb
+++ b/bundler/lib/bundler/environment_preserver.rb
@@ -19,14 +19,7 @@ module Bundler
     BUNDLER_PREFIX = "BUNDLER_ORIG_"
 
     def self.from_env
-      new(env_to_hash(ENV), BUNDLER_KEYS)
-    end
-
-    def self.env_to_hash(env)
-      to_hash = env.to_hash
-      return to_hash unless Gem.win_platform?
-
-      to_hash.each_with_object({}) {|(k,v), a| a[k.upcase] = v }
+      new(ENV.to_hash, BUNDLER_KEYS)
     end
 
     # @param env [Hash]

--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -638,4 +638,22 @@ RSpec.describe "bundler/inline#gemfile" do
 
     expect(out).to include("Installing timeout 999")
   end
+
+  it "does not upcase ENV" do
+    script <<-RUBY
+      require 'bundler/inline'
+
+      ENV['Test_Variable'] = 'value string'
+      puts("before: \#{ENV.each_key.select { |key| key.match?(/test_variable/i) }}")
+
+      gemfile do
+        source "#{file_uri_for(gem_repo1)}"
+      end
+
+      puts("after: \#{ENV.each_key.select { |key| key.match?(/test_variable/i) }}")
+    RUBY
+
+    expect(out).to include("before: [\"Test_Variable\"]")
+    expect(out).to include("after: [\"Test_Variable\"]")
+  end
 end

--- a/bundler/spec/runtime/with_unbundled_env_spec.rb
+++ b/bundler/spec/runtime/with_unbundled_env_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe "Bundler.with_env helpers" do
   describe "Bundler.with_original_env" do
     it "should set ENV to original_env in the block" do
       expected = Bundler.original_env
-      actual = Bundler.with_original_env { Bundler::EnvironmentPreserver.env_to_hash(ENV) }
+      actual = Bundler.with_original_env { ENV.to_hash }
       expect(actual).to eq(expected)
     end
 
@@ -157,7 +157,7 @@ RSpec.describe "Bundler.with_env helpers" do
       expected = Bundler.unbundled_env
 
       actual = Bundler.ui.silence do
-        Bundler.with_clean_env { Bundler::EnvironmentPreserver.env_to_hash(ENV) }
+        Bundler.with_clean_env { ENV.to_hash }
       end
 
       expect(actual).to eq(expected)
@@ -175,7 +175,7 @@ RSpec.describe "Bundler.with_env helpers" do
   describe "Bundler.with_unbundled_env" do
     it "should set ENV to unbundled_env in the block" do
       expected = Bundler.unbundled_env
-      actual = Bundler.with_unbundled_env { Bundler::EnvironmentPreserver.env_to_hash(ENV) }
+      actual = Bundler.with_unbundled_env { ENV.to_hash }
       expect(actual).to eq(expected)
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

People find it strange that their ENV case is changed after `bundler/inline`. See https://github.com/rubygems/rubygems/issues/7530.

## What is your fix for the problem, implemented in this PR?

I originally started upcasing it in https://github.com/rubygems/rubygems/pull/3525, but I wasn't before specific about the problem and did not add a spec.

Checking if this is really needed.

Potentially fixes #7530.

In addition, I'm also cleaning up a Windows workaround that's no longer necessary.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
