### PR TITLE
Add `--target-rbconfig` option to `gem install` and `gem update` commands

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -521,6 +521,7 @@ lib/rubygems/ssl_certs/.document
 lib/rubygems/ssl_certs/rubygems.org/GlobalSignRootCA.pem
 lib/rubygems/ssl_certs/rubygems.org/GlobalSignRootCA_R3.pem
 lib/rubygems/stub_specification.rb
+lib/rubygems/target_rbconfig.rb
 lib/rubygems/text.rb
 lib/rubygems/uninstaller.rb
 lib/rubygems/unknown_command_spell_checker.rb

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -229,6 +229,8 @@ module Bundler
     method_option "system", type: :boolean, banner: "Install to the system location ($BUNDLE_PATH or $GEM_HOME) even if the bundle was previously installed somewhere else for this application"
     method_option "trust-policy", alias: "P", type: :string, banner:       "Gem trust policy (like gem install -P). Must be one of " +
                                                                            Bundler.rubygems.security_policy_keys.join("|")
+    method_option "target-rbconfig", type: :string, banner: "rbconfig.rb for the deployment target platform"
+
     method_option "without", type: :array, banner: "Exclude gems that are part of the specified named group."
     method_option "with", type: :array, banner: "Include gems that are part of the specified named group."
     def install

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -19,6 +19,10 @@ module Bundler
       # Disable color in deployment mode
       Bundler.ui.shell = Thor::Shell::Basic.new if options[:deployment]
 
+      if target_rbconfig_path = options["target-rbconfig"]
+        Bundler.rubygems.set_target_rbconfig(target_rbconfig_path)
+      end
+
       check_for_options_conflicts
 
       check_trust_policy

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -19,7 +19,7 @@ module Bundler
       # Disable color in deployment mode
       Bundler.ui.shell = Thor::Shell::Basic.new if options[:deployment]
 
-      if target_rbconfig_path = options["target-rbconfig"]
+      if target_rbconfig_path = options[:"target-rbconfig"]
         Bundler.rubygems.set_target_rbconfig(target_rbconfig_path)
       end
 

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -34,6 +34,10 @@ module Bundler
       Gem::Command.build_args = args
     end
 
+    def set_target_rbconfig(path)
+      Gem.set_target_rbconfig(path)
+    end
+
     def loaded_specs(name)
       Gem.loaded_specs[name]
     end

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -18,6 +18,7 @@ require_relative "rubygems/compatibility"
 require_relative "rubygems/defaults"
 require_relative "rubygems/deprecate"
 require_relative "rubygems/errors"
+require_relative "rubygems/target_rbconfig"
 
 ##
 # RubyGems is the Ruby standard for publishing and managing third party
@@ -178,6 +179,8 @@ module Gem
   @default_source_date_epoch = nil
 
   @discover_gems_on_require = true
+
+  @target_rbconfig = nil
 
   ##
   # Try to activate a gem containing +path+. Returns true if
@@ -397,6 +400,23 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   end
 
   ##
+  # The RbConfig object for the deployment target platform.
+  #
+  # This is usually the same as the running platform, but may be
+  # different if you are cross-compiling.
+
+  def self.target_rbconfig
+    @target_rbconfig || Gem::TargetRbConfig.for_running_ruby
+  end
+
+  def self.set_target_rbconfig(rbconfig_path)
+    @target_rbconfig = Gem::TargetRbConfig.from_path(rbconfig_path)
+    Gem::Platform.local(refresh: true)
+    Gem.platforms << Gem::Platform.local unless Gem.platforms.include? Gem::Platform.local
+    @target_rbconfig
+  end
+
+  ##
   # Quietly ensure the Gem directory +dir+ contains all the proper
   # subdirectories.  If we can't create a directory due to a permission
   # problem, then we will silently continue.
@@ -450,7 +470,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   # distinction as extensions cannot be shared between the two.
 
   def self.extension_api_version # :nodoc:
