### PR TITLE
Fix funding metadata not being printed in some situations

### DIFF
--- a/bundler/lib/bundler/endpoint_specification.rb
+++ b/bundler/lib/bundler/endpoint_specification.rb
@@ -92,6 +92,17 @@ module Bundler
       end
     end
 
+    # needed for `bundle fund`
+    def metadata
+      if @remote_specification
+        @remote_specification.metadata
+      elsif _local_specification
+        _local_specification.metadata
+      else
+        super
+      end
+    end
+
     def _local_specification
       return unless @loaded_from && File.exist?(local_specification_path)
       eval(File.read(local_specification_path), nil, local_specification_path).tap do |spec|

--- a/bundler/spec/install/gems/fund_spec.rb
+++ b/bundler/spec/install/gems/fund_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe "bundle install" do
 
     context "when gems include a fund URI" do
       it "displays the plural fund message after installing" do
-        install_gemfile <<-G
-          source "#{file_uri_for(gem_repo2)}"
+        install_gemfile <<-G, artifice: "compact_index"
+          source "https://gem.repo2"
           gem 'has_funding_and_other_metadata'
           gem 'has_funding'
           gem 'rack-obama'
@@ -42,8 +42,8 @@ RSpec.describe "bundle install" do
       end
 
       it "displays the singular fund message after installing" do
-        install_gemfile <<-G
-          source "#{file_uri_for(gem_repo2)}"
+        install_gemfile <<-G, artifice: "compact_index"
+          source "https://gem.repo2"
           gem 'has_funding'
           gem 'rack-obama'
         G
@@ -58,8 +58,8 @@ RSpec.describe "bundle install" do
       end
 
       it "does not display the plural fund message after installing" do
-        install_gemfile <<-G
-          source "#{file_uri_for(gem_repo2)}"
+        install_gemfile <<-G, artifice: "compact_index"
+          source "https://gem.repo2"
           gem 'has_funding_and_other_metadata'
           gem 'has_funding'
           gem 'rack-obama'
@@ -69,8 +69,8 @@ RSpec.describe "bundle install" do
       end
 
       it "does not display the singular fund message after installing" do
-        install_gemfile <<-G
-          source "#{file_uri_for(gem_repo2)}"
+        install_gemfile <<-G, artifice: "compact_index"
+          source "https://gem.repo2"
           gem 'has_funding'
           gem 'rack-obama'
         G
@@ -81,8 +81,8 @@ RSpec.describe "bundle install" do
 
     context "when gems do not include fund messages" do
       it "does not display any fund messages" do
-        install_gemfile <<-G
-          source "#{file_uri_for(gem_repo2)}"
+        install_gemfile <<-G, artifice: "compact_index"
+          source "https://gem.repo2"
           gem "activesupport"
         G
 
@@ -92,8 +92,8 @@ RSpec.describe "bundle install" do
 
     context "when a dependency includes a fund message" do
       it "does not display the fund message" do
-        install_gemfile <<-G
-          source "#{file_uri_for(gem_repo2)}"
+        install_gemfile <<-G, artifice: "compact_index"
+          source "https://gem.repo2"
           gem 'gem_with_dependent_funding'
         G
 
@@ -110,8 +110,8 @@ RSpec.describe "bundle install" do
             "funding_uri" => "https://example.com/also_has_funding/funding",
           }
         end
-        install_gemfile <<-G
-          source "#{file_uri_for(gem_repo1)}"
+        install_gemfile <<-G, artifice: "compact_index"
+          source "https://gem.repo1"
           gem 'also_has_funding', :git => '#{lib_path("also_has_funding-1.0")}'
         G
 
@@ -124,8 +124,8 @@ RSpec.describe "bundle install" do
             "funding_uri" => "https://example.com/also_has_funding/funding",
           }
         end
-        install_gemfile <<-G
-          source "#{file_uri_for(gem_repo1)}"
+        install_gemfile <<-G, artifice: "compact_index"
+          source "https://gem.repo1"
           gem 'also_has_funding', :git => '#{lib_path("also_has_funding-1.0")}'
         G
 
@@ -134,8 +134,8 @@ RSpec.describe "bundle install" do
             "funding_uri" => "https://example.com/also_has_funding/funding",
           }
         end
-        install_gemfile <<-G
-          source "#{file_uri_for(gem_repo1)}"
+        install_gemfile <<-G, artifice: "compact_index"
+          source "https://gem.repo1"
           gem 'also_has_funding', :git => '#{lib_path("also_has_funding-1.1")}'
         G
 
@@ -149,14 +149,14 @@ RSpec.describe "bundle install" do
           }
         end
         gemfile <<-G
-          source "#{file_uri_for(gem_repo1)}"
+          source "https://gem.repo1"
           gem 'also_has_funding', :git => '#{lib_path("also_has_funding-1.0")}'
         G
 
-        bundle :install
+        bundle :install, artifice: "compact_index"
         expect(out).to include("1 installed gem you directly depend on is looking for funding.")
 
-        bundle :install
+        bundle :install, artifice: "compact_index"
         expect(out).to include("1 installed gem you directly depend on is looking for funding.")
       end
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Namely, when a gem has not previously been installed, and Bundler is using the compact index API, fund metadata was not getting printed because the proper delegation was not implemented in the specification class used by the compact index.

## What is your fix for the problem, implemented in this PR?

The fix is to add the proper delegations to `Bundler::EndpointSpecification` so that metadata is properly fetched, and to migrate `bundle fund` specs to use the compact index API, so that the problem is caught.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
