### PR TITLE
[CI] Fix Windows CI - Add bin/rake.cmd

### DIFF
--- a/bin/rake.cmd
+++ b/bin/rake.cmd
@@ -1,0 +1,2 @@
+@ECHO OFF
+@"ruby.exe" -x "%~dpn0" %*


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

CI is showing a false positive for Windows jobs.  See most recent run:
https://github.com/rubygems/rubygems/actions/runs/9302255399

Look at any Windows job logs, and check the 'Install Dependencies' and 'Run Tests' steps.  The log for the steps are empty.

The issue is that the current workflow scripts that run Windows jobs are running a ruby file with a shebang line.  Standard Windows shells do not recognize that file type as executable...

## What is your fix for the problem, implemented in this PR?

Add a file `bin/rake.cmd`, which correctly runs `bin/rake` from a normal Windows Shell.

Note that Windows 3.0 fails on the 'Install Dependencies' step (`bin/rake setup`).  The error is:
```
C:/hostedtoolcache/windows/Ruby/3.0.7/x64/lib/ruby/3.0.0/rubygems/installer.rb:262:in `check_executable_overwrite': "rake" from rake conflicts with C:/hostedtoolcache/windows/Ruby/3.0.7/x64/bin/rake (Gem::InstallError)
```

Not sure about what the best fix is...

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
