### PR TITLE
Fix generic platform gems getting incorrectly removed from lockfile

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -638,8 +638,6 @@ module Bundler
 
       @platforms = result.add_extra_platforms!(platforms) if should_add_extra_platforms?
 
-      result.complete_platforms!(platforms)
-
       SpecSet.new(result.for(dependencies, false, @platforms))
     end
 

--- a/bundler/lib/bundler/gem_helpers.rb
+++ b/bundler/lib/bundler/gem_helpers.rb
@@ -46,19 +46,21 @@ module Bundler
     end
     module_function :platform_specificity_match
 
-    def select_best_platform_match(specs, platform)
-      matching = specs.select {|spec| spec.match_platform(platform) }
+    def select_best_platform_match(specs, platform, force_ruby: false)
+      matching = if force_ruby
+        specs.select {|spec| spec.match_platform(Gem::Platform::RUBY) && spec.force_ruby_platform! }
+      else
+        specs.select {|spec| spec.match_platform(platform) }
+      end
 
       sort_best_platform_match(matching, platform)
     end
     module_function :select_best_platform_match
 
-    def force_ruby_platform(specs)
-      matching = specs.select {|spec| spec.match_platform(Gem::Platform::RUBY) && spec.force_ruby_platform! }
-
-      sort_best_platform_match(matching, Gem::Platform::RUBY)
+    def select_best_local_platform_match(specs, force_ruby: false)
+      select_best_platform_match(specs, local_platform, force_ruby: force_ruby).map(&:materialize_for_installation).compact
     end
-    module_function :force_ruby_platform
+    module_function :select_best_local_platform_match
 
     def sort_best_platform_match(matching, platform)
       exact = matching.select {|spec| spec.platform == platform }

--- a/bundler/lib/bundler/gem_helpers.rb
+++ b/bundler/lib/bundler/gem_helpers.rb
@@ -46,11 +46,16 @@ module Bundler
     end
     module_function :platform_specificity_match
 
-    def select_best_platform_match(specs, platform, force_ruby: false)
+    def select_best_platform_match(specs, platform, force_ruby: false, prefer_locked: false)
       matching = if force_ruby
         specs.select {|spec| spec.match_platform(Gem::Platform::RUBY) && spec.force_ruby_platform! }
       else
         specs.select {|spec| spec.match_platform(platform) }
+      end
+
+      if prefer_locked
+        locked_originally = matching.select {|spec| spec.is_a?(LazySpecification) }
+        return locked_originally if locked_originally.any?
       end
 
       sort_best_platform_match(matching, platform)

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -79,7 +79,7 @@ module Bundler
     def solve_versions(root:, logger:)
       solver = PubGrub::VersionSolver.new(source: self, root: root, logger: logger)
       result = solver.solve
-      result.map {|package, version| version.to_specs(package) }.flatten.uniq
+      result.map {|package, version| version.to_specs(package) }.flatten
     rescue PubGrub::SolveFailure => e
       incompatibility = e.incompatibility
 
@@ -270,6 +270,7 @@ module Bundler
         end
 
         platform_specs.flatten!
+        platform_specs.uniq!
 
         ruby_specs = select_best_platform_match(specs, Gem::Platform::RUBY)
         groups << Resolver::Candidate.new(version, specs: ruby_specs) if ruby_specs.any?

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -273,11 +273,11 @@ module Bundler
         platform_specs.uniq!
 
         ruby_specs = select_best_platform_match(specs, Gem::Platform::RUBY)
-        groups << Resolver::Candidate.new(version, specs: ruby_specs) if ruby_specs.any?
+        groups << Resolver::Candidate.new(version, specs: ruby_specs, priority: -1) if ruby_specs.any?
 
         next groups if platform_specs == ruby_specs || package.force_ruby_platform?
 
-        groups << Resolver::Candidate.new(version, specs: platform_specs)
+        groups << Resolver::Candidate.new(version, specs: platform_specs, priority: 1)
 
         groups
       end
@@ -432,8 +432,8 @@ module Bundler
 
     def requirement_to_range(requirement)
       ranges = requirement.requirements.map do |(op, version)|
-        ver = Resolver::Candidate.new(version).generic!
-        platform_ver = Resolver::Candidate.new(version).platform_specific!
+        ver = Resolver::Candidate.new(version, priority: -1)
+        platform_ver = Resolver::Candidate.new(version, priority: 1)
 
         case op
         when "~>"

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -255,7 +255,7 @@ module Bundler
       results = filter_matching_specs(results, locked_requirement) if locked_requirement
 
       results.group_by(&:version).reduce([]) do |groups, (version, specs)|
