### PR TITLE
Relax readline prompt test

### DIFF
--- a/bundler/spec/commands/info_spec.rb
+++ b/bundler/spec/commands/info_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe "bundle info" do
       G
 
       bundle "info rac"
-      expect(out).to match(/\A1 : rack\n2 : rack-obama\n0 : - exit -(\n>.*)?\z/)
+      expect(out).to match(/\A1 : rack\n2 : rack-obama\n0 : - exit -(\n>|\z)/)
     end
   end
 

--- a/bundler/spec/commands/show_spec.rb
+++ b/bundler/spec/commands/show_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe "bundle show", bundler: "< 3" do
       G
 
       bundle "show rac"
-      expect(out).to match(/\A1 : rack\n2 : rack-obama\n0 : - exit -(\n>.*)?\z/)
+      expect(out).to match(/\A1 : rack\n2 : rack-obama\n0 : - exit -(\n>|\z)/)
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

ruby/ruby ci was failing with latest Reline https://github.com/ruby/ruby/actions/runs/9352049059/job/25739247917
The problem is in both Reline (prints escape seqeunce before promt, https://github.com/ruby/reline/pull/716) and bundler (too strict assertion)
This pull request relax the strict assertion of Readline/Reline output sequence.

## What is your fix for the problem, implemented in this PR?

GNU Readline normally prints `"prompt>(characters and escape sequences depend on input and version of readline)\n"`.
When non-tty stdin is closed, GNU Readline does not print the last newline character. The two failing test is depending on this.
```
# STDIN is tty (type C-d)
$ ruby -rreadline -e "p Readline.readline'>'"
>
nil
# STDIN is not a tty
$ echo "\x04" | ruby -rreadline -e "p Readline.readline'>'"
>nil
```

Reline always prints that `\n` now, so the test fails even after https://github.com/ruby/reline/pull/716 is merged. This pull request relaxes the assertion.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
