### PR TITLE
Fix issue when plugin stubs would sometimes not be properly removed by `gem uninstall`

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -515,6 +515,7 @@ lib/rubygems/source_list.rb
 lib/rubygems/spec_fetcher.rb
 lib/rubygems/specification.rb
 lib/rubygems/specification_policy.rb
+lib/rubygems/specification_record.rb
 lib/rubygems/ssl_certs/.document
 lib/rubygems/ssl_certs/rubygems.org/GlobalSignRootCA.pem
 lib/rubygems/ssl_certs/rubygems.org/GlobalSignRootCA_R3.pem

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1044,6 +1044,10 @@ class Gem::Specification < Gem::BasicSpecification
     stub&.to_spec
   end
 
+  ##
+  # Return the best specification that contains the file matching +path+, among
+  # those already activated.
+
   def self.find_active_stub_by_path(path)
     stub = @@active_stub_with_requirable_file[path] ||= stubs.find do |s|
       s.activated? && s.contains_requirable_file?(path)

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -923,16 +923,7 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   ##
-  # Sets the known specs to +specs+. Not guaranteed to work for you in
-  # the future. Use at your own risk. Caveat emptor. Doomy doom doom.
-  # Etc etc.
-  #
-  #--
-  # Makes +specs+ the known specs
-  # Listen, time is a river
-  # Winter comes, code breaks
-  #
-  # -- wilsonb
+  # Sets the known specs to +specs+.
 
   def self.all=(specs)
     @@stubs_by_name = specs.group_by(&:name)

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -859,7 +859,7 @@ class Gem::Specification < Gem::BasicSpecification
   # optionally filtering out specs not matching the current platform
   #
   def self.stubs_for_pattern(pattern, match_platform = true) # :nodoc:
-    installed_stubs = installed_stubs(Gem::Specification.dirs, pattern)
+    installed_stubs = installed_stubs(dirs, pattern)
     installed_stubs.select! {|s| Gem::Platform.match_spec? s } if match_platform
     stubs = installed_stubs + default_stubs(pattern)
     stubs = stubs.uniq(&:full_name)
@@ -1125,7 +1125,7 @@ class Gem::Specification < Gem::BasicSpecification
   # +prerelease+ is true.
 
   def self.latest_specs(prerelease = false)
-    _latest_specs Gem::Specification.stubs, prerelease
+    _latest_specs stubs, prerelease
   end
 
   ##

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -906,9 +906,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Return the directories that Specification uses to find specs.
 
   def self.dirs
-    @@dirs ||= Gem.path.collect do |dir|
-      File.join dir, "specifications"
-    end
+    @@dirs ||= Gem::SpecificationRecord.dirs_from(Gem.path)
   end
 
   ##
@@ -918,7 +916,7 @@ class Gem::Specification < Gem::BasicSpecification
   def self.dirs=(dirs)
     reset
 
-    @@dirs = Array(dirs).map {|dir| File.join dir, "specifications" }
+    @@dirs = Gem::SpecificationRecord.dirs_from(Array(dirs))
   end
 
   extend Enumerable

