### PR TITLE
Properly resolve aliases when `bundle help` is run

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -114,6 +114,8 @@ module Bundler
     class_option "verbose", type: :boolean, desc: "Enable verbose output mode", aliases: "-V"
 
     def help(cli = nil)
+      cli = self.class.all_aliases[cli] if self.class.all_aliases[cli]
+
       case cli
       when "gemfile" then command = "gemfile"
       when nil       then command = "bundle"
@@ -683,7 +685,6 @@ module Bundler
       exec_used = args.index {|a| exec_commands.include? a }
 
       command = args.find {|a| bundler_commands.include? a }
-      command = all_aliases[command] if all_aliases[command]
 
       if exec_used && help_used
         if exec_used + help_used == 1

--- a/bundler/spec/commands/help_spec.rb
+++ b/bundler/spec/commands/help_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe "bundle help" do
     expect(out).to eq(%(["#{man_dir}/bundle-install.1"]))
   end
 
+  it "prexifes bundle commands with bundle- and resolves aliases when finding the man files" do
+    with_fake_man do
+      bundle "help package"
+    end
+    expect(out).to eq(%(["#{man_dir}/bundle-cache.1"]))
+  end
+
   it "simply outputs the human readable file when there is no man on the path" do
     with_path_as("") do
       bundle "help install"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When `bundle help package` is run, Bundler shows the default man page built by thor automatically from command synopsis & flags, rather than our actual documentation.

## What is your fix for the problem, implemented in this PR?

The problem is that `bundle help` does not resolve command aliases, and `package` is an alias of `cache`, so Bundler fails to find the proper man page.

So the solution is to make sure `bundle help` properly resolves command aliases.

Fixes #7594.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
