### PR TITLE
Rename credential email to identifier in WebAuthn poller

### DIFF
--- a/lib/rubygems/gemcutter_utilities/webauthn_poller.rb
+++ b/lib/rubygems/gemcutter_utilities/webauthn_poller.rb
@@ -69,8 +69,10 @@ module Gem::GemcutterUtilities
       rubygems_api_request(:get, "api/v1/webauthn_verification/#{webauthn_token}/status.json") do |request|
         if credentials.empty?
           request.add_field "Authorization", api_key
+        elsif credentials[:identifier] && credentials[:password]
+          request.basic_auth credentials[:identifier], credentials[:password]
         else
-          request.basic_auth credentials[:email], credentials[:password]
+          raise Gem::WebauthnVerificationError, "Provided missing credentials"
         end
       end
     end

--- a/test/rubygems/test_webauthn_poller.rb
+++ b/test/rubygems/test_webauthn_poller.rb
@@ -13,7 +13,7 @@ class WebauthnPollerTest < Gem::TestCase
     @fetcher = Gem::FakeFetcher.new
     Gem::RemoteFetcher.fetcher = @fetcher
     @credentials = {
-      email: "email@example.com",
+      identifier: "email@example.com",
       password: "password",
     }
   end
@@ -120,5 +120,15 @@ class WebauthnPollerTest < Gem::TestCase
 
     assert_equal error.message,
       "Security device verification failed: The token in the link you used has either expired or been used already."
+  end
+
+  def test_poll_for_otp_missing_credentials
+    @credentials = { password: "password" }
+
+    error = assert_raise Gem::WebauthnVerificationError do
+      Gem::GemcutterUtilities::WebauthnPoller.new({}, @host).poll_for_otp(@webauthn_url, @credentials)
+    end
+
+    assert_equal error.message, "Security device verification failed: Provided missing credentials"
   end
 end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

Fixes https://github.com/rubygems/rubygems/issues/7553,

https://github.com/rubygems/rubygems/pull/7422 renames credential email to identifier so it fits username and email. However, this wasn't updated in the Webauthn logic, breaking MFA sign ins with it.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Use the identifier key instead of email when referencing credentials in the webauthn poller. Added error handling such that future renames will be caught through tests.

Thinking if there is a way to not pass credentials to the poller class and have it be dependent in the long term. 🤔 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
