### PR TITLE
Fix `bundle exec` no longer working in truffleruby after explicit `require` of `pathname` was removed

### DIFF
--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -4,14 +4,14 @@ require_relative "version"
 require_relative "rubygems_integration"
 require_relative "current_ruby"
 
+autoload :Pathname, "pathname"
+
 module Bundler
   autoload :WINDOWS, File.expand_path("constants", __dir__)
   autoload :FREEBSD, File.expand_path("constants", __dir__)
   autoload :NULL, File.expand_path("constants", __dir__)
 
   module SharedHelpers
-    autoload :Pathname, "pathname"
-
     def root
       gemfile = find_gemfile
       raise GemfileNotFound, "Could not locate Gemfile" unless gemfile

--- a/bundler/spec/bundler/bundler_spec.rb
+++ b/bundler/spec/bundler/bundler_spec.rb
@@ -233,8 +233,8 @@ RSpec.describe Bundler do
 
       allow(Bundler).to receive(:root).and_return(bundled_app)
 
-      Bundler.mkdir_p(bundled_app.join("foo", "bar"))
-      expect(bundled_app.join("foo", "bar")).to exist
+      Bundler.mkdir_p(bundled_app("foo", "bar"))
+      expect(bundled_app("foo", "bar")).to exist
     end
   end
 

--- a/bundler/spec/bundler/env_spec.rb
+++ b/bundler/spec/bundler/env_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe Bundler::Env do
       before do
         gemfile("source \"#{file_uri_for(gem_repo1)}\"; gemspec")
 
-        File.open(bundled_app.join("foo.gemspec"), "wb") do |f|
+        File.open(bundled_app("foo.gemspec"), "wb") do |f|
           f.write(gemspec)
         end
 

--- a/bundler/spec/bundler/gem_helper_spec.rb
+++ b/bundler/spec/bundler/gem_helper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Bundler::GemHelper do
   before(:each) do
     global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false", "BUNDLE_GEM__LINTER" => "false",
                   "BUNDLE_GEM__CI" => "false", "BUNDLE_GEM__CHANGELOG" => "false"
-    sys_exec("git config --global init.defaultBranch main")
+    git("config --global init.defaultBranch main")
     bundle "gem #{app_name}"
     prepare_gemspec(app_gemspec_path)
   end
@@ -253,11 +253,11 @@ RSpec.describe Bundler::GemHelper do
       end
 
       before do
-        sys_exec("git init", dir: app_path)
-        sys_exec("git config user.email \"you@example.com\"", dir: app_path)
-        sys_exec("git config user.name \"name\"", dir: app_path)
-        sys_exec("git config commit.gpgsign false", dir: app_path)
-        sys_exec("git config push.default simple", dir: app_path)
+        git("init", app_path)
+        git("config user.email \"you@example.com\"", app_path)
+        git("config user.name \"name\"", app_path)
+        git("config commit.gpgsign false", app_path)
+        git("config push.default simple", app_path)
 
         # silence messages
         allow(Bundler.ui).to receive(:confirm)
@@ -271,13 +271,13 @@ RSpec.describe Bundler::GemHelper do
         end
 
         it "when there are uncommitted files" do
-          sys_exec("git add .", dir: app_path)
+          git("add .", app_path)
           expect { Rake.application["release"].invoke }.
             to raise_error("There are files that need to be committed first.")
         end
 
         it "when there is no git remote" do
-          sys_exec("git commit -a -m \"initial commit\"", dir: app_path)
+          git("commit -a -m \"initial commit\"", app_path)
           expect { Rake.application["release"].invoke }.to raise_error(RuntimeError)
         end
       end
@@ -286,8 +286,8 @@ RSpec.describe Bundler::GemHelper do
         let(:repo) { build_git("foo", bare: true) }
 
         before do
-          sys_exec("git remote add origin #{file_uri_for(repo.path)}", dir: app_path)
-          sys_exec('git commit -a -m "initial commit"', dir: app_path)
+          git("remote add origin #{file_uri_for(repo.path)}", app_path)
+          git('commit -a -m "initial commit"', app_path)
         end
 
         context "on releasing" do
@@ -296,7 +296,7 @@ RSpec.describe Bundler::GemHelper do
             mock_confirm_message "Tagged v#{app_version}."
             mock_confirm_message "Pushed git commits and release tag."
 
-            sys_exec("git push -u origin main", dir: app_path)
+            git("push -u origin main", app_path)
           end
 
           it "calls rubygem_push with proper arguments" do
@@ -314,8 +314,8 @@ RSpec.describe Bundler::GemHelper do
 
           it "also works when releasing from an ambiguous reference" do
             # Create a branch with the same name as the tag
-            sys_exec("git checkout -b v#{app_version}", dir: app_path)
-            sys_exec("git push -u origin v#{app_version}", dir: app_path)
+            git("checkout -b v#{app_version}", app_path)
+            git("push -u origin v#{app_version}", app_path)
 
             expect(subject).to receive(:rubygem_push).with(app_gem_path.to_s)
 
@@ -323,7 +323,7 @@ RSpec.describe Bundler::GemHelper do
           end
 
           it "also works with releasing from a branch not yet pushed" do
-            sys_exec("git checkout -b module_function", dir: app_path)
+            git("checkout -b module_function", app_path)
 
             expect(subject).to receive(:rubygem_push).with(app_gem_path.to_s)
 
@@ -337,7 +337,7 @@ RSpec.describe Bundler::GemHelper do
             mock_build_message app_name, app_version
             mock_confirm_message "Pushed git commits and release tag."
 
-            sys_exec("git push -u origin main", dir: app_path)
+            git("push -u origin main", app_path)
             expect(subject).to receive(:rubygem_push).with(app_gem_path.to_s)
           end
 
@@ -353,7 +353,7 @@ RSpec.describe Bundler::GemHelper do
           mock_confirm_message "Tag v#{app_version} has already been created."
           expect(subject).to receive(:rubygem_push).with(app_gem_path.to_s)
 
-          sys_exec("git tag -a -m \"Version #{app_version}\" v#{app_version}", dir: app_path)
+          git("tag -a -m \"Version #{app_version}\" v#{app_version}", app_path)
 
           Rake.application["release"].invoke
         end
@@ -374,10 +374,10 @@ RSpec.describe Bundler::GemHelper do
       end
 
       before do
-        sys_exec("git init", dir: app_path)
-        sys_exec("git config user.email \"you@example.com\"", dir: app_path)
-        sys_exec("git config user.name \"name\"", dir: app_path)
-        sys_exec("git config push.gpgsign simple", dir: app_path)
+        git("init", app_path)
+        git("config user.email \"you@example.com\"", app_path)
+        git("config user.name \"name\"", app_path)
+        git("config push.gpgsign simple", app_path)
 
         # silence messages
         allow(Bundler.ui).to receive(:confirm)

--- a/bundler/spec/bundler/plugin_spec.rb
+++ b/bundler/spec/bundler/plugin_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe Bundler::Plugin do
       end
 
       it "returns plugin dir in global bundle path" do
