### PR TITLE
Enable lockfile checksums on Bundler 3 when there's no previous lockfile

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -115,7 +115,7 @@ module Bundler
         @originally_locked_specs = @locked_specs
         @locked_sources = []
         @locked_platforms = []
-        @locked_checksums = nil
+        @locked_checksums = Bundler.feature_flag.bundler_3_mode?
       end
 
       locked_gem_sources = @locked_sources.select {|s| s.is_a?(Source::Rubygems) }

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Bundler::Definition do
         s.add_dependency "myrack", "1.0"
       end
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.no_checksum "foo", "1.0"
         c.checksum gem_repo1, "myrack", "1.0.0"
       end
@@ -108,7 +108,7 @@ RSpec.describe Bundler::Definition do
         s.add_development_dependency "net-ssh", "1.0"
       end
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.no_checksum "foo", "1.0"
         c.checksum gem_repo1, "myrack", "1.0.0"
       end
@@ -149,14 +149,14 @@ RSpec.describe Bundler::Definition do
     end
 
     it "for a locked gem for another platform" do
-      checksums = checksums_section_when_existing do |c|
-        c.no_checksum "only_java", "1.1", "java"
-      end
-
       install_gemfile <<-G
         source "https://gem.repo1"
         gem "only_java", platform: :jruby
       G
+
+      checksums = checksums_section_when_enabled do |c|
+        c.checksum gem_repo1, "only_java", "1.1", "java"
+      end
 
       bundle "lock --add-platform java"
       bundle :check, env: { "DEBUG" => "1" }
@@ -180,7 +180,7 @@ RSpec.describe Bundler::Definition do
     end
 
     it "for a rubygems gem" do
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.checksum gem_repo1, "foo", "1.0"
       end
 

--- a/bundler/spec/cache/gems_spec.rb
+++ b/bundler/spec/cache/gems_spec.rb
@@ -297,6 +297,7 @@ RSpec.describe "bundle cache" do
 
       simulate_new_machine
 
+      FileUtils.rm bundled_app_lock
       bundle :install, raise_on_error: false
 
       expect(err).to eq <<~E.strip

--- a/bundler/spec/commands/check_spec.rb
+++ b/bundler/spec/commands/check_spec.rb
@@ -407,7 +407,7 @@ RSpec.describe "bundle check" do
       system_gems "depends_on_myrack-1.0", "myrack-1.0", gem_repo: gem_repo4, path: default_bundle_path
       bundle :check
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.no_checksum "depends_on_myrack", "1.0"
         c.no_checksum "myrack", "1.0"
       end
@@ -470,13 +470,15 @@ RSpec.describe "bundle check" do
 
       bundle "check --verbose", dir: tmp("bundle-check-issue")
 
-      checksums = checksums_section_when_existing do |c|
+      lockfile = File.read(tmp("bundle-check-issue/Gemfile.lock"))
+
+      checksums = checksums_section_when_enabled(lockfile) do |c|
         c.checksum gem_repo4, "awesome_print", "1.0"
         c.no_checksum "bundle-check-issue", "9999"
         c.checksum gem_repo2, "dex-dispatch-engine", "1.0"
       end
 
-      expect(File.read(tmp("bundle-check-issue/Gemfile.lock"))).to eq <<~L
+      expect(lockfile).to eq <<~L
         PATH
           remote: .
           specs:

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -674,7 +674,7 @@ RSpec.describe "bundle install with gem sources" do
       end
 
       it "writes current Ruby version to Gemfile.lock" do
-        checksums = checksums_section_when_existing
+        checksums = checksums_section_when_enabled
         expect(lockfile).to eq <<~L
          GEM
            remote: https://gem.repo1/
@@ -699,7 +699,7 @@ RSpec.describe "bundle install with gem sources" do
           source "https://gem.repo1"
         G
 
-        checksums = checksums_section_when_existing
+        checksums = checksums_section_when_enabled
 
         expect(lockfile).to eq <<~L
          GEM
@@ -1249,7 +1249,7 @@ RSpec.describe "bundle install with gem sources" do
         bundle "install", artifice: "compact_index"
       end
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.checksum gem_repo4, "crass", "1.0.6"
         c.checksum gem_repo4, "loofah", "2.12.0"
         c.checksum gem_repo4, "nokogiri", "1.12.4", "x86_64-darwin"

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -258,34 +258,36 @@ RSpec.describe "bundle install with gem sources" do
       end
 
       it "falls back on plain ruby" do
-        simulate_platform "foo-bar-baz"
-        install_gemfile <<-G
-          source "https://gem.repo1"
-          gem "platform_specific"
-        G
+        simulate_platform "foo-bar-baz" do
+          install_gemfile <<-G
+            source "https://gem.repo1"
+            gem "platform_specific"
+          G
 
-        expect(the_bundle).to include_gems("platform_specific 1.0 ruby")
+          expect(the_bundle).to include_gems("platform_specific 1.0 ruby")
+        end
       end
 
       it "installs gems for java" do
-        simulate_platform "java"
-        install_gemfile <<-G
-          source "https://gem.repo1"
-          gem "platform_specific"
-        G
+        simulate_platform "java" do
+          install_gemfile <<-G
+            source "https://gem.repo1"
+            gem "platform_specific"
+          G
 
-        expect(the_bundle).to include_gems("platform_specific 1.0 java")
+          expect(the_bundle).to include_gems("platform_specific 1.0 java")
+        end
       end
 
       it "installs gems for windows" do
-        simulate_platform x86_mswin32
+        simulate_platform x86_mswin32 do
+          install_gemfile <<-G
+            source "https://gem.repo1"
+            gem "platform_specific"
+          G
 
-        install_gemfile <<-G
-          source "https://gem.repo1"
-          gem "platform_specific"
-        G
-
-        expect(the_bundle).to include_gems("platform_specific 1.0 x86-mswin32")
+          expect(the_bundle).to include_gems("platform_specific 1.0 x86-mswin32")
+        end
       end
     end
 

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe "bundle update" do
         gem "countries"
       G
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.checksum(gem_repo4, "countries", "3.1.0")
         c.checksum(gem_repo4, "country_select", "5.1.0")
       end
@@ -510,7 +510,7 @@ RSpec.describe "bundle update" do
 
       original_lockfile = lockfile
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.checksum gem_repo4, "activesupport", "6.0.4.1"
         c.checksum gem_repo4, "tzinfo", "1.2.9"
       end
@@ -536,10 +536,6 @@ RSpec.describe "bundle update" do
       bundle "update activesupport"
       expect(the_bundle).to include_gems("activesupport 6.0.4.1", "tzinfo 1.2.9")
       expect(lockfile).to eq(expected_lockfile)
-
-      # needed because regressing to versions already present on the system
-      # won't add a checksum
-      expected_lockfile = remove_checksums_from_lockfile(expected_lockfile)
 
       lockfile original_lockfile
       bundle "update"
@@ -1249,7 +1245,7 @@ RSpec.describe "bundle update --ruby" do
          #{lockfile_platforms}
 
        DEPENDENCIES
-
+       #{checksums_section_when_enabled}
        BUNDLED WITH
           #{Bundler::VERSION}
       L
@@ -1281,7 +1277,7 @@ RSpec.describe "bundle update --ruby" do
           #{lockfile_platforms}
 
         DEPENDENCIES
-
+        #{checksums_section_when_enabled}
         RUBY VERSION
            #{Bundler::RubyVersion.system}
 
