### PR TITLE
Print a proper error when bin dir does not have writable permission bit

### DIFF
--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -58,6 +58,14 @@ module Bundler
       end
     end
 
+    def ensure_writable_dir(dir)
+      super
+    rescue Gem::FilePermissionError
+      # Ignore permission checks in RubyGems. Instead, go on, and try to write
+      # for real. We properly handle permission errors when they happen.
+      nil
+    end
+
     def generate_plugins
       return unless Gem::Installer.instance_methods(false).include?(:generate_plugins)
 

--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -48,12 +48,14 @@ module Bundler
       spec
     end
 
-    def pre_install_checks
-      super
-    rescue Gem::FilePermissionError
-      # Ignore permission checks in RubyGems. Instead, go on, and try to write
-      # for real. We properly handle permission errors when they happen.
-      nil
+    if Bundler.rubygems.provides?("< 3.5")
+      def pre_install_checks
+        super
+      rescue Gem::FilePermissionError
+        # Ignore permission checks in RubyGems. Instead, go on, and try to write
+        # for real. We properly handle permission errors when they happen.
+        nil
+      end
     end
 
     def generate_plugins

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -899,6 +899,36 @@ RSpec.describe "bundle install with gem sources" do
     end
   end
 
+  describe "when bundle bin dir does not have write access", :permissions do
+    let(:bin_dir) { bundled_app("vendor/#{Bundler.ruby_scope}/bin") }
+
+    before do
+      FileUtils.mkdir_p(bin_dir)
+      gemfile <<-G
+        source "https://gem.repo1"
+        gem "myrack"
+      G
+    end
+
+    it "should display a proper message to explain the problem" do
+      FileUtils.chmod("-w", bin_dir)
+      bundle "config set --local path vendor"
+
+      begin
+        bundle :install, raise_on_error: false
+      ensure
+        FileUtils.chmod("+w", bin_dir)
+      end
+
+      expect(err).not_to include("ERROR REPORT TEMPLATE")
+
+      expect(err).to include(
+        "There was an error while trying to write to `#{bin_dir}`. " \
+        "It is likely that you need to grant write permissions for that path."
+      )
+    end
+  end
+
   describe "when bundle extensions path does not have write access", :permissions do
     let(:extensions_path) { bundled_app("vendor/#{Bundler.ruby_scope}/extensions/#{Gem::Platform.local}/#{Gem.extension_api_version}") }
 

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -818,7 +818,7 @@ RSpec.describe "bundle install with gem sources" do
     end
   end
 
-  describe "when bundle path does not have write access", :permissions do
+  describe "when bundle path does not have cd permission", :permissions do
     let(:bundle_path) { bundled_app("vendor") }
 
     before do
@@ -839,7 +839,7 @@ RSpec.describe "bundle install with gem sources" do
     end
   end
 
-  describe "when bundle gems path does not have write access", :permissions do
+  describe "when bundle gems path does not have cd permission", :permissions do
     let(:gems_path) { bundled_app("vendor/#{Bundler.ruby_scope}/gems") }
 
     before do
@@ -869,7 +869,7 @@ RSpec.describe "bundle install with gem sources" do
     end
   end
 
-  describe "when bundle bin dir does not have write access", :permissions do
+  describe "when bundle bin dir does not have cd permission", :permissions do
     let(:bin_dir) { bundled_app("vendor/#{Bundler.ruby_scope}/bin") }
 
     before do
@@ -929,7 +929,7 @@ RSpec.describe "bundle install with gem sources" do
     end
   end
 
-  describe "when the path of a specific gem is not writable", :permissions do
+  describe "when the path of a specific gem does not have cd permission", :permissions do
     let(:gems_path) { bundled_app("vendor/#{Bundler.ruby_scope}/gems") }
     let(:foo_path) { gems_path.join("foo-1.0.0") }
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In https://github.com/rubygems/rubygems/pull/7748, we dealt with missing "executable" permission bit for the directory, but there's another case where we end up printing the bug report template, i.e., when bin dir is missing "write" permission bit.

## What is your fix for the problem, implemented in this PR?

If bin dir is missing this bit, RubyGems will raise `Gem::FilePermission` error which is not rescued by Bundler.

Checking writability bits directly is unreliable and it's better to try to write directly and handle permission errors. So this PR overrides the `ensure_writable_dir` to not check permission bits directly, and only try to create the directory.

Like with #7211, I think a follow up PR should also remove this from RubyGems, but for now I'm only fixing it in the Bundler side.

Fixes https://github.com/rubygems/rubygems/issues/7793.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
