### PR TITLE
Make it clearer that `add_dependency` is the main way to add non-development dependencies

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -546,9 +546,9 @@ class Gem::Specification < Gem::BasicSpecification
   #
   # Usage:
   #
-  #   spec.add_runtime_dependency 'example', '~> 1.1', '>= 1.1.4'
+  #   spec.add_dependency 'example', '~> 1.1', '>= 1.1.4'
 
-  def add_runtime_dependency(gem, *requirements)
+  def add_dependency(gem, *requirements)
     if requirements.uniq.size != requirements.size
       warn "WARNING: duplicated #{gem} dependency #{requirements}"
     end
@@ -1504,7 +1504,7 @@ class Gem::Specification < Gem::BasicSpecification
 
   private :add_dependency_with_type
 
-  alias_method :add_dependency, :add_runtime_dependency
+  alias_method :add_runtime_dependency, :add_dependency
 
   ##
   # Adds this spec's require paths to LOAD_PATH, in the proper location.


### PR DESCRIPTION
Ref: https://github.com/rubygems/rubygems/issues/7799

## What was the end-user or developer problem that led to this PR?

The Bundler team [recommends](https://github.com/rubygems/rubygems/issues/7799#issuecomment-2192720316) using `add_dependency` for gems using Gemfiles, which is the default case when generating a gem with `bundle gem`. And the gemspec generated by `bundle gem` [suggests](https://github.com/rubygems/rubygems/blob/d024794af7a68031a91c7c8fa37a87d699d53ca9/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt#L47-L48) using it as well.

However in [rubydoc](https://www.rubydoc.info/github/rubygems/rubygems/Gem/Specification#add_runtime_dependency-instance_method) and the [specification reference](https://guides.rubygems.org/specification-reference/#add_runtime_dependency), `add_runtime_dependency` is featured more prominently than `add_dependency`, because `add_runtime_dependency` is the main method, and `add_dependency` is the alias.

## What is your fix for the problem, implemented in this PR?

Make `add_dependency` the main method, and `add_runtime_dependency` the alias. This will start making it clear in the code and in the docs that `add_dependency` is the main way to go.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
