### PR TITLE
Deprecate Bundler constants

### DIFF
--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -14,7 +14,7 @@ module Bundler
 
       Bundler.self_manager.install_locked_bundler_and_restart_with_it_if_needed
 
-      Bundler::SharedHelpers.set_env "RB_USER_INSTALL", "1" if Bundler::FREEBSD
+      Bundler::SharedHelpers.set_env "RB_USER_INSTALL", "1" if Gem.freebsd_platform?
 
       # Disable color in deployment mode
       Bundler.ui.shell = Thor::Shell::Basic.new if options[:deployment]

--- a/bundler/lib/bundler/constants.rb
+++ b/bundler/lib/bundler/constants.rb
@@ -4,6 +4,11 @@ require "rbconfig"
 
 module Bundler
   WINDOWS = RbConfig::CONFIG["host_os"] =~ /(msdos|mswin|djgpp|mingw)/
+  deprecate_constant :WINDOWS
+
   FREEBSD = RbConfig::CONFIG["host_os"].to_s.include?("bsd")
-  NULL    = File::NULL
+  deprecate_constant :FREEBSD
+
+  NULL = File::NULL
+  deprecate_constant :NULL
 end

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -23,6 +23,13 @@ unless Gem.ruby_version.to_s == RUBY_VERSION || RUBY_PATCHLEVEL == -1
 end
 
 module Gem
+  # Can be removed once RubyGems 3.5.11 support is dropped
+  unless Gem.respond_to?(:freebsd_platform?)
+    def self.freebsd_platform?
+      RbConfig::CONFIG["host_os"].to_s.include?("bsd")
+    end
+  end
+
   require "rubygems/specification"
 
   class Specification

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1013,6 +1013,13 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   end
 
   ##
+  # Is this platform FreeBSD
+
+  def self.freebsd_platform?
+    RbConfig::CONFIG["host_os"].to_s.include?("bsd")
+  end
+
+  ##
   # Load +plugins+ as Ruby files
 
   def self.load_plugin_files(plugins) # :nodoc:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler has a constants.rb file that defines three constants but they seem rather arbitrary to me and they are mostly unused. I think we could deprecate them.

## What is your fix for the problem, implemented in this PR?

Migrate the only used constant to RubyGems and deprecate the constants.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
