### PR TITLE
Rakefile is failing to load without requiring shared helpers.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -659,6 +659,7 @@ task :override_version do
 end
 
 namespace :bundler do
+  require_relative "bundler/lib/bundler/shared_helpers"
   chdir(File.expand_path("bundler", __dir__)) do
     require_relative "bundler/lib/bundler/gem_tasks"
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Somehow, a fresh copy of rubygems is failing when running rake.

## What is your fix for the problem, implemented in this PR?

Require bundler shared helpers high enough up that it fixes the issue. If someone else can figure out a better way, I'm open to that. This patch at least solves the issue for now.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
