### PR TITLE
Do not override `@orig_env`

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -535,12 +535,12 @@ class Gem::TestCase < Test::Unit::TestCase
   end
 
   def with_env(overrides, &block)
-    @orig_env = ENV.to_h
+    orig_env = ENV.to_h
     ENV.replace(overrides)
     begin
       block.call
     ensure
-      ENV.replace(@orig_env)
+      ENV.replace(orig_env)
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since the merger of b545daa95d6838a48304edc6003e6ef7ec753898 (ruby/ruby@64542380728b2f0cb0a76a09d08735538350cd9f), `TestFileExhaustive#test_expand_path_for_existent_username` has been failing.

## What is your fix for the problem, implemented in this PR?

Save to a local variable, instead of the instance variable used in `teardown`.
It is used only in `with_env` method, an instance variable has too wide scope.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
