### PR TITLE
Keep credentials in lockfile if they are already there

### DIFF
--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -371,6 +371,112 @@ RSpec.describe "the lockfile format" do
     G
   end
 
+  it "does not add credentials to lockfile when it does not have them already" do
+    bundle "config set http://localgemserver.test/ user:pass"
+
+    gemfile <<~G
+      source "#{file_uri_for(gem_repo1)}"
+
+      source "http://localgemserver.test/" do
+
+      end
+
+      source "http://user:pass@othergemserver.test/" do
+        gem "rack-obama", ">= 1.0"
+      end
+    G
+
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo2, "rack", "1.0.0"
+      c.checksum gem_repo2, "rack-obama", "1.0"
+    end
+
+    lockfile_without_credentials = <<~L
+      GEM
+        remote: #{file_uri_for(gem_repo1)}/
+        specs:
+
+      GEM
+        remote: http://localgemserver.test/
+        specs:
+
+      GEM
+        remote: http://othergemserver.test/
+        specs:
+          rack (1.0.0)
+          rack-obama (1.0)
+            rack
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        rack-obama (>= 1.0)!
+      #{checksums}
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    lockfile lockfile_without_credentials
+
+    bundle "install", artifice: "endpoint_strict_basic_authentication", quiet: true
+
+    expect(lockfile).to eq lockfile_without_credentials
+  end
+
+  it "keeps credentials in lockfile if already there" do
+    bundle "config set http://localgemserver.test/ user:pass"
+
+    gemfile <<~G
+      source "#{file_uri_for(gem_repo1)}"
+
+      source "http://localgemserver.test/" do
+
+      end
+
+      source "http://user:pass@othergemserver.test/" do
+        gem "rack-obama", ">= 1.0"
+      end
+    G
+
+    checksums = checksums_section_when_existing do |c|
+      c.checksum gem_repo2, "rack", "1.0.0"
+      c.checksum gem_repo2, "rack-obama", "1.0"
+    end
+
+    lockfile_with_credentials = <<~L
+      GEM
+        remote: #{file_uri_for(gem_repo1)}/
+        specs:
+
+      GEM
+        remote: http://localgemserver.test/
+        specs:
+
+      GEM
+        remote: http://user:pass@othergemserver.test/
+        specs:
+          rack (1.0.0)
+          rack-obama (1.0)
+            rack
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        rack-obama (>= 1.0)!
+      #{checksums}
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    lockfile lockfile_with_credentials
+
+    bundle "install", artifice: "endpoint_strict_basic_authentication", quiet: true
+
+    expect(lockfile).to eq lockfile_with_credentials
+  end
+
   it "generates lockfiles with multiple requirements" do
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}/"


### PR DESCRIPTION
So that those lockfiles still work with older Bundler versions.

## What was the end-user or developer problem that led to this PR?

Recently, we stopped including credentials in lockfiles when they are specified directly in the Gemfile. This seems good for security and it's also consistent with the recommended way of setting credentials for your sources (through configuration).

However, once existing lockfiles are updated to not include credentials, they stop working with older Bundler versions. This is generally not a problem because bundler automatically switches to the Bundler version that created the lockfile. However, it did cause issues in the realworld. For example:

* Heroku completely disables auto-switching by removing the `BUNDLED WITH` section in the lockfile.
* Auto-switching was (unintentionally) not happening when using binstubs instead of loading the CLI.

## What is your fix for the problem, implemented in this PR?

The auto-switching issue should get fixed by #7719, but even if we fix that, we may want to restore a more conservative approach, namely, don't include credentials in lockfiles by default, but leave them alone if they are already there, so that the lockfile is still compatible with older Bundler versions. 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
