### PR TITLE
Fix truffleruby removing gems from lockfile

### DIFF
--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -16,8 +16,14 @@ permissions: # added using https://github.com/step-security/secure-workflows
 
 jobs:
   ubuntu_lint:
-    name: Lint
+    name: Lint on ${{ matrix.ruby.name }}
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - { name: ruby, value: 3.3.4 }
+          - { name: truffleruby, value: truffleruby-24.0.1 }
     env:
       RUBYOPT: -Ilib
     steps:
@@ -25,7 +31,7 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@a6e6f86333f0a2523ece813039b8b4be04560854 # v1.190.0
         with:
-          ruby-version: 3.3.4
+          ruby-version: ${{ matrix.ruby.value }}
           bundler: none
       - name: Install Dependencies
         run: bin/rake setup

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -630,6 +630,7 @@ module Bundler
     def start_resolution
       local_platform_needed_for_resolvability = @most_specific_non_local_locked_ruby_platform && !@platforms.include?(local_platform)
       @platforms << local_platform if local_platform_needed_for_resolvability
+      add_platform(Gem::Platform::RUBY) if RUBY_ENGINE == "truffleruby"
 
       result = SpecSet.new(resolver.start)
 

--- a/bundler/lib/bundler/force_platform.rb
+++ b/bundler/lib/bundler/force_platform.rb
@@ -2,8 +2,6 @@
 
 module Bundler
   module ForcePlatform
-    private
-
     # The `:force_ruby_platform` value used by dependencies for resolution, and
     # by locked specifications for materialization is `false` by default, except
     # for TruffleRuby. TruffleRuby generally needs to force the RUBY platform

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -237,15 +237,11 @@ module Gem
 
     include ::Bundler::ForcePlatform
 
+    attr_reader :force_ruby_platform
+
     attr_accessor :source, :groups
 
     alias_method :eql?, :==
-
-    def force_ruby_platform
-      return @force_ruby_platform if defined?(@force_ruby_platform) && !@force_ruby_platform.nil?
-
-      @force_ruby_platform = default_force_ruby_platform
-    end
 
     unless method_defined?(:encode_with, false)
       def encode_with(coder)

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -280,7 +280,7 @@ module Bundler
       if platform
         GemHelpers.select_best_platform_match(specs_for_name, platform, force_ruby: dep.force_ruby_platform)
       else
-        GemHelpers.select_best_local_platform_match(specs_for_name, force_ruby: dep.force_ruby_platform)
+        GemHelpers.select_best_local_platform_match(specs_for_name, force_ruby: dep.force_ruby_platform || dep.default_force_ruby_platform)
       end
     end
 

--- a/tool/bundler/dev_gems.rb.lock
+++ b/tool/bundler/dev_gems.rb.lock
@@ -57,9 +57,11 @@ GEM
     webrick (1.8.1)
 
 PLATFORMS
+  aarch64-darwin
   arm64-darwin-22
   arm64-darwin-23
   java
+  ruby
   universal-java-11
   universal-java-18
   universal-java-19

--- a/tool/bundler/release_gems.rb.lock
+++ b/tool/bundler/release_gems.rb.lock
@@ -38,11 +38,13 @@ GEM
     uri (0.13.0)
 
 PLATFORMS
+  aarch64-darwin
   aarch64-linux
   arm64-darwin-20
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  ruby
   universal-java-11
   universal-java-18
   x86_64-darwin-20

--- a/tool/bundler/rubocop_gems.rb.lock
+++ b/tool/bundler/rubocop_gems.rb.lock
@@ -53,11 +53,13 @@ GEM
     unicode-display_width (2.5.0)
 
 PLATFORMS
+  aarch64-darwin
   aarch64-linux
   arm64-darwin-20
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  ruby
   universal-java-11
   universal-java-18
   universal-java-19

--- a/tool/bundler/standard_gems.rb.lock
+++ b/tool/bundler/standard_gems.rb.lock
@@ -69,11 +69,13 @@ GEM
     unicode-display_width (2.5.0)
 
 PLATFORMS
+  aarch64-darwin
   aarch64-linux
   arm64-darwin-20
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  ruby
   universal-java-11
   universal-java-18
   universal-java-19


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When resolving on truffleruby, and multiple platforms are included in the lockfile, Bundler will not respect existing platforms, but always force ruby variants. That means removal of existing version specific variants, introducing lockfile churn between implementations.



## What is your fix for the problem, implemented in this PR?

To prevent this, we introduce the distinction between `Dependency#force_ruby_platform`, only settable via Gemfile, and `Dependency#default_force_ruby_platform`, which is always true on truffleruby for certain dependency names. This way, when resolving lockfile gems for other platforms on truffleruby, we keep platform specific variants in the lockfile.
    
However, that introduces the problem that if only platform specific variants are locked in the lockfile, Bundler won't be able to materialize on truffleruby because the generic variant will be missing. To fix this additional problem, we make sure the generic "ruby" platform is always added when resolving on truffleruby.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