-        platform_specs = package.platforms.map {|platform| select_best_platform_match(specs, platform) }
+        platform_specs = package.platform_specs(specs)
 
         # If package is a top-level dependency,
         #   candidate is only valid if there are matching versions for all resolution platforms.

--- a/bundler/lib/bundler/resolver/base.rb
+++ b/bundler/lib/bundler/resolver/base.rb
@@ -30,6 +30,10 @@ module Bundler
         end.compact
       end
 
+      def specs_compatible_with(result)
+        @base.specs_compatible_with(result)
+      end
+
       def [](name)
         @base[name]
       end

--- a/bundler/lib/bundler/resolver/candidate.rb
+++ b/bundler/lib/bundler/resolver/candidate.rb
@@ -24,8 +24,8 @@ module Bundler
 
       attr_reader :version
 
-      def initialize(version, specs: [], priority: -1)
-        @spec_group = Resolver::SpecGroup.new(specs)
+      def initialize(version, group: nil, priority: -1)
+        @spec_group = group || SpecGroup.new([])
         @version = Gem::Version.new(version)
         @priority = priority
       end

--- a/bundler/lib/bundler/resolver/candidate.rb
+++ b/bundler/lib/bundler/resolver/candidate.rb
@@ -24,10 +24,10 @@ module Bundler
 
       attr_reader :version
 
-      def initialize(version, specs: [])
+      def initialize(version, specs: [], priority: -1)
         @spec_group = Resolver::SpecGroup.new(specs)
         @version = Gem::Version.new(version)
-        @ruby_only = specs.map(&:platform).uniq == [Gem::Platform::RUBY]
+        @priority = priority
       end
 
       def dependencies
@@ -40,18 +40,6 @@ module Bundler
         @spec_group.to_specs(package.force_ruby_platform?)
       end
 
-      def generic!
-        @ruby_only = true
-
-        self
-      end
-
-      def platform_specific!
-        @ruby_only = false
-
-        self
-      end
-
       def prerelease?
         @version.prerelease?
       end
@@ -61,7 +49,7 @@ module Bundler
       end
 
       def sort_obj
-        [@version, @ruby_only ? -1 : 1]
+        [@version, @priority]
       end
 
       def <=>(other)

--- a/bundler/lib/bundler/resolver/package.rb
+++ b/bundler/lib/bundler/resolver/package.rb
@@ -25,6 +25,10 @@ module Bundler
         @prerelease = @dependency.prerelease? || @locked_version&.prerelease? || prerelease ? :consider_first : :ignore
       end
 
+      def platform_specs(specs)
+        platforms.map {|platform| GemHelpers.select_best_platform_match(specs, platform, prefer_locked: !unlock?) }
+      end
+
       def to_s
         @name.delete("\0")
       end

--- a/bundler/lib/bundler/resolver/spec_group.rb
+++ b/bundler/lib/bundler/resolver/spec_group.rb
@@ -44,7 +44,7 @@ module Bundler
       protected
 
       def sorted_spec_names
-        @sorted_spec_names ||= @specs.map(&:full_name).sort
+        @specs.map(&:full_name).sort
       end
 
       private

--- a/bundler/lib/bundler/resolver/spec_group.rb
+++ b/bundler/lib/bundler/resolver/spec_group.rb
@@ -3,6 +3,8 @@
 module Bundler
   class Resolver
     class SpecGroup
+      attr_reader :specs
+
       def initialize(specs)
         @specs = specs
       end
@@ -38,7 +40,19 @@ module Bundler
       def dependencies
         @dependencies ||= @specs.map do |spec|
           __dependencies(spec) + metadata_dependencies(spec)
-        end.flatten.uniq
+        end.flatten.uniq.sort
+      end
+
+      def ==(other)
+        sorted_spec_names == other.sorted_spec_names
+      end
+
+      def merge(other)
+        return false unless equivalent?(other)
+
+        @specs |= other.specs
+
+        true
       end
 
       protected
@@ -48,6 +62,10 @@ module Bundler
       end
 
       private
+
+      def equivalent?(other)
+        name == other.name && version == other.version && source == other.source && dependencies == other.dependencies
+      end
 
       def exemplary_spec
         @specs.first

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -277,13 +277,11 @@ module Bundler
       specs_for_name = lookup[dep.name]
       return [] unless specs_for_name
 
-      matching_specs = if dep.force_ruby_platform
-        GemHelpers.force_ruby_platform(specs_for_name)
+      if platform
+        GemHelpers.select_best_platform_match(specs_for_name, platform, force_ruby: dep.force_ruby_platform)
       else