--- a/lib/rubygems/specification_record.rb
+++ b/lib/rubygems/specification_record.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+module Gem
+  class SpecificationRecord
+    def initialize(dirs)
+      @all = nil
+      @stubs = nil
+      @stubs_by_name = {}
+      @spec_with_requirable_file = {}
+      @active_stub_with_requirable_file = {}
+
+      @dirs = dirs
+    end
+
+    # Sentinel object to represent "not found" stubs
+    NOT_FOUND = Struct.new(:to_spec, :this).new
+    private_constant :NOT_FOUND
+
+    ##
+    # Returns the list of all specifications in the record
+
+    def all
+      @all ||= Gem.loaded_specs.values | stubs.map(&:to_spec)
+    end
+
+    ##
+    # Returns a Gem::StubSpecification for every specification in the record
+
+    def stubs
+      @stubs ||= begin
+        pattern = "*.gemspec"
+        stubs = stubs_for_pattern(pattern, false)
+
+        @stubs_by_name = stubs.select {|s| Gem::Platform.match_spec? s }.group_by(&:name)
+        stubs
+      end
+    end
+
+    ##
+    # Returns a Gem::StubSpecification for every specification in the record
+    # named +name+ only returns stubs that match Gem.platforms
+
+    def stubs_for(name)
+      if @stubs
+        @stubs_by_name[name] || []
+      else
+        @stubs_by_name[name] ||= stubs_for_pattern("#{name}-*.gemspec").select do |s|
+          s.name == name
+        end
+      end
+    end
+
+    ##
+    # Finds stub specifications matching a pattern in the record, optionally
+    # filtering out specs not matching the current platform
+
+    def stubs_for_pattern(pattern, match_platform = true)
+      installed_stubs = installed_stubs(pattern)
+      installed_stubs.select! {|s| Gem::Platform.match_spec? s } if match_platform
+      stubs = installed_stubs + Gem::Specification.default_stubs(pattern)
+      stubs = stubs.uniq(&:full_name)
+      Gem::Specification._resort!(stubs)
+      stubs
+    end
+
+    ##
+    # Adds +spec+ to the the record, keeping the collection properly sorted.
+
+    def add_spec(spec)
+      return if all.include? spec
+
+      all << spec
+      stubs << spec
+      (@stubs_by_name[spec.name] ||= []) << spec
+
+      Gem::Specification._resort!(@stubs_by_name[spec.name])
+      Gem::Specification._resort!(stubs)
+    end
+
+    ##
+    # Removes +spec+ from the record.
+
+    def remove_spec(spec)
+      all.delete spec.to_spec
+      stubs.delete spec
+      (@stubs_by_name[spec.name] || []).delete spec
+    end
+
+    ##
+    # Sets the specs known by the record to +specs+.
+
+    def all=(specs)
+      @stubs_by_name = specs.group_by(&:name)
+      @all = @stubs = specs
+    end
+
+    ##
+    # Return full names of all specs in the record in sorted order.
+
+    def all_names
+      all.map(&:full_name)
+    end
+
+    ##
+    # Return the best specification in the record that contains the file matching +path+.
+
+    def find_by_path(path)
+      path = path.dup.freeze
+      spec = @spec_with_requirable_file[path] ||= stubs.find do |s|
+        s.contains_requirable_file? path
+      end || NOT_FOUND
+
+      spec.to_spec
+    end
+
+    ##
+    # Return the best specification in the record that contains the file
+    # matching +path+ amongst the specs that are not activated.
+
+    def find_inactive_by_path(path)
+      stub = stubs.find do |s|
+        next if s.activated?
+        s.contains_requirable_file? path
+      end
+      stub&.to_spec
+    end
+
+    ##
+    # Return the best specification in the record that contains the file
+    # matching +path+, among those already activated.
+
+    def find_active_stub_by_path(path)
+      stub = @active_stub_with_requirable_file[path] ||= stubs.find do |s|
+        s.activated? && s.contains_requirable_file?(path)
+      end || NOT_FOUND
+
+      stub.this
+    end
+
+    ##
+    # Return the latest specs in the record, optionally including prerelease
+    # specs if +prerelease+ is true.
+
+    def latest_specs(prerelease)
+      Gem::Specification._latest_specs stubs, prerelease
+    end
+
+    ##
+    # Return the latest installed spec in the record for gem +name+.
+
+    def latest_spec_for(name)
+      latest_specs(true).find {|installed_spec| installed_spec.name == name }
+    end
+
+    private
+
+    def installed_stubs(pattern)
+      map_stubs(pattern) do |path, base_dir, gems_dir|
+        Gem::StubSpecification.gemspec_stub(path, base_dir, gems_dir)
+      end
+    end
+
+    def map_stubs(pattern)
+      @dirs.flat_map do |dir|
+        base_dir = File.dirname dir
+        gems_dir = File.join base_dir, "gems"
+        Gem::Specification.gemspec_stubs_in(dir, pattern) {|path| yield path, base_dir, gems_dir }
+      end
+    end
+  end
+end

--- a/lib/rubygems/specification_record.rb
+++ b/lib/rubygems/specification_record.rb
@@ -2,6 +2,16 @@
 
 module Gem
   class SpecificationRecord
+    def self.dirs_from(paths)
+      paths.map do |path|
+        File.join(path, "specifications")
+      end
+    end
+
+    def self.from_path(path)
+      new(dirs_from([path]))
+    end
+
     def initialize(dirs)
       @all = nil
       @stubs = nil

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -32,7 +32,7 @@ class Gem::Uninstaller
   attr_reader :bin_dir
 
   ##
-  # The gem repository the gem will be installed into
+  # The gem repository the gem will be uninstalled from
 
   attr_reader :gem_home
 

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -49,7 +49,8 @@ class Gem::Uninstaller
     # TODO: document the valid options
     @gem                = gem
     @version            = options[:version] || Gem::Requirement.default
-    @gem_home           = File.realpath(options[:install_dir] || Gem.dir)
+    @install_dir        = options[:install_dir]
+    @gem_home           = File.realpath(@install_dir || Gem.dir)
     @force_executables  = options[:executables]
     @force_all          = options[:all]
     @force_ignore       = options[:ignore]
@@ -69,7 +70,7 @@ class Gem::Uninstaller
 
     # only add user directory if install_dir is not set
     @user_install = false
