### PR TITLE
Support `--no-test`, `--no-ci`, and `--no-linter` options

### DIFF
--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -275,6 +275,7 @@ module Bundler
     end
 
     def ask_and_set_test_framework
+      return if skip?(:test)
       test_framework = options[:test] || Bundler.settings["gem.test"]
 
       if test_framework.to_s.empty?
@@ -300,6 +301,10 @@ module Bundler
       test_framework
     end
 
+    def skip?(option)
+      options.key?(option) && options[option].nil?
+    end
+
     def hint_text(setting)
       if Bundler.settings["gem.#{setting}"] == false
         "Your choice will only be applied to this gem."
@@ -310,6 +315,7 @@ module Bundler
     end
 
     def ask_and_set_ci
+      return if skip?(:ci)
       ci_template = options[:ci] || Bundler.settings["gem.ci"]
 
       if ci_template.to_s.empty?
@@ -341,6 +347,7 @@ module Bundler
     end
 
     def ask_and_set_linter
+      return if skip?(:linter)
       linter_template = options[:linter] || Bundler.settings["gem.linter"]
       linter_template = deprecated_rubocop_option if linter_template.nil?
 

--- a/bundler/lib/bundler/man/bundle-gem.1
+++ b/bundler/lib/bundler/man/bundle-gem.1
@@ -44,6 +44,8 @@ When Bundler is configured to not generate tests, an interactive prompt will be 
 .IP
 When Bundler is unconfigured, an interactive prompt will be displayed and the answer will be saved in Bundler's global config for future \fBbundle gem\fR use\.
 .IP "\(bu" 4
+\fB\-\-no\-test\fR: Do not use a test framework (overrides \fB\-\-test\fR specified in the global config)\.
+.IP "\(bu" 4
 \fB\-\-ci\fR, \fB\-\-ci=github\fR, \fB\-\-ci=gitlab\fR, \fB\-\-ci=circle\fR: Specify the continuous integration service that Bundler should use when generating the project\. Acceptable values are \fBgithub\fR, \fBgitlab\fR and \fBcircle\fR\. A configuration file will be generated in the project directory\. Given no option is specified:
 .IP
 When Bundler is configured to generate CI files, this defaults to Bundler's global config setting \fBgem\.ci\fR\.
@@ -52,6 +54,8 @@ When Bundler is configured to not generate CI files, an interactive prompt will 
 .IP
 When Bundler is unconfigured, an interactive prompt will be displayed and the answer will be saved in Bundler's global config for future \fBbundle gem\fR use\.
 .IP "\(bu" 4
+\fB\-\-no\-ci\fR: Do not use a continuous integration service (overrides \fB\-\-ci\fR specified in the global config)\.
+.IP "\(bu" 4
 \fB\-\-linter\fR, \fB\-\-linter=rubocop\fR, \fB\-\-linter=standard\fR: Specify the linter and code formatter that Bundler should add to the project's development dependencies\. Acceptable values are \fBrubocop\fR and \fBstandard\fR\. A configuration file will be generated in the project directory\. Given no option is specified:
 .IP
 When Bundler is configured to add a linter, this defaults to Bundler's global config setting \fBgem\.linter\fR\.
@@ -59,6 +63,8 @@ When Bundler is configured to add a linter, this defaults to Bundler's global co
 When Bundler is configured not to add a linter, an interactive prompt will be displayed and the answer will be used for the current rubygem project\.
 .IP
 When Bundler is unconfigured, an interactive prompt will be displayed and the answer will be saved in Bundler's global config for future \fBbundle gem\fR use\.
+.IP "\(bu" 4
+\fB\-\-no\-linter\fR: Do not add a linter (overrides \fB\-\-linter\fR specified in the global config)\.
 .IP "\(bu" 4
 \fB\-e\fR, \fB\-\-edit[=EDITOR]\fR: Open the resulting GEM_NAME\.gemspec in EDITOR, or the default editor if not specified\. The default is \fB$BUNDLER_EDITOR\fR, \fB$VISUAL\fR, or \fB$EDITOR\fR\.
 .IP "" 0

--- a/bundler/lib/bundler/man/bundle-gem.1.ronn
+++ b/bundler/lib/bundler/man/bundle-gem.1.ronn
@@ -76,6 +76,10 @@ configuration file using the following names:
   the answer will be saved in Bundler's global config for future `bundle gem`
   use.
 
