### PR TITLE
Fix Windows CI that got silently broken recently

### DIFF
--- a/bin/rake.cmd
+++ b/bin/rake.cmd
@@ -1,0 +1,2 @@
+@ECHO OFF
+@"ruby.exe" -x "%~dpn0" %*

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -117,7 +117,14 @@ module Spec
     def gem_activate_and_possibly_install(gem_name)
       gem_activate(gem_name)
     rescue Gem::LoadError => e
-      Gem.install(gem_name, e.requirement)
+      # Windows 3.0 puts a Windows stub script as  `rake` while it should be
+      # named `rake.bat`. RubyGems does not like that and avoids overwriting it
+      # unless explicitly instructed to do so with `force`.
+      if RUBY_VERSION.start_with?("3.0") && Gem.win_platform?
+        Gem.install(gem_name, e.requirement, force: true)
+      else
+        Gem.install(gem_name, e.requirement)
+      end
       retry
     end
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -830,7 +830,9 @@ class Gem::Specification < Gem::BasicSpecification
       next names if names.nonzero?
       versions = b.version <=> a.version
       next versions if versions.nonzero?
-      Gem::Platform.sort_priority(b.platform)
+      platforms = Gem::Platform.sort_priority(b.platform) <=> Gem::Platform.sort_priority(a.platform)
+      next platforms if platforms.nonzero?
+      b.base_dir == Gem.path.first ? 1 : -1
     end
   end
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1615,9 +1615,11 @@ class TestGem < Gem::TestCase
 
     Gem.use_paths Gem.dir, [Gem.dir, Gem.user_dir]
 
+    spec = Gem::Dependency.new("m", "1").to_spec
+
     assert_equal \
       File.join(Gem.dir, "gems", "m-1"),
-      Gem::Dependency.new("m","1").to_spec.gem_dir,
+      spec.gem_dir,
       "Wrong spec selected"
   end
 

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1568,7 +1568,6 @@ class TestGem < Gem::TestCase
 
     tests.each do |name, paths|
       Gem.use_paths paths.first, paths
-      Gem::Specification.reset
       Gem.searcher = nil
 
       assert_equal Gem::Dependency.new("m","1").to_specs,

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -217,7 +217,15 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
   end
 
   def test_execute_system_update_installed_in_non_default_gem_path
-    rubygems_update_spec = quick_gem "rubygems-update", 9 do |s|
+    rubygems_update_spec = Gem::Specification.new do |s|
+      s.name        = "rubygems-update"
+      s.version     = "9"
+      s.author      = "A User"
+      s.email       = "example@example.com"
+      s.homepage    = "http://example.com"
+      s.summary     = "this is a summary"
+      s.description = "This is a test description"
+
       write_file File.join(@tempdir, "setup.rb")
 
       s.files += %w[setup.rb]


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

After https://github.com/rubygems/rubygems/pull/7664, `Gem::StubSpecification` sorting is no longer stable, which causes spec failures under some platforms.

## What is your fix for the problem, implemented in this PR?

Restore a stable criteria for sorting specifications, that keeps the current tests green.

Also, make sure Windows can actually run our tests properly and does not give back a green status without running anything.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
