### PR TITLE
Clarify BUNDLE_USER_CONFIG is a file

### DIFF
--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -307,7 +307,7 @@ Any \fB\.\fR characters in a host name are mapped to a double underscore (\fB__\
 .P
 This means that if you have a gem server named \fBmy\.gem\-host\.com\fR, you'll need to use the \fBBUNDLE_MY__GEM___HOST__COM\fR variable to configure credentials for it through ENV\.
 .SH "CONFIGURE BUNDLER DIRECTORIES"
-Bundler's home, config, cache and plugin directories are able to be configured through environment variables\. The default location for Bundler's home directory is \fB~/\.bundle\fR, which all directories inherit from by default\. The following outlines the available environment variables and their default values
+Bundler's home, cache and plugin directories and config file can be configured through environment variables\. The default location for Bundler's home directory is \fB~/\.bundle\fR, which all directories inherit from by default\. The following outlines the available environment variables and their default values
 .IP "" 4
 .nf
 BUNDLE_USER_HOME : $HOME/\.bundle

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -397,7 +397,7 @@ through ENV.
 
 ## CONFIGURE BUNDLER DIRECTORIES
 
-Bundler's home, config, cache and plugin directories are able to be configured
+Bundler's home, cache and plugin directories and config file can be configured
 through environment variables. The default location for Bundler's home directory is
 `~/.bundle`, which all directories inherit from by default. The following
 outlines the available environment variables and their default values


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->
## What was the end-user or developer problem that led to this PR?
Documentation is not explicit that `BUNDLE_USER_CONFIG` sets a file not a directory.

I assumed that `BUNDLE_USER_CONFIG` was a path to where the config file was to be saved. But I found out that if `export BUNDLE_USER_CONFIG=$XDG_CONFIG_HOME/bundle` is defined in my profile Bundler will create a file called `bundle` in the `$XDG_CONFIG_HOME` folder.

<!-- Write a clear and complete description of the problem -->
## What is your fix for the problem, implemented in this PR?
A slight modification to the relevant documentation. More could be added if deemed necessary.

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [NA] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [NA] Write code to solve the problem
- [NA] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
