### PR TITLE
Fix `bundle lock --add-platform <current_platform>` doing nothing

### DIFF
--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -1008,14 +1008,14 @@ RSpec.describe "bundle lock" do
     end
 
     gemfile <<-G
-      source "https://localgemserver.test"
+      source "https://gem.repo4"
 
       gem "raygun-apm"
     G
 
     lockfile <<-L
       GEM
-        remote: https://localgemserver.test/
+        remote: https://gem.repo4/
         specs:
           raygun-apm (1.0.78-universal-darwin)
 
@@ -1029,7 +1029,7 @@ RSpec.describe "bundle lock" do
          #{Bundler::VERSION}
     L
 
-    bundle "lock --add-platform x86_64-linux", artifice: "compact_index", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+    bundle "lock --add-platform x86_64-linux"
   end
 
   it "does not crash on conflicting ruby requirements between platform versions in two different gems" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since https://github.com/rubygems/rubygems/pull/7731, we make sure to always resolve against the current platform, because under some situations, there's no valid resolution using only generic platform gems.

To not change existing lockfiles, we remove it after resolution if it was not present in the lockfile already. However, if the gem had been explicitly added by `bundle lock --add-platform`  previously, we don't want to remove it. 

## What is your fix for the problem, implemented in this PR?

My fix is to only remove the local platform after resolution when we added it right before resolution for resolvability.

Fixes #7798.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
