### PR TITLE
Fix `gem uninstall --user-install`  for symlinked HOME

### DIFF
--- a/lib/rubygems/commands/uninstall_command.rb
+++ b/lib/rubygems/commands/uninstall_command.rb
@@ -184,7 +184,7 @@ that is a dependency of an existing gem.  You can use the
   rescue Gem::GemNotInHomeException => e
     spec = e.spec
     alert("In order to remove #{spec.name}, please execute:\n" \
-          "\tgem uninstall #{spec.name} --install-dir=#{spec.installation_path}")
+          "\tgem uninstall #{spec.name} --install-dir=#{spec.base_dir}")
   rescue Gem::UninstallError => e
     spec = e.spec
     alert_error("Error: unable to successfully uninstall '#{spec.name}' which is " \

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -51,6 +51,7 @@ class Gem::Uninstaller
     @version            = options[:version] || Gem::Requirement.default
     @install_dir        = options[:install_dir]
     @gem_home           = File.realpath(@install_dir || Gem.dir)
+    @user_dir           = File.exist?(Gem.user_dir) ? File.realpath(Gem.user_dir) : Gem.user_dir
     @force_executables  = options[:executables]
     @force_all          = options[:all]
     @force_ignore       = options[:ignore]
@@ -105,7 +106,7 @@ class Gem::Uninstaller
 
     list, other_repo_specs = list.partition do |spec|
       @gem_home == spec.base_dir ||
-        (@user_install && spec.base_dir == Gem.user_dir)
+        (@user_install && spec.base_dir == @user_dir)
     end
 
     list.sort!
@@ -239,7 +240,7 @@ class Gem::Uninstaller
 
   def remove(spec)
     unless path_ok?(@gem_home, spec) ||
-           (@user_install && path_ok?(Gem.user_dir, spec))
+           (@user_install && path_ok?(@user_dir, spec))
       e = Gem::GemNotInHomeException.new \
         "Gem '#{spec.full_name}' is not installed in directory #{@gem_home}"
       e.spec = spec

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -453,6 +453,32 @@ create_makefile '#{@spec.name}'
     assert_same uninstaller, @post_uninstall_hook_arg
   end
 
+  def test_uninstall_user_install_with_symlinked_home
+    pend "Symlinks not supported or not enabled" unless symlink_supported?
+
+    Gem::Specification.dirs = [Gem.user_dir]
+
+    symlinked_home = File.join(@tempdir, "new-home")
+    FileUtils.ln_s(Gem.user_home, symlinked_home)
+
+    ENV["HOME"] = symlinked_home
+    Gem.instance_variable_set(:@user_home, nil)
+    Gem.instance_variable_set(:@data_home, nil)
+
+    uninstaller = Gem::Uninstaller.new(@user_spec.name,
+                                       executables: true,
+                                       user_install: true,
+                                       force: true)
+
+    gem_dir = File.join @user_spec.gem_dir
+
+    assert_path_exist gem_dir
+
+    uninstaller.uninstall
+
+    assert_path_not_exist gem_dir
+  end
+
   def test_uninstall_wrong_repo
     Dir.mkdir "#{@gemhome}2"
     Gem.use_paths "#{@gemhome}2", [@gemhome]

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -429,7 +429,7 @@ create_makefile '#{@spec.name}'
   end
 
   def test_uninstall_user_install
-    @user_spec = Gem::Specification.find_by_name "b"
+    Gem::Specification.dirs = [Gem.user_dir]
 
     uninstaller = Gem::Uninstaller.new(@user_spec.name,
                                        executables: true,


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`gem uninstall --user-install` won't work if HOME is symlinked, which is the default on FreeBSD.

## What is your fix for the problem, implemented in this PR?

Make sure to expand home to its realpath.

Fixes https://github.com/rubygems/rubygems/issues/6457.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
