### PR TITLE
Fix Windows gem activate order

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -825,6 +825,7 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   def self._resort!(specs) # :nodoc:
+    windows = RbConfig::CONFIG["host_os"].match?(/mswin|mingw/)
     specs.sort! do |a, b|
       names = a.name <=> b.name
       next names if names.nonzero?
@@ -832,7 +833,7 @@ class Gem::Specification < Gem::BasicSpecification
       next versions if versions.nonzero?
       platforms = Gem::Platform.sort_priority(b.platform) <=> Gem::Platform.sort_priority(a.platform)
       next platforms if platforms.nonzero?
-      b.base_dir == Gem.path.first ? 1 : -1
+      b.base_dir == Gem.path.first || windows && !b.default_gem? ? 1 : -1
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

See #7726

On WIndows, when a default gem is also installed in `Gem.default_dir`, requiring it activates the default gem, not the installed gem.  This behavior differs from Ubuntu & macOS.

Note that when the gem is installed to `Gem.user_dir` the behavior on Windows matches Ubuntu & macOS.

## What is your fix for the problem, implemented in this PR?

Fix sorting order in `Gem::Specification._resort!`.

No test provided, I haven't looked at the test suite for quite a while.  Obviously, it isn't covered in it.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