@@ -1369,7 +1365,7 @@ RSpec.describe "bundle update --bundler" do
       build_gem "myrack", "1.0"
     end
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum(gem_repo4, "myrack", "1.0")
     end
 
@@ -1428,7 +1424,7 @@ RSpec.describe "bundle update --bundler" do
     G
     lockfile lockfile.sub(/(^\s*)#{Bundler::VERSION}($)/, "2.3.9")
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum(gem_repo4, "myrack", "1.0")
     end
 
@@ -1623,7 +1619,7 @@ RSpec.describe "bundle update --bundler" do
 
     # Only updates properly on modern RubyGems.
     if Gem.rubygems_version >= Gem::Version.new("3.3.0.dev")
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.checksum(gem_repo4, "myrack", "1.0")
       end
 
@@ -1664,7 +1660,7 @@ RSpec.describe "bundle update --bundler" do
     expect(out).not_to include("Fetching gem metadata from https://rubygems.org/")
 
     # Only updates properly on modern RubyGems.
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum(gem_repo4, "myrack", "1.0")
     end
 
@@ -1905,7 +1901,7 @@ RSpec.describe "bundle update conservative" do
     it "should only change direct dependencies when updating the lockfile with --conservative" do
       bundle "lock --update --conservative"
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.checksum gem_repo4, "isolated_dep", "2.0.1"
         c.checksum gem_repo4, "isolated_owner", "1.0.2"
         c.checksum gem_repo4, "shared_dep", "5.0.1"

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -1108,7 +1108,7 @@ RSpec.describe "bundle update in more complicated situations" do
   end
 
   context "when the lockfile is for a different platform" do
-    before do
+    around do |example|
       build_repo4 do
         build_gem("a", "0.9")
         build_gem("a", "0.9") {|s| s.platform = "java" }
@@ -1134,7 +1134,7 @@ RSpec.describe "bundle update in more complicated situations" do
           a
       L
 
-      simulate_platform linux
+      simulate_platform linux, &example
     end
 
     it "allows updating" do
@@ -1172,14 +1172,14 @@ RSpec.describe "bundle update in more complicated situations" do
         DEPENDENCIES
           a
       L
-
-      simulate_platform linux
     end
 
     it "is not updated because it is not actually included in the bundle" do
-      bundle "update a"
-      expect(last_command.stdboth).to include "Bundler attempted to update a but it was not considered because it is for a different platform from the current one"
-      expect(the_bundle).to_not include_gem "a"
+      simulate_platform linux do
+        bundle "update a"
+        expect(last_command.stdboth).to include "Bundler attempted to update a but it was not considered because it is for a different platform from the current one"
+        expect(the_bundle).to_not include_gem "a"
+      end
     end
   end
 end

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -368,7 +368,7 @@ RSpec.describe "bundle install from an existing gemspec" do
         gemspec :path => "../foo"
       G
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.no_checksum "foo", "1.0"
       end
 
@@ -463,7 +463,7 @@ RSpec.describe "bundle install from an existing gemspec" do
           it "keeps all platform dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 ruby"
 
-            checksums = checksums_section_when_existing do |c|
+            checksums = checksums_section_when_enabled do |c|
               c.no_checksum "foo", "1.0"
               c.checksum gem_repo2, "platform_specific", "1.0"
               c.checksum gem_repo2, "platform_specific", "1.0", "java"
@@ -504,7 +504,7 @@ RSpec.describe "bundle install from an existing gemspec" do
           it "keeps all platform dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 ruby"
 
-            checksums = checksums_section_when_existing do |c|
+            checksums = checksums_section_when_enabled do |c|
               c.no_checksum "foo", "1.0"
               c.checksum gem_repo2, "platform_specific", "1.0"
               c.checksum gem_repo2, "platform_specific", "1.0", "java"
@@ -546,7 +546,7 @@ RSpec.describe "bundle install from an existing gemspec" do
           it "keeps all platform dependencies in the lockfile" do
             expect(the_bundle).to include_gems "foo 1.0", "indirect_platform_specific 1.0", "platform_specific 1.0 ruby"
 
-            checksums = checksums_section_when_existing do |c|
+            checksums = checksums_section_when_enabled do |c|
               c.no_checksum "foo", "1.0"
               c.checksum gem_repo2, "indirect_platform_specific", "1.0"
               c.checksum gem_repo2, "platform_specific", "1.0"
@@ -641,7 +641,7 @@ RSpec.describe "bundle install from an existing gemspec" do
         gemspec :path => "../chef"
       G
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.no_checksum "chef", "17.1.17"
         c.no_checksum "chef", "17.1.17", "universal-mingw32"
         c.checksum gem_repo4, "win32-api", "1.5.3", "universal-mingw32"
@@ -705,9 +705,9 @@ RSpec.describe "bundle install from an existing gemspec" do
     end
 
     it "does not remove the platform specific specs from the lockfile when re-resolving due to gemspec changes" do
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.no_checksum "activeadmin", "2.9.0"
-        c.no_checksum "jruby-openssl", "0.10.7", "java"
+        c.checksum gem_repo4, "jruby-openssl", "0.10.7", "java"
         c.checksum gem_repo4, "railties", "6.1.4"
       end
 

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -180,22 +180,22 @@ RSpec.describe "bundle install from an existing gemspec" do
   end
 
   it "should match a lockfile without needing to re-resolve with development dependencies" do
-    simulate_platform java
+    simulate_platform java do
+      build_lib("foo", path: tmp("foo")) do |s|
+        s.add_dependency "myrack"
+        s.add_development_dependency "thin"
+      end
 
-    build_lib("foo", path: tmp("foo")) do |s|
-      s.add_dependency "myrack"
-      s.add_development_dependency "thin"
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        gemspec :path => '#{tmp("foo")}'
+      G
+
+      bundle "install", verbose: true
+
+      message = "Found no changes, using resolution from the lockfile"
+      expect(out.scan(message).size).to eq(1)
     end
-
-    install_gemfile <<-G
-      source "https://gem.repo1"
-      gemspec :path => '#{tmp("foo")}'
-    G
-
-    bundle "install", verbose: true
-
-    message = "Found no changes, using resolution from the lockfile"
-    expect(out.scan(message).size).to eq(1)
   end
 
   it "should match a lockfile on non-ruby platforms with a transitive platform dependency", :jruby_only do

--- a/bundler/spec/install/gemfile/install_if_spec.rb
+++ b/bundler/spec/install/gemfile/install_if_spec.rb
@@ -18,11 +18,11 @@ RSpec.describe "bundle install with install_if conditionals" do
     expect(the_bundle).not_to include_gems("thin")
     expect(the_bundle).not_to include_gems("foo")
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum gem_repo1, "activesupport", "2.3.5"
-      c.no_checksum "foo", "1.0"
+      c.checksum gem_repo1, "foo", "1.0"
       c.checksum gem_repo1, "myrack", "1.0.0"
-      c.no_checksum "thin", "1.0"
+      c.checksum gem_repo1, "thin", "1.0"
     end
 
     expect(lockfile).to eq <<~L

--- a/bundler/spec/install/gemfile/path_spec.rb
+++ b/bundler/spec/install/gemfile/path_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe "bundle install with explicit source paths" do
       gem "aaa", :path => "./aaa"
     G
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.no_checksum "aaa", "1.0"
       c.no_checksum "demo", "1.0"
     end
@@ -346,7 +346,7 @@ RSpec.describe "bundle install with explicit source paths" do
 
     lockfile_path = lib_path("foo/Gemfile.lock")
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.no_checksum "foo", "0.1.0"
       c.checksum gem_repo4, "graphql", "2.0.15"
     end
@@ -675,7 +675,7 @@ RSpec.describe "bundle install with explicit source paths" do
 
       expect(the_bundle).to include_gems "myrack 0.9.1"
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.no_checksum "foo", "1.0"
         c.checksum gem_repo1, "myrack", "0.9.1"
       end
@@ -742,7 +742,7 @@ RSpec.describe "bundle install with explicit source paths" do
 
       expect(the_bundle).to include_gems "myrack 0.9.1"
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.no_checksum "foo", "1.0"
         c.checksum gem_repo1, "myrack", "0.9.1"
       end
@@ -810,7 +810,7 @@ RSpec.describe "bundle install with explicit source paths" do
         s.add_dependency "myrack", "0.9.1"
       end
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.no_checksum "foo", "1.0"
       end
 
@@ -832,7 +832,7 @@ RSpec.describe "bundle install with explicit source paths" do
 
       bundle "lock"
 
-      checksums.no_checksum "myrack", "0.9.1"
+      checksums.checksum gem_repo1, "myrack", "0.9.1"
 
       expect(lockfile).to eq <<~G
         PATH

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe "bundle install across platforms" do
         gem "pry"
       G
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.checksum gem_repo4, "coderay", "1.1.2"
         c.checksum gem_repo4, "empyrean", "0.1.0"
         c.checksum gem_repo4, "ffi", "1.9.23", "java"
@@ -238,6 +238,8 @@ RSpec.describe "bundle install across platforms" do
       L
 
       bundle "lock --add-platform ruby"
+
+      checksums.checksum gem_repo4, "pry", "0.11.3"
 
       good_lockfile = <<~L
         GEM
@@ -372,7 +374,7 @@ RSpec.describe "bundle install across platforms" do
   end
 
   it "keeps existing platforms when installing with force_ruby_platform" do
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum gem_repo1, "platform_specific", "1.0"
       c.checksum gem_repo1, "platform_specific", "1.0", "java"
     end
@@ -584,7 +586,7 @@ RSpec.describe "bundle install with platform conditionals" do
 
       DEPENDENCIES
         myrack
-      #{checksums_section_when_existing}
+      #{checksums_section_when_enabled}
       BUNDLED WITH
          #{Bundler::VERSION}
     L

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -377,7 +377,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           expect(err).to include("Warning: the gem 'myrack' was found in multiple sources.")
           expect(err).to include("Installed from: https://gem.repo2")
 
-          checksums = checksums_section_when_existing do |c|
+          checksums = checksums_section_when_enabled do |c|
             c.checksum gem_repo3, "depends_on_myrack", "1.0.1"
             c.checksum gem_repo2, "myrack", "1.0.0"
           end
@@ -417,7 +417,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           expect(err).to include("Warning: the gem 'myrack' was found in multiple sources.")
           expect(err).to include("Installed from: https://gem.repo2")
 
-          checksums = checksums_section_when_existing do |c|
+          checksums = checksums_section_when_enabled do |c|
             c.no_checksum "depends_on_myrack", "1.0.1"
             c.no_checksum "myrack", "1.0.0"
           end
@@ -783,7 +783,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           end
         G
 
-        @locked_checksums = checksums_section_when_existing do |c|
+        @locked_checksums = checksums_section_when_enabled do |c|
           c.checksum gem_repo2, "activesupport", "6.0.3.4"
           c.checksum gem_repo2, "concurrent-ruby", "1.1.8"
           c.checksum gem_repo2, "connection_pool", "2.2.3"
@@ -1106,7 +1106,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
 
       it "installs from the default source without any warnings or errors and generates a proper lockfile" do
-        checksums = checksums_section_when_existing do |c|
+        checksums = checksums_section_when_enabled do |c|
           c.checksum gem_repo3, "handsoap", "0.2.5.5"
           c.checksum gem_repo2, "nokogiri", "1.11.1"
           c.checksum gem_repo2, "racca", "1.5.2"
@@ -1692,7 +1692,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
     it "upgrades the lockfile correctly" do
       bundle "lock --update", artifice: "compact_index"
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.checksum gem_repo2, "capybara", "2.5.0"
         c.checksum gem_repo4, "mime-types", "3.0.0"
       end
@@ -1751,7 +1751,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
     it "handles that fine" do
       bundle "install", artifice: "compact_index_extra"
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.checksum gem_repo4, "pdf-writer", "1.1.8"
         c.checksum gem_repo2, "ruport", "1.7.0.3"
       end
@@ -1809,7 +1809,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
     it "handles that fine" do
       bundle "install", artifice: "compact_index_extra"
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.checksum gem_repo4, "pdf-writer", "1.1.8"
         c.checksum gem_repo2, "ruport", "1.7.0.3"
       end
@@ -1861,7 +1861,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
     it "handles that fine" do
       bundle "install --verbose", artifice: "endpoint"
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.checksum gem_repo4, "pdf-writer", "1.1.8"
       end
 

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -1742,14 +1742,14 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
 
       gemfile <<~G
-        source "https://localgemserver.test"
+        source "https://gem.repo4"
 
-        gem "ruport", "= 1.7.0.3", :source => "https://localgemserver.test/extra"
+        gem "ruport", "= 1.7.0.3", :source => "https://gem.repo4/extra"
       G
     end
 
     it "handles that fine" do
-      bundle "install", artifice: "compact_index_extra", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+      bundle "install", artifice: "compact_index_extra"
 
       checksums = checksums_section_when_existing do |c|
         c.checksum gem_repo4, "pdf-writer", "1.1.8"
@@ -1758,12 +1758,12 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
       expect(lockfile).to eq <<~L
         GEM
-          remote: https://localgemserver.test/
+          remote: https://gem.repo4/
           specs:
             pdf-writer (1.1.8)
 
         GEM
-          remote: https://localgemserver.test/extra/
+          remote: https://gem.repo4/extra/
           specs:
             ruport (1.7.0.3)
               pdf-writer (= 1.1.8)
@@ -1800,14 +1800,14 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
 
       gemfile <<~G
-        source "https://localgemserver.test"
+        source "https://gem.repo4"
 
-        gem "ruport", "= 1.7.0.3", :source => "https://localgemserver.test/extra"
+        gem "ruport", "= 1.7.0.3", :source => "https://gem.repo4/extra"
       G
     end
 
     it "handles that fine" do
-      bundle "install", artifice: "compact_index_extra", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+      bundle "install", artifice: "compact_index_extra"
 
       checksums = checksums_section_when_existing do |c|
         c.checksum gem_repo4, "pdf-writer", "1.1.8"
@@ -1816,12 +1816,12 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
       expect(lockfile).to eq <<~L
         GEM
-          remote: https://localgemserver.test/
+          remote: https://gem.repo4/
           specs:
             pdf-writer (1.1.8)
 
         GEM
-          remote: https://localgemserver.test/extra/
+          remote: https://gem.repo4/extra/
           specs:
             ruport (1.7.0.3)
               pdf-writer (= 1.1.8)
@@ -1852,14 +1852,14 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
 
       gemfile <<~G
-        source "https://localgemserver.test"
+        source "https://gem.repo4"
 
         gem "pdf-writer", "= 1.1.8"
       G
     end
 
     it "handles that fine" do
-      bundle "install --verbose", artifice: "endpoint", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+      bundle "install --verbose", artifice: "endpoint"
 
       checksums = checksums_section_when_existing do |c|
         c.checksum gem_repo4, "pdf-writer", "1.1.8"
@@ -1867,7 +1867,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
       expect(lockfile).to eq <<~L
         GEM
-          remote: https://localgemserver.test/
+          remote: https://gem.repo4/
           specs:
             pdf-writer (1.1.8)
 

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "bundle install with specific platforms" do
 
       gemfile google_protobuf
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.checksum gem_repo2, "google-protobuf", "3.0.0.alpha.4.0"
       end
 
@@ -528,7 +528,7 @@ RSpec.describe "bundle install with specific platforms" do
 
     bundle "update"
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum gem_repo4, "sorbet", "0.5.10160"
       c.checksum gem_repo4, "sorbet-runtime", "0.5.10160"
       c.checksum gem_repo4, "sorbet-static", "0.5.10160", Gem::Platform.local
@@ -584,9 +584,9 @@ RSpec.describe "bundle install with specific platforms" do
       G
     end
 
-    checksums = checksums_section_when_existing do |c|
-      c.no_checksum "nokogiri", "1.13.0", "x86_64-darwin"
-      c.no_checksum "sorbet-static", "0.5.10601", "x86_64-darwin"
+    checksums = checksums_section_when_enabled do |c|
+      c.checksum gem_repo4, "nokogiri", "1.13.0", "x86_64-darwin"
+      c.checksum gem_repo4, "sorbet-static", "0.5.10601", "x86_64-darwin"
     end
 
     lockfile <<~L
@@ -680,7 +680,7 @@ RSpec.describe "bundle install with specific platforms" do
 
     bundle "update"
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum gem_repo4, "sorbet", "0.5.10160"
       c.checksum gem_repo4, "sorbet-runtime", "0.5.10160"
       c.checksum gem_repo4, "sorbet-static", "0.5.10160", Gem::Platform.local
@@ -755,7 +755,7 @@ RSpec.describe "bundle install with specific platforms" do
 
       bundle "update"
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.checksum gem_repo4, "nokogiri", "1.14.0", "x86_64-linux"
         c.checksum gem_repo4, "sorbet-static", "0.5.10696", "x86_64-linux"
       end
@@ -799,7 +799,7 @@ RSpec.describe "bundle install with specific platforms" do
         gem "sorbet-static", "= 0.5.10549"
       G
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.checksum gem_repo4, "sorbet-static", "0.5.10549", "universal-darwin-20"
         c.checksum gem_repo4, "sorbet-static", "0.5.10549", "universal-darwin-21"
       end
@@ -822,8 +822,6 @@ RSpec.describe "bundle install with specific platforms" do
       L
 
       bundle "install"
-
-      checksums.no_checksum "sorbet-static", "0.5.10549", "universal-darwin-21"
 
       expect(lockfile).to eq <<~L
         GEM
@@ -917,7 +915,7 @@ RSpec.describe "bundle install with specific platforms" do
       gem "tzinfo", "~> 1.2", platform: :#{not_local_tag}
     G
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum gem_repo4, "nokogiri", "1.13.8"
       c.checksum gem_repo4, "nokogiri", "1.13.8", Gem::Platform.local
     end
@@ -963,9 +961,8 @@ RSpec.describe "bundle install with specific platforms" do
       gem "tzinfo", "~> 1.2", platforms: %i[mingw mswin x64_mingw jruby]
     G
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum gem_repo4, "nokogiri", "1.13.8"
-      c.checksum gem_repo4, "nokogiri", "1.13.8", "arm64-darwin"
     end
 
     original_lockfile = <<~L
@@ -1007,9 +1004,9 @@ RSpec.describe "bundle install with specific platforms" do
       gem "myrack"
     G
 
-    checksums = checksums_section_when_existing do |c|
-      c.no_checksum "concurrent-ruby", "1.2.2"
-      c.no_checksum "myrack", "3.0.7"
+    checksums = checksums_section_when_enabled do |c|
+      c.checksum gem_repo4, "concurrent-ruby", "1.2.2"
+      c.checksum gem_repo4, "myrack", "3.0.7"
     end
 
     lockfile <<~L
@@ -1104,7 +1101,7 @@ RSpec.describe "bundle install with specific platforms" do
         gem "nokogiri", "1.14.0"
       G
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.checksum gem_repo4, "nokogiri", "1.14.0", "x86_64-linux"
       end
 
@@ -1126,7 +1123,7 @@ RSpec.describe "bundle install with specific platforms" do
 
       bundle :install
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.checksum gem_repo4, "nokogiri", "1.14.0"
       end
 
@@ -1235,10 +1232,10 @@ RSpec.describe "bundle install with specific platforms" do
 
       bundle "lock"
 
-      checksums = checksums_section_when_existing do |c|
-        c.no_checksum "nokogiri", "1.14.0"
-        c.no_checksum "nokogiri", "1.14.0", "arm-linux"
-        c.no_checksum "nokogiri", "1.14.0", "x86_64-linux"
+      checksums = checksums_section_when_enabled do |c|
+        c.checksum gem_repo4, "nokogiri", "1.14.0"
+        c.checksum gem_repo4, "nokogiri", "1.14.0", "arm-linux"
+        c.checksum gem_repo4, "nokogiri", "1.14.0", "x86_64-linux"
       end
 
       # locks all compatible platforms, excluding Java and Windows
@@ -1274,8 +1271,8 @@ RSpec.describe "bundle install with specific platforms" do
       bundle "lock"
 
       checksums.delete "nokogiri", "arm-linux"
-      checksums.no_checksum "sorbet-static", "0.5.10696", "universal-darwin-22"
-      checksums.no_checksum "sorbet-static", "0.5.10696", "x86_64-linux"
+      checksums.checksum gem_repo4, "sorbet-static", "0.5.10696", "universal-darwin-22"
+      checksums.checksum gem_repo4, "sorbet-static", "0.5.10696", "x86_64-linux"
 
       # locks only platforms compatible with all gems in the bundle
       expect(lockfile).to eq(<<~L)
@@ -1324,9 +1321,9 @@ RSpec.describe "bundle install with specific platforms" do
       gem "sass-embedded"
     G
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum gem_repo4, "nokogiri", "1.15.5"
-      c.no_checksum "sass-embedded", "1.69.5"
+      c.checksum gem_repo4, "sass-embedded", "1.69.5"
       c.checksum gem_repo4, "sass-embedded", "1.69.5", "x86_64-linux-gnu"
     end
 
@@ -1373,7 +1370,7 @@ RSpec.describe "bundle install with specific platforms" do
       gem "nokogiri"
     G
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum gem_repo4, "nokogiri", "1.15.5", "x86_64-linux"
     end
 
@@ -1420,6 +1417,11 @@ RSpec.describe "bundle install with specific platforms" do
         simulate_platform host_platform do
           bundle "lock"
 
+          checksums = checksums_section_when_enabled do |c|
+            c.checksum gem_repo4, "rcee_precompiled", "0.5.0", "x86_64-linux"
+            c.checksum gem_repo4, "rcee_precompiled", "0.5.0", "x86_64-linux-musl"
+          end
+
           expect(lockfile).to eq(<<~L)
             GEM
               remote: https://gem.repo4/
@@ -1433,7 +1435,7 @@ RSpec.describe "bundle install with specific platforms" do
 
             DEPENDENCIES
               rcee_precompiled (= 0.5.0)
-
+            #{checksums}
             BUNDLED WITH
                #{Bundler::VERSION}
           L
@@ -1462,6 +1464,11 @@ RSpec.describe "bundle install with specific platforms" do
     simulate_platform "x86_64-linux-musl" do
       bundle "lock"
 
+      checksums = checksums_section_when_enabled do |c|
+        c.checksum gem_repo4, "rcee_precompiled", "0.5.0", "x86_64-linux-gnu"
+        c.checksum gem_repo4, "rcee_precompiled", "0.5.0", "x86_64-linux-musl"
+      end
+
       expect(lockfile).to eq(<<~L)
         GEM
           remote: https://gem.repo4/
@@ -1475,7 +1482,7 @@ RSpec.describe "bundle install with specific platforms" do
 
         DEPENDENCIES
           rcee_precompiled (= 0.5.0)
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -1498,6 +1505,10 @@ RSpec.describe "bundle install with specific platforms" do
     simulate_platform "x86_64-darwin-15" do
       bundle "lock"
 
+      checksums = checksums_section_when_enabled do |c|
+        c.checksum gem_repo4, "rcee_precompiled", "0.5.0", "universal-darwin"
+      end
+
       expect(lockfile).to eq(<<~L)
         GEM
           remote: https://gem.repo4/
@@ -1509,7 +1520,7 @@ RSpec.describe "bundle install with specific platforms" do
 
         DEPENDENCIES
           rcee_precompiled (= 0.5.0)
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -149,12 +149,12 @@ RSpec.describe "bundle install with specific platforms" do
     end
 
     it "still installs the generic ruby variant if necessary" do
-      bundle "install --verbose", artifice: "compact_index", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+      bundle "install --verbose"
       expect(out).to include("Installing nokogiri 1.3.10")
     end
 
     it "still installs the generic ruby variant if necessary, even in frozen mode" do
-      bundle "install --verbose", artifice: "compact_index", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s, "BUNDLE_FROZEN" => "true" }
+      bundle "install --verbose", env: { "BUNDLE_FROZEN" => "true" }
       expect(out).to include("Installing nokogiri 1.3.10")
     end
   end
