### PR TITLE
Protect binstub creation with a file lock (initial take)

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -222,7 +222,7 @@ class Gem::Installer
     ruby_executable = false
     existing = nil
 
-    File.open generated_bin, "rb" do |io|
+    Gem.open_file_with_flock generated_bin, "rb+" do |io|
       line = io.gets
       shebang = /^#!.*ruby/o
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I had to restart CI twice in https://github.com/rubygems/rubygems/pull/7669 to get CI to pass. The problem was this spec failure:

```
       $ /opt/hostedtoolcache/Ruby/3.1.5/x64/bin/ruby -I/home/runner/work/rubygems/rubygems/bundler/spec -r/home/runner/work/rubygems/rubygems/bundler/spec/support/artifice/compact_index.rb -r/home/runner/work/rubygems/rubygems/bundler/spec/support/hax.rb /home/runner/work/rubygems/rubygems/bundler/tmp/3/gems/system/bin/bundle install
       Fetching gem metadata from https://gem.repo2/.
       Resolving dependencies...
       Fetching myrack 1.0.0
       Fetching fake 14
       Installing myrack 1.0.0
       Installing fake 14
       Bundle complete! 2 Gemfile dependencies, 3 gems now installed.
       Use `bundle info [gemname]` to see where a bundled gem is installed.
       Post-install message from myrack:
       Myrack's post install message
       # $? => 0
       Invoking `/opt/hostedtoolcache/Ruby/3.1.5/x64/bin/ruby -I/home/runner/work/rubygems/rubygems/bundler/spec -r/home/runner/work/rubygems/rubygems/bundler/spec/support/artifice/compact_index.rb -r/home/runner/work/rubygems/rubygems/bundler/spec/support/hax.rb /home/runner/work/rubygems/rubygems/bundler/tmp/3/gems/system/bin/bundle exec myrackup` failed with output:

       ----------------------------------------------------------------------
       bundler: failed to load command: myrackup (/home/runner/work/rubygems/rubygems/bundler/tmp/3/gems/system/bin/myrackup)
       /home/runner/work/rubygems/rubygems/bundler/tmp/3/gems/system/gems/bundler-2.6.0.dev/lib/bundler/cli/exec.rb:58:in `load': /home/runner/work/rubygems/rubygems/bundler/tmp/3/gems/system/bin/myrackup:30: syntax error, unexpected ')', expecting end-of-input (SyntaxError)
       	from /home/runner/work/rubygems/rubygems/bundler/tmp/3/gems/system/gems/bundler-2.6.0.dev/lib/bundler/cli/exec.rb:58:in `kernel_load'
       	from /home/runner/work/rubygems/rubygems/bundler/tmp/3/gems/system/gems/bundler-2.6.0.dev/lib/bundler/cli/exec.rb:23:in `run'
       	from /home/runner/work/rubygems/rubygems/bundler/tmp/3/gems/system/gems/bundler-2.6.0.dev/lib/bundler/cli.rb:457:in `exec'
       	from /home/runner/work/rubygems/rubygems/bundler/tmp/3/gems/system/gems/bundler-2.6.0.dev/lib/bundler/vendor/thor/lib/thor/command.rb:28:in `run'
       	from /home/runner/work/rubygems/rubygems/bundler/tmp/3/gems/system/gems/bundler-2.6.0.dev/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
       	from /home/runner/work/rubygems/rubygems/bundler/tmp/3/gems/system/gems/bundler-2.6.0.dev/lib/bundler/vendor/thor/lib/thor.rb:527:in `dispatch'
       	from /home/runner/work/rubygems/rubygems/bundler/tmp/3/gems/system/gems/bundler-2.6.0.dev/lib/bundler/cli.rb:35:in `dispatch'
       	from /home/runner/work/rubygems/rubygems/bundler/tmp/3/gems/system/gems/bundler-2.6.0.dev/lib/bundler/vendor/thor/lib/thor/base.rb:584:in `start'
       	from /home/runner/work/rubygems/rubygems/bundler/tmp/3/gems/system/gems/bundler-2.6.0.dev/lib/bundler/cli.rb:29:in `start'
       	from /home/runner/work/rubygems/rubygems/bundler/tmp/3/gems/system/gems/bundler-2.6.0.dev/exe/bundle:28:in `block in <top (required)>'
       	from /home/runner/work/rubygems/rubygems/bundler/tmp/3/gems/system/gems/bundler-2.6.0.dev/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
       	from /home/runner/work/rubygems/rubygems/bundler/tmp/3/gems/system/gems/bundler-2.6.0.dev/exe/bundle:20:in `<top (required)>'
       	from /home/runner/work/rubygems/rubygems/bundler/tmp/3/gems/system/bin/bundle:25:in `load'
       	from /home/runner/work/rubygems/rubygems/bundler/tmp/3/gems/system/bin/bundle:25:in `<main>'
       ----------------------------------------------------------------------
     # ./spec/support/command_execution.rb:26:in `raise_error!'
     # ./spec/support/subprocess.rb:66:in `sh'
     # ./spec/support/helpers.rb:200:in `sys_exec'
     # ./spec/support/helpers.rb:99:in `bundle'
     # ./spec/install/binstubs_spec.rb:36:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:106:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:106:in `block (3 levels) in <top (required)>'
     # ./spec/support/helpers.rb:323:in `block in with_gem_path_as'
     # ./spec/support/helpers.rb:337:in `without_env_side_effects'
     # ./spec/support/helpers.rb:318:in `with_gem_path_as'
     # ./spec/spec_helper.rb:105:in `block (2 levels) in <top (required)>'

Finished in 23 minutes 23 seconds (files took 0.95907 seconds to load)
3587 examples, 1 failure, 15 pending

Failed examples:

rspec ./spec/install/binstubs_spec.rb:35 # bundle install when multiple gems contain the same exe warns about the situation
```

This spec tests a very particular situation when two different gems provide the same executable. In this situation, Bundler prints a warning.

However, as the failure shows, sometimes Bundler will end up generating a corrupt binstub here. I think the problem is that concurrent access to the same file from multiple parallel install thread is not protected by a file lock.

## What is your fix for the problem, implemented in this PR?

Protect access with a file lock.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
