### PR TITLE
Fix issue installing gems with linux-musl variant on non musl linux

### DIFF
--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -65,7 +65,7 @@ module Bundler
 
       platforms.concat(new_platforms)
 
-      less_specific_platform = new_platforms.find {|platform| platform != Gem::Platform::RUBY && Bundler.local_platform === platform }
+      less_specific_platform = new_platforms.find {|platform| platform != Gem::Platform::RUBY && Bundler.local_platform === platform && platform === Bundler.local_platform }
       platforms.delete(Bundler.local_platform) if less_specific_platform
 
       platforms

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -1262,43 +1262,47 @@ RSpec.describe "bundle install with specific platforms" do
     end
   end
 
-  it "adds current musl platform" do
-    build_repo4 do
-      build_gem "rcee_precompiled", "0.5.0" do |s|
-        s.platform = "x86_64-linux"
+  ["x86_64-linux", "x86_64-linux-musl"].each do |host_platform|
+    describe "on host platform #{host_platform}" do
+      it "adds current musl platform" do
+        build_repo4 do
+          build_gem "rcee_precompiled", "0.5.0" do |s|
+            s.platform = "x86_64-linux"
+          end
+
+          build_gem "rcee_precompiled", "0.5.0" do |s|
+            s.platform = "x86_64-linux-musl"
+          end
+        end
+
+        gemfile <<~G
+          source "#{file_uri_for(gem_repo4)}"
+
+          gem "rcee_precompiled", "0.5.0"
+        G
+
+        simulate_platform host_platform do
+          bundle "lock", artifice: "compact_index", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+
+          expect(lockfile).to eq(<<~L)
+            GEM
+              remote: #{file_uri_for(gem_repo4)}/
+              specs:
+                rcee_precompiled (0.5.0-x86_64-linux)
+                rcee_precompiled (0.5.0-x86_64-linux-musl)
+
+            PLATFORMS
+              x86_64-linux
+              x86_64-linux-musl
+
+            DEPENDENCIES
+              rcee_precompiled (= 0.5.0)
+
+            BUNDLED WITH
+               #{Bundler::VERSION}
+          L
+        end
       end
-
-      build_gem "rcee_precompiled", "0.5.0" do |s|
-        s.platform = "x86_64-linux-musl"
-      end
-    end
-
-    gemfile <<~G
-      source "#{file_uri_for(gem_repo4)}"
-
-      gem "rcee_precompiled", "0.5.0"
-    G
-
-    simulate_platform "x86_64-linux-musl" do
-      bundle "lock", artifice: "compact_index", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
-
-      expect(lockfile).to eq(<<~L)
-        GEM
-          remote: #{file_uri_for(gem_repo4)}/
-          specs:
-            rcee_precompiled (0.5.0-x86_64-linux)
-            rcee_precompiled (0.5.0-x86_64-linux-musl)
-
-        PLATFORMS
-          x86_64-linux
-          x86_64-linux-musl
-
-        DEPENDENCIES
-          rcee_precompiled (= 0.5.0)
-
-        BUNDLED WITH
-           #{Bundler::VERSION}
-      L
     end
   end
 


### PR DESCRIPTION
This PR includes a test that reproduces an issue described in rake-compiler/rake-compiler-dock#117 which first started manifesting after rubygems/rubygems@66ee354d 

## What was the end-user or developer problem that led to this PR?

- Given I'm on a host system that identifies as platform `x86_64-linux`
- And a gem has been published with `-linux` and `-linux-musl` native variants (e.g., [rcee_precompiled v0.5.0.1](https://rubygems.org/gems/rcee_precompiled/versions))
- And I have a Gemfile that declares a dependency on that gem
- When I run `bundle install`
- Then I should install the `-linux` variant

The example Gemfile is:

```
source "https://rubygems.org"

gem "rcee_precompiled", "0.5.0.1"
```

However, with bundler 2.5.6 or later, I instead see this error:

```
Could not find gems matching 'rcee_precompiled (= 0.5.0.1)' valid for all resolution platforms (aarch64-linux-musl,
aarch64-linux, arm-linux-musl, arm-linux, arm64-darwin, x86-linux-musl, x86-linux, x86_64-darwin, x86_64-linux-musl) in
rubygems repository https://rubygems.org/ or installed locally.

The source contains the following gems matching 'rcee_precompiled (= 0.5.0.1)':
  * rcee_precompiled-0.5.0.1-aarch64-linux
  * rcee_precompiled-0.5.0.1-aarch64-linux-musl
  * rcee_precompiled-0.5.0.1-arm-linux
  * rcee_precompiled-0.5.0.1-arm-linux-musl
  * rcee_precompiled-0.5.0.1-arm64-darwin
  * rcee_precompiled-0.5.0.1
  * rcee_precompiled-0.5.0.1-x64-mingw-ucrt
  * rcee_precompiled-0.5.0.1-x64-mingw32
  * rcee_precompiled-0.5.0.1-x86-linux
  * rcee_precompiled-0.5.0.1-x86-linux-musl
  * rcee_precompiled-0.5.0.1-x86_64-darwin
  * rcee_precompiled-0.5.0.1-x86_64-linux
  * rcee_precompiled-0.5.0.1-x86_64-linux-musl
```

This happens because the generated `Gemfile.lock` does not include the `x86_64-linux` platform, which is what the test in this PR demonstrates.

The test failure should look like:

```patch
@@ -1,11 +1,9 @@
 GEM
   remote: file:///home/flavorjones/code/oss/rubygems/bundler/tmp/1/gems/remote4/
   specs:
-    rcee_precompiled (0.5.0-x86_64-linux)
     rcee_precompiled (0.5.0-x86_64-linux-musl)

 PLATFORMS
-  x86_64-linux
   x86_64-linux-musl
```


## What is your fix for the problem, implemented in this PR?

I don't have a fix, I'm hoping this test will be helpful for the rubygems maintainers to understand what's going on.