-        expect(subject.root).to eq(home.join(".bundle/plugin"))
+        expect(subject.root).to eq(home(".bundle/plugin"))
       end
     end
   end

--- a/bundler/spec/bundler/plugin_spec.rb
+++ b/bundler/spec/bundler/plugin_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe Bundler::Plugin do
       end
 
       it "returns plugin dir in app .bundle path" do
-        expect(subject.root).to eq(bundled_app.join(".bundle/plugin"))
+        expect(subject.root).to eq(bundled_app(".bundle/plugin"))
       end
     end
 

--- a/bundler/spec/cache/git_spec.rb
+++ b/bundler/spec/cache/git_spec.rb
@@ -164,8 +164,8 @@ RSpec.describe "bundle cache with git" do
       s.add_dependency "submodule"
     end
 
-    sys_exec "git submodule add #{lib_path("submodule-1.0")} submodule-1.0", dir: lib_path("has_submodule-1.0")
-    sys_exec "git commit -m \"submodulator\"", dir: lib_path("has_submodule-1.0")
+    git "submodule add #{lib_path("submodule-1.0")} submodule-1.0", lib_path("has_submodule-1.0")
+    git "commit -m \"submodulator\"", lib_path("has_submodule-1.0")
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"

--- a/bundler/spec/commands/check_spec.rb
+++ b/bundler/spec/commands/check_spec.rb
@@ -447,7 +447,7 @@ RSpec.describe "bundle check" do
         build_gem "dex-dispatch-engine"
       end
 
-      build_lib("bundle-check-issue", path: tmp.join("bundle-check-issue")) do |s|
+      build_lib("bundle-check-issue", path: tmp("bundle-check-issue")) do |s|
         s.write "Gemfile", <<-G
           source "https://localgemserver.test"
 
@@ -461,14 +461,14 @@ RSpec.describe "bundle check" do
         s.add_dependency "awesome_print"
       end
 
-      bundle "install", artifice: "compact_index_extra", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }, dir: tmp.join("bundle-check-issue")
+      bundle "install", artifice: "compact_index_extra", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }, dir: tmp("bundle-check-issue")
     end
 
     it "does not corrupt lockfile when changing version" do
-      version_file = tmp.join("bundle-check-issue/bundle-check-issue.gemspec")
+      version_file = tmp("bundle-check-issue/bundle-check-issue.gemspec")
       File.write(version_file, File.read(version_file).gsub(/s\.version = .+/, "s.version = '9999'"))
 
-      bundle "check --verbose", dir: tmp.join("bundle-check-issue")
+      bundle "check --verbose", dir: tmp("bundle-check-issue")
 
       checksums = checksums_section_when_existing do |c|
         c.checksum gem_repo4, "awesome_print", "1.0"
@@ -476,7 +476,7 @@ RSpec.describe "bundle check" do
         c.checksum gem_repo2, "dex-dispatch-engine", "1.0"
       end
 
-      expect(File.read(tmp.join("bundle-check-issue/Gemfile.lock"))).to eq <<~L
+      expect(File.read(tmp("bundle-check-issue/Gemfile.lock"))).to eq <<~L
         PATH
           remote: .
           specs:

--- a/bundler/spec/commands/init_spec.rb
+++ b/bundler/spec/commands/init_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "bundle init" do
   end
 
   context "given --gemspec option" do
-    let(:spec_file) { tmp.join("test.gemspec") }
+    let(:spec_file) { tmp("test.gemspec") }
 
     it "should generate from an existing gemspec" do
       File.open(spec_file, "w") do |file|
@@ -160,7 +160,7 @@ RSpec.describe "bundle init" do
     end
 
     context "given --gemspec option" do
-      let(:spec_file) { tmp.join("test.gemspec") }
+      let(:spec_file) { tmp("test.gemspec") }
 
       before do
         File.open(spec_file, "w") do |file|

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -461,8 +461,8 @@ RSpec.describe "bundle install with gem sources" do
     end
 
     it "includes the gem without warning if two gemspecs add it with the same requirement" do
-      gem1 = tmp.join("my-gem-1")
-      gem2 = tmp.join("my-gem-2")
+      gem1 = tmp("my-gem-1")
+      gem2 = tmp("my-gem-2")
 
       build_lib "my-gem", path: gem1 do |s|
         s.add_development_dependency "rubocop", "~> 1.36.0"

--- a/bundler/spec/commands/list_spec.rb
+++ b/bundler/spec/commands/list_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe "bundle list" do
 
       build_git "git_test", "1.0.0", path: lib_path("git_test")
 
-      build_lib("gemspec_test", path: tmp.join("gemspec_test")) do |s|
+      build_lib("gemspec_test", path: tmp("gemspec_test")) do |s|
         s.add_dependency "bar", "=1.0.0"
       end
 
@@ -135,7 +135,7 @@ RSpec.describe "bundle list" do
         gem "rack"
         gem "rails"
         gem "git_test", :git => "#{lib_path("git_test")}"
-        gemspec :path => "#{tmp.join("gemspec_test")}"
+        gemspec :path => "#{tmp("gemspec_test")}"
       G
     end
 

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe "bundle gem" do
   let(:minitest_test_class_name) { "class TestMygem < Minitest::Test" }
 
   before do
-    sys_exec("git config --global user.name 'Bundler User'")
-    sys_exec("git config --global user.email user@example.com")
-    sys_exec("git config --global github.user bundleuser")
+    git("config --global user.name 'Bundler User'")
+    git("config --global user.email user@example.com")
+    git("config --global github.user bundleuser")
 
     global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false", "BUNDLE_GEM__LINTER" => "false",
                   "BUNDLE_GEM__CI" => "false", "BUNDLE_GEM__CHANGELOG" => "false"
@@ -109,7 +109,7 @@ RSpec.describe "bundle gem" do
     end
 
     it "generates the README with a section for the Code of Conduct, respecting the configured git default branch", git: ">= 2.28.0" do
-      sys_exec("git config --global init.defaultBranch main")
+      git("config --global init.defaultBranch main")
       bundle "gem #{gem_name} --coc"
 
       expect(bundled_app("#{gem_name}/README.md").read).to include("## Code of Conduct")
@@ -419,7 +419,7 @@ RSpec.describe "bundle gem" do
 
     context "git config github.user is absent" do
       before do
-        sys_exec("git config --global --unset github.user")
+        git("config --global --unset github.user")
         bundle "gem #{gem_name}"
       end
 
@@ -601,8 +601,8 @@ RSpec.describe "bundle gem" do
 
     context "git config user.{name,email} is not set" do
       before do
-        sys_exec("git config --global --unset user.name")
-        sys_exec("git config --global --unset user.email")
+        git("config --global --unset user.name")
+        git("config --global --unset user.email")
         bundle "gem #{gem_name}"
       end
 
@@ -1317,7 +1317,7 @@ RSpec.describe "bundle gem" do
   context "testing --github-username option against git and bundle config settings" do
     context "without git config set" do
       before do
-        sys_exec("git config --global --unset github.user")
+        git("config --global --unset github.user")
       end
       context "with github-username option in bundle config settings set to some value" do
         before do
