### PR TITLE
Protect creating binstubs with a file lock

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -780,6 +780,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
   ##
   # Safely write a file in binary mode on all platforms.
+
   def self.write_binary(path, data)
     open_file(path, "wb") do |io|
       io.write data

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -813,12 +813,12 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
       rescue Errno::ENOSYS, Errno::ENOTSUP
       end
       yield io
-    end
-  rescue Errno::ENOLCK # NFS
-    if Thread.main != Thread.current
-      raise
-    else
-      open_file_without_flock(path, flags, &block)
+    rescue Errno::ENOLCK # NFS
+      if Thread.main != Thread.current
+        raise
+      else
+        open_file_without_flock(path, flags, &block)
+      end
     end
   end
 

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -792,21 +792,18 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   end
 
   ##
-  # Open a file with given flags. It requires special logic on Windows, like
-  # protecting access with flock
+  # Open a file with given flags
 
   def self.open_file(path, flags, &block)
-    if !java_platform? && win_platform?
-      open_file_with_flock(path, flags, &block)
-    else
-      open_file_without_flock(path, flags, &block)
-    end
+    File.open(path, flags, &block)
   end
 
   ##
   # Open a file with given flags, and protect access with flock
 
-  def self.open_file_with_flock(path, flags, &block)
+  def self.open_file_with_flock(path, &block)
+    flags = File.exist?(path) ? "r+" : "a+"
+
     File.open(path, flags) do |io|
       begin
         io.flock(File::LOCK_EX)
@@ -817,7 +814,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
       if Thread.main != Thread.current
         raise
       else
-        open_file_without_flock(path, flags, &block)
+        open_file(path, flags, &block)
       end
     end
   end
@@ -1317,10 +1314,6 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     attr_reader :pre_uninstall_hooks
 
     private
-
-    def open_file_without_flock(path, flags, &block)
-      File.open(path, flags, &block)
-    end
 
     def already_loaded?(file)
       $LOADED_FEATURES.any? do |feature_path|

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -222,7 +222,7 @@ class Gem::Installer
     ruby_executable = false
     existing = nil
 
-    Gem.open_file_with_flock generated_bin, "rb+" do |io|
+    File.open generated_bin, "rb" do |io|
       line = io.gets
       shebang = /^#!.*ruby/o
 
@@ -541,8 +541,8 @@ class Gem::Installer
     require "fileutils"
     FileUtils.rm_f bin_script_path # prior install may have been --no-wrappers
 
-    File.open bin_script_path, "wb", 0o755 do |file|
-      file.print app_script_text(filename)
+    Gem.open_file_with_flock(bin_script_path) do |file|
+      file.write app_script_text(filename)
       file.chmod(options[:prog_mode] || 0o755)
     end
 

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -538,12 +538,14 @@ class Gem::Installer
   def generate_bin_script(filename, bindir)
     bin_script_path = File.join bindir, formatted_program_filename(filename)
 
-    require "fileutils"
-    FileUtils.rm_f bin_script_path # prior install may have been --no-wrappers
+    Gem.open_file_with_flock("#{bin_script_path}.lock") do
+      require "fileutils"
+      FileUtils.rm_f bin_script_path # prior install may have been --no-wrappers
 
-    Gem.open_file_with_flock(bin_script_path) do |file|
-      file.write app_script_text(filename)
-      file.chmod(options[:prog_mode] || 0o755)
+      File.open(bin_script_path, "wb", 0o755) do |file|
+        file.write app_script_text(filename)
+        file.chmod(options[:prog_mode] || 0o755)
+      end
     end
 
     verbose bin_script_path

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -500,8 +500,7 @@ class Gem::Installer
       dir_mode = options[:prog_mode] || (mode | 0o111)
 
       unless dir_mode == mode
-        require "fileutils"
-        FileUtils.chmod dir_mode, bin_path
+        File.chmod dir_mode, bin_path
       end
 
       check_executable_overwrite filename


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I'm still seeing CI flakies after #7797 :(

Issues are related to a particular Bundler spec that tests conflicting binstubs between different gems. Bundler 2 do allow installing these but prints a warnings on usage. After #7669, the dummy gems in this spec were renamed from "fake" and "rack" to "fake" and "myrack". That caused the binstubs generated by each dummy gem to be of different length (because of the longer name of "myrack"). And that made some race condition bugs show up.

These bugs consist of concurrent install threads trying to write the same binstub. There are two issues (adapted from comments below):

#### Issue 1:

* Process A truncates binstub FOO (this is not currently protected with a file lock).
* Process B truncates binstub FOO (this is not current protected with a file lock).
* Process A writes binstub FOO for gem BAR from the beginning of file.
* Process B writes binstub FOO for gem BAZ from the beginning of file.

If binstub FOO for gem BAR is bigger than binstub FOO for gem BAZ, garbage bytes will be left around, corrupting the binstub.

#### Issue 2:

* Process A removes prior binstub FOO.
* Process B removes prior binstub FOO (does nothing actually because Process A already removed it).
* Process A writes binstub FOO for gem BAR from the beginning of file.
* Process B writes binstub FOO for gem BAZ from the beginning of file.

Similarly as before, if binstub FOO for gem BAR is bigger that binstub FOO for gem BAZ, garbage bytes will be left around at the end of the file, corrupting the binstub.

## What is your fix for the problem, implemented in this PR?

Fix for issue 1 is to avoid truncating the binstub, and fix for issue 2 is to also protect the removal of the previous binstub with a file lock.


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
