### PR TITLE
Move compact index concurrency to fetcher

### DIFF
--- a/bundler/spec/bundler/fetcher/compact_index_spec.rb
+++ b/bundler/spec/bundler/fetcher/compact_index_spec.rb
@@ -10,10 +10,12 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
   let(:remote)      { double(:remote, cache_slug: "lsjdf", uri: display_uri) }
   let(:gem_remote_fetcher) { nil }
   let(:compact_index) { described_class.new(downloader, remote, display_uri, gem_remote_fetcher) }
+  let(:compact_index_client) { double(:compact_index_client, available?: true, info: [["lskdjf", "1", nil, [], []]]) }
 
   before do
     allow(response).to receive(:is_a?).with(Gem::Net::HTTPNotModified).and_return(true)
     allow(compact_index).to receive(:log_specs) {}
+    allow(compact_index).to receive(:compact_index_client).and_return(compact_index_client)
   end
 
   describe "#specs_for_names" do
@@ -34,11 +36,6 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
     end
 
     describe "#available?" do
-      before do
-        allow(compact_index).to receive(:compact_index_client).
-          and_return(double(:compact_index_client, available?: true))
-      end
-
       it "returns true" do
         expect(compact_index).to be_available
       end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Finishing #7672 was made significantly harder because of the way the tests for the Fetcher::CompactIndex couldn't encapsulate CompactIndexClient behavior as a simple mock. This is because the concurrency model was split between the fetcher and the client only for the benefit of a single method on the client. 

## What is your fix for the problem, implemented in this PR?

It's much easier if the caller can just use the client concurrently if desired. Nothing else changes except pushing the concurrency model completely into Fetcher::CompactIndex. This makes sense especially after the refactor in #7678 which made `execution_mode` seem out of place. The only method using it was `dependencies` (which I consider soft deprecated now since it just maps and then calls info.)

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
