### PR TITLE
Fix typo making compact index in debug mode crash

### DIFF
--- a/bundler/lib/bundler/compact_index_client.rb
+++ b/bundler/lib/bundler/compact_index_client.rb
@@ -75,7 +75,7 @@ module Bundler
     end
 
     def info(name)
-      Bundler::CompactIndexClient.debug { "info(#{names})" }
+      Bundler::CompactIndexClient.debug { "info(#{name})" }
       @parser.info(name)
     end
 

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -15,6 +15,21 @@ RSpec.describe "compact index api" do
     expect(the_bundle).to include_gems "rack 1.0.0"
   end
 
+  it "has a debug mode" do
+    gemfile <<-G
+      source "#{source_uri}"
+      gem "rack"
+    G
+
+    bundle :install, artifice: "compact_index", env: { "DEBUG_COMPACT_INDEX" => "true" }
+    expect(out).to include("Fetching gem metadata from #{source_uri}")
+    expect(err).to include("[Bundler::CompactIndexClient] available?")
+    expect(err).to include("[Bundler::CompactIndexClient] fetching versions")
+    expect(err).to include("[Bundler::CompactIndexClient] info(rack)")
+    expect(err).to include("[Bundler::CompactIndexClient] fetching info/rack")
+    expect(the_bundle).to include_gems "rack 1.0.0"
+  end
+
   it "should URI encode gem names" do
     gemfile <<-G
       source "#{source_uri}"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

A crash when using the `DEBUG_COMPACT_INDEX` environment variable.

## What is your fix for the problem, implemented in this PR?

Fix a small typo introduced by https://github.com/rubygems/rubygems/pull/7705.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
