### PR TITLE
Reorganize and refactor CompactIndexClient

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -54,6 +54,7 @@ bundler/lib/bundler/compact_index_client.rb
 bundler/lib/bundler/compact_index_client/cache.rb
 bundler/lib/bundler/compact_index_client/cache_file.rb
 bundler/lib/bundler/compact_index_client/gem_parser.rb
+bundler/lib/bundler/compact_index_client/parser.rb
 bundler/lib/bundler/compact_index_client/updater.rb
 bundler/lib/bundler/constants.rb
 bundler/lib/bundler/current_ruby.rb

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -42,6 +42,7 @@ module Bundler
   autoload :Checksum,               File.expand_path("bundler/checksum", __dir__)
   autoload :CLI,                    File.expand_path("bundler/cli", __dir__)
   autoload :CIDetector,             File.expand_path("bundler/ci_detector", __dir__)
+  autoload :CompactIndexClient,     File.expand_path("bundler/compact_index_client", __dir__)
   autoload :Definition,             File.expand_path("bundler/definition", __dir__)
   autoload :Dependency,             File.expand_path("bundler/dependency", __dir__)
   autoload :Deprecate,              File.expand_path("bundler/deprecate", __dir__)

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -767,13 +767,10 @@ module Bundler
 
       return unless SharedHelpers.md5_available?
 
-      latest = Fetcher::CompactIndex.
-               new(nil, Source::Rubygems::Remote.new(Gem::URI("https://rubygems.org")), nil, nil).
-               send(:compact_index_client).
-               instance_variable_get(:@cache).
-               dependencies("bundler").
-               map {|d| Gem::Version.new(d.first) }.
-               max
+      require_relative "vendored_uri"
+      remote = Source::Rubygems::Remote.new(Gem::URI("https://rubygems.org"))
+      cache_path = Bundler.user_cache.join("compact_index", remote.cache_slug)
+      latest = Bundler::CompactIndexClient.new(cache_path).latest_version("bundler")
       return unless latest
 
       current = Gem::Version.new(VERSION)

--- a/bundler/lib/bundler/compact_index_client/parser.rb
+++ b/bundler/lib/bundler/compact_index_client/parser.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Bundler
+  class CompactIndexClient
+    class Parser
+      # `compact_index` - an object responding to #names, #versions, #info(name, checksum),
+      #                   returning the file contents as a string
+      def initialize(compact_index)
+        @compact_index = compact_index
+        @info_checksums = nil
+        @versions_by_name = nil
+        @available = nil
+      end
+
+      def names
+        lines(@compact_index.names)
+      end
+
+      def versions
+        @versions_by_name ||= Hash.new {|hash, key| hash[key] = [] }
+        @info_checksums = {}
+
+        lines(@compact_index.versions).each do |line|
+          name, versions_string, checksum = line.split(" ", 3)
+          @info_checksums[name] = checksum || ""
+          versions_string.split(",") do |version|
+            delete = version.delete_prefix!("-")
+            version = version.split("-", 2).unshift(name)
+            if delete
+              @versions_by_name[name].delete(version)
+            else
+              @versions_by_name[name] << version
+            end
+          end
+        end
+
+        @versions_by_name
+      end
+
+      def info(name)
+        data = @compact_index.info(name, info_checksums[name])
+        lines(data).map {|line| gem_parser.parse(line).unshift(name) }
+      end
+
+      def available?
+        return @available unless @available.nil?
+        @available = !info_checksums.empty?
+      end
+
+      private
+
+      def info_checksums
+        @info_checksums ||= lines(@compact_index.versions).each_with_object({}) do |line, checksums|
+          parse_version_checksum(line, checksums)
+        end
+      end
+
+      def lines(data)
+        return [] if data.nil? || data.empty?
+        lines = data.split("\n")
+        header = lines.index("---")
+        header ? lines[header + 1..-1] : lines
+      end
+
+      def gem_parser
+        @gem_parser ||= GemParser.new
+      end
+
+      # This is mostly the same as `split(" ", 3)` but it avoids allocating extra objects.
+      # This method gets called at least once for every gem when parsing versions.
+      def parse_version_checksum(line, checksums)
+        line.freeze # allows slicing into the string to not allocate a copy of the line
+        name_end = line.index(" ")
+        checksum_start = line.index(" ", name_end + 1) + 1
+        checksum_end = line.size - checksum_start
+        # freeze name since it is used as a hash key
+        # pre-freezing means a frozen copy isn't created
+        name = line[0, name_end].freeze
+        checksum = line[checksum_start, checksum_end]
+        checksums[name] = checksum
+      end
+    end
+  end
+end

--- a/bundler/lib/bundler/fetcher/compact_index.rb
+++ b/bundler/lib/bundler/fetcher/compact_index.rb
@@ -4,8 +4,6 @@ require_relative "base"
 require_relative "../worker"
 
 module Bundler
