### PR TITLE
Hide patchlevel from lockfile

### DIFF
--- a/bundler/lib/bundler/ruby_version.rb
+++ b/bundler/lib/bundler/ruby_version.rb
@@ -43,7 +43,6 @@ module Bundler
 
     def to_s(versions = self.versions)
       output = String.new("ruby #{versions_string(versions)}")
-      output << "p#{patchlevel}" if patchlevel && patchlevel != "-1"
       output << " (#{engine} #{versions_string(engine_versions)})" unless engine == "ruby"
 
       output
@@ -72,8 +71,7 @@ module Bundler
     def ==(other)
       versions == other.versions &&
         engine == other.engine &&
-        engine_versions == other.engine_versions &&
-        patchlevel == other.patchlevel
+        engine_versions == other.engine_versions
     end
 
     def host

--- a/bundler/spec/bundler/ruby_version_spec.rb
+++ b/bundler/spec/bundler/ruby_version_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "Bundler::RubyVersion and its subclasses" do
 
     describe "#to_s" do
       it "should return info string with the ruby version, patchlevel, engine, and engine version" do
-        expect(subject.to_s).to eq("ruby 2.0.0p645 (jruby 2.0.1)")
+        expect(subject.to_s).to eq("ruby 2.0.0 (jruby 2.0.1)")
       end
 
       context "no patchlevel" do
@@ -115,7 +115,7 @@ RSpec.describe "Bundler::RubyVersion and its subclasses" do
         let(:engine) { "ruby" }
 
         it "should return info string with the ruby version and patchlevel" do
-          expect(subject.to_s).to eq("ruby 2.0.0p645")
+          expect(subject.to_s).to eq("ruby 2.0.0")
         end
       end
 
@@ -145,12 +145,6 @@ RSpec.describe "Bundler::RubyVersion and its subclasses" do
 
       context "the versions do not match" do
         let(:other_version) { "1.21.6" }
-
-        it_behaves_like "two ruby versions are not equal"
-      end
-
-      context "the patchlevels do not match" do
-        let(:other_patchlevel) { "21" }
 
         it_behaves_like "two ruby versions are not equal"
       end

--- a/bundler/spec/install/gemfile/ruby_spec.rb
+++ b/bundler/spec/install/gemfile/ruby_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "ruby requirement" do
         myrack
 
       RUBY VERSION
-         ruby 2.1.4p422
+         ruby 2.1.4
 
       BUNDLED WITH
          #{Bundler::VERSION}


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The ruby core team consider to stop to increase `RUBY_PATCHLEVEL` each commits on stable branch like `ruby_3_3`.

It means comparison feature of patchlevel and show patchlevel are meaningless in lockfile of Bundler. We already hide patchlevel with `ruby -v` from Ruby 3.2.

## What is your fix for the problem, implemented in this PR?

I also removed patchlevel from lockfile and comparison condition of patchlevel. It's good time to remove that at this year because Ruby 3.1 will be EOL at next year. 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
