### PR TITLE
Don't let `bundle config` report a path without a Gemfile as "local app"

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -358,7 +358,7 @@ module Bundler
     def settings
       @settings ||= Settings.new(app_config_path)
     rescue GemfileNotFound
-      @settings = Settings.new(Pathname.new(".bundle").expand_path)
+      @settings = Settings.new
     end
 
     # @return [Hash] Environment present before Bundler was activated

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -103,6 +103,7 @@ module Bundler
     def initialize(root = nil)
       @root            = root
       @local_config    = load_config(local_config_file)
+      @local_root      = root || Pathname.new(".bundle").expand_path
 
       @env_config      = ENV.to_h
       @env_config.select! {|key, _value| key.start_with?("BUNDLE_") }
@@ -142,7 +143,7 @@ module Bundler
     end
 
     def set_local(key, value)
-      local_config_file || raise(GemfileNotFound, "Could not locate Gemfile")
+      local_config_file = @local_root.join("config")
 
       set_key(key, value, @local_config, local_config_file)
     end

--- a/bundler/spec/bundler/settings_spec.rb
+++ b/bundler/spec/bundler/settings_spec.rb
@@ -6,12 +6,18 @@ RSpec.describe Bundler::Settings do
   subject(:settings) { described_class.new(bundled_app) }
 
   describe "#set_local" do
-    context "when the local config file is not found" do
+    context "root is nil" do
       subject(:settings) { described_class.new(nil) }
 
-      it "raises a GemfileNotFound error with explanation" do
-        expect { subject.set_local("foo", "bar") }.
-          to raise_error(Bundler::GemfileNotFound, "Could not locate Gemfile")
+      before do
+        allow(Pathname).to receive(:new).and_call_original
+        allow(Pathname).to receive(:new).with(".bundle").and_return home(".bundle")
+      end
+
+      it "works" do
+        subject.set_local("foo", "bar")
+
+        expect(subject["foo"]).to eq("bar")
       end
     end
   end

--- a/bundler/spec/commands/config_spec.rb
+++ b/bundler/spec/commands/config_spec.rb
@@ -79,6 +79,14 @@ RSpec.describe ".bundle/config" do
       expect(home(".bundle/config")).to exist
     end
 
+    it "does not list global settings as local" do
+      bundle "config set --global foo bar"
+      bundle "config list", dir: home
+
+      expect(out).to include("for the current user")
+      expect(out).not_to include("for your local app")
+    end
+
     it "works with an absolute path" do
       ENV["BUNDLE_APP_CONFIG"] = tmp("foo/bar").to_s
       bundle "config set --local path vendor/bundle"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If Bundler is run from the HOME directory, user settings are incorrectly reported as local settings.

## What is your fix for the problem, implemented in this PR?

When there's no Gemfile, like usually in the HOME directory, we were falling back to using `$HOME/.bundle` as config root, making `bundle config` believe there's actually a local application.

Instead, the config root in this situation should be nil. The one case where we still want to consider a config root is when explicitly setting local configuration from the home folder. In that case, we keep the default to `$HOME/.bundle` as the config root.

Fixes #7679.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