-        GemHelpers.select_best_platform_match(specs_for_name, platform || Bundler.local_platform)
+        GemHelpers.select_best_local_platform_match(specs_for_name, force_ruby: dep.force_ruby_platform)
       end
-      matching_specs.map!(&:materialize_for_installation).compact! if platform.nil?
-      matching_specs
     end
 
     def tsort_each_child(s)

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -71,12 +71,6 @@ module Bundler
       platforms
     end
 
-    def complete_platforms!(platforms)
-      platforms.each do |platform|
-        complete_platform(platform)
-      end
-    end
-
     def validate_deps(s)
       s.runtime_dependencies.each do |dep|
         next if dep.name == "bundler"
@@ -158,6 +152,12 @@ module Bundler
       @specs.detect {|spec| spec.name == name && spec.match_platform(platform) }
     end
 
+    def specs_compatible_with(other)
+      select do |spec|
+        other.valid?(spec)
+      end
+    end
+
     def delete_by_name(name)
       @specs.reject! {|spec| spec.name == name }
 
@@ -195,6 +195,10 @@ module Bundler
       lookup.keys
     end
 
+    def valid?(s)
+      s.matches_current_metadata? && valid_dependencies?(s)
+    end
+
     private
 
     def reset!
@@ -209,7 +213,7 @@ module Bundler
         spec = specs.first
         matching_specs = spec.source.specs.search([spec.name, spec.version])
         platform_spec = GemHelpers.select_best_platform_match(matching_specs, platform).find do |s|
-          s.matches_current_metadata? && valid_dependencies?(s)
+          valid?(s)
         end
 
         if platform_spec

--- a/bundler/spec/bundler/resolver/candidate_spec.rb
+++ b/bundler/spec/bundler/resolver/candidate_spec.rb
@@ -2,20 +2,19 @@
 
 RSpec.describe Bundler::Resolver::Candidate do
   it "compares fine" do
-    version1 = described_class.new("1.12.5", specs: [Gem::Specification.new("foo", "1.12.5") {|s| s.platform = Gem::Platform::RUBY }])
-    version2 = described_class.new("1.12.5") # passing no specs creates a platform specific candidate, so sorts higher
+    version1 = described_class.new("1.12.5", priority: -1)
+    version2 = described_class.new("1.12.5", priority: 1)
 
-    expect(version2 >= version1).to be true
+    expect(version2 > version1).to be true
 
-    expect(version1.generic! == version2.generic!).to be true
-    expect(version1.platform_specific! == version2.platform_specific!).to be true
+    version1 = described_class.new("1.12.5")
+    version2 = described_class.new("1.12.5")
 
-    expect(version1.platform_specific! >= version2.generic!).to be true
-    expect(version2.platform_specific! >= version1.generic!).to be true
+    expect(version2 == version1).to be true
 
-    version1 = described_class.new("1.12.5", specs: [Gem::Specification.new("foo", "1.12.5") {|s| s.platform = Gem::Platform::RUBY }])
-    version2 = described_class.new("1.12.5", specs: [Gem::Specification.new("foo", "1.12.5") {|s| s.platform = Gem::Platform::X64_LINUX }])
+    version1 = described_class.new("1.12.5", priority: 1)
+    version2 = described_class.new("1.12.5", priority: -1)
 
-    expect(version2 >= version1).to be true
+    expect(version2 < version1).to be true
   end
 end

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -1663,7 +1663,8 @@ RSpec.describe "bundle lock" do
             nokogiri (1.14.2)
 
         PLATFORMS
-          #{lockfile_platforms}
+          ruby
+          x86_64-linux
 
         DEPENDENCIES
           foo!

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -1467,9 +1467,7 @@ RSpec.describe "bundle lock" do
          #{Bundler::VERSION}
     L
 
-    bundle "lock", raise_on_error: false
-
-    expect(err).to eq <<~ERR.strip
+    expected_error = <<~ERR.strip
       Could not find compatible versions
 
           Because every version of activemodel depends on activesupport = 6.0.4
@@ -1493,28 +1491,13 @@ RSpec.describe "bundle lock" do
             version solving has failed.
     ERR
 
