### PR TITLE
Accept WASI as an OS name in Gem::Platform

### DIFF
--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -134,6 +134,7 @@ class Gem::Platform
                       when /netbsdelf/ then             ["netbsdelf", nil]
                       when /openbsd(\d+\.\d+)?/ then    ["openbsd",   $1]
                       when /solaris(\d+\.\d+)?/ then    ["solaris",   $1]
+                      when /wasi/ then                  ["wasi",      nil]
                       # test
                       when /^(\w+_platform)(\d+)?/ then [$1,          $2]
                       else ["unknown", nil]

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -145,6 +145,9 @@ class TestGemPlatform < Gem::TestCase
       "x86_64-openbsd3.9" => ["x86_64",    "openbsd",   "3.9"],
       "x86_64-openbsd4.0" => ["x86_64",    "openbsd",   "4.0"],
       "x86_64-openbsd" => ["x86_64", "openbsd", nil],
+      "wasm32-wasi" => ["wasm32", "wasi", nil],
+      "wasm32-wasip1" => ["wasm32", "wasi", nil],
+      "wasm32-wasip2" => ["wasm32", "wasi", nil],
     }
 
     test_cases.each do |arch, expected|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This allows users to specify wasm32-wasi in `--platform` option. This is especially necessary when cross-compiling extension libraries to place them in appropriate arch-os specific directories.

## What is your fix for the problem, implemented in this PR?

Updated `Gem::Platform` to accept wasi as OS name.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