@@ -176,14 +176,14 @@ RSpec.describe "bundle install with specific platforms" do
       bundle "config set --local path vendor/bundle", env: { "BUNDLER_VERSION" => "2.1.4" }
 
       gemfile <<-G
-        source "https://localgemserver.test"
+        source "https://gem.repo2"
         gem "libv8"
       G
 
       # simulate lockfile created with old bundler, which only locks for ruby platform
       lockfile <<-L
         GEM
-          remote: https://localgemserver.test/
+          remote: https://gem.repo2/
           specs:
             libv8 (8.4.255.0)
 
@@ -197,10 +197,10 @@ RSpec.describe "bundle install with specific platforms" do
            2.1.4
       L
 
-      bundle "install --verbose", artifice: "compact_index", env: { "BUNDLER_VERSION" => "2.1.4", "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }
+      bundle "install --verbose", env: { "BUNDLER_VERSION" => "2.1.4" }
       expect(out).to include("Installing libv8 8.4.255.0 (universal-darwin)")
 
-      bundle "add mini_racer --verbose", artifice: "compact_index", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }
+      bundle "add mini_racer --verbose"
       expect(out).to include("Using libv8 8.4.255.0 (universal-darwin)")
     end
   end
@@ -213,14 +213,14 @@ RSpec.describe "bundle install with specific platforms" do
       end
 
       gemfile <<-G
