### PR TITLE
Only allow valid values for `--test`, `--ci`, and `--linter` options

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -552,10 +552,13 @@ module Bundler
     method_option :rubocop, type: :boolean, desc: "Add rubocop to the generated Rakefile and gemspec. Set a default with `bundle config set --global gem.rubocop true`."
     method_option :changelog, type: :boolean, desc: "Generate changelog file. Set a default with `bundle config set --global gem.changelog true`."
     method_option :test, type: :string, lazy_default: Bundler.settings["gem.test"] || "", aliases: "-t", banner: "Use the specified test framework for your library",
+                         enum: %w[rspec minitest test-unit],
                          desc: "Generate a test directory for your library, either rspec, minitest or test-unit. Set a default with `bundle config set --global gem.test (rspec|minitest|test-unit)`."
     method_option :ci, type: :string, lazy_default: Bundler.settings["gem.ci"] || "",
+                       enum: %w[github gitlab circle],
                        desc: "Generate CI configuration, either GitHub Actions, GitLab CI or CircleCI. Set a default with `bundle config set --global gem.ci (github|gitlab|circle)`"
     method_option :linter, type: :string, lazy_default: Bundler.settings["gem.linter"] || "",
+                           enum: %w[rubocop standard],
                            desc: "Add a linter and code formatter, either RuboCop or Standard. Set a default with `bundle config set --global gem.linter (rubocop|standard)`"
     method_option :github_username, type: :string, default: Bundler.settings["gem.github_username"], banner: "Set your username on GitHub", desc: "Fill in GitHub username on README so that you don't have to do it manually. Set a default with `bundle config set --global gem.github_username <your_username>`."
 

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -269,11 +269,11 @@ RSpec.describe "bundle gem" do
     end
   end
 
-  shared_examples_for "--linter=none flag" do
+  shared_examples_for "--no-linter flag" do
     define_negated_matcher :exclude, :include
 
     before do
-      bundle "gem #{gem_name} --linter=none"
+      bundle "gem #{gem_name} --no-linter"
     end
 
     it "generates a gem skeleton without rubocop" do
@@ -854,6 +854,17 @@ RSpec.describe "bundle gem" do
       end
     end
 
+    context "--test parameter set to an invalid value" do
+      before do
+        bundle "gem #{gem_name} --test=foo", raise_on_error: false
+      end
+
+      it "fails loudly" do
+        expect(last_command).to be_failure
+        expect(err).to match(/Expected '--test' to be one of .*; got foo/)
+      end
+    end
+
     context "gem.test setting set to test-unit" do
       before do
         bundle "config set gem.test test-unit"
@@ -998,6 +1009,17 @@ RSpec.describe "bundle gem" do
       end
     end
 
+    context "--ci set to an invalid value" do
+      before do
+        bundle "gem #{gem_name} --ci=foo", raise_on_error: false
+      end
+
+      it "fails loudly" do
+        expect(last_command).to be_failure
+        expect(err).to match(/Expected '--ci' to be one of .*; got foo/)
+      end
+    end
+
     context "gem.ci setting set to none" do
       it "doesn't generate any CI config" do
         expect(bundled_app("#{gem_name}/.github/workflows/main.yml")).to_not exist
@@ -1121,6 +1143,17 @@ RSpec.describe "bundle gem" do
 
         expect(bundled_app("#{gem_name}/.standard.yml")).to exist
         expect(bundled_app("#{gem_name}/.rubocop.yml")).to_not exist
+      end
+    end
+
+    context "--linter set to an invalid value" do
+      before do
+        bundle "gem #{gem_name} --linter=foo", raise_on_error: false
+      end
+
+      it "fails loudly" do
+        expect(last_command).to be_failure
+        expect(err).to match(/Expected '--linter' to be one of .*; got foo/)
       end
     end
 
@@ -1288,7 +1321,7 @@ RSpec.describe "bundle gem" do
       end
       it_behaves_like "--linter=rubocop flag"
       it_behaves_like "--linter=standard flag"
-      it_behaves_like "--linter=none flag"
+      it_behaves_like "--no-linter flag"
       it_behaves_like "--rubocop flag"
       it_behaves_like "--no-rubocop flag"
     end
@@ -1299,7 +1332,7 @@ RSpec.describe "bundle gem" do
       end
       it_behaves_like "--linter=rubocop flag"
       it_behaves_like "--linter=standard flag"
-      it_behaves_like "--linter=none flag"
+      it_behaves_like "--no-linter flag"
       it_behaves_like "--rubocop flag"
       it_behaves_like "--no-rubocop flag"
     end
@@ -1310,7 +1343,7 @@ RSpec.describe "bundle gem" do
       end
       it_behaves_like "--linter=rubocop flag"
       it_behaves_like "--linter=standard flag"
-      it_behaves_like "--linter=none flag"
+      it_behaves_like "--no-linter flag"
     end
 
     context "with linter option in bundle config settings set to standard" do
@@ -1319,7 +1352,7 @@ RSpec.describe "bundle gem" do
       end
       it_behaves_like "--linter=rubocop flag"
       it_behaves_like "--linter=standard flag"
-      it_behaves_like "--linter=none flag"
+      it_behaves_like "--no-linter flag"
     end
 
     context "with linter option in bundle config settings set to false" do
@@ -1328,7 +1361,7 @@ RSpec.describe "bundle gem" do
       end
       it_behaves_like "--linter=rubocop flag"
       it_behaves_like "--linter=standard flag"
-      it_behaves_like "--linter=none flag"
+      it_behaves_like "--no-linter flag"
     end
 
     context "with changelog option in bundle config settings set to true" do


### PR DESCRIPTION
Fixes https://github.com/rubygems/rubygems/issues/7774.

## What was the end-user or developer problem that led to this PR?

`bundle gem mygem --test=none` generates a Gemfile with `gem "none", "~> "`.
More generally, `bundle gem mygem --test=foo` generates a Gemfile with `gem "foo", "~> "`.

We [should not allow invalid values](https://github.com/rubygems/rubygems/pull/7775#issuecomment-2191472429) for `--test`, and the same should be done for `--ci` and `--linter` to be consistent.

## What is your fix for the problem, implemented in this PR?

Set valid values for each option by using Thor's `enum`. If the user provides an invalid value, the CLI will fail loudly like so:

```
$ bundle gem mygem --test=foo
Expected '--test' to be one of rspec, minitest, test-unit; got foo
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
