### PR TITLE
Don't print bug report template when bin dir is not writable

### DIFF
--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -29,7 +29,10 @@ module Bundler
       write_build_info_file
       run_post_build_hooks
 
-      generate_bin
+      SharedHelpers.filesystem_access(bin_dir, :write) do
+        generate_bin
+      end
+
       generate_plugins
 
       write_spec

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -871,6 +871,36 @@ RSpec.describe "bundle install with gem sources" do
     end
   end
 
+  describe "when bundle bin dir does not have write access", :permissions do
+    let(:bin_dir) { bundled_app("vendor/#{Bundler.ruby_scope}/bin") }
+
+    before do
+      FileUtils.mkdir_p(bin_dir)
+      gemfile <<-G
+        source "#{file_uri_for(gem_repo1)}"
+        gem 'rack'
+      G
+    end
+
+    it "should display a proper message to explain the problem" do
+      FileUtils.chmod("-x", bin_dir)
+      bundle "config set --local path vendor"
+
+      begin
+        bundle :install, raise_on_error: false
+      ensure
+        FileUtils.chmod("+x", bin_dir)
+      end
+
+      expect(err).not_to include("ERROR REPORT TEMPLATE")
+
+      expect(err).to include(
+        "There was an error while trying to write to `#{bin_dir}`. " \
+        "It is likely that you need to grant write permissions for that path."
+      )
+    end
+  end
+
   describe "when bundle extensions path does not have write access", :permissions do
     let(:extensions_path) { bundled_app("vendor/#{Bundler.ruby_scope}/extensions/#{Gem::Platform.local}/#{Gem.extension_api_version}") }
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When directory to write RubyGems binstubs is not writable, Bundler crashes and prints the bug report template.

## What is your fix for the problem, implemented in this PR?

Wrap executable installation with the proper helper so that we print friendly errors instead.

Fixes #7745.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