+* `--no-test`:
+  Do not use a test framework (overrides `--test` specified in the global
+  config).
+
 * `--ci`, `--ci=github`, `--ci=gitlab`, `--ci=circle`:
   Specify the continuous integration service that Bundler should use when
   generating the project. Acceptable values are `github`, `gitlab`
@@ -92,6 +96,10 @@ configuration file using the following names:
   the answer will be saved in Bundler's global config for future `bundle gem`
   use.
 
+* `--no-ci`:
+  Do not use a continuous integration service (overrides `--ci` specified in
+  the global config).
+
 * `--linter`, `--linter=rubocop`, `--linter=standard`:
   Specify the linter and code formatter that Bundler should add to the
   project's development dependencies. Acceptable values are `rubocop` and
@@ -107,6 +115,9 @@ configuration file using the following names:
   When Bundler is unconfigured, an interactive prompt will be displayed and
   the answer will be saved in Bundler's global config for future `bundle gem`
   use.
+
+* `--no-linter`:
+  Do not add a linter (overrides `--linter` specified in the global config).
 
 * `-e`, `--edit[=EDITOR]`:
   Open the resulting GEM_NAME.gemspec in EDITOR, or the default editor if not

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -937,6 +937,15 @@ RSpec.describe "bundle gem" do
       it_behaves_like "test framework is absent"
     end
 
+    context "gem.test setting set to a test framework and --no-test" do
+      before do
+        bundle "config set gem.test rspec"
+        bundle "gem #{gem_name} --no-test"
+      end
+
+      it_behaves_like "test framework is absent"
+    end
+
     context "--ci with no argument" do
       it "does not generate any CI config" do
         bundle "gem #{gem_name}"
@@ -1075,6 +1084,19 @@ RSpec.describe "bundle gem" do
       end
     end
 
+    context "gem.ci setting set to a CI service and --no-ci" do
+      before do
+        bundle "config set gem.ci github"
+        bundle "gem #{gem_name} --no-ci"
+      end
+
+      it "does not generate any CI config" do
+        expect(bundled_app("#{gem_name}/.github/workflows/main.yml")).to_not exist
+        expect(bundled_app("#{gem_name}/.gitlab-ci.yml")).to_not exist
+        expect(bundled_app("#{gem_name}/.circleci/config.yml")).to_not exist
+      end
+    end
+
     context "--linter with no argument" do
       it "does not generate any linter config" do
         bundle "gem #{gem_name}"
@@ -1199,6 +1221,18 @@ RSpec.describe "bundle gem" do
         hint = "Future `bundle gem` calls will use your choice. " \
                "This setting can be changed anytime with `bundle config gem.linter`."
         expect(out).to match(hint)
+      end
+    end
+
+    context "gem.linter setting set to a linter and --no-linter" do
+      before do
+        bundle "config set gem.linter rubocop"
+        bundle "gem #{gem_name} --no-linter"
+      end
+
+      it "does not generate any linter config" do
+        expect(bundled_app("#{gem_name}/.rubocop.yml")).to_not exist
+        expect(bundled_app("#{gem_name}/.standard.yml")).to_not exist
       end
     end
 


### PR DESCRIPTION
Follow-up or alternative for https://github.com/rubygems/rubygems/pull/7775.

## What was the end-user or developer problem that led to this PR?

The `--no-test`, `--no-ci`, and `--no-linter` options are currently not supported.

@simi has [mentioned](https://github.com/rubygems/rubygems/pull/7775#issuecomment-2178487458) `--no-test` as a potential alternative to `--test=none` to skip tests. If we want to support `--no-test`, we should also support `--no-ci` and `--no-linter` to be consistent.

## What is your fix for the problem, implemented in this PR?

This PR adds support for `--no-test`, `--no-ci`, and `--no-linter`:

- Added a `skip?(option)` convenience method to more easily detect when the user provides a `--no-x` or `--skip-x` option, which Thor parses by explicitly setting `options[:x]` to `nil`.
- Made all `ask_and_set_x` methods return early if `x` is skipped. Returning early is done on purpose to be in line with the behavior of other existing `--no-mit`/`--no-coc`/etc options, which when provided do not set any Bundler global config setting. In that sense `--no-x` is just a one-off disabling flag.
- Documented these new options in the bundle-gem man page.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
