### PR TITLE
Dump `RbConfig` elements to escape special characters

### DIFF
--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -323,10 +323,10 @@ install:
       end
       RUBY
       RbConfig::CONFIG.each do |k, v|
-        f.puts %(RbConfig::CONFIG[#{k.dump}] = #{v.dump})
+        f.puts %(RbConfig::CONFIG[#{k.dump}] = #{v&.dump || "nil"})
       end
       RbConfig::MAKEFILE_CONFIG.each do |k, v|
-        f.puts %(RbConfig::MAKEFILE_CONFIG[#{k.dump}] = #{v.dump})
+        f.puts %(RbConfig::MAKEFILE_CONFIG[#{k.dump}] = #{v&.dump || "nil"})
       end
       f.puts "RbConfig::CONFIG['host_os'] = 'fake_os'"
       f.puts "RbConfig::CONFIG['arch'] = 'fake_arch'"

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -323,10 +323,10 @@ install:
       end
       RUBY
       RbConfig::CONFIG.each do |k, v|
-        f.puts %(RbConfig::CONFIG["#{k}"] = "#{v}")
+        f.puts %(RbConfig::CONFIG[#{k.dump}] = #{v.dump})
       end
       RbConfig::MAKEFILE_CONFIG.each do |k, v|
-        f.puts %(RbConfig::MAKEFILE_CONFIG["#{k}"] = "#{v}")
+        f.puts %(RbConfig::MAKEFILE_CONFIG[#{k.dump}] = #{v.dump})
       end
       f.puts "RbConfig::CONFIG['host_os'] = 'fake_os'"
       f.puts "RbConfig::CONFIG['arch'] = 'fake_arch'"

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -2577,6 +2577,7 @@ end
 
     yield
   ensure
-    RbConfig::CONFIG["LIBRUBY_RELATIVE"] = orig_libruby_relative
+    # RbConfig::CONFIG values are strings only, there should not be a nil.
+    RbConfig::CONFIG["LIBRUBY_RELATIVE"] = orig_libruby_relative if orig_libruby_relative
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since ruby/ruby@273d41b9e3c90d4d3fe2ffcb88477197d528b9a0 (cf2843f7a2), 
[unexpected error] is occurring on Windows.

```
  D:/a/ruby/ruby/src/lib/mkmf.rb:58:in 'Kernel.load': --> D:/a/_temp/rubytest.pe5gph/test_rubygems_20240618-3196-6h9sug/fake_rbconfig.rb
  Unmatched `(', missing `)' ?Unmatched keyword, missing `end' ?
```
```
  >  19  RbConfig::CONFIG["BUILD_FILE_SEPARATOR"] = "\"
  >  20  RbConfig::CONFIG["PATH_SEPARATOR"] = ";"
```
```
  D:/a/_temp/rubytest.pe5gph/test_rubygems_20240618-3196-6h9sug/fake_rbconfig.rb:20: syntax error, unexpected constant, expecting end-of-input (SyntaxError)
  ...bConfig::CONFIG["PATH_SEPARATOR"] = ";"
  ...                 ^~~~~~~~~~~~~~
  
  	from D:/a/ruby/ruby/src/lib/mkmf.rb:58:in '<module:MakeMakefile>'
  	from D:/a/ruby/ruby/src/lib/mkmf.rb:46:in '<top (required)>'
  	from <internal:D:/a/ruby/ruby/src/lib/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
  	from <internal:D:/a/ruby/ruby/src/lib/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
```

This is because `RbConfig::CONFIG["BUILD_FILE_SEPARATOR"]` is a backslash on Windows, and parsed to escape the closing double quote.

[unexpected error]: https://github.com/ruby/ruby/actions/runs/9557130739/job/26343690582#step:24:417

## What is your fix for the problem, implemented in this PR?

Use `String#dump` instead of naively embedding strings.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
