### PR TITLE
Fix crash caused by RubyGems `require` gem activation logic running before Bundler can properly register its own monkeypatches

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -589,10 +589,13 @@ end
 
 desc "Check RubyGems integration"
 task :check_rubygems_integration do
-  # Bundler monkeypatches RubyGems in some ways that could potentially break gem
-  # activation. Run a non trivial binstub activation, with two different
-  # versions of a dependent gem installed.
+  # Bundler monkeypatches RubyGems in some ways that could potentially break gem activation.
+
+  # Run a non trivial binstub activation, with two different versions of a dependent gem installed.
   sh("ruby -Ilib -S gem install reline:0.3.0 reline:0.3.1 irb && ruby -Ibundler/lib -rbundler -S irb --version")
+
+  # With two psych versions installed, load a gem that depends on pysch and then load rubygems extensions.
+  sh("ruby -Ilib -S gem install psych:5.1.1 psych:5.1.2 rdoc && ruby -Ibundler/lib -rrdoc/task -rbundler/rubygems_ext -e1")
 end
 
 namespace :man do

--- a/bundler/lib/bundler/constants.rb
+++ b/bundler/lib/bundler/constants.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rbconfig"
+
 module Bundler
   WINDOWS = RbConfig::CONFIG["host_os"] =~ /(msdos|mswin|djgpp|mingw)/
   FREEBSD = RbConfig::CONFIG["host_os"].to_s.include?("bsd")

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -4,9 +4,7 @@ require "rubygems" unless defined?(Gem)
 
 module Bundler
   class RubygemsIntegration
-    require "monitor"
-
-    EXT_LOCK = Monitor.new
+    autoload :Monitor, "monitor"
 
     def initialize
       @replaced_methods = {}
@@ -173,7 +171,7 @@ module Bundler
     end
 
     def ext_lock
-      EXT_LOCK
+      @ext_lock ||= Monitor.new
     end
 
     def spec_from_gem(path)

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
-require "pathname"
-require "rbconfig"
-
 require_relative "version"
-require_relative "constants"
 require_relative "rubygems_integration"
 require_relative "current_ruby"
 
 module Bundler
+  autoload :WINDOWS, File.expand_path("constants", __dir__)
+  autoload :FREEBSD, File.expand_path("constants", __dir__)
+  autoload :NULL, File.expand_path("constants", __dir__)
+
   module SharedHelpers
+    autoload :Pathname, "pathname"
+
     def root
       gemfile = find_gemfile
       raise GemfileNotFound, "Could not locate Gemfile" unless gemfile


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In https://github.com/rubygems/rubygems/pull/7603, we added a monkeypatch to `Gem::StubSpecification#data` so that when we fail to read the underlying gemspec due to not being readable, we can print a friendly error message. In order to do that, we reused a Bundler helper that knows how to rescue filesystem errors and re-raise them in way that Bundler knows how to handle in a friendly way.

This usage of `Bundler::SharedHelpers` was added without an explicit `require` because Bundler is supposed to setup an `autoload` for `Bundler::SharedHelpers`. However, the `autoload` does not seem to be triggering under some situations, such as when loading our own Rakefile. But that also does not happen always, but only when you have two different versions of `psych` installed in your system.

This is why:

* Our Rakefile first loads `rdoc/task` which activates `rdoc`, which depends on `psych >= 4.0`.
* Because there are multiple matching `psych` versions in the system, RubyGems `require` does not automatically activate `psych` but adds it to `Gem::Specification.unresolved_deps` and then further `require` calls will check in the potential paths for those `unresolved_deps` to see if any unresolved dependency can be activated. This enables logic that ends up using `Gem::StubSpecification#data`.
* Then `bundler/gem_tasks` is required that eventually requires `bundler/rubygems_ext` and enables the monkeypatch to `Gem::StubSpecification#data`.
* Then, before `bundler/gem_tasks` eventually loads `bundler.rb` and sets up an autoload for `Bundler::SharedHelpers`, other `require` calls are run that eventually use `Gem::Specification#data` for gem activation without `Bundler::SharedHelpers` being available yet.

## What is your fix for the problem, implemented in this PR?

The fix to `require "bundler/shared_helpers"` before using it. However, that's not enough because that `require` itself ends up running into the same error. So on top of that, I made sure no standard `require` calls are used during loading of `bundler/shared_helpers`.

Closes #7638.

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