-    if RbConfig::CONFIG["ENABLE_SHARED"] == "no"
+    if target_rbconfig["ENABLE_SHARED"] == "no"
       "#{ruby_api_version}-static"
     else
       ruby_api_version
@@ -810,7 +830,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   # Returns a String containing the API compatibility version of Ruby
 
   def self.ruby_api_version
-    @ruby_api_version ||= RbConfig::CONFIG["ruby_version"].dup
+    @ruby_api_version ||= target_rbconfig["ruby_version"].dup
   end
 
   def self.env_requirement(gem_name)

--- a/lib/rubygems/ext/cargo_builder.rb
+++ b/lib/rubygems/ext/cargo_builder.rb
@@ -16,9 +16,14 @@ class Gem::Ext::CargoBuilder < Gem::Ext::Builder
     @profile = :release
   end
 
-  def build(extension, dest_path, results, args = [], lib_dir = nil, cargo_dir = Dir.pwd)
+  def build(extension, dest_path, results, args = [], lib_dir = nil, cargo_dir = Dir.pwd,
+    target_rbconfig=Gem.target_rbconfig)
     require "tempfile"
     require "fileutils"
+
+    if target_rbconfig.path
+      warn "--target-rbconfig is not yet supported for Rust extensions. Ignoring"
+    end
 
     # Where's the Cargo.toml of the crate we're building
     cargo_toml = File.join(cargo_dir, "Cargo.toml")

--- a/lib/rubygems/ext/cmake_builder.rb
+++ b/lib/rubygems/ext/cmake_builder.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 class Gem::Ext::CmakeBuilder < Gem::Ext::Builder
-  def self.build(extension, dest_path, results, args=[], lib_dir=nil, cmake_dir=Dir.pwd)
+  def self.build(extension, dest_path, results, args=[], lib_dir=nil, cmake_dir=Dir.pwd,
+    target_rbconfig=Gem.target_rbconfig)
+    if target_rbconfig.path
+      warn "--target-rbconfig is not yet supported for CMake extensions. Ignoring"
+    end
+
     unless File.exist?(File.join(cmake_dir, "Makefile"))
       require_relative "../command"
       cmd = ["cmake", ".", "-DCMAKE_INSTALL_PREFIX=#{dest_path}", *Gem::Command.build_args]
@@ -9,7 +14,7 @@ class Gem::Ext::CmakeBuilder < Gem::Ext::Builder
       run cmd, results, class_name, cmake_dir
     end
 
-    make dest_path, results, cmake_dir
+    make dest_path, results, cmake_dir, target_rbconfig: target_rbconfig
 
     results
   end

--- a/lib/rubygems/ext/configure_builder.rb
+++ b/lib/rubygems/ext/configure_builder.rb
@@ -7,14 +7,19 @@
 #++
 
 class Gem::Ext::ConfigureBuilder < Gem::Ext::Builder
-  def self.build(extension, dest_path, results, args=[], lib_dir=nil, configure_dir=Dir.pwd)
+  def self.build(extension, dest_path, results, args=[], lib_dir=nil, configure_dir=Dir.pwd,
+    target_rbconfig=Gem.target_rbconfig)
+    if target_rbconfig.path
+      warn "--target-rbconfig is not yet supported for configure-based extensions. Ignoring"
+    end
+
     unless File.exist?(File.join(configure_dir, "Makefile"))
       cmd = ["sh", "./configure", "--prefix=#{dest_path}", *args]
 
       run cmd, results, class_name, configure_dir
     end
 
-    make dest_path, results, configure_dir
+    make dest_path, results, configure_dir, target_rbconfig: target_rbconfig
 
     results
   end

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -45,7 +45,10 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
 
       full_tmp_dest = File.join(extension_dir, tmp_dest_relative)
 
