### PR TITLE
Fix duplicated config keys generated when `fallback_timeout` uri option is used

### DIFF
--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -493,7 +493,7 @@ module Bundler
         return {} unless valid_file
         serializer_class.load(file.read).inject({}) do |config, (k, v)|
           k = k.dup
-          k << "/" if /https?:/i.match?(k) && !%r{/\Z}.match?(k)
+          k << "/" if /https?:/i.match?(k) && !k.end_with?("/", "__#{FALLBACK_TIMEOUT_URI_OPTION.upcase}")
           k.gsub!(".", "__")
 
           unless k.start_with?("#")

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -538,7 +538,7 @@ module Bundler
       key.gsub!("-", "___")
       key.upcase!
 
-      key.prepend("BUNDLE_")
+      key.gsub(/\A([ #]*)/, '\1BUNDLE_')
     end
 
     # TODO: duplicates Rubygems#normalize_uri

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -523,16 +523,14 @@ module Bundler
       YAMLSerializer
     end
 
-    PER_URI_OPTIONS = %w[
-      fallback_timeout
-    ].freeze
+    FALLBACK_TIMEOUT_URI_OPTION = "fallback_timeout"
 
     NORMALIZE_URI_OPTIONS_PATTERN =
       /
         \A
         (\w+\.)? # optional prefix key
         (https?.*?) # URI
-        (\.#{Regexp.union(PER_URI_OPTIONS)})? # optional suffix key
+        (\.#{FALLBACK_TIMEOUT_URI_OPTION})? # optional suffix key
         \z
       /ix
 

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -492,6 +492,10 @@ module Bundler
         valid_file = file.exist? && !file.size.zero?
         return {} unless valid_file
         serializer_class.load(file.read).inject({}) do |config, (k, v)|
+          k = k.dup
+          k << "/" if /https?:/i.match?(k) && !%r{/\Z}.match?(k)
+          k.gsub!(".", "__")
+
           unless k.start_with?("#")
             if k.include?("-")
               Bundler.ui.warn "Your #{file} config includes `#{k}`, which contains the dash character (`-`).\n" \

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -533,7 +533,7 @@ module Bundler
       /ix
 
     def self.key_for(key)
-      key = normalize_uri(key).to_s if key.is_a?(String) && key.start_with?("http", "mirror.http")
+      key = normalize_uri(key) if key.is_a?(String) && key.start_with?("http", "mirror.http")
       key = key_to_s(key).gsub(".", "__")
       key.gsub!("-", "___")
       key.upcase!

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -533,8 +533,9 @@ module Bundler
       /ix
 
     def self.key_for(key)
-      key = normalize_uri(key) if key.is_a?(String) && key.start_with?("http", "mirror.http")
-      key = key_to_s(key).gsub(".", "__")
+      key = key_to_s(key)
+      key = normalize_uri(key) if key.start_with?("http", "mirror.http")
+      key = key.gsub(".", "__")
       key.gsub!("-", "___")
       key.upcase!
 

--- a/bundler/lib/bundler/yaml_serializer.rb
+++ b/bundler/lib/bundler/yaml_serializer.rb
@@ -60,7 +60,6 @@ module Bundler
           indent, key, quote, val = match.captures
           val = strip_comment(val)
 
-          convert_to_backward_compatible_key!(key)
           depth = indent.size / 2
           if quote.empty? && val.empty?
             new_hash = {}
@@ -92,14 +91,8 @@ module Bundler
       end
     end
 
-    # for settings' keys
-    def convert_to_backward_compatible_key!(key)
-      key << "/" if /https?:/i.match?(key) && !%r{/\Z}.match?(key)
-      key.gsub!(".", "__")
-    end
-
     class << self
-      private :dump_hash, :convert_to_backward_compatible_key!
+      private :dump_hash
     end
   end
 end

--- a/bundler/spec/commands/config_spec.rb
+++ b/bundler/spec/commands/config_spec.rb
@@ -447,7 +447,7 @@ E
     it "does not make bundler crash and ignores the configuration" do
       bundle "config list --parseable"
 
-      expect(out).to eq("#mirror.https://rails-assets.org/=http://localhost:9292")
+      expect(out).to be_empty
       expect(err).to be_empty
 
       ruby(<<~RUBY)

--- a/bundler/spec/commands/config_spec.rb
+++ b/bundler/spec/commands/config_spec.rb
@@ -358,6 +358,12 @@ end
 E
       expect(out).to eq("http://gems.example.org/ => http://gem-mirror.example.org/")
     end
+
+    it "allows configuring fallback timeout for each mirror, and does not duplicate configs", rubygems: ">= 3.5.12" do
+      bundle "config set --global mirror.https://rubygems.org.fallback_timeout 1"
+      bundle "config set --global mirror.https://rubygems.org.fallback_timeout 2"
+      expect(File.read(home(".bundle/config"))).to include("BUNDLE_MIRROR").once
+    end
   end
 
   describe "quoting" do

--- a/bundler/spec/support/filters.rb
+++ b/bundler/spec/support/filters.rb
@@ -14,7 +14,7 @@ class RequirementChecker < Proc
   attr_accessor :provided
 
   def inspect
-    "\"!= #{provided}\""
+    "\"#{provided}\""
   end
 end
 

--- a/lib/rubygems/yaml_serializer.rb
+++ b/lib/rubygems/yaml_serializer.rb
@@ -60,7 +60,6 @@ module Gem
           indent, key, quote, val = match.captures
           val = strip_comment(val)
 
-          convert_to_backward_compatible_key!(key)
           depth = indent.size / 2
           if quote.empty? && val.empty?
             new_hash = {}
@@ -92,14 +91,8 @@ module Gem
       end
     end
 
-    # for settings' keys
-    def convert_to_backward_compatible_key!(key)
-      key << "/" if /https?:/i.match?(key) && !%r{/\Z}.match?(key)
-      key.gsub!(".", "__")
-    end
-
     class << self
-      private :dump_hash, :convert_to_backward_compatible_key!
+      private :dump_hash
     end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When configuring mirror uris with the `fallback_timeout` option, like

```
bundle config set 'mirror.https://rubygems.org.fallback_timeout' 3
```

further configurations will not override the previous one, but add a new entry with "/" appended.

As a result, when running

```
bundle config set --global 'mirror.https://rubygems.org.fallback_timeout' 3
bundle config set --global 'mirror.https://rubygems.org.fallback_timeout' 2
```

configuration ends up like this:

```
---
BUNDLE_MIRROR__HTTPS://RUBYGEMS__ORG/__FALLBACK_TIMEOUT/: "3"
BUNDLE_MIRROR__HTTPS://RUBYGEMS__ORG/__FALLBACK_TIMEOUT: "2"
```

## What is your fix for the problem, implemented in this PR?

The reason is that we have compatibility code that appends "/" to uris, I guess to automatically fix some old bad configurations. The condition is, if we find a configuration line including "http", we append a backlash to the end of the configuration name.

This generally works, except when configuring `fallback_timeout` for a URI. In that case, the configuration key include the URI does not end with the URI name, but with `__FALLBACK_TIMEOUT`.

The fix is to account for this particular case, and avoid appending the slash if configuring fallback timeout.

Fixes https://github.com/rubygems/rubygems/issues/7688.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
