### PR TITLE
Fix `bundle update <gem_name>` edge case

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -1058,6 +1058,7 @@ module Bundler
                 (@new_platform && platforms.last == platform) ||
                 @path_changes ||
                 @dependency_changes ||
+                @locked_spec_with_invalid_deps ||
                 !@originally_locked_specs.incomplete_for_platform?(dependencies, platform)
 
         remove_platform(platform)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When locked only to "ruby platform", and some locked spec does not meet locked dependencies, Bundler would remove the only locked platform and end up creating a lockfile with empty sections.

## What is your fix for the problem, implemented in this PR?

We can't rely on our criteria to remove invalid platforms if locked specs are not valid in the first place.

This fixes a problem found by Dependabot specs.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
