### PR TITLE
Remove hacks no longer needed

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -130,12 +130,12 @@ end
 namespace :vendor do
   desc "Download vendored gems to tmp"
   task :bundle do
-    sh({ "BUNDLE_PATH" => "../../tmp/vendor", "BUNDLER_GEM_DEFAULT_DIR" => "../../tmp/vendor" }, "ruby", "--disable-gems", "-r./bundler/spec/support/hax.rb", "-I", "lib", "bundler/spec/support/bundle.rb", "install", "--gemfile=tool/bundler/vendor_gems.rb")
+    sh({ "BUNDLE_PATH" => "../../tmp/vendor" }, "ruby", "--disable-gems", "-I", "lib", "bundler/spec/support/bundle.rb", "install", "--gemfile=tool/bundler/vendor_gems.rb")
   end
 
   desc "Install patched vendored gems"
   task install: :bundle do
-    sh({ "BUNDLE_GEMFILE" => "tool/bundler/vendor_gems.rb", "BUNDLE_PATH" => "../../tmp/vendor", "BUNDLER_GEM_DEFAULT_DIR" => "../../tmp/vendor" }, "ruby", "-rpathname", "-r./bundler/spec/support/hax.rb", "-I", "lib", "bundler/spec/support/bundle.rb", "exec", "tool/automatiek/vendor.rb")
+    sh({ "BUNDLE_GEMFILE" => "tool/bundler/vendor_gems.rb", "BUNDLE_PATH" => "../../tmp/vendor" }, "ruby", "--disable-gems", "-I", "lib", "bundler/spec/support/bundle.rb", "exec", "tool/automatiek/vendor.rb")
   end
 
   desc "Check vendored gems are up to date"

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -141,13 +141,6 @@ RSpec.shared_examples "bundle install --standalone" do
 
   describe "with default gems and a lockfile", :ruby_repo do
     before do
-      realworld_system_gems "tsort --version 0.1.0"
-
-      necessary_system_gems = ["optparse --version 0.1.1", "psych --version 3.3.2", "logger --version 1.4.3", "etc --version 1.2.0", "stringio --version 3.1.0"]
-      necessary_system_gems += ["shellwords --version 0.1.0", "base64 --version 0.1.0", "resolv --version 0.2.1"] if Gem.rubygems_version < Gem::Version.new("3.3.a")
-      necessary_system_gems += ["yaml --version 0.1.1"] if Gem.rubygems_version < Gem::Version.new("3.4.a")
-      realworld_system_gems(*necessary_system_gems, path: scoped_gem_path(bundled_app("bundle")))
-
       build_gem "foo", "1.0.0", to_system: true, default: true do |s|
         s.add_dependency "bar"
       end
@@ -170,9 +163,9 @@ RSpec.shared_examples "bundle install --standalone" do
       bundle "lock", dir: cwd, artifice: "compact_index"
     end
 
-    it "works and points to the vendored copies, not to the default copies", :realworld do
+    it "works and points to the vendored copies, not to the default copies" do
       bundle "config set --local path #{bundled_app("bundle")}"
-      bundle :install, standalone: true, dir: cwd, artifice: "compact_index", env: { "BUNDLER_GEM_DEFAULT_DIR" => system_gem_path.to_s }
+      bundle :install, standalone: true, dir: cwd, artifice: "compact_index"
 
       load_path_lines = bundled_app("bundle/bundler/setup.rb").read.split("\n").select {|line| line.start_with?("$:.unshift") }
 

--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -591,17 +591,13 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(err).to be_empty
   end
 
-  it "when requiring fileutils after does not show redefinition warnings", :realworld do
+  it "when requiring fileutils after does not show redefinition warnings" do
     Dir.mkdir tmp("path_without_gemfile")
 
     default_fileutils_version = ruby "gem 'fileutils', '< 999999'; require 'fileutils'; puts FileUtils::VERSION", raise_on_error: false
     skip "fileutils isn't a default gem" if default_fileutils_version.empty?
 
-    realworld_system_gems "fileutils --version 1.4.1"
-
-    realworld_system_gems "pathname --version 0.2.0"
-
-    script <<-RUBY, dir: tmp("path_without_gemfile"), env: { "BUNDLER_GEM_DEFAULT_DIR" => system_gem_path.to_s }
+    script <<-RUBY, dir: tmp("path_without_gemfile")
       require "bundler/inline"
 
       gemfile(true) do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Cleaning things up.

## What is your fix for the problem, implemented in this PR?

Since we have started treating default gems as regular gems when possible, I think these hacks are no longer necessary.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
