### PR TITLE
Restrict generic `arm` to only match 32-bit arm

### DIFF
--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -46,6 +46,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby.value }}
           bundler: none
+      - name: Update RBS # https://github.com/ruby/rbs/pull/1612
+        run: ruby -e 'begin; require "rbs"; rescue LoadError; exit; end; exec(*%w{gem install --version 3.4.0 rbs}) if Gem::Requirement.new([">= 1.6", "< 3.1.1"]).satisfied_by?(Gem::Version.new(RBS::VERSION))'
       - name: Install Dependencies
         run: bin/rake setup
       - name: Run Test

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -258,7 +258,7 @@ module Gem
 
         # cpu
         ([nil,"universal"].include?(@cpu) || [nil, "universal"].include?(other.cpu) || @cpu == other.cpu ||
-        (@cpu == "arm" && other.cpu.start_with?("arm"))) &&
+        (@cpu == "arm" && other.cpu.start_with?("armv"))) &&
 
           # os
           @os == other.os &&

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -177,7 +177,7 @@ class Gem::Platform
   # they have the same version, or either one has no version
   #
   # Additionally, the platform will match if the local CPU is 'arm' and the
-  # other CPU starts with "arm" (for generic ARM family support).
+  # other CPU starts with "armv" (for generic 32-bit ARM family support).
   #
   # Of note, this method is not commutative. Indeed the OS 'linux' has a
   # special case: the version is the libc name, yet while "no version" stands
@@ -198,7 +198,7 @@ class Gem::Platform
 
     # cpu
     ([nil,"universal"].include?(@cpu) || [nil, "universal"].include?(other.cpu) || @cpu == other.cpu ||
-    (@cpu == "arm" && other.cpu.start_with?("arm"))) &&
+    (@cpu == "arm" && other.cpu.start_with?("armv"))) &&
 
       # os
       @os == other.os &&

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -368,18 +368,27 @@ class TestGemPlatform < Gem::TestCase
     arm   = Gem::Platform.new "arm-linux"
     armv5 = Gem::Platform.new "armv5-linux"
     armv7 = Gem::Platform.new "armv7-linux"
+    arm64 = Gem::Platform.new "arm64-linux"
 
     util_set_arch "armv5-linux"
     assert((arm   === Gem::Platform.local), "arm   === armv5")
     assert((armv5 === Gem::Platform.local), "armv5 === armv5")
     refute((armv7 === Gem::Platform.local), "armv7 === armv5")
+    refute((arm64 === Gem::Platform.local), "arm64 === armv5")
     refute((Gem::Platform.local === arm), "armv5 === arm")
 
     util_set_arch "armv7-linux"
     assert((arm   === Gem::Platform.local), "arm   === armv7")
     refute((armv5 === Gem::Platform.local), "armv5 === armv7")
     assert((armv7 === Gem::Platform.local), "armv7 === armv7")
+    refute((arm64 === Gem::Platform.local), "arm64 === armv7")
     refute((Gem::Platform.local === arm), "armv7 === arm")
+
+    util_set_arch "arm64-linux"
+    refute((arm   === Gem::Platform.local), "arm   === arm64")
+    refute((armv5 === Gem::Platform.local), "armv5 === arm64")
+    refute((armv7 === Gem::Platform.local), "armv7 === arm64")
+    assert((arm64 === Gem::Platform.local), "arm64 === arm64")
   end
 
   def test_equals3_universal_mingw


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Fixes #7821

## What is your fix for the problem, implemented in this PR?

Restrict `arm-` gem to only match runtime with name start with `armv`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
