### PR TITLE
Clear temporary directory

### DIFF
--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -197,18 +197,17 @@ command to remove old versions.
       yield
     else
       require "tmpdir"
-      tmpdir = Dir.mktmpdir
-      FileUtils.mv Gem.plugindir, tmpdir
+      Dir.mktmpdir("gem_update") do |tmpdir|
+        FileUtils.mv Gem.plugindir, tmpdir
 
-      status = yield
+        status = yield
 
-      if status
-        FileUtils.rm_rf tmpdir
-      else
-        FileUtils.mv File.join(tmpdir, "plugins"), Gem.plugindir
+        unless status
+          FileUtils.mv File.join(tmpdir, "plugins"), Gem.plugindir
+        end
+
+        status
       end
-
-      status
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

It appears that a temporary directory for plugins remains when "setup.rb" fails.
Just I found this by searching for `Dir.mktmpdir` called without a block, but I'm not sure if this really happens.

## What is your fix for the problem, implemented in this PR?

Move the processing to a block and call `Dir.mktmpdir` with it.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
