### PR TITLE
Fix for gems not downloading from git via http

### DIFF
--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -181,15 +181,15 @@ module Bundler
 
             if err.include?("Could not find remote branch")
               raise MissingGitRevisionError.new(command_with_no_credentials, nil, explicit_ref, credential_filtered_uri)
-            elsif err.include?("dumb http transport does not support shallow capabilities")
+            else
               idx = command.index("--depth")
               if idx
                 command.delete_at(idx)
                 command.delete_at(idx)
+                command_with_no_credentials = check_allowed(command)
+
                 err += "Retrying without --depth argument."
               end
-              raise GitCommandError.new(command_with_no_credentials, path, err)
-            else
               raise GitCommandError.new(command_with_no_credentials, path, err)
             end
           end

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -181,6 +181,14 @@ module Bundler
 
             if err.include?("Could not find remote branch")
               raise MissingGitRevisionError.new(command_with_no_credentials, nil, explicit_ref, credential_filtered_uri)
+            elsif err.include?("dumb http transport does not support shallow capabilities")
+              idx = command.index("--depth")
+              if idx
+                command.delete_at(idx)
+                command.delete_at(idx)
+                err += "Retrying without --depth argument."
+              end
+              raise GitCommandError.new(command_with_no_credentials, path, err)
             else
               raise GitCommandError.new(command_with_no_credentials, path, err)
             end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

https://github.com/rubygems/rubygems/issues/7547

## What is your fix for the problem, implemented in this PR?

The depth arguments in the git command were causing the problem. If we get the error on the first try, we remove the depth arguments from the command and try again. 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
