### PR TITLE
Never remove executables that may belong to a default gem

### DIFF
--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -178,7 +178,7 @@ class Gem::Uninstaller
   # Removes installed executables and batch files (windows only) for +spec+.
 
   def remove_executables(spec)
-    return if spec.executables.empty?
+    return if spec.executables.empty? || default_spec_matches?(spec)
 
     executables = spec.executables.clone
 

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -827,10 +827,8 @@ class Gem::TestCase < Test::Unit::TestCase
     Gem.instance_variable_set(:@default_gem_load_paths, [*Gem.send(:default_gem_load_paths), lib_dir])
     $LOAD_PATH.unshift(lib_dir)
     files.each do |file|
-      rb_path = File.join(lib_dir, file)
-      FileUtils.mkdir_p(File.dirname(rb_path))
-      File.open(rb_path, "w") do |rb|
-        rb << "# #{file}"
+      write_file File.join(lib_dir, file) do |io|
+        io.write "# #{file}"
       end
     end
 

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -816,8 +816,14 @@ class Gem::TestCase < Test::Unit::TestCase
     Gem::Specification.unresolved_deps.values.map(&:to_s).sort
   end
 
-  def new_default_spec(name, version, deps = nil, *files)
+  def new_default_spec(name, version, deps = nil, *files, executable: false)
     spec = util_spec name, version, deps
+
+    if executable
+      spec.executables = %w[executable]
+
+      write_file File.join(@tempdir, "bin", "executable")
+    end
 
     spec.loaded_from = File.join(@gemhome, "specifications", "default", spec.spec_name)
     spec.files = files

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -81,6 +81,35 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
     assert_equal "Successfully uninstalled z-2", output.shift
   end
 
+  def test_execute_does_not_remove_default_gem_executables
+    z_1_default = new_default_spec "z", "1", executable: true
+    install_default_gems z_1_default
+
+    z_1, = util_gem "z", "1" do |spec|
+      util_make_exec spec
+    end
+    install_gem z_1, force: true
+
+    Gem::Specification.reset
+
+    @cmd.options[:all] = true
+    @cmd.options[:force] = true
+    @cmd.options[:executables] = true
+    @cmd.options[:args] = %w[z]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert File.exist? File.join(@gemhome, "bin", "executable")
+
+    output = @ui.output.split "\n"
+
+    refute_includes output, "Removing executable"
+    assert_equal "Successfully uninstalled z-1", output.shift
+    assert_equal "There was both a regular copy and a default copy of z-1. The regular copy was successfully uninstalled, but the default copy was left around because default gems can't be removed.", output.shift
+  end
+
   def test_execute_dependency_order
     initial_install
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I have `irb` as a default gem:

```
$ gem list irb
*** LOCAL GEMS ***

irb (default: 1.13.1)

$ which irb
/Users/deivid/.asdf/installs/ruby/3.3.3/bin/irb
```

If I install the same version as a regular gem, and then uninstall it again, suddenly my default version is no longer functional because the `irb` executable is either gone or point to some other executable:

```
$ gem install irb:1.13.1                      
Fetching irb-1.13.1.gem
Successfully installed irb-1.13.1
1 gem installed

$ gem uninstall irb:1.13.1 --force --executables      
Gem irb-1.13.1 cannot be uninstalled because it is a default gem
Removing irb
Successfully uninstalled irb-1.13.1
There was both a regular copy and a default copy of irb-1.13.1. The regular copy was successfully uninstalled, but the default copy was left around because default gems can't be removed.

$ which irb
/usr/bin/irb
```

## What is your fix for the problem, implemented in this PR?

The fix is to skip executable removal if there's a matching default copy.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
