### PR TITLE
Update `--ext=rust` to support compiling the native extension from source

### DIFF
--- a/bundler/lib/bundler/templates/newgem/Gemfile.tt
+++ b/bundler/lib/bundler/templates/newgem/Gemfile.tt
@@ -9,9 +9,6 @@ gem "rake", "~> 13.0"
 <%- if config[:ext] -%>
 
 gem "rake-compiler"
-<%- if config[:ext] == 'rust' -%>
-gem "rb_sys", "~> 0.9.63"
-<%- end -%>
 <%- end -%>
 <%- if config[:test] -%>
 

--- a/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -37,15 +37,15 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-<%- if config[:ext] == 'c' -%>
+<%- if config[:ext] == 'c' || config[:ext] == 'rust' -%>
   spec.extensions = ["ext/<%= config[:underscored_name] %>/extconf.rb"]
-<%- end -%>
-<%- if config[:ext] == 'rust' -%>
-  spec.extensions = ["ext/<%= config[:underscored_name] %>/Cargo.toml"]
 <%- end -%>
 
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"
+<%- if config[:ext] == 'rust' -%>
+  spec.add_dependency "rb_sys", "~> 0.9.91"
+<%- end -%>
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -1518,7 +1518,7 @@ RSpec.describe "bundle gem" do
       it "includes rake-compiler, but no Rust related changes" do
         expect(bundled_app("#{gem_name}/Gemfile").read).to include('gem "rake-compiler"')
 
-        expect(bundled_app("#{gem_name}/Gemfile").read).to_not include('gem "rb_sys"')
+        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to_not include('spec.add_dependency "rb_sys"')
         expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to_not include('spec.required_rubygems_version = ">= ')
       end
 
@@ -1578,7 +1578,7 @@ RSpec.describe "bundle gem" do
 
       it "includes rake-compiler, rb_sys gems and required_rubygems_version constraint" do
         expect(bundled_app("#{gem_name}/Gemfile").read).to include('gem "rake-compiler"')
-        expect(bundled_app("#{gem_name}/Gemfile").read).to include('gem "rb_sys"')
+        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to include('spec.add_dependency "rb_sys"')
         expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to include('spec.required_rubygems_version = ">= ')
       end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I needed to apply some tiny changes to the skeleton generated by the `--ext=rust` option to compile my native extension from source.

## What is your fix for the problem, implemented in this PR?

When gem consumers install a gem with a native extension and their platform is not included the pre-compiled bundles, they need to compile it locally and rely on the `extconf.rb` file.

Referencing the `extconf.rb` file in the gemspec is required  to make that work. We also need to include `rb_sys` as a dependency because the Rust `extconf.rb` depends on it.

Here's a demo of this change in action :)

https://github.com/rubygems/rubygems/assets/1079279/54e543a8-0827-4fce-bab6-1bb8c0740b42

Closes #7693.


