### PR TITLE
Make sure to not re-resolve when a not fully specific local platform is locked

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -621,11 +621,13 @@ module Bundler
     end
 
     def start_resolution
+      @platforms |= [local_platform]
+
       result = SpecSet.new(resolver.start)
 
       @resolved_bundler_version = result.find {|spec| spec.name == "bundler" }&.version
 
-      if @current_ruby_locked_platform && @current_ruby_locked_platform != local_platform
+      if most_specific_ruby_locked_platform_is_not_local_platform?
         @platforms.delete(result.incomplete_for_platform?(dependencies, @current_ruby_locked_platform) ? @current_ruby_locked_platform : local_platform)
       end
 
@@ -667,8 +669,13 @@ module Bundler
 
     def add_current_platform
       @current_ruby_locked_platform = most_specific_locked_platform if current_ruby_platform_locked?
+      return if most_specific_ruby_locked_platform_is_not_local_platform?
 
       add_platform(local_platform)
+    end
+
+    def most_specific_ruby_locked_platform_is_not_local_platform?
+      @current_ruby_locked_platform && @current_ruby_locked_platform != local_platform
     end
 
     def change_reason

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -1434,6 +1434,40 @@ RSpec.describe "bundle install with specific platforms" do
     end
   end
 
+  it "does not re-resolve when a specific platform, but less specific than the current platform, is locked" do
+    build_repo4 do
+      build_gem "nokogiri"
+    end
+
+    gemfile <<~G
+      source "#{file_uri_for(gem_repo4)}"
+
+      gem "nokogiri"
+    G
+
+    lockfile <<~L
+      GEM
+        remote: #{file_uri_for(gem_repo4)}/
+        specs:
+          nokogiri (1.0)
+
+      PLATFORMS
+        arm64-darwin
+
+      DEPENDENCIES
+        nokogiri!
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    simulate_platform "arm64-darwin-23" do
+      bundle "install --verbose"
+
+      expect(out).to include("Found no changes, using resolution from the lockfile")
+    end
+  end
+
   private
 
   def setup_multiplatform_gem


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The changes in #7731 made it so that Bundler will always re-resolve if a specific platform is present in the lockfile, but less specific than the current platform.

For example, when you have `arm64-darwin` in your lockfile, and your local platform is `arm64-darwin-23`.

This did not happen before.

## What is your fix for the problem, implemented in this PR?

Make sure to not add the current platform to the list of resolution platforms in this case, so that a re-resolve is not triggered due to "a new platform has been added". Still, to keep fixing #7723, make sure to explicitly make sure the local platform is always present when resolving, in case we ended up re-resolving for other reasons (like a new dependency being added).

Fixes #7750.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
