### PR TITLE
Fix another sort stability issue

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -99,6 +99,13 @@ class Gem::BasicSpecification
   end
 
   ##
+  # Regular gems take precedence over default gems
+
+  def default_gem_priority
+    default_gem? ? 1 : -1
+  end
+
+  ##
   # Returns full path to the directory where gem's extensions are installed.
 
   def extension_dir

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -106,6 +106,13 @@ class Gem::BasicSpecification
   end
 
   ##
+  # Gems higher up in +gem_path+ take precedence
+
+  def base_dir_priority(gem_path)
+    gem_path.index(base_dir) || gem_path.size
+  end
+
+  ##
   # Returns full path to the directory where gem's extensions are installed.
 
   def extension_dir

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -832,6 +832,8 @@ class Gem::Specification < Gem::BasicSpecification
       next versions if versions.nonzero?
       platforms = Gem::Platform.sort_priority(b.platform) <=> Gem::Platform.sort_priority(a.platform)
       next platforms if platforms.nonzero?
+      default_gem = a.default_gem_priority <=> b.default_gem_priority
+      next default_gem if default_gem.nonzero?
       b.base_dir == Gem.path.first ? 1 : -1
     end
   end

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -771,6 +771,11 @@ class Gem::Specification < Gem::BasicSpecification
   end
   private_class_method :clear_load_cache
 
+  def self.gem_path # :nodoc:
+    Gem.path
+  end
+  private_class_method :gem_path
+
   def self.each_gemspec(dirs) # :nodoc:
     dirs.each do |dir|
       Gem::Util.glob_files_in_dir("*.gemspec", dir).each do |path|
@@ -834,7 +839,7 @@ class Gem::Specification < Gem::BasicSpecification
       next platforms if platforms.nonzero?
       default_gem = a.default_gem_priority <=> b.default_gem_priority
       next default_gem if default_gem.nonzero?
-      b.base_dir == Gem.path.first ? 1 : -1
+      a.base_dir_priority(gem_path) <=> b.base_dir_priority(gem_path)
     end
   end
 
@@ -910,7 +915,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Return the directories that Specification uses to find specs.
 
   def self.dirs
-    @@dirs ||= Gem::SpecificationRecord.dirs_from(Gem.path)
+    @@dirs ||= Gem::SpecificationRecord.dirs_from(gem_path)
   end
 
   ##

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -489,6 +489,22 @@ class TestGemRequire < Gem::TestCase
     assert_equal %w[default-3.0], loaded_spec_names
   end
 
+  def test_default_gem_and_normal_gem_same_version
+    default_gem_spec = new_default_spec("default", "3.0",
+                                        nil, "default/gem.rb")
+    install_default_gems(default_gem_spec)
+    normal_gem_spec = util_spec("default", "3.0", nil,
+                               "lib/default/gem.rb")
+    install_specs(normal_gem_spec)
+
+    # Load default ruby gems fresh as if we've just started a ruby script.
+    Gem::Specification.reset
+
+    assert_require "default/gem"
+    assert_equal %w[default-3.0], loaded_spec_names
+    refute Gem.loaded_specs["default"].default_gem?
+  end
+
   def test_normal_gem_does_not_shadow_default_gem
     default_gem_spec = new_default_spec("foo", "2.0", nil, "foo.rb")
     install_default_gems(default_gem_spec)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Under some circumstances, when a default gem is at the same version as a regular gem, it would take precedence because ties there were not properly broken.

## What is your fix for the problem, implemented in this PR?

Make sure to explicitly consider default gems for sorting. Also, to resolve further potential ambiguities, consider all positions in `GEM_PATH` for sorting, not just the first one.

Fixes #7726.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
