### PR TITLE
Fix `bundle fund` when the gemfile contains optional groups

### DIFF
--- a/bundler/lib/bundler/cli/fund.rb
+++ b/bundler/lib/bundler/cli/fund.rb
@@ -16,7 +16,7 @@ module Bundler
       deps = if groups.any?
         Bundler.definition.dependencies_for(groups)
       else
-        Bundler.definition.current_dependencies
+        Bundler.definition.requested_dependencies
       end
 
       fund_info = deps.each_with_object([]) do |dep, arr|

--- a/bundler/spec/commands/fund_spec.rb
+++ b/bundler/spec/commands/fund_spec.rb
@@ -55,6 +55,42 @@ RSpec.describe "bundle fund" do
     expect(out).to_not include("gem_with_dependent_funding")
   end
 
+  it "does not consider fund information for uninstalled optional dependencies" do
+    install_gemfile <<-G
+      source "#{file_uri_for(gem_repo2)}"
+      group :whatever, optional: true do
+        gem 'has_funding_and_other_metadata'
+      end
+      gem 'has_funding'
+      gem 'rack-obama'
+    G
+
+    bundle "fund"
+
+    expect(out).to include("* has_funding (1.2.3)\n  Funding: https://example.com/has_funding/funding")
+    expect(out).to_not include("has_funding_and_other_metadata")
+    expect(out).to_not include("rack-obama")
+  end
+
+  it "considers fund information for installed optional dependencies" do
+    bundle "config set with whatever"
+
+    install_gemfile <<-G
+      source "#{file_uri_for(gem_repo2)}"
+      group :whatever, optional: true do
+        gem 'has_funding_and_other_metadata'
+      end
+      gem 'has_funding'
+      gem 'rack-obama'
+    G
+
+    bundle "fund"
+
+    expect(out).to include("* has_funding_and_other_metadata (1.0)\n  Funding: https://example.com/has_funding_and_other_metadata/funding")
+    expect(out).to include("* has_funding (1.2.3)\n  Funding: https://example.com/has_funding/funding")
+    expect(out).to_not include("rack-obama")
+  end
+
   it "prints message if none of the gems have fund information" do
     install_gemfile <<-G
       source "#{file_uri_for(gem_repo2)}"


### PR DESCRIPTION
Closes #7757

## What was the end-user or developer problem that led to this PR?

`bundle fund` errors when the gemfile contains optional groups

## What is your fix for the problem, implemented in this PR?

`current_dependencies` doesn't return gems in optional groups, while `specs` would. As suggested in https://github.com/rubygems/rubygems/issues/7757#issuecomment-2168340472, use `requested_dependencies` instead which does the right thing.

The error lies here: https://github.com/rubygems/rubygems/blob/4ce4e978eb5259a6887012240e76eafc540471fc/bundler/lib/bundler/cli/fund.rb#L16-L27

specs doesn't contain enough data, some dependencies are present which aren't in the spec resulting in `spec.metadata` blowing up.

Note that only the first test I created actually fails without this change. I added the second one for consistencies sake but it's not strictly necessary.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
