### PR TITLE
Try fix flaky test failures

### DIFF
--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -145,11 +145,9 @@ module Gem
 
   module BetterPermissionError
     def data
-      require_relative "shared_helpers"
-
-      Bundler::SharedHelpers.filesystem_access(loaded_from, :read) do
-        super
-      end
+      super
+    rescue Errno::EACCES
+      raise Bundler::PermissionError.new(loaded_from, :read)
     end
   end
 

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "pathname"
-
 require "rubygems" unless defined?(Gem)
 
 # We can't let `Gem::Source` be autoloaded in the `Gem::Specification#source`
@@ -47,7 +45,7 @@ module Gem
 
     def full_gem_path
       if source.respond_to?(:root)
-        Pathname.new(loaded_from).dirname.expand_path(source.root).to_s
+        File.expand_path(File.dirname(loaded_from), source.root)
       else
         rg_full_gem_path
       end

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -4,7 +4,9 @@ require "rubygems" unless defined?(Gem)
 
 module Bundler
   class RubygemsIntegration
-    autoload :Monitor, "monitor"
+    require "monitor"
+
+    EXT_LOCK = Monitor.new
 
     def initialize
       @replaced_methods = {}
@@ -171,7 +173,7 @@ module Bundler
     end
 
     def ext_lock
-      @ext_lock ||= Monitor.new
+      EXT_LOCK
     end
 
     def spec_from_gem(path)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since today I'm seeing test failures in unrelated PRs, apparently related to RubyGems stub specification loading.

## What is your fix for the problem, implemented in this PR?

The only PR that I've merged today that could be related is #7647, and from that PR the only thing that I believe could possibly create some race condition is creating the monitor used for making sure the PWD is not leaked across processes lazily.

Trying another approach to see if spec failures go away.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