-      if Gem.install_extension_in_lib && lib_dir
+      is_cross_compiling = target_rbconfig["platform"] != RbConfig::CONFIG["platform"]
+      # Do not copy extension libraries by default when cross-compiling
+      # not to conflict with the one already built for the host platform.
+      if Gem.install_extension_in_lib && lib_dir && !is_cross_compiling
         FileUtils.mkdir_p lib_dir
         entries = Dir.entries(full_tmp_dest) - %w[. ..]
         entries = entries.map {|entry| File.join full_tmp_dest, entry }

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -7,7 +7,8 @@
 #++
 
 class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
-  def self.build(extension, dest_path, results, args=[], lib_dir=nil, extension_dir=Dir.pwd)
+  def self.build(extension, dest_path, results, args=[], lib_dir=nil, extension_dir=Dir.pwd,
+    target_rbconfig=Gem.target_rbconfig)
     require "fileutils"
     require "tempfile"
 
@@ -23,6 +24,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
 
     begin
       cmd = ruby << File.basename(extension)
+      cmd << "--target-rbconfig=#{target_rbconfig.path}" if target_rbconfig.path
       cmd.push(*args)
 
       run(cmd, results, class_name, extension_dir) do |s, r|
@@ -39,7 +41,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
 
       ENV["DESTDIR"] = nil
 
-      make dest_path, results, extension_dir, tmp_dest_relative
+      make dest_path, results, extension_dir, tmp_dest_relative, target_rbconfig: target_rbconfig
 
       full_tmp_dest = File.join(extension_dir, tmp_dest_relative)
 
@@ -55,7 +57,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
         destent.exist? || FileUtils.mv(ent.path, destent.path)
       end
 
-      make dest_path, results, extension_dir, tmp_dest_relative, ["clean"]
+      make dest_path, results, extension_dir, tmp_dest_relative, ["clean"], target_rbconfig: target_rbconfig
     ensure
       ENV["DESTDIR"] = destdir
     end

--- a/lib/rubygems/ext/rake_builder.rb
+++ b/lib/rubygems/ext/rake_builder.rb
@@ -9,7 +9,12 @@ require_relative "../shellwords"
 #++
 
 class Gem::Ext::RakeBuilder < Gem::Ext::Builder
-  def self.build(extension, dest_path, results, args=[], lib_dir=nil, extension_dir=Dir.pwd)
+  def self.build(extension, dest_path, results, args=[], lib_dir=nil, extension_dir=Dir.pwd,
+    target_rbconfig=Gem.target_rbconfig)
+    if target_rbconfig.path
+      warn "--target-rbconfig is not yet supported for Rake extensions. Ignoring"
+    end
+
     if /mkrf_conf/i.match?(File.basename(extension))
       run([Gem.ruby, File.basename(extension), *args], results, class_name, extension_dir)
     end

--- a/lib/rubygems/install_update_options.rb
+++ b/lib/rubygems/install_update_options.rb
@@ -179,6 +179,11 @@ module Gem::InstallUpdateOptions
                "Suggest alternates when gems are not found") do |v,_o|
       options[:suggest_alternate] = v
     end
+
+    add_option(:"Install/Update", "--target-rbconfig [FILE]",
+                "rbconfig.rb for the deployment target platform") do |v, _o|
+      Gem.set_target_rbconfig(v)
+    end
   end
 
   ##

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -847,7 +847,7 @@ TEXT
   # configure scripts and rakefiles or mkrf_conf files.
 
   def build_extensions
-    builder = Gem::Ext::Builder.new spec, build_args
+    builder = Gem::Ext::Builder.new spec, build_args, Gem.target_rbconfig
 
     builder.build_extensions
   end
@@ -993,7 +993,7 @@ TEXT
   end
 
   def rb_config
-    RbConfig::CONFIG
+    Gem.target_rbconfig
   end
 
   def ruby_install_name

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -12,9 +12,10 @@ class Gem::Platform
 
   attr_accessor :cpu, :os, :version
 
