### PR TITLE
Use get_byte_ranges instead of byte_ranges in Rack::Utils

### DIFF
--- a/bundler/spec/support/artifice/helpers/compact_index.rb
+++ b/bundler/spec/support/artifice/helpers/compact_index.rb
@@ -40,7 +40,7 @@ class CompactIndexAPI < Endpoint
     end
 
     def requested_range_for(response_body)
-      ranges = Rack::Utils.byte_ranges(env, response_body.bytesize)
+      ranges = Rack::Utils.get_byte_ranges(env["HTTP_RANGE"], response_body.bytesize)
 
       if ranges
         status 206


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I got the spec failing related with `Rack::Utils.byte_ranges` like:

```
        Diff:
        @@ -1,3 +1,5 @@
        +`byte_ranges` is deprecated, please use `get_byte_ranges`
        +`byte_ranges` is deprecated, please use `get_byte_ranges`
         Bundler found mismatched checksums. This is a potential security risk.
           rack (1.0.0) sha256=2222222222222222222222222222222222222222222222222222222222222222
             from the API at http://localgemserver.test/
      # ./spec/install/gems/compact_index_spec.rb:1025:in `block (3 levels) in <top (required)>'
      # ./spec/spec_helper.rb:106:in `block (4 levels) in <top (required)>'
      # ./spec/spec_helper.rb:106:in `block (3 levels) in <top (required)>'
      # ./spec/support/helpers.rb:289:in `block in with_gem_path_as'
      # ./spec/support/helpers.rb:303:in `without_env_side_effects'
      # ./spec/support/helpers.rb:284:in `with_gem_path_as'
      # ./spec/spec_helper.rb:105:in `block (2 levels) in <top (required)>'
```

I'm not sure why this happened on my environment.

## What is your fix for the problem, implemented in this PR?

Use `get_range_bytes` instead of `range_bytes` for that.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
