### PR TITLE
Changelogs for RubyGems 3.5.11 and Bundler 2.5.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,47 @@
+# 3.5.11 / 2024-05-28
+
+## Enhancements:
+
+* Update SPDX license list as of 2024-05-22. Pull request
+  [#7689](https://github.com/rubygems/rubygems/pull/7689) by
+  github-actions[bot]
+* Fix the update_rubygems inconsistency (--disable-gems). Pull request
+  [#7658](https://github.com/rubygems/rubygems/pull/7658) by x-yuri
+* Accept WASI as an OS name in Gem::Platform. Pull request
+  [#7629](https://github.com/rubygems/rubygems/pull/7629) by kateinoigakukun
+* Warn if RubyGems version explicitly set in gemspec does not match
+  running version. Pull request
+  [#7460](https://github.com/rubygems/rubygems/pull/7460) by
+  deivid-rodriguez
+* Installs bundler 2.5.11 as a default gem.
+
+## Bug fixes:
+
+* Fix binstubs sometimes not getting regenerated when `--destdir` is
+  given. Pull request
+  [#7660](https://github.com/rubygems/rubygems/pull/7660) by
+  deivid-rodriguez
+* Fix `gem uninstall --user-install`  for symlinked HOME. Pull request
+  [#7645](https://github.com/rubygems/rubygems/pull/7645) by
+  deivid-rodriguez
+* Fix issue when plugin stubs would sometimes not be properly removed by
+  `gem uninstall`. Pull request
+  [#7631](https://github.com/rubygems/rubygems/pull/7631) by
+  deivid-rodriguez
+* Fix plugins uninstallation for user installed gems. Pull request
+  [#6456](https://github.com/rubygems/rubygems/pull/6456) by voxik
+
+## Performance:
+
+* Use a constant empty tar header to avoid extra allocations. Pull request
+  [#7484](https://github.com/rubygems/rubygems/pull/7484) by segiddins
+
+## Documentation:
+
+* Recommend `bin/rake` over `rake` in contributing docs. Pull request
+  [#7648](https://github.com/rubygems/rubygems/pull/7648) by
+  deivid-rodriguez
+
 # 3.5.10 / 2024-05-03
 
 ## Security:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,31 @@
+# 2.5.11 (May 28, 2024)
+
+## Deprecations:
+
+  - Deprecate Bundler constants [#7653](https://github.com/rubygems/rubygems/pull/7653)
+
+## Enhancements:
+
+  - Bump `bundle gem` generated COC to Contributor Covenant 2.1 [#7692](https://github.com/rubygems/rubygems/pull/7692)
+  - Retry a full clone when git server does not support shallow capabilities [#7649](https://github.com/rubygems/rubygems/pull/7649)
+
+## Bug fixes:
+
+  - Fix regression when caching gems from secondary sources [#7659](https://github.com/rubygems/rubygems/pull/7659)
+  - Fix error when Bundler installation is corrupted [#7642](https://github.com/rubygems/rubygems/pull/7642)
+  - Fix crash caused by RubyGems `require` gem activation logic running before Bundler can properly register its own monkeypatches [#7647](https://github.com/rubygems/rubygems/pull/7647)
+
+## Performance:
+
+  - Update cache checksums to decrease string allocations [#7637](https://github.com/rubygems/rubygems/pull/7637)
+  - Fix performance regression in applications with a local cache [#7680](https://github.com/rubygems/rubygems/pull/7680)
+
+## Documentation:
+
+  - Recommend `bin/rake` over `rake` in contributing docs [#7648](https://github.com/rubygems/rubygems/pull/7648)
+  - Monthly man update for May 2024 [#7640](https://github.com/rubygems/rubygems/pull/7640)
+  - Clarify Bundler support policy [#7633](https://github.com/rubygems/rubygems/pull/7633)
+
 # 2.5.10 (May 3, 2024)
 
 ## Security:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.5.11 and Bundler 2.5.11 into master.