### PR TITLE
Changelogs for RubyGems 3.5.10 and Bundler 2.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# 3.5.10 / 2024-05-03
+
+## Security:
+
+* Add a limit to the size of the metadata and checksums files in a gem
+  package. Pull request
+  [#7568](https://github.com/rubygems/rubygems/pull/7568) by segiddins
+
+## Enhancements:
+
+* Don't fully require `rubygems` from `rubygems/package` to prevent some
+  circular require warnings when using Bundler. Pull request
+  [#7612](https://github.com/rubygems/rubygems/pull/7612) by
+  deivid-rodriguez
+* Installs bundler 2.5.10 as a default gem.
+
+## Bug fixes:
+
+* Rename credential email to identifier in WebAuthn poller. Pull request
+  [#7623](https://github.com/rubygems/rubygems/pull/7623) by jenshenny
+
 # 3.5.9 / 2024-04-12
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,27 @@
+# 2.5.10 (May 3, 2024)
+
+## Security:
+
+  - Never write credentials to lockfiles [#7560](https://github.com/rubygems/rubygems/pull/7560)
+
+## Enhancements:
+
+  - Add auto_install support to require "bundler/setup" [#6561](https://github.com/rubygems/rubygems/pull/6561)
+  - Add `--glob` flag to `bundle add` [#7557](https://github.com/rubygems/rubygems/pull/7557)
+
+## Bug fixes:
+
+  - Make sure `bundle update <specific_gems>` can always update to the latest resolvable version of each requested gem [#7558](https://github.com/rubygems/rubygems/pull/7558)
+  - Show better error when installed gemspecs are unreadable [#7603](https://github.com/rubygems/rubygems/pull/7603)
+  - Fix `bundle update` not working on an out of sync lockfile [#7607](https://github.com/rubygems/rubygems/pull/7607)
+  - Don't upcase Windows ENV before backing it up [#7574](https://github.com/rubygems/rubygems/pull/7574)
+  - Properly resolve aliases when `bundle help` is run [#7601](https://github.com/rubygems/rubygems/pull/7601)
+  - Fix issue installing gems with linux-musl variant on non musl linux [#7583](https://github.com/rubygems/rubygems/pull/7583)
+
+## Documentation:
+
+  - Clarify `bundle check` behaviour in docs [#7613](https://github.com/rubygems/rubygems/pull/7613)
+
 # 2.5.9 (April 12, 2024)
 
 ## Bug fixes:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.5.10 and Bundler 2.5.10 into master.