### PR TITLE
Recommend `bin/rake` over `rake` in contributing docs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,9 +7,9 @@
   "remoteUser": "vscode",
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
   // Use 'postCreateCommand' to run commands after the container is created.
-  "onCreateCommand": "rake setup",
+  "onCreateCommand": "bin/rake setup",
   // Use 'updateContentCommand' to run commands when the container is updated.
-  "updateContentCommand": "rake update",
+  "updateContentCommand": "bin/rake update",
   // Configure tool-specific properties.
   "containerEnv": {
     "EDITOR": "code --wait",

--- a/.github/workflows/daily-rubygems.yml
+++ b/.github/workflows/daily-rubygems.yml
@@ -42,8 +42,8 @@ jobs:
 
       - name: Test rubygems
         run: |
-          rake setup
-          rake test
+          bin/rake setup
+          bin/rake test
 
       - name: Get previous status
         if: always()

--- a/.github/workflows/realworld-bundler.yml
+++ b/.github/workflows/realworld-bundler.yml
@@ -111,7 +111,7 @@ jobs:
           ruby-version: 3.3.1
           bundler: none
       - name: Prepare dependencies
-        run: rake setup
+        run: bin/rake setup
       - name: Download all used cassettes as artifacts
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:

--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -56,18 +56,18 @@ jobs:
           echo "BINDGEN_EXTRA_CLANG_ARGS=$((gcm clang).source -replace "bin\clang.exe","include")" >> $env:GITHUB_ENV
         if: matrix.ruby.name == 'mswin'
       - name: Install Dependencies
-        run: rake setup
+        run: bin/rake setup
       - name: Run Test
-        run: rake test
+        run: bin/rake test
         if: matrix.ruby.name != 'truffleruby' && matrix.ruby.name != 'jruby'
       - name: Run Test isolatedly
-        run: rake test:isolated
+        run: bin/rake test:isolated
         if: matrix.ruby.name == '3.3' && matrix.os.name != 'Windows'
       - name: Run Test (JRuby)
-        run: JRUBY_OPTS=--debug rake test
+        run: JRUBY_OPTS=--debug bin/rake test
         if: startsWith(matrix.ruby.name, 'jruby')
       - name: Run Test (Truffleruby)
-        run: TRUFFLERUBYOPT="--experimental-options --testing-rubygems" rake test
+        run: TRUFFLERUBYOPT="--experimental-options --testing-rubygems" bin/rake test
         if: matrix.ruby.name == 'truffleruby'
 
     timeout-minutes: 60

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -28,11 +28,11 @@ jobs:
           ruby-version: 3.3.1
           bundler: none
       - name: Install Dependencies
-        run: rake setup
+        run: bin/rake setup
       - name: Run Lint
-        run: rake rubocop
+        run: bin/rake rubocop
       - name: Generate docs
-        run: rake docs
+        run: bin/rake docs
       - name: Install & Check Dependencies
         run: bin/rake dev:frozen_deps
       - name: Misc checks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ here: https://guides.rubygems.org/contributing/
 
 ### Installing dependencies
 
-    rake setup
+    bin/rake setup
 
 > **NOTE**: If the above fails with permission related errors, you're most
 > likely using a global Ruby installation (like the one packaged by your OS),
@@ -58,7 +58,7 @@ To run commands like `bundle install` from the repo:
 
 To run the entire test suite you can use:
 
-    rake test
+    bin/rake test
 
 To run an individual test file located for example in `test/rubygems/test_deprecate.rb` you can use:
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Our `bin/rake` script automatically installs `rake` if missing when running "setup tasks" and also makes sure to activate a consistent version of `rake`.

On top of that, it seems less prone to gem activation issues since it does not run into the same problem reported at #7638.

## What is your fix for the problem, implemented in this PR?

Consistently recommend and use `bin/rake`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