-        source "https://localgemserver.test"
+        source "https://gem.repo4"
         gem "grpc"
       G
 
       # simulate lockfile created with old bundler, which only locks for ruby platform
       lockfile <<-L
         GEM
-          remote: https://localgemserver.test/
+          remote: https://gem.repo4/
           specs:
             grpc (1.50.0)
 
@@ -234,7 +234,7 @@ RSpec.describe "bundle install with specific platforms" do
            #{Bundler::VERSION}
       L
 
-      bundle "install --verbose", artifice: "compact_index_precompiled_before", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+      bundle "install --verbose", artifice: "compact_index_precompiled_before"
       expect(out).to include("Installing grpc 1.50.0 (universal-darwin)")
     end
   end
@@ -1331,7 +1331,7 @@ RSpec.describe "bundle install with specific platforms" do
     end
 
     simulate_platform "x86_64-linux" do
-      bundle "install --verbose", artifice: "compact_index", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+      bundle "install --verbose"
 
       # locks all compatible platforms, excluding Java and Windows
       expect(lockfile).to eq(<<~L)
@@ -1378,7 +1378,7 @@ RSpec.describe "bundle install with specific platforms" do
     end
 
     simulate_platform "x86_64-linux" do
-      bundle "install --verbose", artifice: "compact_index", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+      bundle "install --verbose"
 
       expect(lockfile).to eq(<<~L)
         GEM
