### PR TITLE
Raise a friendly error whenever commands executed by test suite take more than a minute

### DIFF
--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -849,8 +849,7 @@ RSpec.describe "bundle update" do
     end
 
     bundle "update", all: true
-    out.sub!("Removing foo (1.0)\n", "")
-    expect(out).to match(/Resolving dependencies\.\.\.\.*\nFetching foo 2\.0 \(was 1\.0\)\nInstalling foo 2\.0 \(was 1\.0\)\nBundle updated/)
+    expect(out.sub("Removing foo (1.0)\n", "")).to match(/Resolving dependencies\.\.\.\.*\nFetching foo 2\.0 \(was 1\.0\)\nInstalling foo 2\.0 \(was 1\.0\)\nBundle updated/)
   end
 
   it "shows error message when Gemfile.lock is not preset and gem is specified" do

--- a/bundler/spec/support/command_execution.rb
+++ b/bundler/spec/support/command_execution.rb
@@ -1,7 +1,37 @@
 # frozen_string_literal: true
 
 module Spec
-  CommandExecution = Struct.new(:command, :working_directory, :exitstatus, :original_stdout, :original_stderr) do
+  class CommandExecution
+    def initialize(command, working_directory:, timeout:)
+      @command = command
+      @working_directory = working_directory
+      @timeout = timeout
+      @original_stdout = String.new
+      @original_stderr = String.new
+    end
+
+    attr_accessor :exitstatus, :command, :original_stdout, :original_stderr
+    attr_reader :timeout
+    attr_writer :failure_reason
+
+    def raise_error!
+      return unless failure?
+
+      error_header = if failure_reason == :timeout
+        "Invoking `#{command}` was aborted after #{timeout} seconds with output:"
+      else
+        "Invoking `#{command}` failed with output:"
+      end
+
+      raise <<~ERROR
+        #{error_header}
+
+        ----------------------------------------------------------------------
+        #{stdboth}
+        ----------------------------------------------------------------------
+      ERROR
+    end
+
     def to_s
       "$ #{command}"
     end
@@ -12,11 +42,11 @@ module Spec
     end
 
     def stdout
-      original_stdout
+      normalize(original_stdout)
     end
 
     def stderr
-      original_stderr
+      normalize(original_stderr)
     end
 
     def to_s_verbose
@@ -36,6 +66,14 @@ module Spec
     def failure?
       return true unless exitstatus
       exitstatus > 0
+    end
+
+    private
+
+    attr_reader :failure_reason
+
+    def normalize(string)
+      string.force_encoding(Encoding::UTF_8).strip.gsub("\r\n", "\n")
     end
   end
 end

--- a/bundler/spec/support/command_execution.rb
+++ b/bundler/spec/support/command_execution.rb
@@ -15,13 +15,8 @@ module Spec
       original_stdout
     end
 
-    # Can be removed once/if https://github.com/oneclick/rubyinstaller2/pull/369 is resolved
     def stderr
-      return original_stderr unless Gem.win_platform?
-
-      original_stderr.split("\n").reject do |l|
-        l.include?("operating_system_defaults")
-      end.join("\n")
+      original_stderr
     end
 
     def to_s_verbose


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If CI times out, it's hard to investigate since we just get a bunch of dots in the CI output.

## What is your fix for the problem, implemented in this PR?

Make sure if a single subcommand takes too long, we fail the spec with a proper error that shows the output of the command before it was interrupted.

Implementation is mostly copied from tty-command. I wanted to start using the library instead but there's some usages of `Open3` in our test suite that are not supported by `tty-command`, like sending a specific signal to the process.

So I copied its timeout implementation.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