-    @user_install = options[:user_install] unless options[:install_dir]
+    @user_install = options[:user_install] unless @install_dir
 
     # Optimization: populated during #uninstall
     @default_specs_matching_uninstall_params = []
@@ -290,7 +291,8 @@ class Gem::Uninstaller
   # Regenerates plugin wrappers after removal.
 
   def regenerate_plugins
-    latest = Gem::Specification.latest_spec_for(@spec.name)
+    specification_record = @install_dir ? Gem::SpecificationRecord.from_path(@install_dir) : Gem::Specification.specification_record
+    latest = specification_record.latest_spec_for(@spec.name)
     return if latest.nil?
 
     regenerate_plugins_for(latest, plugin_dir_for(@spec))

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -534,6 +534,16 @@ class Gem::TestCase < Test::Unit::TestCase
     ENV["BUNDLE_GEMFILE"] = File.join(@tempdir, "Gemfile")
   end
 
+  def with_env(overrides, &block)
+    @orig_env = ENV.to_h
+    ENV.replace(overrides)
+    begin
+      block.call
+    ensure
+      ENV.replace(@orig_env)
+    end
+  end
+
   ##
   # A git_gem is used with a gem dependencies file.  The gem created here
   # has no files, just a gem specification for the given +name+ and +version+.

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -76,8 +76,6 @@ class Gem::TestCase < Test::Unit::TestCase
 
   attr_accessor :uri # :nodoc:
 
-  @@tempdirs = []
-
   def assert_activate(expected, *specs)
     specs.each do |spec|
       case spec
@@ -451,8 +449,6 @@ class Gem::TestCase < Test::Unit::TestCase
 
     Dir.chdir @current_dir
 
-    FileUtils.rm_rf @tempdir
-
     ENV.replace(@orig_env)
 
     Gem::ConfigFile.send :remove_const, :SYSTEM_WIDE_CONFIG_FILE
@@ -481,12 +477,9 @@ class Gem::TestCase < Test::Unit::TestCase
 
     @back_ui.close
 
-    refute_directory_exists @tempdir, "may be still in use"
-    ghosts = @@tempdirs.filter_map do |test_name, tempdir|
-      test_name if File.exist?(tempdir)
-    end
-    @@tempdirs << [method_name, @tempdir]
-    assert_empty ghosts
+    FileUtils.rm_rf @tempdir
+
+    refute_directory_exists @tempdir, "#{@tempdir} used by test #{method_name} is still in use"
   end
 
   def credential_setup

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -516,7 +516,10 @@ class TestGem < Gem::TestCase
 
     Gem.clear_paths
 
-    assert_nil Gem::Specification.send(:class_variable_get, :@@all)
+    with_env("GEM_HOME" => "foo", "GEM_PATH" => "bar") do
+      assert_equal("foo", Gem.dir)
+      assert_equal("bar", Gem.path.first)
+    end
   end
 
   def test_self_configuration

--- a/test/rubygems/test_gem_ci_detector.rb
+++ b/test/rubygems/test_gem_ci_detector.rb
@@ -3,7 +3,7 @@
 require_relative "helper"
 require "rubygems"
 
-class TestCiDetector < Test::Unit::TestCase
+class TestCiDetector < Gem::TestCase
   def test_ci?
     with_env("FOO" => "bar") { assert_equal(false, Gem::CIDetector.ci?) }
     with_env("CI" => "true") { assert_equal(true, Gem::CIDetector.ci?) }
@@ -27,18 +27,6 @@ class TestCiDetector < Test::Unit::TestCase
     end
     with_env("TASKCLUSTER_ROOT_URL" => "https://foo.bar", "DSARI" => "1", "CI_NAME" => "") do
       assert_equal(["dsari", "taskcluster"], Gem::CIDetector.ci_strings)
-    end
-  end
-
-  private
-
-  def with_env(overrides, &block)
-    @orig_env = ENV.to_h
-    ENV.replace(overrides)
-    begin
-      block.call
-    ensure
-      ENV.replace(@orig_env)
     end
   end
 end

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -967,7 +967,10 @@ dependencies: []
 
   def test_self_stubs_for_lazy_loading
     Gem.loaded_specs.clear
-    Gem::Specification.class_variable_set(:@@stubs, nil)
+
+    specification_record = Gem::Specification.specification_record
+
+    specification_record.instance_variable_set(:@stubs, nil)
 
     dir_standard_specs = File.join Gem.dir, "specifications"
 
@@ -975,9 +978,9 @@ dependencies: []
     save_gemspec("b-1", "1", dir_standard_specs) {|s| s.name = "b" }
 
     assert_equal ["a-1"], Gem::Specification.stubs_for("a").map(&:full_name)