-  def self.local
-    @local ||= begin
-      arch = RbConfig::CONFIG["arch"]
+  def self.local(refresh: false)
+    return @local if @local && !refresh
+    @local = begin
+      arch = Gem.target_rbconfig["arch"]
       arch = "#{arch}_60" if /mswin(?:32|64)$/.match?(arch)
       new(arch)
     end

--- a/lib/rubygems/target_rbconfig.rb
+++ b/lib/rubygems/target_rbconfig.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rbconfig"
+
+##
+# A TargetConfig is a wrapper around an RbConfig object that provides a
+# consistent interface for querying configuration for *deployment target
+# platform*, where the gem being installed is intended to run on.
+#
+# The TargetConfig is typically created from the RbConfig of the running Ruby
+# process, but can also be created from an RbConfig file on disk for cross-
+# compiling gems.
+
+class Gem::TargetRbConfig
+  attr_reader :path
+
+  def initialize(rbconfig, path)
+    @rbconfig = rbconfig
+    @path = path
+  end
+
+  ##
+  # Creates a TargetRbConfig for the platform that RubyGems is running on.
+
+  def self.for_running_ruby
+    new(::RbConfig, nil)
+  end
+
+  ##
+  # Creates a TargetRbConfig from the RbConfig file at the given path.
+  # Typically used for cross-compiling gems.
+
+  def self.from_path(rbconfig_path)
+    namespace = Module.new do |m|
+      # Load the rbconfig.rb file within a new anonymous module to avoid
+      # conflicts with the rbconfig for the running platform.
+      Kernel.load rbconfig_path, m
+    end
+    rbconfig = namespace.const_get(:RbConfig)
+
+    new(rbconfig, rbconfig_path)
+  end
+
+  ##
+  # Queries the configuration for the given key.
+
+  def [](key)
+    @rbconfig::CONFIG[key]
+  end
+end

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -330,6 +330,7 @@ install:
       end
       f.puts "RbConfig::CONFIG['host_os'] = 'fake_os'"
       f.puts "RbConfig::CONFIG['arch'] = 'fake_arch'"
+      f.puts "RbConfig::CONFIG['platform'] = 'fake_platform'"
     end
 
     system(Gem.ruby, "-rmkmf", "-e", "exit MakeMakefile::RbConfig::CONFIG['host_os'] == 'fake_os'",
@@ -340,6 +341,9 @@ install:
     @builder = Gem::Ext::Builder.new @spec, "", Gem::TargetRbConfig.from_path(fake_rbconfig)
 
     FileUtils.mkdir_p @spec.gem_dir
+    lib_dir = File.join(@spec.gem_dir, "lib")
+
+    FileUtils.mkdir lib_dir
 
     File.open File.join(@spec.gem_dir, "extconf.rb"), "w" do |f|
       f.write <<-'RUBY'
@@ -367,6 +371,7 @@ install:
     arch=fake_arch
     DUMP
     assert_path_exist @spec.extension_dir
+    assert_equal [], Dir.glob(File.join(lib_dir, "*"))
   end
 
   def test_initialize


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Today, CRuby runs on many platforms. But not all platforms are capable of running build tools (e.g. WebAssembly/WASI), so cross-target compilation against extensions libraries is essential for those platforms.

Currently, there is no way to cross-compile extension libraries in gems at _install-time_.

## What is your fix for the problem, implemented in this PR?

This patch adds `--target-rbconfig` option to specify the rbconfig.rb file for the deployment target platform. It basically pass through it to mkmf. The underlying `--target-rbconfig` support in mkmf has been introduced recently https://bugs.ruby-lang.org/issues/20345

At the moment, this option is only available when the following requirements are met:
- `extconf.rb`-based extensions
- requires mkmf in the latest master branch.

But we can relax the first requirement for Cargo builder by adding a support in rb-sys later.

```console
$ GEM_HOME=/tmp/gems-wasm32-wasi gem install nokogiri --target-rbconfig path/to/wasm32-wasi/rbconfig.rb
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
