### PR TITLE
Rust gems should install if extension is extconf.rb and not Cargo.toml.

### DIFF
--- a/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.extensions = ["ext/<%= config[:underscored_name] %>/extconf.rb"]
 <%- end -%>
 <%- if config[:ext] == 'rust' -%>
-  spec.extensions = ["ext/<%= config[:underscored_name] %>/Cargo.toml"]
+  spec.extensions = ["ext/<%= config[:underscored_name] %>/extconf.rb"]
 <%- end -%>
 
   # Uncomment to register a new dependency of your gem


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Try to install a rust gem scaffolded with bundle gem --ext=rust.

## What is your fix for the problem, implemented in this PR?

This is a quick fix. I do not expect it to be merged as is.

I fixed the templating of the gemspec file to refer to extconf.rb instead of Cargo.toml.

I'm not sure it is the right way to proceed. Would appreciate advice or feedback.