-    assert_equal 1, Gem::Specification.class_variable_get(:@@stubs_by_name).length
+    assert_equal 1, specification_record.instance_variable_get(:@stubs_by_name).length
     assert_equal ["b-1"], Gem::Specification.stubs_for("b").map(&:full_name)
-    assert_equal 2, Gem::Specification.class_variable_get(:@@stubs_by_name).length
+    assert_equal 2, specification_record.instance_variable_get(:@stubs_by_name).length
 
     assert_equal(
       Gem::Specification.stubs_for("a").map(&:object_id),
@@ -986,7 +989,7 @@ dependencies: []
 
     Gem.loaded_specs.delete "a"
     Gem.loaded_specs.delete "b"
-    Gem::Specification.class_variable_set(:@@stubs, nil)
+    specification_record.instance_variable_set(:@stubs, nil)
   end
 
   def test_self_stubs_for_no_lazy_loading_after_all_specs_setup


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`gem uninstall <gem> --install-dir <dir>` will fail to remove plugin stubs if the version being removed is also installed globally.

See for example how, without `rubygems-server` installed globally, plugin is properly removed from `--install-dir`:

```
$ gem list rubygems-server

*** LOCAL GEMS ***


$ gem install rubygems-server --install-dir foo && gem uninstall rubygems-server --install-dir foo && tree foo/plugins
Fetching rubygems-server-0.3.0.gem
Successfully installed rubygems-server-0.3.0
1 gem installed
Successfully uninstalled rubygems-server-0.3.0
foo/plugins

0 directories, 0 files
```

However, if I have `rubygems-server` installed in my standard GEM_HOME, `gem uninstall` will fail to clean it up from `--install-dir`:

```
$ gem install rubygems-server --install-dir foo && gem uninstall rubygems-server --install-dir foo && tree foo/plugins
/home/deivid/code/rubygems/rubygems/foo/gems/rubygems-server-0.3.0/lib/rubygems/server.rb:36: warning: already initialized constant Gem::Server::SEARCH
/home/deivid/.asdf/installs/ruby/3.3.1/lib/ruby/gems/3.3.0/gems/rubygems-server-0.3.0/lib/rubygems/server.rb:36: warning: previous definition of SEARCH was here
/home/deivid/code/rubygems/rubygems/foo/gems/rubygems-server-0.3.0/lib/rubygems/server.rb:46: warning: already initialized constant Gem::Server::DOC_TEMPLATE
/home/deivid/.asdf/installs/ruby/3.3.1/lib/ruby/gems/3.3.0/gems/rubygems-server-0.3.0/lib/rubygems/server.rb:46: warning: previous definition of DOC_TEMPLATE was here
/home/deivid/code/rubygems/rubygems/foo/gems/rubygems-server-0.3.0/lib/rubygems/server.rb:130: warning: already initialized constant Gem::Server::RDOC_CSS
/home/deivid/.asdf/installs/ruby/3.3.1/lib/ruby/gems/3.3.0/gems/rubygems-server-0.3.0/lib/rubygems/server.rb:130: warning: previous definition of RDOC_CSS was here
/home/deivid/code/rubygems/rubygems/foo/gems/rubygems-server-0.3.0/lib/rubygems/server.rb:340: warning: already initialized constant Gem::Server::RDOC_NO_DOCUMENTATION
/home/deivid/.asdf/installs/ruby/3.3.1/lib/ruby/gems/3.3.0/gems/rubygems-server-0.3.0/lib/rubygems/server.rb:340: warning: previous definition of RDOC_NO_DOCUMENTATION was here
/home/deivid/code/rubygems/rubygems/foo/gems/rubygems-server-0.3.0/lib/rubygems/server.rb:374: warning: already initialized constant Gem::Server::RDOC_SEARCH_TEMPLATE
/home/deivid/.asdf/installs/ruby/3.3.1/lib/ruby/gems/3.3.0/gems/rubygems-server-0.3.0/lib/rubygems/server.rb:374: warning: previous definition of RDOC_SEARCH_TEMPLATE was here
Successfully installed rubygems-server-0.3.0
1 gem installed
Successfully uninstalled rubygems-server-0.3.0
foo/plugins
└── rubygems-server_plugin.rb

1 directory, 1 file
```

## What is your fix for the problem, implemented in this PR?

In order to keep plugins up to date, `gem uninstall` does the following:

* First removes the plugin stub for the gem being removed.
* Then check whether any versions of the gem are still installed, and regenerates the plugin stub again to point to the latest installed version.

The second check, however, was checking globally installed gems instead of gems in `--install-dir`.

The solution is to make sure that check uses `--install-dir`  rather than the default GEM_HOME. 

To implement it, I extracted the functionality that deals with the list of know specifications to a separate `SpecificationRecord` class that can take a custom directory (`--install-dir` in this case).

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
