### PR TITLE
Should rescue vendored net-http exception

### DIFF
--- a/test/rubygems/test_bundled_ca.rb
+++ b/test/rubygems/test_bundled_ca.rb
@@ -33,7 +33,7 @@ class TestGemBundledCA < Gem::TestCase
     http.verify_mode = OpenSSL::SSL::VERIFY_PEER
     http.cert_store = bundled_certificate_store
     http.get("/")
-  rescue Errno::ENOENT, Errno::ETIMEDOUT, SocketError, Net::OpenTimeout
+  rescue Errno::ENOENT, Errno::ETIMEDOUT, SocketError, Gem::Net::OpenTimeout
     pend "#{host} seems offline, I can't tell whether ssl would work."
   rescue OpenSSL::SSL::SSLError => e
     # Only fail for certificate verification errors


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Today when I run the tests on a plane, test_bundled_ca.rb failed.
It looks making on-line tests pending if off-line, but uninitialized constant exceptions occurred instead.

```
  1) Error:
TestGemBundledCA#test_accessing_www_rubygems:
NameError: uninitialized constant TestGemBundledCA::Net
    /Users/nobu/src/ruby/master/src/test/rubygems/test_bundled_ca.rb:36:in 'TestGemBundledCA#assert_https'
    /Users/nobu/src/ruby/master/src/test/rubygems/test_bundled_ca.rb:51:in 'TestGemBundledCA#test_accessing_www_rubygems'

  2) Error:
TestGemBundledCA#test_accessing_new_index:
NameError: uninitialized constant TestGemBundledCA::Net
    /Users/nobu/src/ruby/master/src/test/rubygems/test_bundled_ca.rb:36:in 'TestGemBundledCA#assert_https'
    /Users/nobu/src/ruby/master/src/test/rubygems/test_bundled_ca.rb:59:in 'TestGemBundledCA#test_accessing_new_index'
```

Since 99d91c9ed2d, this test file uses vendored net-http, but the `rescue` line in `assert_https` is still using non-vendored constant.

## What is your fix for the problem, implemented in this PR?

Use the vendored constant.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
