### PR TITLE
Improve default gem handling by treating default gems as any other gem

### DIFF
--- a/bundler/lib/bundler/installer/gem_installer.rb
+++ b/bundler/lib/bundler/installer/gem_installer.rb
@@ -54,7 +54,6 @@ module Bundler
       spec.source.install(
         spec,
         force: force,
-        ensure_builtin_gems_cached: standalone,
         build_args: Array(spec_settings),
         previous_spec: previous_spec,
       )

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -481,7 +481,21 @@ module Bundler
     end
 
     def all_specs
+      SharedHelpers.major_deprecation 2, "Bundler.rubygems.all_specs has been removed in favor of Bundler.rubygems.installed_specs"
+
       Gem::Specification.stubs.map do |stub|
+        StubSpecification.from_stub(stub)
+      end
+    end
+
+    def installed_specs
+      Gem::Specification.stubs.reject(&:default_gem?).map do |stub|
+        StubSpecification.from_stub(stub)
+      end
+    end
+
+    def default_specs
+      Gem::Specification.default_stubs.map do |stub|
         StubSpecification.from_stub(stub)
       end
     end

--- a/bundler/spec/bundler/installer/gem_installer_spec.rb
+++ b/bundler/spec/bundler/installer/gem_installer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Bundler::GemInstaller do
     it "invokes install method with empty build_args" do
       allow(spec_source).to receive(:install).with(
         spec,
-        { force: false, ensure_builtin_gems_cached: false, build_args: [], previous_spec: nil }
+        { force: false, build_args: [], previous_spec: nil }
       )
       subject.install_from_spec
     end
@@ -28,7 +28,7 @@ RSpec.describe Bundler::GemInstaller do
       allow(Bundler.settings).to receive(:[]).with("build.dummy").and_return("--with-dummy-config=dummy")
       expect(spec_source).to receive(:install).with(
         spec,
-        { force: false, ensure_builtin_gems_cached: false, build_args: ["--with-dummy-config=dummy"], previous_spec: nil }
+        { force: false, build_args: ["--with-dummy-config=dummy"], previous_spec: nil }
       )
       subject.install_from_spec
     end
@@ -42,7 +42,7 @@ RSpec.describe Bundler::GemInstaller do
       allow(Bundler.settings).to receive(:[]).with("build.dummy").and_return("--with-dummy-config=dummy --with-another-dummy-config")
       expect(spec_source).to receive(:install).with(
         spec,
-        { force: false, ensure_builtin_gems_cached: false, build_args: ["--with-dummy-config=dummy", "--with-another-dummy-config"], previous_spec: nil }
+        { force: false, build_args: ["--with-dummy-config=dummy", "--with-another-dummy-config"], previous_spec: nil }
       )
       subject.install_from_spec
     end

--- a/bundler/spec/commands/open_spec.rb
+++ b/bundler/spec/commands/open_spec.rb
@@ -164,7 +164,6 @@ RSpec.describe "bundle open" do
 
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
-        gem "json"
       G
     end
 

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -942,9 +942,9 @@ end
     G
 
     run <<-R
-      puts Bundler.rubygems.all_specs.map(&:name)
+      puts Bundler.rubygems.installed_specs.map(&:name)
       Gem.refresh
-      puts Bundler.rubygems.all_specs.map(&:name)
+      puts Bundler.rubygems.installed_specs.map(&:name)
     R
 
     expect(out).to eq("activesupport\nbundler\nactivesupport\nbundler")
@@ -1374,6 +1374,24 @@ end
         puts defined?(URI) || "undefined"
       RUBY
       expect(out).to eq("undefined\nconstant")
+    end
+
+    it "activates default gems when they are part of the bundle, but not installed explicitly", :ruby_repo do
+      default_json_version = ruby "gem 'json'; require 'json'; puts JSON::VERSION"
+
+      build_repo2 do
+        build_gem "json", default_json_version
+      end
+
+      gemfile "source \"#{file_uri_for(gem_repo2)}\"; gem 'json'"
+
+      ruby <<-RUBY
+        require "bundler/setup"
+        require "json"
+        puts defined?(::JSON) ? "JSON defined" : "JSON undefined"
+      RUBY
+
+      expect(err).to be_empty
     end
 
     describe "default gem activation" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler behaves inconsistently in presence of default gems, and that can be confusing. See for example the situation in https://github.com/ruby/ruby/pull/9163#issuecomment-1846994447.

## What is your fix for the problem, implemented in this PR?

My fix is that, once a default gem is specified directly in the Gemfile, or resolved as a transitive dependency, it becomes part of the bundle and gets treated as a "regular gem", so it's cached, explicitly installed in the configured location, etc.

NOTE: This is an improved version of https://github.com/rubygems/rubygems/pull/7242 (which had to be reverted) which fixes the issues in the initial approach and makes the change fully backwards compatible. If at `bundler/setup` time, default gems are found to be missing in the installed location, we will still fallback to considering them, but by default `bundle install` will treat them as regular gems and install them normally.

I think the new approach should also fix https://github.com/rubygems/rubygems/issues/4088.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
