### PR TITLE
Fix circular require warning

### DIFF
--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -767,6 +767,18 @@ end
     expect(err).to be_empty
   end
 
+  it "can require rubygems without warnings, when using a local cache", rubygems: ">= 3.5.10" do
+    install_gemfile <<-G
+      source "#{file_uri_for(gem_repo1)}"
+      gem "rack"
+    G
+
+    bundle "package"
+    bundle %(exec ruby -w -e "require 'rubygems'")
+
+    expect(err).to be_empty
+  end
+
   context "when the user has `MANPATH` set", :man do
     before { ENV["MANPATH"] = "/foo#{File::PATH_SEPARATOR}" }
 

--- a/lib/rubygems/deprecate.rb
+++ b/lib/rubygems/deprecate.rb
@@ -69,99 +69,101 @@
 #       end
 #     end
 
-module Gem::Deprecate
-  def self.skip # :nodoc:
-    @skip ||= false
-  end
-
-  def self.skip=(v) # :nodoc:
-    @skip = v
-  end
-
-  ##
-  # Temporarily turn off warnings. Intended for tests only.
-
-  def skip_during
-    original = Gem::Deprecate.skip
-    Gem::Deprecate.skip = true
-    yield
-  ensure
-    Gem::Deprecate.skip = original
-  end
-
-  def self.next_rubygems_major_version # :nodoc:
-    Gem::Version.new(Gem.rubygems_version.segments.first).bump
-  end
-
-  ##
-  # Simple deprecation method that deprecates +name+ by wrapping it up
-  # in a dummy method. It warns on each call to the dummy method
-  # telling the user of +repl+ (unless +repl+ is :none) and the
-  # year/month that it is planned to go away.
-
-  def deprecate(name, repl, year, month)
-    class_eval do
-      old = "_deprecated_#{name}"
-      alias_method old, name
-      define_method name do |*args, &block|
-        klass = is_a? Module
-        target = klass ? "#{self}." : "#{self.class}#"
-        msg = [
-          "NOTE: #{target}#{name} is deprecated",
-          repl == :none ? " with no replacement" : "; use #{repl} instead",
-          format(". It will be removed on or after %4d-%02d.", year, month),
-          "\n#{target}#{name} called from #{Gem.location_of_caller.join(":")}",
-        ]
-        warn "#{msg.join}." unless Gem::Deprecate.skip
-        send old, *args, &block
-      end
-      ruby2_keywords name if respond_to?(:ruby2_keywords, true)
+module Gem
+  module Deprecate
+    def self.skip # :nodoc:
+      @skip ||= false
     end
-  end
 
-  ##
-  # Simple deprecation method that deprecates +name+ by wrapping it up
-  # in a dummy method. It warns on each call to the dummy method
-  # telling the user of +repl+ (unless +repl+ is :none) and the
-  # Rubygems version that it is planned to go away.
-
-  def rubygems_deprecate(name, replacement=:none)
-    class_eval do
-      old = "_deprecated_#{name}"
-      alias_method old, name
-      define_method name do |*args, &block|
-        klass = is_a? Module
-        target = klass ? "#{self}." : "#{self.class}#"
-        msg = [
-          "NOTE: #{target}#{name} is deprecated",
-          replacement == :none ? " with no replacement" : "; use #{replacement} instead",
-          ". It will be removed in Rubygems #{Gem::Deprecate.next_rubygems_major_version}",
-          "\n#{target}#{name} called from #{Gem.location_of_caller.join(":")}",
-        ]
-        warn "#{msg.join}." unless Gem::Deprecate.skip
-        send old, *args, &block
-      end
-      ruby2_keywords name if respond_to?(:ruby2_keywords, true)
+    def self.skip=(v) # :nodoc:
+      @skip = v
     end
-  end
 
-  # Deprecation method to deprecate Rubygems commands
-  def rubygems_deprecate_command(version = Gem::Deprecate.next_rubygems_major_version)
-    class_eval do
-      define_method "deprecated?" do
-        true
-      end
+    ##
+    # Temporarily turn off warnings. Intended for tests only.
 
