### PR TITLE
Allow Artifactory to add blank lines to versions file

### DIFF
--- a/bundler/spec/bundler/compact_index_client/parser_spec.rb
+++ b/bundler/spec/bundler/compact_index_client/parser_spec.rb
@@ -56,6 +56,22 @@ RSpec.describe Bundler::CompactIndexClient::Parser do
       compact_index.versions = nil
       expect(parser).not_to be_available
     end
+
+    context "with Artifactory" do
+      # Artifactory is adding seemingly random blank lines to the versions file
+      let(:versions) { <<~VERSIONS }
+        a 1.0.0,1.0.1,1.1.0 aaa111
+
+        b 2.0.0,2.0.0-java bbb222
+        c 3.0.0,3.0.3,3.3.3 ccc333
+        c -3.0.3 ccc333yanked
+      VERSIONS
+
+      it "parses the versions file correctly even with blank lines in the file" do
+        expect(parser).to be_available
+        expect(parser.versions).not_to be_empty
+      end
+    end
   end
 
   describe "#names" do


### PR DESCRIPTION
I see no reason for these lines to exist, but, like an appendix, they do exist and, for some people, they explode.

## What was the end-user or developer problem that led to this PR?

After we released #7637, some Artifactory users found that they were getting NoMethodErrors when parsing the versions file.

## What is your fix for the problem, implemented in this PR?

I reached out to JFrog to see if Artifactory will fix the issue, but in the meantime we will handle blank lines more gracefully.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
