### PR TITLE
Use `caller_locations` instead of splitting `caller`

### DIFF
--- a/bundler/lib/bundler/env.rb
+++ b/bundler/lib/bundler/env.rb
@@ -120,7 +120,7 @@ module Bundler
         specs = Bundler.rubygems.find_name(name)
         out << ["  #{name}", "(#{specs.map(&:version).join(",")})"] unless specs.empty?
       end
-      if (exe = caller.last.split(":").first)&.match? %r{(exe|bin)/bundler?\z}
+      if (exe = caller_locations.last.absolute_path)&.match? %r{(exe|bin)/bundler?\z}
         shebang = File.read(exe).lines.first
         shebang.sub!(/^#!\s*/, "")
         unless shebang.start_with?(Gem.ruby, "/usr/bin/env ruby")

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -220,7 +220,7 @@ module Bundler
 
       [::Kernel.singleton_class, ::Kernel].each do |kernel_class|
         redefine_method(kernel_class, :gem) do |dep, *reqs|
-          if executables&.include?(File.basename(caller.first.split(":").first))
+          if executables&.include?(File.basename(caller_locations(1, 1).first.path))
             break
           end
 

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -245,7 +245,7 @@ module Spec
     end
 
     def update_repo(path, build_compact_index: true)
-      if path == gem_repo1 && caller.first.split(" ").last == "`build_repo`"
+      if path == gem_repo1 && caller.first.split(" ").last != "`build_repo'"
         raise "Updating gem_repo1 is unsupported -- use gem_repo2 instead"
       end
       return unless block_given?

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -245,7 +245,8 @@ module Spec
     end
 
     def update_repo(path, build_compact_index: true)
-      if path == gem_repo1 && caller.first.split(" ").last != "`build_repo'"
+      exempted_caller = Gem.ruby_version >= Gem::Version.new("3.4.0.dev") ? "#{Module.nesting.first}#build_repo" : "build_repo"
+      if path == gem_repo1 && caller_locations(1, 1).first.label != exempted_caller
         raise "Updating gem_repo1 is unsupported -- use gem_repo2 instead"
       end
       return unless block_given?

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -874,7 +874,7 @@ class Gem::Specification < Gem::BasicSpecification
   # You probably want to use one of the Enumerable methods instead.
 
   def self.all
-    warn "NOTE: Specification.all called from #{caller.first}" unless
+    warn "NOTE: Specification.all called from #{caller(1, 1).first}" unless
       Gem::Deprecate.skip
     _all
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Collecting all call locations as strings then extracting just one and splitting seems inefficient.

## What is your fix for the problem, implemented in this PR?

Use `caller_locations` instead of splitting `caller`.
Also limit caller ranges.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
