### PR TITLE
Fix `gem uninstall` unresolved specifications warning

### DIFF
--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -210,4 +210,25 @@ class Gem::StubSpecification < Gem::BasicSpecification
   def stubbed?
     data.is_a? StubLine
   end
+
+  def ==(other) # :nodoc:
+    self.class === other &&
+      name == other.name &&
+      version == other.version &&
+      platform == other.platform
+  end
+
+  alias_method :eql?, :== # :nodoc:
+
+  def hash # :nodoc:
+    name.hash ^ version.hash ^ platform.hash
+  end
+
+  def <=>(other) # :nodoc:
+    sort_obj <=> other.sort_obj
+  end
+
+  def sort_obj # :nodoc:
+    [name, version, Gem::Platform.sort_priority(platform)]
+  end
 end

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -32,7 +32,7 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
       @cmd.execute
     end
 
-    assert_equal %w[a_evil-9 b-2 c-1.2 default-1 dep_x-1 pl-1-x86-linux x-1],
+    assert_equal %w[a-4 a_evil-9 b-2 c-1.2 default-1 dep_x-1 pl-1-x86-linux x-1],
                  Gem::Specification.all_names.sort
   end
 

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -19,8 +19,6 @@ class TestGemUninstaller < Gem::InstallerTestCase
         @user_spec = @user_installer.spec
       end
     end
-
-    Gem::Specification.reset
   end
 
   def test_initialize_expand_path


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

```
$ gem install rake && gem uninstall rake --force --all --executables
Successfully installed rake-13.2.1
1 gem installed
Removing rake
Successfully uninstalled rake-13.2.1
WARN: Unresolved or ambiguous specs during Gem::Specification.reset:
      psych (>= 4.0.0)
      Available/installed versions of this gem:
      - 5.1.2
      - 5.1.1
WARN: Clearing out unresolved specs. Try 'gem cleanup <gem>'
Please report a bug if this causes problems.
Removing rake
Successfully uninstalled rake-13.2.1
```

## What is your fix for the problem, implemented in this PR?

Don't reset specifications after `gem uninstall`.

In order to achieve that, we need to make sure we work with non materialized (stub) specifications, so that we can call `SpecificationRecord#remove_spec` and keep them up to date after uninstallation.

After this patch:

```
$ gem install rake && gem uninstall rake --force --all --executables
Successfully installed rake-13.2.1
1 gem installed
Removing rake
Successfully uninstalled rake-13.2.1
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
