### PR TITLE
Don't print warning about nil versions being discouraged during tests

### DIFF
--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3953,11 +3953,11 @@ end
 
   def test_validate_for_resolution_validates_required_attributes
     e = assert_raise Gem::InvalidSpecificationException do
-      @a1.version = nil
+      @a1.name = nil
       @a1.validate_for_resolution
     end
 
-    assert_equal "missing value for attribute version", e.message
+    assert_equal "missing value for attribute name", e.message
   end
 
   def test_validate_for_resolution_validates_name


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since https://github.com/rubygems/rubygems/pull/7707, running RubyGems tests prints an spurious warning about nil versions being discouraged.

## What is your fix for the problem, implemented in this PR?

Test another attribute, so that the warning is not printed.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