+    bundle "lock", raise_on_error: false
+    expect(err).to eq(expected_error)
+
     lockfile lockfile.gsub(/PLATFORMS\n  #{local_platform}/m, "PLATFORMS\n  #{lockfile_platforms("ruby")}")
 
     bundle "lock", raise_on_error: false
-
-    expect(err).to eq <<~ERR.strip
-      Could not find compatible versions
-
-      Because rails >= 7.0.3.1, < 7.0.4 depends on activemodel = 7.0.3.1
-        and rails >= 7.0.2.3, < 7.0.3.1 depends on activemodel = 7.0.2.3,
-        rails >= 7.0.2.3, < 7.0.4 requires activemodel = 7.0.2.3 OR = 7.0.3.1.
-      And because every version of activemodel depends on activesupport = 6.0.4,
-        rails >= 7.0.2.3, < 7.0.4 requires activesupport = 6.0.4.
-      Because rails >= 7.0.3.1, < 7.0.4 depends on activesupport = 7.0.3.1
-        and rails >= 7.0.2.3, < 7.0.3.1 depends on activesupport = 7.0.2.3,
-        rails >= 7.0.2.3, < 7.0.4 requires activesupport = 7.0.2.3 OR = 7.0.3.1.
-      Thus, rails >= 7.0.2.3, < 7.0.4 cannot be used.
-      And because rails >= 7.0.4 depends on activemodel = 7.0.4,
-        rails >= 7.0.2.3 requires activemodel = 7.0.4.
-      So, because activemodel = 7.0.4 could not be found in rubygems repository https://gem.repo4/ or installed locally
-        and Gemfile depends on rails >= 7.0.2.3,
-        version solving has failed.
-    ERR
+    expect(err).to eq(expected_error)
   end
 
   it "does not accidentally resolves to prereleases" do

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -1470,22 +1470,19 @@ RSpec.describe "bundle lock" do
     expected_error = <<~ERR.strip
       Could not find compatible versions
 
-          Because every version of activemodel depends on activesupport = 6.0.4
-            and rails >= 7.0.2.3, < 7.0.3.1 depends on activesupport = 7.0.2.3,
-            every version of activemodel is incompatible with rails >= 7.0.2.3, < 7.0.3.1.
-          And because rails >= 7.0.2.3, < 7.0.3.1 depends on activemodel = 7.0.2.3,
-            rails >= 7.0.2.3, < 7.0.3.1 cannot be used.
-      (1) So, because rails >= 7.0.3.1, < 7.0.4 depends on activemodel = 7.0.3.1
-            and rails >= 7.0.4 depends on activemodel = 7.0.4,
-            rails >= 7.0.2.3 requires activemodel = 7.0.3.1 OR = 7.0.4.
-
-          Because rails >= 7.0.2.3, < 7.0.3.1 depends on activemodel = 7.0.2.3
-            and rails >= 7.0.3.1, < 7.0.4 depends on activesupport = 7.0.3.1,
-            rails >= 7.0.2.3, < 7.0.4 requires activemodel = 7.0.2.3 or activesupport = 7.0.3.1.
-          And because rails >= 7.0.4 depends on activesupport = 7.0.4
+          Because rails >= 7.0.4 depends on activemodel = 7.0.4
+            and rails >= 7.0.3.1, < 7.0.4 depends on activemodel = 7.0.3.1,
+            rails >= 7.0.3.1 requires activemodel = 7.0.3.1 OR = 7.0.4.
+      (1) So, because rails >= 7.0.2.3, < 7.0.3.1 depends on activemodel = 7.0.2.3
             and every version of activemodel depends on activesupport = 6.0.4,
-            activemodel != 7.0.2.3 is incompatible with rails >= 7.0.2.3.
-          And because rails >= 7.0.2.3 requires activemodel = 7.0.3.1 OR = 7.0.4 (1),
+            rails >= 7.0.2.3 requires activesupport = 6.0.4.
+
+          Because rails >= 7.0.2.3, < 7.0.3.1 depends on activesupport = 7.0.2.3
+            and rails >= 7.0.3.1, < 7.0.4 depends on activesupport = 7.0.3.1,
+            rails >= 7.0.2.3, < 7.0.4 requires activesupport = 7.0.2.3 OR = 7.0.3.1.
+          And because rails >= 7.0.4 depends on activesupport = 7.0.4,
+            rails >= 7.0.2.3 requires activesupport = 7.0.2.3 OR = 7.0.3.1 OR = 7.0.4.
+          And because rails >= 7.0.2.3 requires activesupport = 6.0.4 (1),
             rails >= 7.0.2.3 cannot be used.
           So, because Gemfile depends on rails >= 7.0.2.3,
             version solving has failed.


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I learned through a [dependabot-core ticket](https://github.com/dependabot/dependabot-core/issues/10085), that sometimes Bundler will replace generic gems with platform specific variants, even when updating completely unrelated gems.

## What is your fix for the problem, implemented in this PR?

The PR refactors the resolver to avoid doing this, and always keep existing lockfile gems if they are compatible with the resolution found. Every existing spec passes except some error messages that as a result of the refactorings are slightly shorter and more consistent.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
