### PR TITLE
Remove client-side MD5 ETag transition from compact index client

### DIFF
--- a/bundler/lib/bundler/compact_index_client/cache_file.rb
+++ b/bundler/lib/bundler/compact_index_client/cache_file.rb
@@ -86,11 +86,6 @@ module Bundler
         end
       end
 
-      # remove this method when we stop generating md5 digests for legacy etags
-      def md5
-        @digests && @digests["md5"]
-      end
-
       def digests?
         @digests&.any?
       end

--- a/bundler/lib/bundler/compact_index_client/updater.rb
+++ b/bundler/lib/bundler/compact_index_client/updater.rb
@@ -28,7 +28,6 @@ module Bundler
 
         CacheFile.copy(local_path) do |file|
           etag = etag_path.read.tap(&:chomp!) if etag_path.file?
-          etag ||= generate_etag(etag_path, file) # Remove this after 2.5.0 has been out for a while.
 
           # Subtract a byte to ensure the range won't be empty.
           # Avoids 416 (Range Not Satisfiable) responses.
@@ -65,16 +64,6 @@ module Bundler
 
       def etag_for_request(etag_path)
         etag_path.read.tap(&:chomp!) if etag_path.file?
-      end
-
-      # When first releasing this opaque etag feature, we want to generate the old MD5 etag
-      # based on the content of the file. After that it will always use the saved opaque etag.
-      # This transparently saves existing users with good caches from updating a bunch of files.
-      # Remove this behavior after 2.5.0 has been out for a while.
-      def generate_etag(etag_path, file)
-        etag = file.md5.hexdigest
-        CacheFile.write(etag_path, etag)
-        etag
       end
 
       def etag_from_response(response)

--- a/bundler/spec/bundler/compact_index_client/updater_spec.rb
+++ b/bundler/spec/bundler/compact_index_client/updater_spec.rb
@@ -119,23 +119,7 @@ RSpec.describe Bundler::CompactIndexClient::Updater do
 
     context "without an etag file" do
       let(:headers) do
-        {
-          "Range" => "bytes=2-",
-          # This MD5 feature should be deleted after sufficient time has passed since release.
-          # From then on, requests that still don't have a saved etag will be made without this header.
-          "If-None-Match" => %("#{Digest::MD5.hexdigest(local_body)}"),
-        }
-      end
-
-      it "saves only the etag_path if generated etag matches" do
-        expect(fetcher).to receive(:call).once.with(remote_path, headers).and_return(response)
-        allow(response).to receive(:is_a?).with(Gem::Net::HTTPPartialContent) { false }
-        allow(response).to receive(:is_a?).with(Gem::Net::HTTPNotModified) { true }
-
-        updater.update(remote_path, local_path, etag_path)
-
-        expect(local_path.read).to eq("abc")
-        expect(%("#{etag_path.read}")).to eq(headers["If-None-Match"])
+        { "Range" => "bytes=2-" }
       end
 
       it "appends the file" do


### PR DESCRIPTION

## What was the end-user or developer problem that led to this PR?

This was an offramp for generated etags to allow existing caches to be served until people could upgrade. It has been about 6 months since the transitional version was released, so we can remove this transitional code now.

## What is your fix for the problem, implemented in this PR?

Remove CompactIndexClient code that generated ETags using MD5.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