@@ -1418,7 +1418,7 @@ RSpec.describe "bundle install with specific platforms" do
         G
 
         simulate_platform host_platform do
-          bundle "lock", artifice: "compact_index", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+          bundle "lock"
 
           expect(lockfile).to eq(<<~L)
             GEM
@@ -1460,7 +1460,7 @@ RSpec.describe "bundle install with specific platforms" do
     G
 
     simulate_platform "x86_64-linux-musl" do
-      bundle "lock", artifice: "compact_index", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+      bundle "lock"
 
       expect(lockfile).to eq(<<~L)
         GEM
@@ -1496,7 +1496,7 @@ RSpec.describe "bundle install with specific platforms" do
     G
 
     simulate_platform "x86_64-darwin-15" do
-      bundle "lock", artifice: "compact_index", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+      bundle "lock"
 
       expect(lockfile).to eq(<<~L)
         GEM

--- a/bundler/spec/install/gems/dependency_api_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_spec.rb
@@ -119,24 +119,24 @@ RSpec.describe "gemcutter's dependency API" do
   end
 
   it "falls back when the API errors out" do
-    simulate_platform x86_mswin32
-
-    build_repo2 do
-      # The rcov gem is platform mswin32, but has no arch
-      build_gem "rcov" do |s|
-        s.platform = Gem::Platform.new([nil, "mswin32", nil])
-        s.write "lib/rcov.rb", "RCOV = '1.0.0'"
+    simulate_platform x86_mswin32 do
+      build_repo2 do
+        # The rcov gem is platform mswin32, but has no arch
+        build_gem "rcov" do |s|
+          s.platform = Gem::Platform.new([nil, "mswin32", nil])
+          s.write "lib/rcov.rb", "RCOV = '1.0.0'"
+        end
       end
+
+      gemfile <<-G
+        source "#{source_uri}"
+        gem "rcov"
+      G
+
+      bundle :install, artifice: "windows", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }
+      expect(out).to include("Fetching source index from #{source_uri}")
+      expect(the_bundle).to include_gems "rcov 1.0.0"
     end
-
-    gemfile <<-G
-      source "#{source_uri}"
-      gem "rcov"
-    G
-
-    bundle :install, artifice: "windows", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }
-    expect(out).to include("Fetching source index from #{source_uri}")
-    expect(the_bundle).to include_gems "rcov 1.0.0"
   end
 
   it "falls back when hitting the Gemcutter Dependency Limit" do

