### PR TITLE
Allow bundle command in new gems with invalid metadata

### DIFF
--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -32,6 +32,9 @@ module Gem
 
   require "rubygems/specification"
 
+  # Can be removed once RubyGems 3.5.15 support is dropped
+  VALIDATES_FOR_RESOLUTION = Specification.new.respond_to?(:validate_for_resolution).freeze
+
   class Specification
     require_relative "match_metadata"
     require_relative "match_platform"
@@ -131,6 +134,12 @@ module Gem
       !default_gem? && !File.directory?(full_gem_path)
     end
 
+    unless VALIDATES_FOR_RESOLUTION
+      def validate_for_resolution
+        SpecificationPolicy.new(self).validate_for_resolution
+      end
+    end
+
     private
 
     def dependencies_to_gemfile(dependencies, group = nil)
@@ -147,6 +156,14 @@ module Gem
         gemfile << "end\n" if group
       end
       gemfile
+    end
+  end
+
+  unless VALIDATES_FOR_RESOLUTION
+    class SpecificationPolicy
+      def validate_for_resolution
+        validate_required!
+      end
     end
   end
 

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -52,7 +52,7 @@ module Bundler
     end
 
     def validate(spec)
-      Bundler.ui.silence { spec.validate(false) }
+      Bundler.ui.silence { spec.validate_for_resolution }
     rescue Gem::InvalidSpecificationException => e
       error_message = "The gemspec at #{spec.loaded_from} is not valid. Please fix this gemspec.\n" \
         "The validation error was '#{e.message}'\n"

--- a/bundler/spec/bundler/rubygems_integration_spec.rb
+++ b/bundler/spec/bundler/rubygems_integration_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe Bundler::RubygemsIntegration do
     end
     subject { Bundler.rubygems.validate(spec) }
 
-    it "validates with packaging mode disabled" do
-      expect(spec).to receive(:validate).with(false)
+    it "validates for resolution" do
+      expect(spec).to receive(:validate_for_resolution)
       subject
     end
 
     context "with an invalid spec" do
       before do
-        expect(spec).to receive(:validate).with(false).
+        expect(spec).to receive(:validate_for_resolution).
           and_raise(Gem::InvalidSpecificationException.new("TODO is not an author"))
       end
 

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -674,6 +674,7 @@ RSpec.describe "bundle exec" do
             s.version = '1.0'
             s.summary = 'TODO: Add summary'
             s.authors = 'Me'
+            s.rubygems_version = nil
           end
         G
       end
@@ -686,7 +687,7 @@ RSpec.describe "bundle exec" do
       bundle "exec irb", raise_on_error: false
 
       expect(err).to match("The gemspec at #{lib_path("foo-1.0").join("foo.gemspec")} is not valid")
-      expect(err).to match('"TODO" is not a summary')
+      expect(err).to match(/missing value for attribute rubygems_version|rubygems_version must not be nil/)
     end
   end
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2586,6 +2586,10 @@ class Gem::Specification < Gem::BasicSpecification
     @test_files.delete_if       {|x| File.directory?(x) && !File.symlink?(x) }
   end
 
+  def validate_for_resolution
+    Gem::SpecificationPolicy.new(self).validate_for_resolution
+  end
+
   def validate_metadata
     Gem::SpecificationPolicy.new(self).validate_metadata
   end

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -45,6 +45,7 @@ class Gem::SpecificationPolicy
 
   def validate(strict = false)
     validate_required!
+    validate_required_metadata!
 
     validate_optional(strict) if packaging || strict
 
@@ -85,13 +86,15 @@ class Gem::SpecificationPolicy
 
     validate_authors_field
 
-    validate_metadata
-
     validate_licenses_length
 
-    validate_lazy_metadata
-
     validate_duplicate_dependencies
+  end
+
+  def validate_required_metadata!
+    validate_metadata
+
+    validate_lazy_metadata
   end
 
   def validate_optional(strict)
@@ -118,6 +121,13 @@ class Gem::SpecificationPolicy
         alert_warning help_text
       end
     end
+  end
+
+  ##
+  # Implementation for Specification#validate_for_resolution
+
+  def validate_for_resolution
+    validate_required!
   end
 
   ##

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3951,6 +3951,40 @@ end
     assert_equal ["default-2.0.0.0"], Gem::Specification.map(&:full_name)
   end
 
+  def test_validate_for_resolution_validates_required_attributes
+    e = assert_raise Gem::InvalidSpecificationException do
+      @a1.version = nil
+      @a1.validate_for_resolution
+    end
+
+    assert_equal "missing value for attribute version", e.message
+  end
+
+  def test_validate_for_resolution_validates_name
+    e = assert_raise Gem::InvalidSpecificationException do
+      @a1.name = 123
+      @a1.validate_for_resolution
+    end
+
+    assert_equal 'invalid value for attribute name: "123" must be a string', e.message
+  end
+
+  def test_validate_for_resolution_validates_duplicate_dependencies
+    e = assert_raise Gem::InvalidSpecificationException do
+      @a1.add_dependency "foo", "1.2.3"
+      @a1.add_dependency "foo", "3.4.5"
+      @a1.validate_for_resolution
+    end
+
+    assert_match "duplicate dependency on foo", e.message
+  end
+
+  def test_validate_for_resolution_ignores_metadata
+    @a1.summary = "TODO: Invalid summary"
+    @a1.metadata["homepage_uri"] = "TODO: Invalid homepage URI"
+    @a1.validate_for_resolution
+  end
+
   def util_setup_deps
     @gem = util_spec "awesome", "1.0" do |awesome|
       awesome.add_runtime_dependency "bonobo", []


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Fixes #7699.

When a gem author creates a new gem using `bundle gem`, they are currently unable to successfully run any commands like `bundle add` until they have fixed metadata validation issues in the default generated gemspec. The author probably shouldn't need to worry about adding proper metadata to the gemspec until they are ready to publish, so this adds unnecessary friction upfront.

## What is your fix for the problem, implemented in this PR?

As per the suggestion from @deivid-rodriguez in #7688, this PR switches out the full gemspec validation for the `Specification#validate_for_resolution` method which only validates resolution related information such as name, version, platform, and dependencies.

For dependency checks, it only runs `validate_duplicate_dependencies` and not `validate_dependencies`. That's because `validate_dependencies` is not part of the current validation (only when `packaging` or `strict` is true—not the case when called from Bundler), so I wasn't sure whether to add it here.

I noticed the `validate_platform` method isn't super useful, because it's not possible to set `Specification#platform=` with a non-valid value. As such, I was unable to write a test that would trigger an error here.

I also wasn't sure how best to add a feature that spans both RubyGems and Bundler. I added a check in Bundler that `Specification#validate_for_resolution` exists before calling it. Are these released separately, so it's possible a user has a newer version of Bundler and an older version of RubyGems? Is there a better way to handle this.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