@@ -1354,7 +1354,7 @@ RSpec.describe "bundle gem" do
   context "testing github_username bundle config against git config settings" do
     context "without git config set" do
       before do
-        sys_exec("git config --global --unset github.user")
+        git("config --global --unset github.user")
       end
 
       it_behaves_like "github_username configuration"

--- a/bundler/spec/commands/open_spec.rb
+++ b/bundler/spec/commands/open_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "bundle open" do
       G
 
       bundle "open foo", env: { "EDITOR" => "echo editor", "VISUAL" => "", "BUNDLER_EDITOR" => "" }
-      expect(out).to include("editor #{default_bundle_path.join("bundler", "gems", "foo-1.0-#{ref}")}")
+      expect(out).to include("editor #{default_bundle_path("bundler", "gems", "foo-1.0-#{ref}")}")
     end
 
     it "suggests alternatives for similar-sounding gems" do

--- a/bundler/spec/commands/remove_spec.rb
+++ b/bundler/spec/commands/remove_spec.rb
@@ -634,14 +634,14 @@ RSpec.describe "bundle remove" do
 
   context "with gemspec" do
     it "should not remove the gem" do
-      build_lib("foo", path: tmp.join("foo")) do |s|
+      build_lib("foo", path: tmp("foo")) do |s|
         s.write("foo.gemspec", "")
         s.add_dependency "rack"
       end
 
       install_gemfile(<<-G)
         source "#{file_uri_for(gem_repo1)}"
-        gemspec :path => '#{tmp.join("foo")}', :name => 'foo'
+        gemspec :path => '#{tmp("foo")}', :name => 'foo'
       G
 
       bundle "remove foo"

--- a/bundler/spec/install/gemfile/eval_gemfile_spec.rb
+++ b/bundler/spec/install/gemfile/eval_gemfile_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "bundle install with gemfile that uses eval_gemfile" do
   before do
-    build_lib("gunks", path: bundled_app.join("gems/gunks")) do |s|
+    build_lib("gunks", path: bundled_app("gems/gunks")) do |s|
       s.name    = "gunks"
       s.version = "0.0.1"
     end

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -39,14 +39,14 @@ RSpec.describe "bundle install from an existing gemspec" do
   end
 
   it "should install runtime and development dependencies" do
-    build_lib("foo", path: tmp.join("foo")) do |s|
+    build_lib("foo", path: tmp("foo")) do |s|
       s.write("Gemfile", "source :rubygems\ngemspec")
       s.add_dependency "bar", "=1.0.0"
       s.add_development_dependency "bar-dev", "=1.0.0"
     end
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}"
-      gemspec :path => '#{tmp.join("foo")}'
+      gemspec :path => '#{tmp("foo")}'
     G
 
     expect(the_bundle).to include_gems "bar 1.0.0"
@@ -54,16 +54,16 @@ RSpec.describe "bundle install from an existing gemspec" do
   end
 
   it "that is hidden should install runtime and development dependencies" do
-    build_lib("foo", path: tmp.join("foo")) do |s|
+    build_lib("foo", path: tmp("foo")) do |s|
       s.write("Gemfile", "source :rubygems\ngemspec")
       s.add_dependency "bar", "=1.0.0"
       s.add_development_dependency "bar-dev", "=1.0.0"
     end
-    FileUtils.mv tmp.join("foo", "foo.gemspec"), tmp.join("foo", ".gemspec")
+    FileUtils.mv tmp("foo", "foo.gemspec"), tmp("foo", ".gemspec")
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}"
-      gemspec :path => '#{tmp.join("foo")}'
+      gemspec :path => '#{tmp("foo")}'
     G
 
     expect(the_bundle).to include_gems "bar 1.0.0"
@@ -76,42 +76,42 @@ RSpec.describe "bundle install from an existing gemspec" do
       build_gem "baz", "1.1"
     end
 
-    build_lib("foo", path: tmp.join("foo")) do |s|
+    build_lib("foo", path: tmp("foo")) do |s|
       s.write("Gemfile", "source :rubygems\ngemspec")
       s.add_dependency "baz", ">= 1.0", "< 1.1"
     end
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}"
-      gemspec :path => '#{tmp.join("foo")}'
+      gemspec :path => '#{tmp("foo")}'
     G
 
     expect(the_bundle).to include_gems "baz 1.0"
   end
 
   it "should raise if there are no gemspecs available" do
-    build_lib("foo", path: tmp.join("foo"), gemspec: false)
+    build_lib("foo", path: tmp("foo"), gemspec: false)
 
     install_gemfile <<-G, raise_on_error: false
       source "#{file_uri_for(gem_repo2)}"
-      gemspec :path => '#{tmp.join("foo")}'
+      gemspec :path => '#{tmp("foo")}'
     G