--- a/bundler/spec/install/gems/flex_spec.rb
+++ b/bundler/spec/install/gems/flex_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe "bundle flex_install" do
     it "should work when you install" do
       bundle "install"
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.checksum gem_repo1, "myrack", "0.9.1"
         c.checksum gem_repo1, "myrack-obama", "1.0"
       end
@@ -313,7 +313,7 @@ RSpec.describe "bundle flex_install" do
         gem "myrack"
       G
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.checksum gem_repo1, "myrack", "1.0.0"
       end
 

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -210,9 +210,9 @@ RSpec.describe "bundle install with install-time dependencies" do
           end
         end
 
-        install_gemfile <<-G, artifice: "compact_index", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }
+        install_gemfile <<-G
           ruby "#{Gem.ruby_version}"
-          source "http://localgemserver.test/"
+          source "https://gem.repo2"
           gem 'myrack'
         G
 
@@ -231,9 +231,9 @@ RSpec.describe "bundle install with install-time dependencies" do
           end
         end
 
-        install_gemfile <<-G, artifice: "endpoint", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }
+        install_gemfile <<-G, artifice: "endpoint"
           ruby "#{Gem.ruby_version}"
-          source "http://localgemserver.test/"
+          source "https://gem.repo2"
           gem 'myrack'
         G
 
@@ -254,7 +254,7 @@ RSpec.describe "bundle install with install-time dependencies" do
           end
 
           gemfile <<-G
-            source "http://localgemserver.test/"
+            source "https://gem.repo2"
             gem 'parallel_tests'
           G
 
@@ -264,7 +264,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
           lockfile <<~L
             GEM
-              remote: http://localgemserver.test/
+              remote: https://gem.repo2/
               specs:
                 parallel_tests (3.8.0)
 
@@ -280,7 +280,7 @@ RSpec.describe "bundle install with install-time dependencies" do
         end
 
         it "automatically updates lockfile to use the older version" do
-          bundle "install --verbose", artifice: "compact_index", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }
+          bundle "install --verbose"
 
           checksums = checksums_section_when_existing do |c|
             c.checksum gem_repo2, "parallel_tests", "3.7.0"
@@ -288,7 +288,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
           expect(lockfile).to eq <<~L
             GEM
-              remote: http://localgemserver.test/
+              remote: https://gem.repo2/
               specs:
                 parallel_tests (3.7.0)
 
@@ -305,7 +305,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
         it "gives a meaningful error if we're in frozen mode" do
           expect do
-            bundle "install --verbose", artifice: "compact_index", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s, "BUNDLE_FROZEN" => "true" }, raise_on_error: false
+            bundle "install --verbose", env: { "BUNDLE_FROZEN" => "true" }, raise_on_error: false
           end.not_to change { lockfile }
 
           expect(err).to include("parallel_tests-3.8.0 requires ruby version >= #{next_ruby_minor}")
@@ -338,7 +338,7 @@ RSpec.describe "bundle install with install-time dependencies" do
           end
 
           gemfile <<-G
-            source "http://localgemserver.test/"
+            source "https://gem.repo2"
             gem 'rubocop'
           G
 
@@ -349,7 +349,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
           lockfile <<~L
             GEM
-              remote: http://localgemserver.test/
+              remote: https://gem.repo2/
               specs:
                 rubocop (1.35.0)
                   rubocop-ast (>= 1.20.1, < 2.0)
@@ -367,7 +367,7 @@ RSpec.describe "bundle install with install-time dependencies" do
         end
 
         it "automatically updates lockfile to use the older compatible versions" do
-          bundle "install --verbose", artifice: "compact_index", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }
+          bundle "install --verbose"
 
           checksums = checksums_section_when_existing do |c|
             c.checksum gem_repo2, "rubocop", "1.28.2"
@@ -376,7 +376,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
           expect(lockfile).to eq <<~L
             GEM
-              remote: http://localgemserver.test/
+              remote: https://gem.repo2/
               specs:
                 rubocop (1.28.2)
                   rubocop-ast (>= 1.17.0, < 2.0)
@@ -540,9 +540,9 @@ RSpec.describe "bundle install with install-time dependencies" do
           build_gem "foo1", "1.0"
         end
 
-        install_gemfile <<-G, artifice: "compact_index_rate_limited", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+        install_gemfile <<-G, artifice: "compact_index_rate_limited"
           ruby "#{Gem.ruby_version}"
-          source "http://localgemserver.test/"
+          source "https://gem.repo4"
           gem 'myrack'
           gem 'foo1'
         G
@@ -564,9 +564,9 @@ RSpec.describe "bundle install with install-time dependencies" do
         end
 
         simulate_platform x86_mingw32 do
-          install_gemfile <<-G, artifice: "compact_index", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+          install_gemfile <<-G, artifice: "compact_index"
             ruby "#{Gem.ruby_version}"
-            source "http://localgemserver.test/"
+            source "https://gem.repo4"
             gem 'myrack'
           G
         end
@@ -590,8 +590,8 @@ RSpec.describe "bundle install with install-time dependencies" do
       let(:error_message_requirement) { "= #{Gem.ruby_version}" }
 
       it "raises a proper error that mentions the current Ruby version during resolution" do
-        install_gemfile <<-G, artifice: "compact_index", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }, raise_on_error: false
-          source "http://localgemserver.test/"
+        install_gemfile <<-G, raise_on_error: false
+          source "https://gem.repo2"
           gem 'require_ruby'
         G
 
@@ -611,8 +611,8 @@ RSpec.describe "bundle install with install-time dependencies" do
 
       shared_examples_for "ruby version conflicts" do
         it "raises an error during resolution" do
-          install_gemfile <<-G, artifice: "compact_index", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo2.to_s }, raise_on_error: false
-            source "http://localgemserver.test/"
+          install_gemfile <<-G, raise_on_error: false
+            source "https://gem.repo2"
             ruby #{ruby_requirement}
             gem 'require_ruby'
           G

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -282,7 +282,7 @@ RSpec.describe "bundle install with install-time dependencies" do
         it "automatically updates lockfile to use the older version" do
           bundle "install --verbose"
 
-          checksums = checksums_section_when_existing do |c|
+          checksums = checksums_section_when_enabled do |c|
             c.checksum gem_repo2, "parallel_tests", "3.7.0"
           end
 
@@ -369,7 +369,7 @@ RSpec.describe "bundle install with install-time dependencies" do
         it "automatically updates lockfile to use the older compatible versions" do
           bundle "install --verbose"
 
-          checksums = checksums_section_when_existing do |c|
+          checksums = checksums_section_when_enabled do |c|
             c.checksum gem_repo2, "rubocop", "1.28.2"
             c.checksum gem_repo2, "rubocop-ast", "1.17.0"
           end

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -1368,32 +1368,32 @@ RSpec.describe "the lockfile format" do
       end
     end
 
-    simulate_platform "universal-java-16"
+    simulate_platform "universal-java-16" do
+      install_gemfile <<-G
+        source "https://gem.repo2"
+        gem "platform_specific"
+      G
 
-    install_gemfile <<-G
-      source "https://gem.repo2"
-      gem "platform_specific"
-    G
+      checksums = checksums_section_when_existing do |c|
+        c.checksum gem_repo2, "platform_specific", "1.0", "universal-java-16"
+      end
 
