### PR TITLE
Fix `gem pristine` sometimes failing to pristine user installed gems

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -144,6 +144,19 @@ class Gem::BasicSpecification
   end
 
   ##
+  # Returns the full name of this Gem (see `Gem::BasicSpecification#full_name`).
+  # Information about where the gem is installed is also included if not
+  # installed in the default GEM_HOME.
+
+  def full_name_with_location
+    if base_dir != Gem.dir
+      "#{full_name} in #{base_dir}"
+    else
+      full_name
+    end
+  end
+
+  ##
   # Full paths in the gem to add to <code>$LOAD_PATH</code> when this gem is
   # activated.
 

--- a/lib/rubygems/commands/pristine_command.rb
+++ b/lib/rubygems/commands/pristine_command.rb
@@ -148,7 +148,7 @@ extensions will be restored.
       end
 
       unless spec.extensions.empty? || options[:extensions] || options[:only_executables] || options[:only_plugins]
-        say "Skipped #{spec.full_name}, it needs to compile an extension"
+        say "Skipped #{spec.full_name_with_location}, it needs to compile an extension"
         next
       end
 
@@ -157,7 +157,7 @@ extensions will be restored.
       unless File.exist?(gem) || options[:only_executables] || options[:only_plugins]
         require_relative "../remote_fetcher"
 
-        say "Cached gem for #{spec.full_name} not found, attempting to fetch..."
+        say "Cached gem for #{spec.full_name_with_location} not found, attempting to fetch..."
 
         dep = Gem::Dependency.new spec.name, spec.version
         found, _ = Gem::SpecFetcher.fetcher.spec_for_dependency dep
@@ -201,7 +201,7 @@ extensions will be restored.
         installer.install
       end
 
-      say "Restored #{spec.full_name}"
+      say "Restored #{spec.full_name_with_location}"
     end
   end
 end

--- a/lib/rubygems/specification_record.rb
+++ b/lib/rubygems/specification_record.rb
@@ -68,7 +68,6 @@ module Gem
       installed_stubs = installed_stubs(pattern)
       installed_stubs.select! {|s| Gem::Platform.match_spec? s } if match_platform
       stubs = installed_stubs + Gem::Specification.default_stubs(pattern)
-      stubs = stubs.uniq(&:full_name)
       Gem::Specification._resort!(stubs)
       stubs
     end

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1562,11 +1562,11 @@ class TestGem < Gem::TestCase
     assert_equal m1.gem_dir, File.join(Gem.user_dir, "gems", "m-1")
 
     tests = [
-      [:dir0, [Gem.dir, Gem.user_dir], m0],
-      [:dir1, [Gem.user_dir, Gem.dir], m1],
+      [:dir0, [Gem.dir, Gem.user_dir]],
+      [:dir1, [Gem.user_dir, Gem.dir]],
     ]
 
-    tests.each do |name, paths, expected|
+    tests.each do |name, paths|
       Gem.use_paths paths.first, paths
       Gem::Specification.reset
       Gem.searcher = nil
@@ -1575,8 +1575,8 @@ class TestGem < Gem::TestCase
                    Gem::Dependency.new("m","1").to_specs.sort
 
       assert_equal \
-        [expected.gem_dir],
-        Gem::Dependency.new("m","1").to_specs.map(&:gem_dir).sort,
+        [m0.gem_dir, m1.gem_dir],
+        Gem::Dependency.new("m","1").to_specs.map(&:gem_dir).uniq.sort,
         "Wrong specs for #{name}"
 
       spec = Gem::Dependency.new("m","1").to_spec

--- a/test/rubygems/test_gem_commands_pristine_command.rb
+++ b/test/rubygems/test_gem_commands_pristine_command.rb
@@ -96,7 +96,7 @@ class TestGemCommandsPristineCommand < Gem::TestCase
     out = @ui.output.split("\n")
 
     assert_equal "Restoring gems to pristine condition...", out.shift
-    assert_equal "Restored #{a.full_name}", out.shift
+    assert_equal "Restored #{a.full_name} in #{Gem.user_dir}", out.shift
     assert_empty out, out.inspect
   ensure
     FileUtils.chmod(0o755, @gemhome)
@@ -404,7 +404,7 @@ class TestGemCommandsPristineCommand < Gem::TestCase
     out = @ui.output.split "\n"
 
     assert_equal "Restoring gems to pristine condition...", out.shift
-    assert_equal "Restored #{a.full_name}", out.shift
+    assert_equal "Restored #{a.full_name} in #{@gemhome}", out.shift
     assert_equal "Restored #{b.full_name}", out.shift
     assert_empty out, out.inspect
 
@@ -476,8 +476,9 @@ class TestGemCommandsPristineCommand < Gem::TestCase
 
     [
       "Restoring gems to pristine condition...",
-      "Cached gem for a-1 not found, attempting to fetch...",
-      "Restored a-1",
+      "Cached gem for a-1 in #{@gemhome} not found, attempting to fetch...",
+      "Restored a-1 in #{@gemhome}",
+      "Restored b-1 in #{@gemhome}",
       "Cached gem for b-1 not found, attempting to fetch...",
       "Restored b-1",
     ].each do |line|
@@ -495,7 +496,7 @@ class TestGemCommandsPristineCommand < Gem::TestCase
     assert_path_exist File.join(gemhome2, "cache", "b-1.gem")
     assert_path_not_exist File.join(@gemhome, "cache", "b-2.gem")
     assert_path_exist File.join(gemhome2, "gems", "b-1")
-    assert_path_not_exist File.join(@gemhome, "gems", "b-1")
+    assert_path_exist File.join(@gemhome, "gems", "b-1")
   end
 
   def test_execute_no_gem


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If the same version of a gem is installed in the default gem home, and in the user home, `gem pristine` will fail to pristine the user installed one.

## What is your fix for the problem, implemented in this PR?

Make sure all copies are properly pristined by not removing duplicates from the stubs list.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