-  autoload :CompactIndexClient, File.expand_path("../compact_index_client", __dir__)
-
   class Fetcher
     class CompactIndex < Base
       def self.compact_index_request(method_name)
@@ -61,7 +59,7 @@ module Bundler
           return nil
         end
         # Read info file checksums out of /versions, so we can know if gems are up to date
-        compact_index_client.update_and_parse_checksums!
+        compact_index_client.available?
       rescue CompactIndexClient::Updater::MismatchedChecksumError => e
         Bundler.ui.debug(e.message)
         nil

--- a/bundler/spec/bundler/compact_index_client/parser_spec.rb
+++ b/bundler/spec/bundler/compact_index_client/parser_spec.rb
@@ -1,0 +1,221 @@
+# frozen_string_literal: true
+
+require "bundler/compact_index_client"
+require "bundler/compact_index_client/parser"
+
+TestCompactIndexClient = Struct.new(:names, :versions, :info_data) do
+  # Requiring the checksum to match the input data helps ensure
+  # that we are parsing the correct checksum from the versions file
+  def info(name, checksum)
+    info_data.dig(name, checksum)
+  end
+
+  def set_info_data(name, value)
+    info_data[name] = value
+  end
+end
+
+RSpec.describe Bundler::CompactIndexClient::Parser do
+  subject(:parser) { described_class.new(compact_index) }
+
+  let(:compact_index) { TestCompactIndexClient.new(names, versions, info_data) }
+  let(:names) { "a\nb\nc\n" }
+  let(:versions) { <<~VERSIONS }
+    a 1.0.0,1.0.1,1.1.0 aaa111
+    b 2.0.0,2.0.0-java bbb222
+    c 3.0.0,3.0.3,3.3.3 ccc333
+    c -3.0.3 ccc333yanked
+  VERSIONS
+  let(:info_data) do
+    {
+      "a" => { "aaa111" => a_info },
+      "b" => { "bbb222" => b_info },
+      "c" => { "ccc333yanked" => c_info },
+    }
+  end
+  let(:a_info) { <<~INFO }
+    1.0.0 |checksum:aaa1,ruby:>= 3.0.0,rubygems:>= 3.2.3
+    1.0.1 |checksum:aaa2,ruby:>= 3.0.0,rubygems:>= 3.2.3
+    1.1.0 |checksum:aaa3,ruby:>= 3.0.0,rubygems:>= 3.2.3
+  INFO
+  let(:b_info) { <<~INFO }
+    2.0.0 a:~> 1.0&<= 3.0|checksum:bbb1
+    2.0.0-java a:~> 1.0&<= 3.0|checksum:bbb2
+  INFO
+  let(:c_info) { <<~INFO }
+    3.0.0 a:= 1.0.0,b:~> 2.0|checksum:ccc1,ruby:>= 2.7.0,rubygems:>= 3.0.0
+    3.3.3 a:>= 1.1.0,b:~> 2.0|checksum:ccc3,ruby:>= 3.0.0,rubygems:>= 3.2.3
+  INFO
+
+  describe "#available?" do
+    it "returns true versions are available" do
+      expect(parser).to be_available
+    end
+
+    it "returns false when versions are not available" do
+      compact_index.versions = nil
+      expect(parser).not_to be_available
+    end
+  end
+
+  describe "#names" do
+    it "returns the names" do
+      expect(parser.names).to eq(%w[a b c])
+    end
+
+    it "returns an empty array when names is empty" do
+      compact_index.names = ""
+      expect(parser.names).to eq([])
+    end
+
+    it "returns an empty array when names is not readable" do
+      compact_index.names = nil
+      expect(parser.names).to eq([])
+    end
+  end
+
+  describe "#versions" do
+    it "returns the versions" do
+      expect(parser.versions).to eq(
+        "a" => [
+          ["a", "1.0.0"],
+          ["a", "1.0.1"],
+          ["a", "1.1.0"],
+        ],
+        "b" => [
+          ["b", "2.0.0"],
+          ["b", "2.0.0", "java"],
+        ],
+        "c" => [
+          ["c", "3.0.0"],
+          ["c", "3.3.3"],
+        ],
+      )
+    end
+
+    it "returns an empty hash when versions is empty" do
+      compact_index.versions = ""
+      expect(parser.versions).to eq({})
+    end
+
+    it "returns an empty hash when versions is not readable" do
+      compact_index.versions = nil
+      expect(parser.versions).to eq({})
+    end
+  end
+
+  describe "#info" do
+    it "returns the info for example gem 'a' which has no deps" do
+      expect(parser.info("a")).to eq(
+        [
+          [
+            "a",
+            "1.0.0",
+            nil,
+            [],
+            [
+              ["checksum", ["aaa1"]],
+              ["ruby", [">= 3.0.0"]],
+              ["rubygems", [">= 3.2.3"]],
+            ],
+          ],
+          [
+            "a",
+            "1.0.1",
+            nil,
+            [],
+            [
+              ["checksum", ["aaa2"]],
+              ["ruby", [">= 3.0.0"]],
+              ["rubygems", [">= 3.2.3"]],
+            ],
+          ],
+          [
+            "a",
+            "1.1.0",
+            nil,
+            [],
+            [
+              ["checksum", ["aaa3"]],
+              ["ruby", [">= 3.0.0"]],
+              ["rubygems", [">= 3.2.3"]],
+            ],
+          ],
+        ]
+      )
+    end
+
+    it "returns the info for example gem 'b' which has platform and compound deps" do
+      expect(parser.info("b")).to eq(
+        [
+          [
+            "b",
+            "2.0.0",
+            nil,
+            [
+              ["a", ["~> 1.0", "<= 3.0"]],
+            ],
+            [
+              ["checksum", ["bbb1"]],
+            ],
+          ],
+          [
+            "b",
+            "2.0.0",
+            "java",
+            [
+              ["a", ["~> 1.0", "<= 3.0"]],
+            ],
+            [
+              ["checksum", ["bbb2"]],
+            ],
+          ],
+        ]
+      )
+    end
+
+    it "returns the info for example gem 'c' which has deps and yanked version (requires use of correct info checksum)" do
+      expect(parser.info("c")).to eq(
+        [
+          [
+            "c",
+            "3.0.0",
+            nil,
+            [
+              ["a", ["= 1.0.0"]],
+              ["b", ["~> 2.0"]],
+            ],
+            [
+              ["checksum", ["ccc1"]],
+              ["ruby", [">= 2.7.0"]],
+              ["rubygems", [">= 3.0.0"]],
+            ],
+          ],
+          [
+            "c",
+            "3.3.3",
+            nil,
+            [
+              ["a", [">= 1.1.0"]],
+              ["b", ["~> 2.0"]],
+            ],
+            [
+              ["checksum", ["ccc3"]],
+              ["ruby", [">= 3.0.0"]],
+              ["rubygems", [">= 3.2.3"]],
+            ],
+          ],
+        ]
+      )
+    end
+
+    it "returns an empty array when the info is empty" do
+      compact_index.set_info_data("a", {})
+      expect(parser.info("a")).to eq([])
+    end
+
+    it "returns an empty array when the info is not readable" do
+      expect(parser.info("d")).to eq([])
+    end
+  end
+end

