### PR TITLE
Fix error when Bundler installation is corrupted

### DIFF
--- a/bundler/lib/bundler/errors.rb
+++ b/bundler/lib/bundler/errors.rb
@@ -230,4 +230,18 @@ module Bundler
 
     status_code(38)
   end
+
+  class CorruptBundlerInstallError < BundlerError
+    def initialize(loaded_spec)
+      @loaded_spec = loaded_spec
+    end
+
+    def message
+      "The running version of Bundler (#{Bundler::VERSION}) does not match the version of the specification installed for it (#{@loaded_spec.version}). " \
+      "This can be caused by reinstalling Ruby without removing previous installation, leaving around an upgraded default version of Bundler. " \
+      "Reinstalling Ruby from scratch should fix the problem."
+    end
+
+    status_code(39)
+  end
 end

--- a/bundler/lib/bundler/source/metadata.rb
+++ b/bundler/lib/bundler/source/metadata.rb
@@ -11,6 +11,8 @@ module Bundler
           end
 
           if local_spec = Gem.loaded_specs["bundler"]
+            raise CorruptBundlerInstallError.new(local_spec) if local_spec.version.to_s != Bundler::VERSION
+
             idx << local_spec
           else
             idx << Gem::Specification.new do |s|

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -1407,4 +1407,33 @@ RSpec.describe "bundle install with gem sources" do
       expect(bundled_app(".bundle/config")).not_to exist
     end
   end
+
+  context "when bundler installation is corrupt" do
+    before do
+      system_gems "bundler-9.99.8"
+
+      replace_version_file("9.99.9", dir: system_gem_path("gems/bundler-9.99.8"))
+    end
+
+    it "shows a proper error" do
+      lockfile <<~L
+        GEM
+          remote: #{file_uri_for(gem_repo1)}/
+          specs:
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+
+        BUNDLED WITH
+           9.99.8
+      L
+
+      install_gemfile "source \"#{file_uri_for(gem_repo1)}\"", env: { "BUNDLER_VERSION" => "9.99.8" }, raise_on_error: false
+
+      expect(err).not_to include("ERROR REPORT TEMPLATE")
+      expect(err).to include("The running version of Bundler (9.99.9) does not match the version of the specification installed for it (9.99.8)")
+    end
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If one upgrades the default copy of Bundler through `gem update --system`, and then reinstalls Ruby without removing the previous copy. Then the new installation will have a correct default bundler gemspec, but a higher copy installed in site_dir.

This causes a crash when running Bundler and prints the bug report template.

## What is your fix for the problem, implemented in this PR?

This could probably be fixed in Ruby install script, by removing any previous Bundler default copies, but if the problem is already there, I think it's best to print a proper user error.

Fixes #7381.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
