### PR TITLE
Rust gems should install if extension is extconf.rb and not Cargo.toml.

### DIFF
--- a/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.extensions = ["ext/<%= config[:underscored_name] %>/extconf.rb"]
 <%- end -%>
 <%- if config[:ext] == 'rust' -%>
-  spec.extensions = ["ext/<%= config[:underscored_name] %>/Cargo.toml"]
+  spec.extensions = ["ext/<%= config[:underscored_name] %>/extconf.rb"]
 <%- end -%>
 
   # Uncomment to register a new dependency of your gem


### PR DESCRIPTION
https://github.com/rubygems/rubygems/issues/7693
