### PR TITLE
Add useful error message for plugin load

### DIFF
--- a/bundler/lib/bundler/plugin.rb
+++ b/bundler/lib/bundler/plugin.rb
@@ -342,7 +342,26 @@ module Bundler
       # done to avoid conflicts
       path = index.plugin_path(name)
 
-      Gem.add_to_load_path(*index.load_paths(name))
+      paths = index.load_paths(name)
+      invalid_paths = paths.reject {|p| File.directory?(p) }
+
+      if invalid_paths.any?
+        Bundler.ui.warn <<~MESSAGE
+          The following plugin paths don't exist: #{invalid_paths.join(", ")}.
+
+          This can happen if the plugin was installed with a different version of Ruby that has since been uninstalled.
+
+          If you would like to reinstall the plugin, run:
+
+          bundler plugin uninstall #{name} && bundler plugin install #{name}
+
+          Continuing without installing plugin #{name}.
+        MESSAGE
+
+        return
+      end
+
+      Gem.add_to_load_path(*paths)
 
       load path.join(PLUGIN_FILE_NAME)
 

--- a/bundler/spec/bundler/plugin_spec.rb
+++ b/bundler/spec/bundler/plugin_spec.rb
@@ -333,5 +333,28 @@ RSpec.describe Bundler::Plugin do
         end.to output("win\n").to_stdout
       end
     end
+
+    context "the plugin load_path is invalid" do
+      before do
+        allow(index).to receive(:load_paths).with("foo-plugin").
+          and_return(["invalid-file-name1", "invalid-file-name2"])
+      end
+
+      it "outputs a useful warning" do
+        msg =
+          "The following plugin paths don't exist: invalid-file-name1, invalid-file-name2.\n\n" \
+          "This can happen if the plugin was " \
+          "installed with a different version of Ruby that has since been uninstalled.\n\n" \
+          "If you would like to reinstall the plugin, run:\n\n" \
+          "bundler plugin uninstall foo-plugin && bundler plugin install foo-plugin\n\n" \
+          "Continuing without installing plugin foo-plugin.\n"
+
+        expect(Bundler.ui).to receive(:warn).with(msg)
+
+        Plugin.hook(Bundler::Plugin::Events::EVENT1)
+
+        expect(subject.loaded?("foo-plugin")).to be_falsey
+      end
+    end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When starting to work on my first issue, I found that `rake setup` failed for me. This was due to having previously installed a plugin, whose files had since been deleted (presumably when I uninstalled that version of Ruby).

Fixes https://github.com/rubygems/rubygems/issues/7636.

## What is your fix for the problem, implemented in this PR?

Check to see whether each load path for the plugin is a directory. If it is not, notify the user in a friendly message which plugin in the problem and how to resolve the issue.


## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