-    checksums = checksums_section_when_existing do |c|
-      c.checksum gem_repo2, "platform_specific", "1.0", "universal-java-16"
+      expect(lockfile).to eq <<~G
+        GEM
+          remote: https://gem.repo2/
+          specs:
+            platform_specific (1.0-universal-java-16)
+
+        PLATFORMS
+          universal-java-16
+
+        DEPENDENCIES
+          platform_specific
+        #{checksums}
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      G
     end
-
-    expect(lockfile).to eq <<~G
-      GEM
-        remote: https://gem.repo2/
-        specs:
-          platform_specific (1.0-universal-java-16)
-
-      PLATFORMS
-        universal-java-16
-
-      DEPENDENCIES
-        platform_specific
-      #{checksums}
-      BUNDLED WITH
-         #{Bundler::VERSION}
-    G
   end
 
   it "does not add duplicate gems" do

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "the lockfile format" do
   end
 
   it "generates a simple lockfile for a single source, gem" do
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum(gem_repo2, "myrack", "1.0.0")
     end
 
@@ -281,7 +281,7 @@ RSpec.describe "the lockfile format" do
       gem "myrack-obama"
     G
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum gem_repo2, "myrack", "1.0.0"
       c.checksum gem_repo2, "myrack-obama", "1.0"
     end
@@ -312,7 +312,7 @@ RSpec.describe "the lockfile format" do
       gem "myrack-obama", ">= 1.0"
     G
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum gem_repo2, "myrack", "1.0.0"
       c.checksum gem_repo2, "myrack-obama", "1.0"
     end
@@ -351,7 +351,7 @@ RSpec.describe "the lockfile format" do
       end
     G
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum gem_repo2, "myrack", "1.0.0"
       c.checksum gem_repo2, "myrack-obama", "1.0"
     end
@@ -398,7 +398,7 @@ RSpec.describe "the lockfile format" do
       end
     G
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum gem_repo2, "myrack", "1.0.0"
       c.checksum gem_repo2, "myrack-obama", "1.0"
     end
@@ -459,7 +459,7 @@ RSpec.describe "the lockfile format" do
       end
     G
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum gem_repo2, "myrack", "1.0.0"
       c.checksum gem_repo2, "myrack-obama", "1.0"
     end
@@ -503,7 +503,7 @@ RSpec.describe "the lockfile format" do
       gem "net-sftp"
     G
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum gem_repo2, "net-sftp", "1.1.1"
       c.checksum gem_repo2, "net-ssh", "1.0"
     end
@@ -537,7 +537,7 @@ RSpec.describe "the lockfile format" do
       gem "foo", :git => "#{lib_path("foo-1.0")}"
     G
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.no_checksum "foo", "1.0"
     end
 
@@ -605,7 +605,7 @@ RSpec.describe "the lockfile format" do
   it "serializes global git sources" do
     git = build_git "foo"
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.no_checksum "foo", "1.0"
     end
 
@@ -642,7 +642,7 @@ RSpec.describe "the lockfile format" do
     git = build_git "foo"
     update_git "foo", branch: "omg"
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.no_checksum "foo", "1.0"
     end
 
@@ -678,7 +678,7 @@ RSpec.describe "the lockfile format" do
     git = build_git "foo"
     update_git "foo", tag: "omg"
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.no_checksum "foo", "1.0"
     end
 
@@ -799,7 +799,7 @@ RSpec.describe "the lockfile format" do
   it "serializes pinned path sources to the lockfile" do
     build_lib "foo"
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.no_checksum "foo", "1.0"
     end
 
@@ -832,14 +832,14 @@ RSpec.describe "the lockfile format" do
   it "serializes pinned path sources to the lockfile even when packaging" do
     build_lib "foo"
 
-    checksums = checksums_section_when_existing do |c|
-      c.no_checksum "foo", "1.0"
-    end
-
     install_gemfile <<-G
       source "https://gem.repo1"
       gem "foo", :path => "#{lib_path("foo-1.0")}"
     G
+
+    checksums = checksums_section_when_enabled do |c|
+      c.no_checksum "foo", "1.0"
+    end
 
     bundle "config set cache_all true"
     bundle :cache
@@ -870,7 +870,7 @@ RSpec.describe "the lockfile format" do
     build_lib "foo"
     bar = build_git "bar"
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.no_checksum "foo", "1.0"
       c.no_checksum "bar", "1.0"
       c.checksum gem_repo2, "myrack", "1.0.0"
@@ -921,7 +921,7 @@ RSpec.describe "the lockfile format" do
       gem "myrack", :source => "https://gem.repo2/"
     G
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum gem_repo2, "myrack", "1.0.0"
     end
 
@@ -951,7 +951,7 @@ RSpec.describe "the lockfile format" do
       gem "myrack-obama"
     G
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum gem_repo2, "actionpack", "2.3.2"
       c.checksum gem_repo2, "activesupport", "2.3.2"
       c.checksum gem_repo2, "myrack", "1.0.0"
@@ -992,7 +992,7 @@ RSpec.describe "the lockfile format" do
       gem "rails"
     G
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum gem_repo2, "actionmailer", "2.3.2"
       c.checksum gem_repo2, "actionpack", "2.3.2"
       c.checksum gem_repo2, "activerecord", "2.3.2"
@@ -1050,7 +1050,7 @@ RSpec.describe "the lockfile format" do
       gem 'double_deps'
     G
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum gem_repo2, "double_deps", "1.0"
       c.checksum gem_repo2, "net-ssh", "1.0"
     end
@@ -1082,7 +1082,7 @@ RSpec.describe "the lockfile format" do
       gem "myrack-obama", ">= 1.0", :require => "myrack/obama"
     G
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum gem_repo2, "myrack", "1.0.0"
       c.checksum gem_repo2, "myrack-obama", "1.0"
     end
@@ -1113,7 +1113,7 @@ RSpec.describe "the lockfile format" do
       gem "myrack-obama", ">= 1.0", :group => :test
     G
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum gem_repo2, "myrack", "1.0.0"
       c.checksum gem_repo2, "myrack-obama", "1.0"
     end
@@ -1140,7 +1140,7 @@ RSpec.describe "the lockfile format" do
   it "stores relative paths when the path is provided in a relative fashion and in Gemfile dir" do
     build_lib "foo", path: bundled_app("foo")
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.no_checksum "foo", "1.0"
     end
 
@@ -1175,7 +1175,7 @@ RSpec.describe "the lockfile format" do
   it "stores relative paths when the path is provided in a relative fashion and is above Gemfile dir" do
     build_lib "foo", path: bundled_app(File.join("..", "foo"))
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.no_checksum "foo", "1.0"
     end
 
@@ -1210,16 +1210,16 @@ RSpec.describe "the lockfile format" do
   it "stores relative paths when the path is provided in an absolute fashion but is relative" do
     build_lib "foo", path: bundled_app("foo")
 
-    checksums = checksums_section_when_existing do |c|
-      c.no_checksum "foo", "1.0"
-    end
-
     install_gemfile <<-G
       source "https://gem.repo1"
       path File.expand_path("foo", __dir__) do
         gem "foo"
       end
     G
+
+    checksums = checksums_section_when_enabled do |c|
+      c.no_checksum "foo", "1.0"
+    end
 
     expect(lockfile).to eq <<~G
       PATH
@@ -1245,7 +1245,7 @@ RSpec.describe "the lockfile format" do
   it "stores relative paths when the path is provided for gemspec" do
     build_lib("foo", path: tmp("foo"))
 
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.no_checksum "foo", "1.0"
     end
 
