### PR TITLE
Refine the fake_rbconfig test

### DIFF
--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -323,10 +323,10 @@ install:
       end
       RUBY
       RbConfig::CONFIG.each do |k, v|
-        f.puts %(RbConfig::CONFIG[#{k.dump}] = #{v&.dump || "nil"})
+        f.puts %(RbConfig::CONFIG[#{k.dump}] = #{v.dump})
       end
       RbConfig::MAKEFILE_CONFIG.each do |k, v|
-        f.puts %(RbConfig::MAKEFILE_CONFIG[#{k.dump}] = #{v&.dump || "nil"})
+        f.puts %(RbConfig::MAKEFILE_CONFIG[#{k.dump}] = #{v.dump})
       end
       f.puts "RbConfig::CONFIG['host_os'] = 'fake_os'"
       f.puts "RbConfig::CONFIG['arch'] = 'fake_arch'"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

A follow up of #7773.

## What is your fix for the problem, implemented in this PR?

- Properly check if just mkmf ignores `--target-rbconfig` option, or something failed.
- Remove no longer needed workaround.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