-      define_method "deprecation_warning" do
-        msg = [
-          "#{command} command is deprecated",
-          ". It will be removed in Rubygems #{version}.\n",
-        ]
+    def skip_during
+      original = Gem::Deprecate.skip
+      Gem::Deprecate.skip = true
+      yield
+    ensure
+      Gem::Deprecate.skip = original
+    end
 
-        alert_warning msg.join.to_s unless Gem::Deprecate.skip
+    def self.next_rubygems_major_version # :nodoc:
+      Gem::Version.new(Gem.rubygems_version.segments.first).bump
+    end
+
+    ##
+    # Simple deprecation method that deprecates +name+ by wrapping it up
+    # in a dummy method. It warns on each call to the dummy method
+    # telling the user of +repl+ (unless +repl+ is :none) and the
+    # year/month that it is planned to go away.
+
+    def deprecate(name, repl, year, month)
+      class_eval do
+        old = "_deprecated_#{name}"
+        alias_method old, name
+        define_method name do |*args, &block|
+          klass = is_a? Module
+          target = klass ? "#{self}." : "#{self.class}#"
+          msg = [
+            "NOTE: #{target}#{name} is deprecated",
+            repl == :none ? " with no replacement" : "; use #{repl} instead",
+            format(". It will be removed on or after %4d-%02d.", year, month),
+            "\n#{target}#{name} called from #{Gem.location_of_caller.join(":")}",
+          ]
+          warn "#{msg.join}." unless Gem::Deprecate.skip
+          send old, *args, &block
+        end
+        ruby2_keywords name if respond_to?(:ruby2_keywords, true)
       end
     end
-  end
 
-  module_function :rubygems_deprecate, :rubygems_deprecate_command, :skip_during
+    ##
+    # Simple deprecation method that deprecates +name+ by wrapping it up
+    # in a dummy method. It warns on each call to the dummy method
+    # telling the user of +repl+ (unless +repl+ is :none) and the
+    # Rubygems version that it is planned to go away.
+
+    def rubygems_deprecate(name, replacement=:none)
+      class_eval do
+        old = "_deprecated_#{name}"
+        alias_method old, name
+        define_method name do |*args, &block|
+          klass = is_a? Module
+          target = klass ? "#{self}." : "#{self.class}#"
+          msg = [
+            "NOTE: #{target}#{name} is deprecated",
+            replacement == :none ? " with no replacement" : "; use #{replacement} instead",
+            ". It will be removed in Rubygems #{Gem::Deprecate.next_rubygems_major_version}",
+            "\n#{target}#{name} called from #{Gem.location_of_caller.join(":")}",
+          ]
+          warn "#{msg.join}." unless Gem::Deprecate.skip
+          send old, *args, &block
+        end
+        ruby2_keywords name if respond_to?(:ruby2_keywords, true)
+      end
+    end
+
+    # Deprecation method to deprecate Rubygems commands
+    def rubygems_deprecate_command(version = Gem::Deprecate.next_rubygems_major_version)
+      class_eval do
+        define_method "deprecated?" do
+          true
+        end
+
+        define_method "deprecation_warning" do
+          msg = [
+            "#{command} command is deprecated",
+            ". It will be removed in Rubygems #{version}.\n",
+          ]
+
+          alert_warning msg.join.to_s unless Gem::Deprecate.skip
+        end
+      end
+    end
+
+    module_function :rubygems_deprecate, :rubygems_deprecate_command, :skip_during
+  end
 end

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -7,7 +7,6 @@
 
 # rubocop:enable Style/AsciiComments
 
-require_relative "../rubygems"
 require_relative "security"
 require_relative "user_interaction"
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since https://github.com/rubygems/rubygems/commit/bbe4da0450f92efa245c73805c6d06a5bc561ac0, cached gems are considered more frequently, and considering cached gems uses `Gem::Package` because it extracts specs from cached packages.

This introduced a circular dependency because due to the feature introduced by 963cb65a2db6117bfe4fb2900c17c0d3bd979498, a `bundle exec` invocation will require `bundler/setup` at the end of `rubygems` require, and that (due to the above change) will require `rubygems/package`, which since 73c199b087a94689a0e49b76e5333193f2310dcb requires "rubygems" again, causing the circularity. 

## What is your fix for the problem, implemented in this PR?

My fix is to not require `rubygems` from `rubygems/package`. Apparently it's not necessary.

Fixes #7611 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
