### PR TITLE
Auto switch to locked bundler version even when using binstubs

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -167,6 +167,10 @@ module Bundler
       end
     end
 
+    def auto_switch
+      self_manager.restart_with_locked_bundler_if_needed
+    end
+
     # Automatically install dependencies if Bundler.settings[:auto_install] exists.
     # This is set through config cmd `bundle config set --global auto_install 1`.
     #

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -65,7 +65,7 @@ module Bundler
         Bundler.reset_settings_and_root!
       end
 
-      Bundler.self_manager.restart_with_locked_bundler_if_needed
+      Bundler.auto_switch
 
       Bundler.settings.set_command_option_if_given :retry, options[:retry]
 

--- a/bundler/lib/bundler/self_manager.rb
+++ b/bundler/lib/bundler/self_manager.rb
@@ -92,6 +92,7 @@ module Bundler
     def autoswitching_applies?
       ENV["BUNDLER_VERSION"].nil? &&
         Bundler.rubygems.supports_bundler_trampolining? &&
+        ruby_can_restart_with_same_arguments? &&
         SharedHelpers.in_bundle? &&
         lockfile_version
     end
@@ -149,6 +150,10 @@ module Bundler
 
     def released?(version)
       !version.to_s.end_with?(".dev")
+    end
+
+    def ruby_can_restart_with_same_arguments?
+      $PROGRAM_NAME != "-e"
     end
 
     def updating?

--- a/bundler/lib/bundler/setup.rb
+++ b/bundler/lib/bundler/setup.rb
@@ -5,6 +5,9 @@ require_relative "shared_helpers"
 if Bundler::SharedHelpers.in_bundle?
   require_relative "../bundler"
 
+  # autoswitch to locked Bundler version if available
+  Bundler.auto_switch
+
   # try to auto_install first before we get to the `Bundler.ui.silence`, so user knows what is happening
   Bundler.auto_install
 

--- a/bundler/spec/runtime/self_management_spec.rb
+++ b/bundler/spec/runtime/self_management_spec.rb
@@ -35,6 +35,17 @@ RSpec.describe "Self management", rubygems: ">= 3.3.0.dev", realworld: true do
       bundle "-v", artifice: nil
       expect(out).to end_with(previous_minor[0] == "2" ? "Bundler version #{previous_minor}" : previous_minor)
 
+      # App now uses locked version, even when not using the CLI directly
+      file = bundled_app("bin/bundle_version.rb")
+      create_file file, <<-RUBY
+        #!#{Gem.ruby}
+        require 'bundler/setup'
+        puts Bundler::VERSION
+      RUBY
+      file.chmod(0o777)
+      sys_exec "bin/bundle_version.rb", artifice: nil
+      expect(out).to eq(previous_minor)
+
       # Subsequent installs use the locked version without reinstalling
       bundle "install --verbose", artifice: nil
       expect(out).to include("Using bundler #{previous_minor}")
@@ -56,6 +67,17 @@ RSpec.describe "Self management", rubygems: ">= 3.3.0.dev", realworld: true do
       # App now uses locked version
       bundle "-v"
       expect(out).to end_with(previous_minor[0] == "2" ? "Bundler version #{previous_minor}" : previous_minor)
+
+      # App now uses locked version, even when not using the CLI directly
+      file = bundled_app("bin/bundle_version.rb")
+      create_file file, <<-RUBY
+        #!#{Gem.ruby}
+        require 'bundler/setup'
+        puts Bundler::VERSION
+      RUBY
+      file.chmod(0o777)
+      sys_exec "bin/bundle_version.rb", artifice: nil
+      expect(out).to eq(previous_minor)
 
       # Subsequent installs use the locked version without reinstalling
       bundle "install --verbose"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When people are running bundler through binstubs (that require `bundler/setup` instead of loading the CLI), and they are also installing gems to a local path, Bundler will fail to auto-switch to the locked version.

This may cause old Bundler versions to run new lockfiles, causing issues like #7715.

## What is your fix for the problem, implemented in this PR?

My fix is to make sure auto-switch also happens when requiring `bundler/setup`, and not only when loading the CLI.

Fixes #7715.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
