### PR TITLE
Fix slow and incorrect resolution when adding `sorbet` to a Gemfile and the lockfile only includes "RUBY" in the platforms section

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -650,7 +650,6 @@ module Bundler
 
     def current_ruby_platform_locked?
       return false unless generic_local_platform_is_ruby?
-      return false if Bundler.settings[:force_ruby_platform] && !@platforms.include?(Gem::Platform::RUBY)
 
       current_platform_locked?
     end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -624,6 +624,11 @@ module Bundler
       result = SpecSet.new(resolver.start)
 
       @resolved_bundler_version = result.find {|spec| spec.name == "bundler" }&.version
+
+      if @current_ruby_locked_platform && @current_ruby_locked_platform != local_platform
+        @platforms.delete(result.incomplete_for_platform?(dependencies, @current_ruby_locked_platform) ? @current_ruby_locked_platform : local_platform)
+      end
+
       @platforms = result.add_extra_platforms!(platforms) if should_add_extra_platforms?
 
       result.complete_platforms!(platforms)
@@ -661,7 +666,7 @@ module Bundler
     end
 
     def add_current_platform
-      return if current_ruby_platform_locked?
+      @current_ruby_locked_platform = most_specific_locked_platform if current_ruby_platform_locked?
 
       add_platform(local_platform)
     end
@@ -1049,7 +1054,6 @@ module Bundler
                 !@originally_locked_specs.incomplete_for_platform?(dependencies, platform)
 
         remove_platform(platform)
-        add_current_platform if platform == Gem::Platform::RUBY
       end
     end
 

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -11,8 +11,6 @@ module Spec
     include Spec::Options
     include Spec::Subprocess
 
-    class TimeoutExceeded < StandardError; end
-
     def reset!
       Dir.glob("#{tmp}/{gems/*,*}", File::FNM_DOTMATCH).each do |dir|
         next if %w[base base_system remote1 rubocop standard gems rubygems . ..].include?(File.basename(dir))

--- a/bundler/spec/support/subprocess.rb
+++ b/bundler/spec/support/subprocess.rb
@@ -4,6 +4,8 @@ require_relative "command_execution"
 
 module Spec
   module Subprocess
+    class TimeoutExceeded < StandardError; end
+
     def command_executions
       @command_executions ||= []
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If RUBY is the only platform in the lockfile, we were skipping adding the local platform to the list of resolution platforms. This generally works anyways, because we had some code to still add it if the RUBY platform is not valid for the set of locked gems.
    
However, sometimes it can happen that "RUBY" is valid for the current set of locked gems, but when adding a new dependency, it becomes invalid. For example, when adding sorbet to a Gemfile, that will introduce `sorbet-static` as an indirect dependency which does not have a generic "RUBY" variant. This will cause resolution to take a long time continuously backtracking trying to find solutions that don't introduce `sorbet-static` as a dependency and will eventually fail.

## What is your fix for the problem, implemented in this PR?

Instead, we can always add the local platform to the set of resolution platforms before resolving, and remove it as necessary after resolution so that we lock the correct set of platforms.

Fixes #7723.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
