### PR TITLE
Bundler: Show "Installed" message after installing a gem

### DIFF
--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -202,7 +202,10 @@ module Bundler
         message += " with native extensions" if spec.extensions.any?
         Bundler.ui.confirm message
 
+        start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         installed_spec = installer.install
+        end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        Bundler.ui.confirm "Installed #{version_message(spec, options[:previous_spec])} in %.3fs" % (end_time - start_time)
 
         spec.full_gem_path = installed_spec.full_gem_path
         spec.loaded_from = installed_spec.loaded_from


### PR DESCRIPTION
Add an "Installed XXX in Y.YYYs" message after installing a gem. 

Example output:
```
Fetching buffering_logger 3.1.1
Installing buffering_logger 3.1.1
Installed buffering_logger 3.1.1 in 0.004s
```
☝️ the last line is new.

## What was the end-user or developer problem that led to this PR?

When installing gems in parallel (e.g. `bundle install --jobs 4`), I wanted it to be easier to tell when each gem finished installing and how long each gem took to install.

Currently, especially when reviewing logs on production servers, I have timestamps on log lines but I still can't tell which gems are taking a long time to install because I can't get a time diff between starting a particular gem and finishing the install (if I'm installing gems in parallel). Gems with native extensions are often ones that are slow that I'd like to identify.

## What is your fix for the problem, implemented in this PR?

Measure the time elapsed while installing (not including fetching) and print it out.

If this looks OK I will add some tests.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
