### PR TITLE
Fix `bundle gem --test=none` adding "none" gem

### DIFF
--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -97,11 +97,10 @@ module Bundler
 
       templates.merge!("gitignore.tt" => ".gitignore") if use_git
 
-      if test_framework = ask_and_set_test_framework
-        config[:test] = test_framework
-        config[:test_framework_version] = TEST_FRAMEWORK_VERSIONS[test_framework]
+      if config[:test] = ask_and_set_test_framework
+        config[:test_framework_version] = TEST_FRAMEWORK_VERSIONS[config[:test]]
 
-        case test_framework
+        case config[:test]
         when "rspec"
           templates.merge!(
             "rspec.tt" => ".rspec",
@@ -280,13 +279,11 @@ module Bundler
       if test_framework.to_s.empty?
         Bundler.ui.confirm "Do you want to generate tests with your gem?"
         Bundler.ui.info hint_text("test")
+        test_framework = Bundler.ui.ask "Enter a test framework. rspec/minitest/test-unit/(none):"
+      end
 
-        result = Bundler.ui.ask "Enter a test framework. rspec/minitest/test-unit/(none):"
-        if /rspec|minitest|test-unit/.match?(result)
-          test_framework = result
-        else
-          test_framework = false
-        end
+      unless /rspec|minitest|test-unit/.match?(test_framework.to_s)
+        test_framework = false
       end
 
       if Bundler.settings["gem.test"].nil?

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -854,6 +854,30 @@ RSpec.describe "bundle gem" do
       end
     end
 
+    context "--test parameter set to none" do
+      before do
+        bundle "gem #{gem_name} --test=none"
+      end
+
+      it "does not include gem 'none' in Gemfile" do
+        expect(bundled_app("#{gem_name}/Gemfile").read).not_to include('gem "none"')
+      end
+
+      it_behaves_like "test framework is absent"
+    end
+
+    context "--test parameter set to foo" do
+      before do
+        bundle "gem #{gem_name} --test=foo"
+      end
+
+      it "does not include gem 'foo' in Gemfile" do
+        expect(bundled_app("#{gem_name}/Gemfile").read).not_to include('gem "foo"')
+      end
+
+      it_behaves_like "test framework is absent"
+    end
+
     context "gem.test setting set to test-unit" do
       before do
         bundle "config set gem.test test-unit"


### PR DESCRIPTION
Fixes #7774.

## What was the end-user or developer problem that led to this PR?

`bundle gem mygem --test=none` generates a Gemfile with `gem "none", "~> "`.

More generally, `bundle gem mygem --test=foo` generates a Gemfile with `gem "foo", "~> "`.

## What is your fix for the problem, implemented in this PR?

The problem happens because of this condition in Bundler's `Gemfile.tt`:
  https://github.com/rubygems/rubygems/blob/38f483a5f3c6f06149011cb165401d9387240142/bundler/lib/bundler/templates/newgem/Gemfile.tt#L16-L19

When `config[:test]` is `"none"`, or `"foo"`, or any other value, this value will show as-is as a bogus gem in the Gemfile with a bogus `"~> "` version.

I changed `Bundler::CLI::Gem#ask_and_set_test_framework` from sometimes checking for approved `rspec|minitest|test-unit` values (when value is blank), to always checking for approved values. If the value is not in the regex, it is considered the same as not providing it. I then changed the caller code to be more in line with the rest of the `config[:xyz] = ask_and_set_xyz` caller code, so that `config[:test]` can simply be used as-is in `Gemfile.tt` and no change is needed in that file.

Alternative I considered: at first I thought about changing the condition in `Gemfile.tt` but it didn't feel right as it would clutter the template, and the regex condition already belonged  in `ask_and_set_test_framework` so it felt like it should stay there and not be duplicated across 2 files.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
