### PR TITLE
Fix double colons in questions asked from GemcutterUtilities

### DIFF
--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -130,8 +130,8 @@ module Gem::GemcutterUtilities
 
     say "The existing key doesn't have access of #{scope} on #{pretty_host}. Please sign in to update access."
 
-    identifier = ask "Username/email"
-    password   = ask_for_password "      Password"
+    identifier = ask "Username/email: "
+    password   = ask_for_password "      Password: "
 
     response = rubygems_api_request(:put, "api/v1/api_key",
                                     sign_in_host, scope: scope) do |request|
@@ -159,8 +159,8 @@ module Gem::GemcutterUtilities
     say "Don't have an account yet? " \
         "Create one at #{sign_in_host}/sign_up"
 
-    identifier = ask "Username/email: "
-    password   = ask_for_password "      Password: "
+    identifier = ask "Username/email"
+    password   = ask_for_password "      Password"
     say "\n"
 
     key_name     = get_key_name(scope)
@@ -275,7 +275,7 @@ module Gem::GemcutterUtilities
       otp_thread[:otp]
     else
       say "You have enabled multi-factor authentication. Please enter OTP code."
-      ask "Code"
+      ask "Code:"
     end
   end
 

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -130,8 +130,8 @@ module Gem::GemcutterUtilities
 
     say "The existing key doesn't have access of #{scope} on #{pretty_host}. Please sign in to update access."
 
-    identifier = ask "Username/email: "
-    password   = ask_for_password "      Password: "
+    identifier = ask "Username/email"
+    password   = ask_for_password "      Password"
 
     response = rubygems_api_request(:put, "api/v1/api_key",
                                     sign_in_host, scope: scope) do |request|
@@ -275,7 +275,7 @@ module Gem::GemcutterUtilities
       otp_thread[:otp]
     else
       say "You have enabled multi-factor authentication. Please enter OTP code."
-      ask "Code: "
+      ask "Code"
     end
   end
 
@@ -374,7 +374,7 @@ module Gem::GemcutterUtilities
     ts = Time.now.strftime("%Y%m%d%H%M%S")
     default_key_name = "#{hostname}-#{user}-#{ts}"
 
-    key_name = ask "API Key name [#{default_key_name}]: " unless scope
+    key_name = ask "API Key name [#{default_key_name}]" unless scope
     if key_name.nil? || key_name.empty?
       default_key_name
     else

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -275,7 +275,7 @@ module Gem::GemcutterUtilities
       otp_thread[:otp]
     else
       say "You have enabled multi-factor authentication. Please enter OTP code."
-      ask "Code:"
+      ask "Code: "
     end
   end
 
@@ -374,7 +374,7 @@ module Gem::GemcutterUtilities
     ts = Time.now.strftime("%Y%m%d%H%M%S")
     default_key_name = "#{hostname}-#{user}-#{ts}"
 
-    key_name = ask "API Key name [#{default_key_name}]" unless scope
+    key_name = ask "API Key name [#{default_key_name}]: " unless scope
     if key_name.nil? || key_name.empty?
       default_key_name
     else


### PR DESCRIPTION
At some point, this is using Thor, and it automaticlaly adds a trailing `:` with space, so we don't need to do it ourselves.

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

I was using https://github.com/rubygems/configure_trusted_publisher and got minorly annoyed by the double `:` prompts:

```
Enter your RubyGems.org credentials.
Don't have an account yet? Create one at https://rubygems.org/sign_up

Username/email: : pickles@example.com

      Password: : 
You have enabled multi-factor authentication. Please enter OTP code.

Code: : 12345678
```

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

Update these `ask` calls to not include the `:`

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