-    expect(err).to match(/There are no gemspecs at #{tmp.join("foo")}/)
+    expect(err).to match(/There are no gemspecs at #{tmp("foo")}/)
   end
 
   it "should raise if there are too many gemspecs available" do
-    build_lib("foo", path: tmp.join("foo")) do |s|
+    build_lib("foo", path: tmp("foo")) do |s|
       s.write("foo2.gemspec", build_spec("foo", "4.0").first.to_ruby)
     end
 
     install_gemfile <<-G, raise_on_error: false
       source "#{file_uri_for(gem_repo2)}"
-      gemspec :path => '#{tmp.join("foo")}'
+      gemspec :path => '#{tmp("foo")}'
     G
-    expect(err).to match(/There are multiple gemspecs at #{tmp.join("foo")}/)
+    expect(err).to match(/There are multiple gemspecs at #{tmp("foo")}/)
   end
 
   it "should pick a specific gemspec" do
-    build_lib("foo", path: tmp.join("foo")) do |s|
+    build_lib("foo", path: tmp("foo")) do |s|
       s.write("foo2.gemspec", "")
       s.add_dependency "bar", "=1.0.0"
       s.add_development_dependency "bar-dev", "=1.0.0"
@@ -119,7 +119,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
     install_gemfile(<<-G)
       source "#{file_uri_for(gem_repo2)}"
-      gemspec :path => '#{tmp.join("foo")}', :name => 'foo'
+      gemspec :path => '#{tmp("foo")}', :name => 'foo'
     G
 
     expect(the_bundle).to include_gems "bar 1.0.0"
@@ -127,7 +127,7 @@ RSpec.describe "bundle install from an existing gemspec" do
   end
 
   it "should use a specific group for development dependencies" do
-    build_lib("foo", path: tmp.join("foo")) do |s|
+    build_lib("foo", path: tmp("foo")) do |s|
       s.write("foo2.gemspec", "")
       s.add_dependency "bar", "=1.0.0"
       s.add_development_dependency "bar-dev", "=1.0.0"
@@ -135,7 +135,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
     install_gemfile(<<-G)
       source "#{file_uri_for(gem_repo2)}"
-      gemspec :path => '#{tmp.join("foo")}', :name => 'foo', :development_group => :dev
+      gemspec :path => '#{tmp("foo")}', :name => 'foo', :development_group => :dev
     G
 
     expect(the_bundle).to include_gems "bar 1.0.0"
@@ -144,33 +144,33 @@ RSpec.describe "bundle install from an existing gemspec" do
   end
 
   it "should match a lockfile even if the gemspec defines development dependencies" do
-    build_lib("foo", path: tmp.join("foo")) do |s|
+    build_lib("foo", path: tmp("foo")) do |s|
       s.write("Gemfile", "source '#{file_uri_for(gem_repo1)}'\ngemspec")
       s.add_dependency "actionpack", "=2.3.2"
       s.add_development_dependency "rake", rake_version
     end
 
-    bundle "install", dir: tmp.join("foo")
+    bundle "install", dir: tmp("foo")
     # This should really be able to rely on $stderr, but, it's not written
     # right, so we can't. In fact, this is a bug negation test, and so it'll
     # ghost pass in future, and will only catch a regression if the message
     # doesn't change. Exit codes should be used correctly (they can be more
     # than just 0 and 1).
     bundle "config set --local deployment true"
-    output = bundle("install", dir: tmp.join("foo"))
+    output = bundle("install", dir: tmp("foo"))
     expect(output).not_to match(/You have added to the Gemfile/)
     expect(output).not_to match(/You have deleted from the Gemfile/)
     expect(output).not_to match(/the lockfile can't be updated because frozen mode is set/)
   end
 
   it "should match a lockfile without needing to re-resolve" do
-    build_lib("foo", path: tmp.join("foo")) do |s|
+    build_lib("foo", path: tmp("foo")) do |s|
       s.add_dependency "rack"
     end
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
-      gemspec :path => '#{tmp.join("foo")}'
+      gemspec :path => '#{tmp("foo")}'
     G
 
     bundle "install", verbose: true
@@ -182,14 +182,14 @@ RSpec.describe "bundle install from an existing gemspec" do
   it "should match a lockfile without needing to re-resolve with development dependencies" do
     simulate_platform java
 
-    build_lib("foo", path: tmp.join("foo")) do |s|
+    build_lib("foo", path: tmp("foo")) do |s|
       s.add_dependency "rack"
       s.add_development_dependency "thin"
     end
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
-      gemspec :path => '#{tmp.join("foo")}'
+      gemspec :path => '#{tmp("foo")}'
     G
 
     bundle "install", verbose: true
@@ -199,14 +199,14 @@ RSpec.describe "bundle install from an existing gemspec" do
   end
 
   it "should match a lockfile on non-ruby platforms with a transitive platform dependency", :jruby_only do
-    build_lib("foo", path: tmp.join("foo")) do |s|
+    build_lib("foo", path: tmp("foo")) do |s|
       s.add_dependency "platform_specific"
     end
 
     system_gems "platform_specific-1.0-java", path: default_bundle_path
 
     install_gemfile <<-G
-      gemspec :path => '#{tmp.join("foo")}'
+      gemspec :path => '#{tmp("foo")}'
     G
 
     bundle "update --bundler", artifice: "compact_index", verbose: true
@@ -214,13 +214,13 @@ RSpec.describe "bundle install from an existing gemspec" do
   end
 
   it "should evaluate the gemspec in its directory" do
-    build_lib("foo", path: tmp.join("foo"))
-    File.open(tmp.join("foo/foo.gemspec"), "w") do |s|
-      s.write "raise 'ahh' unless Dir.pwd == '#{tmp.join("foo")}'"
+    build_lib("foo", path: tmp("foo"))
+    File.open(tmp("foo/foo.gemspec"), "w") do |s|
+      s.write "raise 'ahh' unless Dir.pwd == '#{tmp("foo")}'"
     end
 
     install_gemfile <<-G, raise_on_error: false
-      gemspec :path => '#{tmp.join("foo")}'
+      gemspec :path => '#{tmp("foo")}'
     G
     expect(last_command.stdboth).not_to include("ahh")
   end
@@ -248,7 +248,7 @@ RSpec.describe "bundle install from an existing gemspec" do
   end
 
   it "allows conflicts" do
-    build_lib("foo", path: tmp.join("foo")) do |s|
+    build_lib("foo", path: tmp("foo")) do |s|
       s.version = "1.0.0"
       s.add_dependency "bar", "= 1.0.0"
     end
@@ -260,14 +260,14 @@ RSpec.describe "bundle install from an existing gemspec" do
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}"
       gem "deps"
-      gemspec :path => '#{tmp.join("foo")}', :name => 'foo'
+      gemspec :path => '#{tmp("foo")}', :name => 'foo'
     G
 
     expect(the_bundle).to include_gems "foo 1.0.0"
   end
 
   it "does not break Gem.finish_resolve with conflicts" do
-    build_lib("foo", path: tmp.join("foo")) do |s|
+    build_lib("foo", path: tmp("foo")) do |s|
       s.version = "1.0.0"
       s.add_dependency "bar", "= 1.0.0"
     end
@@ -281,7 +281,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}"
       gem "deps"
-      gemspec :path => '#{tmp.join("foo")}', :name => 'foo'
+      gemspec :path => '#{tmp("foo")}', :name => 'foo'
     G
 
     expect(the_bundle).to include_gems "foo 1.0.0"
@@ -359,7 +359,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     let(:source_uri) { "http://localgemserver.test" }
 
     before do
-      build_lib("foo", path: tmp.join("foo")) do |s|
+      build_lib("foo", path: tmp("foo")) do |s|
         s.add_dependency "rack", "=1.0.0"
       end
 
@@ -398,7 +398,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     context "using JRuby with explicit platform", :jruby_only do
       before do
         create_file(
-          tmp.join("foo", "foo-java.gemspec"),
+          tmp("foo", "foo-java.gemspec"),
           build_spec("foo", "1.0", "java") do
             dep "rack", "=1.0.0"
             @spec.authors = "authors"
@@ -589,7 +589,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
   context "with multiple platforms" do
     before do
-      build_lib("foo", path: tmp.join("foo")) do |s|
+      build_lib("foo", path: tmp("foo")) do |s|
         s.version = "1.0.0"
         s.add_development_dependency "rack"
         s.write "foo-universal-java.gemspec", build_spec("foo", "1.0.0", "universal-java") {|sj| sj.runtime "rack", "1.0.0" }.first.to_ruby
@@ -601,7 +601,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
-        gemspec :path => '#{tmp.join("foo")}', :name => 'foo'
+        gemspec :path => '#{tmp("foo")}', :name => 'foo'
       G
 
       expect(the_bundle).to include_gems "foo 1.0.0", "rack 1.0.0"
@@ -613,7 +613,7 @@ RSpec.describe "bundle install from an existing gemspec" do
       bundle "config set --local without development"
       install_gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
-        gemspec :path => '#{tmp.join("foo")}', :name => 'foo'
+        gemspec :path => '#{tmp("foo")}', :name => 'foo'
       G
 
       expect(the_bundle).to include_gem "foo 1.0.0"
@@ -623,7 +623,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
   context "with multiple platforms and resolving for more specific platforms" do
     before do
-      build_lib("chef", path: tmp.join("chef")) do |s|
+      build_lib("chef", path: tmp("chef")) do |s|
         s.version = "17.1.17"
         s.write "chef-universal-mingw32.gemspec", build_spec("chef", "17.1.17", "universal-mingw32") {|sw| sw.runtime "win32-api", "~> 1.5.3" }.first.to_ruby
       end
@@ -682,7 +682,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
   context "with multiple locked platforms" do
     before do
-      build_lib("activeadmin", path: tmp.join("activeadmin")) do |s|
+      build_lib("activeadmin", path: tmp("activeadmin")) do |s|
         s.version = "2.9.0"
         s.add_dependency "railties", ">= 5.2", "< 6.2"
       end
@@ -735,7 +735,7 @@ RSpec.describe "bundle install from an existing gemspec" do
            #{Bundler::VERSION}
       L
 
-      gemspec = tmp.join("activeadmin/activeadmin.gemspec")
+      gemspec = tmp("activeadmin/activeadmin.gemspec")
       File.write(gemspec, File.read(gemspec).sub(">= 5.2", ">= 6.0"))
 
       previous_lockfile = lockfile

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe "bundle install with git sources" do
         s.write("lib/foo.rb", "raise 'FAIL'")
       end
 
-      sys_exec("git update-ref -m \"Bundler Spec!\" refs/bundler/1 main~1", dir: lib_path("foo-1.0"))
+      git("update-ref -m \"Bundler Spec!\" refs/bundler/1 main~1", lib_path("foo-1.0"))
 
       # want to ensure we don't fallback to HEAD
       update_git "foo", path: lib_path("foo-1.0"), branch: "rando" do |s|
@@ -308,7 +308,7 @@ RSpec.describe "bundle install with git sources" do
         s.write("lib/foo.rb", "raise 'FAIL'")
       end
 
-      sys_exec("git update-ref -m \"Bundler Spec!\" refs/bundler/1 main~1", dir: lib_path("foo-1.0"))
+      git("update-ref -m \"Bundler Spec!\" refs/bundler/1 main~1", lib_path("foo-1.0"))
 
       # want to ensure we don't fallback to HEAD
       update_git "foo", path: lib_path("foo-1.0"), branch: "rando" do |s|
@@ -332,7 +332,7 @@ RSpec.describe "bundle install with git sources" do
     end
 
     it "does not download random non-head refs" do
-      sys_exec("git update-ref -m \"Bundler Spec!\" refs/bundler/1 main~1", dir: lib_path("foo-1.0"))
+      git("update-ref -m \"Bundler Spec!\" refs/bundler/1 main~1", lib_path("foo-1.0"))
 
       bundle "config set global_gem_cache true"
 
@@ -346,7 +346,7 @@ RSpec.describe "bundle install with git sources" do
       # ensure we also git fetch after cloning
       bundle :update, all: true
 
-      sys_exec("git ls-remote .", dir: Dir[home(".bundle/cache/git/foo-*")].first)
+      git("ls-remote .", Dir[home(".bundle/cache/git/foo-*")].first)
 
       expect(out).not_to include("refs/bundler/1")
     end
@@ -906,7 +906,7 @@ RSpec.describe "bundle install with git sources" do
     bundle "update", all: true
     expect(the_bundle).to include_gems "forced 1.1"
 
-    sys_exec("git reset --hard HEAD^", dir: lib_path("forced-1.0"))
+    git("reset --hard HEAD^", lib_path("forced-1.0"))
 
     bundle "update", all: true
     expect(the_bundle).to include_gems "forced 1.0"
@@ -920,8 +920,8 @@ RSpec.describe "bundle install with git sources" do
     build_git "has_submodule", "1.0" do |s|
       s.add_dependency "submodule"
     end
-    sys_exec "git submodule add #{lib_path("submodule-1.0")} submodule-1.0", dir: lib_path("has_submodule-1.0")
-    sys_exec "git commit -m \"submodulator\"", dir: lib_path("has_submodule-1.0")
+    git "submodule add #{lib_path("submodule-1.0")} submodule-1.0", lib_path("has_submodule-1.0")
+    git "commit -m \"submodulator\"", lib_path("has_submodule-1.0")
 
     install_gemfile <<-G, raise_on_error: false
       source "#{file_uri_for(gem_repo1)}"
@@ -942,8 +942,8 @@ RSpec.describe "bundle install with git sources" do
     build_git "has_submodule", "1.0" do |s|
       s.add_dependency "submodule"
     end
-    sys_exec "git submodule add #{lib_path("submodule-1.0")} submodule-1.0", dir: lib_path("has_submodule-1.0")
-    sys_exec "git commit -m \"submodulator\"", dir: lib_path("has_submodule-1.0")
+    git "submodule add #{lib_path("submodule-1.0")} submodule-1.0", lib_path("has_submodule-1.0")
+    git "commit -m \"submodulator\"", lib_path("has_submodule-1.0")
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -962,8 +962,8 @@ RSpec.describe "bundle install with git sources" do
     build_git "submodule", "1.0"
     build_git "has_submodule", "1.0"
 
-    sys_exec "git submodule add #{lib_path("submodule-1.0")} submodule-1.0", dir: lib_path("has_submodule-1.0")
-    sys_exec "git commit -m \"submodulator\"", dir: lib_path("has_submodule-1.0")
+    git "submodule add #{lib_path("submodule-1.0")} submodule-1.0", lib_path("has_submodule-1.0")
+    git "commit -m \"submodulator\"", lib_path("has_submodule-1.0")
 
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -1292,7 +1292,7 @@ RSpec.describe "bundle install with git sources" do
             void Init_foo() { rb_define_global_function("foo", &foo, 0); }
           C
         end
-        sys_exec("git commit -m \"commit for iteration #{i}\" ext/foo.c", dir: git_reader.path)
+        git("commit -m \"commit for iteration #{i}\" ext/foo.c", git_reader.path)
 
         git_commit_sha = git_reader.ref_for("HEAD")
 

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "bundle install with git sources" do
     end
 
     it "does not write to cache on bundler/setup" do
-      cache_path = default_bundle_path.join("cache")
+      cache_path = default_bundle_path("cache")
       FileUtils.rm_rf(cache_path)
       ruby "require 'bundler/setup'"
       expect(cache_path).not_to exist
@@ -59,7 +59,7 @@ RSpec.describe "bundle install with git sources" do
       bundle "update foo"
 
       sha = git.ref_for("main", 11)
-      spec_file = default_bundle_path.join("bundler/gems/foo-1.0-#{sha}/foo.gemspec")
+      spec_file = default_bundle_path("bundler/gems/foo-1.0-#{sha}/foo.gemspec")
       expect(spec_file).to exist
       ruby_code = Gem::Specification.load(spec_file.to_s).to_ruby
       file_code = File.read(spec_file)

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -1484,14 +1484,14 @@ RSpec.describe "bundle install with gems on multiple sources" do
         build_gem "bar"
       end
 
-      build_lib("gemspec_test", path: tmp.join("gemspec_test")) do |s|
+      build_lib("gemspec_test", path: tmp("gemspec_test")) do |s|
         s.add_dependency "bar", "=1.0.0"
       end
 
       install_gemfile <<-G, artifice: "compact_index"
         source "https://gem.repo2"
         gem "rack"
-        gemspec :path => "#{tmp.join("gemspec_test")}"
+        gemspec :path => "#{tmp("gemspec_test")}"
       G
     end
 
@@ -1506,7 +1506,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         build_gem "bar"
       end
 
-      build_lib("gemspec_test", path: tmp.join("gemspec_test")) do |s|
+      build_lib("gemspec_test", path: tmp("gemspec_test")) do |s|
         s.add_development_dependency "bar"
       end
 
@@ -1517,7 +1517,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           gem "bar"
         end
 
-        gemspec :path => "#{tmp.join("gemspec_test")}"
+        gemspec :path => "#{tmp("gemspec_test")}"
       G
     end
 

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -1117,7 +1117,7 @@ RSpec.describe "the lockfile format" do
   end
 
   it "stores relative paths when the path is provided for gemspec" do
-    build_lib("foo", path: tmp.join("foo"))
+    build_lib("foo", path: tmp("foo"))
 
     checksums = checksums_section_when_existing do |c|
       c.no_checksum "foo", "1.0"

--- a/bundler/spec/runtime/gem_tasks_spec.rb
+++ b/bundler/spec/runtime/gem_tasks_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
 
   context "rake build when path has spaces", :ruby_repo do
     before do
-      spaced_bundled_app = tmp.join("bundled app")
+      spaced_bundled_app = tmp("bundled app")
       FileUtils.cp_r bundled_app, spaced_bundled_app
       bundle "exec rake build", dir: spaced_bundled_app
     end
@@ -69,7 +69,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
 
   context "rake build when path has brackets", :ruby_repo do
     before do
-      bracketed_bundled_app = tmp.join("bundled[app")
+      bracketed_bundled_app = tmp("bundled[app")
       FileUtils.cp_r bundled_app, bracketed_bundled_app
       bundle "exec rake build", dir: bracketed_bundled_app
     end

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -767,7 +767,7 @@ end
     expect(err).to be_empty
   end
 
-  it "can require rubygems without warnings, when using a local cache" do
+  it "can require rubygems without warnings, when using a local cache", :truffleruby do
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
       gem "rack"

--- a/bundler/spec/support/build_metadata.rb
+++ b/bundler/spec/support/build_metadata.rb
@@ -41,7 +41,7 @@ module Spec
     end
 
     def git_commit_sha
-      ruby_core_tarball? ? "unknown" : sys_exec("git rev-parse --short HEAD", dir: source_root).strip
+      ruby_core_tarball? ? "unknown" : git("rev-parse --short HEAD", source_root).strip
     end
 
     extend self

--- a/bundler/spec/support/env.rb
+++ b/bundler/spec/support/env.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Spec
+  module Env
+    def ruby_core?
+      !ENV["GEM_COMMAND"].nil?
+    end
+  end
+end

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -177,7 +177,7 @@ module Spec
       "#{Gem.ruby} -S #{ENV["GEM_PATH"]}/bin/rake"
     end
 
-    def git(cmd, path, options = {})
+    def git(cmd, path = Dir.pwd, options = {})
       sys_exec("git #{cmd}", options.merge(dir: path))
     end
 
@@ -510,7 +510,7 @@ module Spec
     end
 
     def revision_for(path)
-      sys_exec("git rev-parse HEAD", dir: path).strip
+      git("rev-parse HEAD", path).strip
     end
 
     def with_read_only(pattern)

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -124,7 +124,7 @@ module Spec
     end
 
     def bundler(cmd, options = {})
-      options[:bundle_bin] = system_gem_path.join("bin/bundler")
+      options[:bundle_bin] = system_gem_path("bin/bundler")
       bundle(cmd, options)
     end
 

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
-require_relative "command_execution"
 require_relative "the_bundle"
 require_relative "path"
+require_relative "options"
+require_relative "subprocess"
 
 module Spec
   module Helpers
     include Spec::Path
+    include Spec::Options
+    include Spec::Subprocess
 
     class TimeoutExceeded < StandardError; end
 
@@ -29,22 +32,6 @@ module Spec
       TheBundle.new(*args)
     end
 
-    def command_executions
-      @command_executions ||= []
-    end
-
-    def last_command
-      command_executions.last || raise("There is no last command")
-    end
-
-    def out
-      last_command.stdout
-    end
-
-    def err
-      last_command.stderr
-    end
-
     MAJOR_DEPRECATION = /^\[DEPRECATED\]\s*/
 
     def err_without_deprecations
@@ -53,10 +40,6 @@ module Spec
 
     def deprecations
       err.split("\n").select {|l| l =~ MAJOR_DEPRECATION }.join("\n").split(MAJOR_DEPRECATION)
-    end
-
-    def exitstatus
-      last_command.exitstatus
     end
 
     def run(cmd, *args)
@@ -177,83 +160,13 @@ module Spec
       "#{Gem.ruby} -S #{ENV["GEM_PATH"]}/bin/rake"
     end
 
-    def git(cmd, path = Dir.pwd, options = {})
-      sys_exec("git #{cmd}", options.merge(dir: path))
-    end
-
-    def sys_exec(cmd, options = {})
+    def sys_exec(cmd, options = {}, &block)
       env = options[:env] || {}
       env["RUBYOPT"] = opt_add(opt_add("-r#{spec_dir}/support/switch_rubygems.rb", env["RUBYOPT"]), ENV["RUBYOPT"])
-      dir = options[:dir] || bundled_app
-      command_execution = CommandExecution.new(cmd.to_s, working_directory: dir, timeout: 60)
+      options[:env] = env
+      options[:dir] ||= bundled_app
 
-      require "open3"
-      require "shellwords"
-      Open3.popen3(env, *cmd.shellsplit, chdir: dir) do |stdin, stdout, stderr, wait_thr|
-        yield stdin, stdout, wait_thr if block_given?
-        stdin.close
-
-        stdout_handler = ->(data) { command_execution.original_stdout << data }
-        stderr_handler = ->(data) { command_execution.original_stderr << data }
-
-        stdout_thread = read_stream(stdout, stdout_handler, timeout: command_execution.timeout)
-        stderr_thread = read_stream(stderr, stderr_handler, timeout: command_execution.timeout)
-
-        stdout_thread.join
-        stderr_thread.join
-
-        status = wait_thr.value
-        command_execution.exitstatus = if status.exited?
-          status.exitstatus
-        elsif status.signaled?
-          exit_status_for_signal(status.termsig)
-        end
-      rescue TimeoutExceeded
-        command_execution.failure_reason = :timeout
-        command_execution.exitstatus = exit_status_for_signal(Signal.list["INT"])
-      end
-
-      unless options[:raise_on_error] == false || command_execution.success?
-        command_execution.raise_error!
-      end
-
-      command_executions << command_execution
-
-      command_execution.stdout
-    end
-
-    # Mostly copied from https://github.com/piotrmurach/tty-command/blob/49c37a895ccea107e8b78d20e4cb29de6a1a53c8/lib/tty/command/process_runner.rb#L165-L193
-    def read_stream(stream, handler, timeout:)
-      Thread.new do
-        Thread.current.report_on_exception = false
-        cmd_start = Time.now
-        readers = [stream]
-
-        while readers.any?
-          ready = IO.select(readers, nil, readers, timeout)
-          raise TimeoutExceeded if ready.nil?
-
-          ready[0].each do |reader|
-            chunk = reader.readpartial(16 * 1024)
-            handler.call(chunk)
-
-            # control total time spent reading
-            runtime = Time.now - cmd_start
-            time_left = timeout - runtime
-            raise TimeoutExceeded if time_left < 0.0
-          rescue Errno::EAGAIN, Errno::EINTR
-          rescue EOFError, Errno::EPIPE, Errno::EIO
-            readers.delete(reader)
-            reader.close
-          end
-        end
-      end
-    end
-
-    def all_commands_output
-      return "" if command_executions.empty?
-
-      "\n\nCommands:\n#{command_executions.map(&:to_s_verbose).join("\n\n")}"
+      sh(cmd, options, &block)
     end
 
     def config(config = nil, path = bundled_app(".bundle/config"))
@@ -398,16 +311,6 @@ module Spec
       with_path_as([path.to_s, ENV["PATH"]].join(File::PATH_SEPARATOR)) do
         yield
       end
-    end
-
-    def opt_add(option, options)
-      [option.strip, options].compact.reject(&:empty?).join(" ")
-    end
-
-    def opt_remove(option, options)
-      return unless options
-
-      options.split(" ").reject {|opt| opt.strip == option.strip }.join(" ")
     end
 
     def break_git!

--- a/bundler/spec/support/options.rb
+++ b/bundler/spec/support/options.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Spec
+  module Options
+    def opt_add(option, options)
+      [option.strip, options].compact.reject(&:empty?).join(" ")
+    end
+
+    def opt_remove(option, options)
+      return unless options
+
+      options.split(" ").reject {|opt| opt.strip == option.strip }.join(" ")
+    end
+  end
+end

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -270,7 +270,7 @@ module Spec
     def git_ls_files(glob)
       skip "Not running on a git context, since running tests from a tarball" if ruby_core_tarball?
 
-      sys_exec("git ls-files -z -- #{glob}", dir: source_root).split("\x0")
+      git("ls-files -z -- #{glob}", source_root).split("\x0")
     end
 
     def tracked_files_glob

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -3,8 +3,12 @@
 require "pathname"
 require "rbconfig"
 
+require_relative "env"
+
 module Spec
   module Path
+    include Spec::Env
+
     def source_root
       @source_root ||= Pathname.new(ruby_core? ? "../../.." : "../..").expand_path(__dir__)
     end
@@ -255,10 +259,6 @@ module Spec
       contents = File.read(gemspec_file)
       contents.sub!(/(^\s+s\.required_ruby_version\s*=\s*)"[^"]+"/, %(\\1"#{version}"))
       File.open(gemspec_file, "w") {|f| f << contents }
-    end
-
-    def ruby_core?
-      !ENV["GEM_COMMAND"].nil?
     end
 
     def git_root

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -109,7 +109,7 @@ module Spec
     end
 
     def home(*path)
-      tmp.join("home", *path)
+      tmp("home", *path)
     end
 
     def default_bundle_path(*path)
@@ -129,13 +129,13 @@ module Spec
     end
 
     def bundled_app(*path)
-      root = tmp.join("bundled_app")
+      root = tmp("bundled_app")
       FileUtils.mkdir_p(root)
       root.join(*path)
     end
 
     def bundled_app2(*path)
-      root = tmp.join("bundled_app2")
+      root = tmp("bundled_app2")
       FileUtils.mkdir_p(root)
       root.join(*path)
     end
@@ -161,15 +161,15 @@ module Spec
     end
 
     def base_system_gems
-      tmp.join("gems/base")
+      tmp("gems/base")
     end
 
     def rubocop_gems
-      tmp.join("gems/rubocop")
+      tmp("gems/rubocop")
     end
 
     def standard_gems
-      tmp.join("gems/standard")
+      tmp("gems/standard")
     end
 
     def file_uri_for(path)

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -258,14 +258,7 @@ module Spec
     end
 
     def ruby_core?
-      # avoid to warnings
-      @ruby_core ||= nil
-
-      if @ruby_core.nil?
-        @ruby_core = true & ENV["GEM_COMMAND"]
-      else
-        @ruby_core
-      end
+      !ENV["GEM_COMMAND"].nil?
     end
 
     def git_root

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -58,7 +58,7 @@ module Spec
     end
 
     def gem_bin
-      @gem_bin ||= ruby_core? ? ENV["GEM_COMMAND"] : "gem"
+      @gem_bin ||= ENV["GEM_COMMAND"] || "gem"
     end
 
     def path

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -70,7 +70,7 @@ module Spec
 
       ENV["BUNDLE_PATH"] = nil
       ENV["GEM_HOME"] = ENV["GEM_PATH"] = Path.base_system_gem_path.to_s
-      ENV["PATH"] = [Path.system_gem_path.join("bin"), ENV["PATH"]].join(File::PATH_SEPARATOR)
+      ENV["PATH"] = [Path.system_gem_path("bin"), ENV["PATH"]].join(File::PATH_SEPARATOR)
       ENV["PATH"] = [Path.bindir, ENV["PATH"]].join(File::PATH_SEPARATOR) if Path.ruby_core?
     end
 

--- a/bundler/spec/support/rubygems_version_manager.rb
+++ b/bundler/spec/support/rubygems_version_manager.rb
@@ -65,7 +65,7 @@ class RubygemsVersionManager
   def switch_local_copy_if_needed
     return unless local_copy_switch_needed?
 
-    sys_exec("git checkout #{target_tag}", dir: local_copy_path)
+    git("checkout #{target_tag}", local_copy_path)
 
     ENV["RGV"] = local_copy_path.to_s
   end
@@ -84,7 +84,7 @@ class RubygemsVersionManager
   end
 
   def local_copy_tag
-    sys_exec("git rev-parse --abbrev-ref HEAD", dir: local_copy_path)
+    git("rev-parse --abbrev-ref HEAD", local_copy_path)
   end
 
   def local_copy_path
@@ -97,7 +97,7 @@ class RubygemsVersionManager
     rubygems_path = source_root.join("tmp/rubygems")
 
     unless rubygems_path.directory?
-      sys_exec("git clone .. #{rubygems_path}", dir: source_root)
+      git("clone .. #{rubygems_path}", source_root)
     end
 
     rubygems_path

--- a/bundler/spec/support/rubygems_version_manager.rb
+++ b/bundler/spec/support/rubygems_version_manager.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
-require "pathname"
-require_relative "helpers"
-require_relative "path"
+require_relative "options"
+require_relative "env"
+require_relative "subprocess"
 
 class RubygemsVersionManager
-  include Spec::Helpers
-  include Spec::Path
+  include Spec::Options
+  include Spec::Env
+  include Spec::Subprocess
 
   def initialize(source)
     @source = source
@@ -57,7 +58,7 @@ class RubygemsVersionManager
 
     cmd = [RbConfig.ruby, $0, *ARGV].compact
 
-    ENV["RUBYOPT"] = opt_add("-I#{local_copy_path.join("lib")}", opt_remove("--disable-gems", ENV["RUBYOPT"]))
+    ENV["RUBYOPT"] = opt_add("-I#{File.join(local_copy_path, "lib")}", opt_remove("--disable-gems", ENV["RUBYOPT"]))
 
     exec(ENV, *cmd)
   end
@@ -67,12 +68,12 @@ class RubygemsVersionManager
 
     git("checkout #{target_tag}", local_copy_path)
 
-    ENV["RGV"] = local_copy_path.to_s
+    ENV["RGV"] = local_copy_path
   end
 
   def rubygems_unrequire_needed?
     require "rubygems"
-    !$LOADED_FEATURES.include?(local_copy_path.join("lib/rubygems.rb").to_s)
+    !$LOADED_FEATURES.include?(File.join(local_copy_path, "lib/rubygems.rb"))
   end
 
   def local_copy_switch_needed?
@@ -94,9 +95,9 @@ class RubygemsVersionManager
   def resolve_local_copy_path
     return expanded_source if source_is_path?
 
-    rubygems_path = source_root.join("tmp/rubygems")
+    rubygems_path = File.join(source_root, "tmp/rubygems")
 
-    unless rubygems_path.directory?
+    unless File.directory?(rubygems_path)
       git("clone .. #{rubygems_path}", source_root)
     end
 
@@ -104,11 +105,15 @@ class RubygemsVersionManager
   end
 
   def source_is_path?
-    expanded_source.directory?
+    File.directory?(expanded_source)
   end
 
   def expanded_source
-    @expanded_source ||= Pathname.new(@source).expand_path(source_root)
+    @expanded_source ||= File.expand_path(@source, source_root)
+  end
+
+  def source_root
+    @source_root ||= File.expand_path(ruby_core? ? "../../.." : "../..", __dir__)
   end
 
   def resolve_target_tag

--- a/bundler/spec/support/subprocess.rb
+++ b/bundler/spec/support/subprocess.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require_relative "command_execution"
+
+module Spec
+  module Subprocess
+    def command_executions
+      @command_executions ||= []
+    end
+
+    def last_command
+      command_executions.last || raise("There is no last command")
+    end
+
+    def out
+      last_command.stdout
+    end
+
+    def err
+      last_command.stderr
+    end
+
+    def exitstatus
+      last_command.exitstatus
+    end
+
+    def git(cmd, path = Dir.pwd, options = {})
+      sh("git #{cmd}", options.merge(dir: path))
+    end
+
+    def sh(cmd, options = {})
+      dir = options[:dir]
+      env = options[:env] || {}
+
+      command_execution = CommandExecution.new(cmd.to_s, working_directory: dir, timeout: 60)
+
+      require "open3"
+      require "shellwords"
+      Open3.popen3(env, *cmd.shellsplit, chdir: dir) do |stdin, stdout, stderr, wait_thr|
+        yield stdin, stdout, wait_thr if block_given?
+        stdin.close
+
+        stdout_handler = ->(data) { command_execution.original_stdout << data }
+        stderr_handler = ->(data) { command_execution.original_stderr << data }
+
+        stdout_thread = read_stream(stdout, stdout_handler, timeout: command_execution.timeout)
+        stderr_thread = read_stream(stderr, stderr_handler, timeout: command_execution.timeout)
+
+        stdout_thread.join
+        stderr_thread.join
+
+        status = wait_thr.value
+        command_execution.exitstatus = if status.exited?
+          status.exitstatus
+        elsif status.signaled?
+          exit_status_for_signal(status.termsig)
+        end
+      rescue TimeoutExceeded
+        command_execution.failure_reason = :timeout
+        command_execution.exitstatus = exit_status_for_signal(Signal.list["INT"])
+      end
+
+      unless options[:raise_on_error] == false || command_execution.success?
+        command_execution.raise_error!
+      end
+
+      command_executions << command_execution
+
+      command_execution.stdout
+    end
+
+    # Mostly copied from https://github.com/piotrmurach/tty-command/blob/49c37a895ccea107e8b78d20e4cb29de6a1a53c8/lib/tty/command/process_runner.rb#L165-L193
+    def read_stream(stream, handler, timeout:)
+      Thread.new do
+        Thread.current.report_on_exception = false
+        cmd_start = Time.now
+        readers = [stream]
+
+        while readers.any?
+          ready = IO.select(readers, nil, readers, timeout)
+          raise TimeoutExceeded if ready.nil?
+
+          ready[0].each do |reader|
+            chunk = reader.readpartial(16 * 1024)
+            handler.call(chunk)
+
+            # control total time spent reading
+            runtime = Time.now - cmd_start
+            time_left = timeout - runtime
+            raise TimeoutExceeded if time_left < 0.0
+          rescue Errno::EAGAIN, Errno::EINTR
+          rescue EOFError, Errno::EPIPE, Errno::EIO
+            readers.delete(reader)
+            reader.close
+          end
+        end
+      end
+    end
+
+    def all_commands_output
+      return "" if command_executions.empty?
+
+      "\n\nCommands:\n#{command_executions.map(&:to_s_verbose).join("\n\n")}"
+    end
+  end
+end

--- a/bundler/spec/update/git_spec.rb
+++ b/bundler/spec/update/git_spec.rb
@@ -142,8 +142,8 @@ RSpec.describe "bundle update" do
           s.add_dependency "submodule"
         end
 
-        sys_exec "git submodule add #{lib_path("submodule-1.0")} submodule-1.0", dir: lib_path("has_submodule-1.0")
-        sys_exec "git commit -m \"submodulator\"", dir: lib_path("has_submodule-1.0")
+        git "submodule add #{lib_path("submodule-1.0")} submodule-1.0", lib_path("has_submodule-1.0")
+        git "commit -m \"submodulator\"", lib_path("has_submodule-1.0")
       end
 
       it "it unlocks the source when submodules are added to a git source" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

After `require "pathname"` was removed at https://github.com/rubygems/rubygems/commit/8c8aaecc48134861a788109b87a82b9e5b145c6e, `bundle exec` no longer works in truffleruby.

## What is your fix for the problem, implemented in this PR?

After the `require "pathname"` removal, what's providing `pathname` is this autoload:

https://github.com/rubygems/rubygems/blob/b678d920a695a9480334518d56a62c7c7249a94e/bundler/lib/bundler/shared_helpers.rb#L13

However, that kind of `autoload` under a module is not recommended (warns in verbose mode since Ruby 3.2) and does not work at all in truffleruby.

Moving the autoload to the top level fixes things.

This PR also includes a few refactorings to our tests, to avoid specs loading `pathname` by default before `bundler` code actually takes over, making this issue actually surface.

Closes #7696.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
