### PR TITLE
Fix the update_rubygems inconsistency (--disable-gems)

### DIFF
--- a/exe/update_rubygems
+++ b/exe/update_rubygems
@@ -34,5 +34,5 @@ else
   update_dir = File.dirname(update_dir)
   Dir.chdir update_dir
   ENV["GEM_PREV_VER"] = Gem::VERSION
-  abort unless system(Gem.ruby, "setup.rb", *ARGV)
+  abort unless system(Gem.ruby, "--disable-gems", "setup.rb", *ARGV)
 end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

[`gem update --system`][a], as opposed to [`update_rubygems`][b], disables gems (`--disable-gems`) when running `setup.rb`. As a result `setup.rb` gets [reexecuted][c] if one uses `update_rubygems`. Fixes #7621.

[a]: https://github.com/rubygems/rubygems/blob/v3.5.9/lib/rubygems/commands/update_command.rb#L186
[b]: https://github.com/rubygems/rubygems/blob/v3.5.9/exe/update_rubygems#L37
[c]: https://github.com/rubygems/rubygems/blob/v3.5.9/setup.rb#L17-L19

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

Apparently when `--disable-gems` was [added][d] to `gem update --system`, `update_rubygems` was left as is. My solution is to sync `update_rubygems` with `gem update --system` (make it pass `--disable-gems` to `setup.rb` as well).

[d]: https://github.com/rubygems/rubygems/commit/e271578f7725eefdb05642d604368be18eb428ee

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

