### PR TITLE
Fix regression when caching gems from secondary sources

### DIFF
--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -129,6 +129,7 @@ module Bundler
     def materialized_for_all_platforms
       @specs.map do |s|
         next s unless s.is_a?(LazySpecification)
+        s.source.cached!
         s.source.remote!
         spec = s.materialize_for_installation
         raise GemNotFound, "Could not find #{s.full_name} in any of the sources" unless spec


### PR DESCRIPTION

## What was the end-user or developer problem that led to this PR?

If `cache_all_platforms` setting is enabled, the secondary source was no longer considering cached gems.

That means that if the remote secondary source has removed its gems, then this was now resulting in an error while before the previously cached gem from the source would still be used.

This is a regression from https://github.com/rubygems/rubygems/pull/7516.

## What is your fix for the problem, implemented in this PR?

This commit restores previous behavior by explicit enabling cached gems when materializing gems for all platforms so that they can be cached in vendor/cache.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
