### PR TITLE
Don't validate local gemspecs twice unnecessarily

### DIFF
--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -32,6 +32,16 @@ module Bundler
         @local      = false
       end
 
+      def remote!
+        @local_specs = nil
+        @allow_remote = true
+      end
+
+      def cached!
+        @local_specs = nil
+        @allow_cached = true
+      end
+
       def self.from_lock(options)
         new(options.merge("uri" => options.delete("remote")))
       end

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -33,11 +33,15 @@ module Bundler
       end
 
       def remote!
+        return if @allow_remote
+
         @local_specs = nil
         @allow_remote = true
       end
 
       def cached!
+        return if @allow_cached
+
         @local_specs = nil
         @allow_cached = true
       end

--- a/bundler/lib/bundler/source/path.rb
+++ b/bundler/lib/bundler/source/path.rb
@@ -18,9 +18,6 @@ module Bundler
         @options = options.dup
         @glob = options["glob"] || DEFAULT_GLOB
 
-        @allow_cached = false
-        @allow_remote = false
-
         @root_path = options["root_path"] || root
 
         if options["path"]
@@ -39,16 +36,6 @@ module Bundler
         # Stores the original path. If at any point we move to the
         # cached directory, we still have the original path to copy from.
         @original_path = @path
-      end
-
-      def remote!
-        @local_specs = nil
-        @allow_remote = true
-      end
-
-      def cached!
-        @local_specs = nil
-        @allow_cached = true
       end
 
       def self.from_lock(options)

--- a/bundler/spec/install/gemspecs_spec.rb
+++ b/bundler/spec/install/gemspecs_spec.rb
@@ -157,5 +157,25 @@ RSpec.describe "bundle install" do
       expect(err).to include("but your Gemfile specified")
       expect(exitstatus).to eq(18)
     end
+
+    it "validates gemspecs just once when everything installed and lockfile up to date" do
+      build_lib "foo"
+
+      install_gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gemspec path: "#{lib_path("foo-1.0")}"
+
+        module Monkey
+          def validate(spec)
+            puts "Validate called on \#{spec.full_name}"
+          end
+        end
+        Bundler.rubygems.extend(Monkey)
+      G
+
+      bundle "install"
+
+      expect(out).to include("Validate called on foo-1.0").once
+    end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

After https://github.com/rubygems/rubygems/commit/639f0b72f40979b552b4bae44a122cfd176115aa, we started validating local gemspecs unnecessarily, as reported by #7722.

## What is your fix for the problem, implemented in this PR?

My fix is to let `remote!` and `cached!` be noops for path sources, since they only deal with local specifications. Previously they were expiring local gemspecs, causing them to be loaded and validated again if `remote!` or `cached!` was called on them (which https://github.com/rubygems/rubygems/commit/639f0b72f40979b552b4bae44a122cfd176115aa started doing).

Closes #7722.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