@@ -1276,7 +1276,7 @@ RSpec.describe "the lockfile format" do
   end
 
   it "keeps existing platforms in the lockfile" do
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.no_checksum "myrack", "1.0.0"
     end
 
@@ -1340,6 +1340,11 @@ RSpec.describe "the lockfile format" do
       G
       bundle "lock --add-platform x64-mingw-ucrt"
 
+      checksums = checksums_section_when_enabled do |c|
+        c.checksum gem_repo4, "google-protobuf", "3.25.1"
+        c.checksum gem_repo4, "google-protobuf", "3.25.1", "arm64-darwin-23"
+      end
+
       expect(lockfile).to eq <<~L
         GEM
           remote: https://gem.repo4/
@@ -1354,7 +1359,7 @@ RSpec.describe "the lockfile format" do
 
         DEPENDENCIES
           google-protobuf
-
+        #{checksums}
         BUNDLED WITH
            #{Bundler::VERSION}
       L
@@ -1374,7 +1379,7 @@ RSpec.describe "the lockfile format" do
         gem "platform_specific"
       G
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.checksum gem_repo2, "platform_specific", "1.0", "universal-java-16"
       end
 
@@ -1397,7 +1402,7 @@ RSpec.describe "the lockfile format" do
   end
 
   it "does not add duplicate gems" do
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum(gem_repo2, "activesupport", "2.3.5")
       c.checksum(gem_repo2, "myrack", "1.0.0")
     end
@@ -1433,7 +1438,7 @@ RSpec.describe "the lockfile format" do
   end
 
   it "does not add duplicate dependencies" do
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum(gem_repo2, "myrack", "1.0.0")
     end
 
@@ -1461,7 +1466,7 @@ RSpec.describe "the lockfile format" do
   end
 
   it "does not add duplicate dependencies with versions" do
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum(gem_repo2, "myrack", "1.0.0")
     end
 
@@ -1489,7 +1494,7 @@ RSpec.describe "the lockfile format" do
   end
 
   it "does not add duplicate dependencies in different groups" do
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum(gem_repo2, "myrack", "1.0.0")
     end
 
@@ -1539,7 +1544,7 @@ RSpec.describe "the lockfile format" do
   end
 
   it "works correctly with multiple version dependencies" do
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum(gem_repo2, "myrack", "0.9.1")
     end
 
@@ -1566,7 +1571,7 @@ RSpec.describe "the lockfile format" do
   end
 
   it "captures the Ruby version in the lockfile" do
-    checksums = checksums_section_when_existing do |c|
+    checksums = checksums_section_when_enabled do |c|
       c.checksum(gem_repo2, "myrack", "0.9.1")
     end
 

--- a/bundler/spec/plugins/source/example_spec.rb
+++ b/bundler/spec/plugins/source/example_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "real source plugins" do
     it "writes to lock file" do
       bundle "install"
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.no_checksum "a-path-gem", "1.0"
       end
 
@@ -340,7 +340,7 @@ RSpec.describe "real source plugins" do
       revision = revision_for(lib_path("ma-gitp-gem-1.0"))
       bundle "install"
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.no_checksum "ma-gitp-gem", "1.0"
       end
 

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -48,13 +48,14 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
         nokogiri
     G
 
-    simulate_platform "x86-darwin-10"
-    install_gemfile <<-G
-      source "https://gem.repo1"
-      gem "nokogiri"
-    G
+    simulate_platform "x86-darwin-10" do
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        gem "nokogiri"
+      G
 
-    expect(the_bundle).to include_gems "nokogiri 1.4.2"
+      expect(the_bundle).to include_gems "nokogiri 1.4.2"
+    end
   end
 
   it "will keep both platforms when both ruby and a specific ruby platform are locked and the bundle is unlocked" do
@@ -200,15 +201,15 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
         nokogiri
     G
 
-    simulate_platform "x86-darwin-100"
+    simulate_platform "x86-darwin-100" do
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        gem "nokogiri"
+        gem "platform_specific"
+      G
 
-    install_gemfile <<-G
-      source "https://gem.repo1"
-      gem "nokogiri"
-      gem "platform_specific"
-    G
-
-    expect(the_bundle).to include_gems "nokogiri 1.4.2", "platform_specific 1.0 x86-darwin-100"
+      expect(the_bundle).to include_gems "nokogiri 1.4.2", "platform_specific 1.0 x86-darwin-100"
+    end
   end
 
   it "allows specifying only-ruby-platform on jruby", :jruby_only do

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -27,8 +27,6 @@ module Spec
     end
 
     def build_repo1
-      rake_path = Dir["#{base_system_gems}/**/rake*.gem"].first
-
       build_repo gem_repo1 do
         FileUtils.cp rake_path, "#{gem_repo1}/gems/"
 
@@ -231,12 +229,9 @@ module Spec
     end
 
     def check_test_gems!
-      rake_path = Dir["#{base_system_gems}/**/rake*.gem"].first
-
       if rake_path.nil?
         FileUtils.rm_rf(base_system_gems)
         Spec::Rubygems.install_test_deps
-        rake_path = Dir["#{base_system_gems}/**/rake*.gem"].first
       end
 
       if rake_path.nil?

--- a/bundler/spec/support/checksums.rb
+++ b/bundler/spec/support/checksums.rb
@@ -54,11 +54,11 @@ module Spec
       ChecksumsBuilder.new(enabled, &block)
     end
 
-    def checksums_section_when_existing(&block)
+    def checksums_section_when_enabled(target_lockfile = nil, &block)
       begin
-        enabled = lockfile.match?(/^CHECKSUMS$/)
+        enabled = (target_lockfile || lockfile).match?(/^CHECKSUMS$/)
       rescue Errno::ENOENT
-        enabled = false
+        enabled = Bundler.feature_flag.bundler_3_mode?
       end
       checksums_section(enabled, &block)
     end

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -425,7 +425,7 @@ module Spec
     def simulate_platform(platform)
       old = ENV["BUNDLER_SPEC_PLATFORM"]
       ENV["BUNDLER_SPEC_PLATFORM"] = platform.to_s
-      yield if block_given?
+      yield
     ensure
       ENV["BUNDLER_SPEC_PLATFORM"] = old if block_given?
     end

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -265,6 +265,10 @@ module Spec
       ruby_core? ? source_root : source_root.parent
     end
 
+    def rake_path
+      Dir["#{base_system_gems}/**/rake*.gem"].first
+    end
+
     private
 
     def git_ls_files(glob)

--- a/bundler/spec/update/git_spec.rb
+++ b/bundler/spec/update/git_spec.rb
@@ -309,7 +309,7 @@ RSpec.describe "bundle update" do
 
       bundle "update --source bar"
 
-      checksums = checksums_section_when_existing do |c|
+      checksums = checksums_section_when_enabled do |c|
         c.no_checksum "foo", "2.0"
         c.checksum gem_repo2, "myrack", "1.0.0"
       end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We have "lockfile checksums" code in place, but we don't yet generate any lockfile checksums by default. The test suite does support some lockfile with checkums, but all that is currently "disabled" because those lockfiles are never generated.

## What is your fix for the problem, implemented in this PR?

This PR gets some coverage in place and enables lockfile checksums by default in the followin case:

* Bundler 3.
* Lockfile is first generated.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
