### PR TITLE
Fix credentials being readded when re-resolving without a full unlock

### DIFF
--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -10,7 +10,7 @@ module Bundler
       # Ask for X gems per API request
       API_REQUEST_SIZE = 50
 
-      attr_reader :remotes
+      attr_accessor :remotes
 
       def initialize(options = {})
         @options = options
@@ -20,9 +20,10 @@ module Bundler
         @allow_cached = false
         @allow_local = options["allow_local"] || false
         @checksum_store = Checksum::Store.new
-        @original_remotes = nil
 
         Array(options["remotes"]).reverse_each {|r| add_remote(r) }
+
+        @lockfile_remotes = @remotes if options["from_lockfile"]
       end
 
       def caches
@@ -92,12 +93,7 @@ module Bundler
 
       def self.from_lock(options)
         options["remotes"] = Array(options.delete("remote")).reverse
-        new(options)
-      end
-
-      def remotes=(new_remotes)
-        @original_remotes = @remotes
-        @remotes = new_remotes
+        new(options.merge("from_lockfile" => true))
       end
 
       def to_lock
@@ -470,7 +466,7 @@ module Bundler
       private
 
       def lockfile_remotes
-        @original_remotes || credless_remotes
+        @lockfile_remotes || credless_remotes
       end
 
       # Checks if the requested spec exists in the global cache. If it does,

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -419,8 +419,16 @@ RSpec.describe "the lockfile format" do
 
     lockfile lockfile_without_credentials
 
+    # when not re-resolving
     bundle "install", artifice: "endpoint_strict_basic_authentication", quiet: true
+    expect(lockfile).to eq lockfile_without_credentials
 
+    # when re-resolving with full unlock
+    bundle "update", artifice: "endpoint_strict_basic_authentication"
+    expect(lockfile).to eq lockfile_without_credentials
+
+    # when re-resolving without ful unlocking
+    bundle "update rack-obama", artifice: "endpoint_strict_basic_authentication"
     expect(lockfile).to eq lockfile_without_credentials
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I tried to implement a more stable behavior for locking credentials in #7720, but I missed one case.

The problem is that in the "re-resolve without full unlock" case, the `Source::Rubygems#remotes=` setter is called twice, so original lockfile credentials are lost.

## What is your fix for the problem, implemented in this PR?

My fix is to set original credentials only when parsing the lockfile initially, not every time sources are replaced, so that they are never overwritten.

Fixes https://github.com/rubygems/rubygems/issues/7761.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
