### PR TITLE
Fix `bundle update` not working on an out of sync lockfile

### DIFF
--- a/bin/rake
+++ b/bin/rake
@@ -3,7 +3,7 @@
 
 require_relative "../bundler/spec/support/rubygems_ext"
 
-if ["dev:deps", "dev:frozen_deps", "spec:deps", "spec:parallel_deps"].include?(ARGV[0])
+if ["setup", "dev:deps", "dev:frozen_deps", "spec:deps", "spec:parallel_deps"].include?(ARGV[0])
   Spec::Rubygems.gem_load_and_possibly_install("rake", "rake")
 else
   Spec::Rubygems.gem_load("rake", "rake")

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -92,11 +92,12 @@ module Bundler
         @platforms = @locked_platforms.dup
         @locked_bundler_version = @locked_gems.bundler_version
         @locked_ruby_version = @locked_gems.ruby_version
+        @originally_locked_deps = @locked_gems.dependencies
         @originally_locked_specs = SpecSet.new(@locked_gems.specs)
         @locked_checksums = @locked_gems.checksums
 
         if unlock != true
-          @locked_deps    = @locked_gems.dependencies
+          @locked_deps    = @originally_locked_deps
           @locked_specs   = @originally_locked_specs
           @locked_sources = @locked_gems.sources
         else
@@ -111,6 +112,7 @@ module Bundler
         @locked_gems    = nil
         @locked_deps    = {}
         @locked_specs   = SpecSet.new([])
+        @originally_locked_deps = {}
         @originally_locked_specs = @locked_specs
         @locked_sources = []
         @locked_platforms = []
@@ -835,9 +837,7 @@ module Bundler
           dep.source = sources.get(dep.source)
         end
 
-        next if unlocking?
-
-        unless locked_dep = @locked_deps[dep.name]
+        unless locked_dep = @originally_locked_deps[dep.name]
           changes = true
           next
         end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

A multiplatform lockfile may fail to `bundle update` when the Gemfile dependencies have been edited.

## What is your fix for the problem, implemented in this PR?

We fixed a issue related to lockfile platforms a while ago, but that implied that some existing lockfiles would have invalid platforms and no longer work. To make that fix backwards compatible I added code to cleanup those invalid platforms before resolving.

That cleanup should be skipped though in some cases, like when dependencies have been added to the Gemfile, because those dependencies won't be valid for any platform since they have not be resolved yet.

The code to skip cleanup in the above case was not correct for situations when `bundle update` has been run, hence causing this problem.

The fix is to correct "dependencies have changed" detection for the `bundle update` case.

Fixes #7585.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
