### PR TITLE
    Fix binstubs sometimes not getting regenerated when `--destdir` is given

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -585,6 +585,8 @@ abort "#{deprecation_message}"
 
     args = %w[--all --only-executables --silent]
     args << "--bindir=#{bindir}"
+    args << "--install-dir=#{default_dir}"
+
     if options[:env_shebang]
       args << "--env-shebang"
     end

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -271,15 +271,7 @@ class Gem::Dependency
   end
 
   def matching_specs(platform_only = false)
-    env_req = Gem.env_requirement(name)
-    matches = Gem::Specification.stubs_for(name).find_all do |spec|
-      requirement.satisfied_by?(spec.version) && env_req.satisfied_by?(spec.version)
-    end.map(&:to_spec)
-
-    if prioritizes_bundler?
-      require_relative "bundler_version_finder"
-      Gem::BundlerVersionFinder.prioritize!(matches)
-    end
+    matches = Gem::Specification.find_all_by_name(name, requirement)
 
     if platform_only
       matches.reject! do |spec|
@@ -295,10 +287,6 @@ class Gem::Dependency
 
   def specific?
     @requirement.specific?
-  end
-
-  def prioritizes_bundler?
-    name == "bundler" && !specific?
   end
 
   def to_specs

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -344,7 +344,7 @@ class Gem::Installer
 
     say spec.post_install_message if options[:post_install_message] && !spec.post_install_message.nil?
 
-    Gem::Specification.add_spec(spec)
+    Gem::Specification.add_spec(spec) unless @install_dir
 
     load_plugin
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -925,31 +925,15 @@ class Gem::Specification < Gem::BasicSpecification
   # Enumerate every known spec.  See ::dirs= and ::add_spec to set the list of
   # specs.
 
-  def self.each
-    return enum_for(:each) unless block_given?
-
-    _all.each do |x|
-      yield x
-    end
+  def self.each(&block)
+    specification_record.each(&block)
   end
 
   ##
   # Returns every spec that matches +name+ and optional +requirements+.
 
   def self.find_all_by_name(name, *requirements)
-    req = Gem::Requirement.create(*requirements)
-    env_req = Gem.env_requirement(name)
-
-    matches = stubs_for(name).find_all do |spec|
-      req.satisfied_by?(spec.version) && env_req.satisfied_by?(spec.version)
-    end.map(&:to_spec)
-
-    if name == "bundler" && !req.specific?
-      require_relative "bundler_version_finder"
-      Gem::BundlerVersionFinder.prioritize!(matches)
-    end
-
-    matches
+    specification_record.find_all_by_name(name, *requirements)
   end
 
   ##


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes, installing RubyGems with `--destdir` option will not get binstubs properly regenerated.

## What is your fix for the problem, implemented in this PR?

Make sure that binstub regeneration considers the proper gem home.

Fixes https://github.com/rubygems/rubygems/issues/5134.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