--- a/bundler/spec/bundler/fetcher/compact_index_spec.rb
+++ b/bundler/spec/bundler/fetcher/compact_index_spec.rb
@@ -4,13 +4,15 @@
 require "bundler/compact_index_client"
 
 RSpec.describe Bundler::Fetcher::CompactIndex do
-  let(:downloader)  { double(:downloader) }
+  let(:response) { double(:response) }
+  let(:downloader) { double(:downloader, fetch: response) }
   let(:display_uri) { Gem::URI("http://sampleuri.com") }
   let(:remote)      { double(:remote, cache_slug: "lsjdf", uri: display_uri) }
   let(:gem_remote_fetcher) { nil }
   let(:compact_index) { described_class.new(downloader, remote, display_uri, gem_remote_fetcher) }
 
   before do
+    allow(response).to receive(:is_a?).with(Gem::Net::HTTPNotModified).and_return(true)
     allow(compact_index).to receive(:log_specs) {}
   end
 
@@ -34,7 +36,7 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
     describe "#available?" do
       before do
         allow(compact_index).to receive(:compact_index_client).
-          and_return(double(:compact_index_client, update_and_parse_checksums!: true))
+          and_return(double(:compact_index_client, available?: true))
       end
 
       it "returns true" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The way the cache and client interact, and the way the parsing is split between the two, plus some of the hacks we use made me want to refactor the compact index client.

## What is your fix for the problem, implemented in this PR?

Oh jeeze... what didn't I do. I layered all of the bits of the compact index so each can focus on one thing and then pass down to the next step without exposing its implementation details. The cache only does cache and not parsing. I extracted a parser. I wonder if the parser is really the same as the client. It could just move back into the cilent, but I like that it's a very basic class that just expects a simple client.

The cache is now responsible for updating so that only the updater knows about the files that get written and from outside the cache you only deal with strings. This makes the cache and the updating completely transparent. The cache now takes care of tracking which endpoints have been fetch too, just like a cache ought to.

My goal was really just to have some fun and understand the compact index better, but the result is nice. I particularly like pulling the Parser out of the cache/client.

I think I have it close to working now. It tries very hard not to change any actual behavior or approaches. For example, the parsing is just as efficient/inefficient as it was before, so #7637 is still applicable (though it moved, so this should probably merge after).

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
