### PR TITLE
Use preferred `add_dependency` instead of `add_runtime_dependency`

### DIFF
--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -1188,19 +1188,19 @@ RSpec.describe "bundle install with gem sources" do
 
         build_gem "nokogiri", "1.12.4" do |s|
           s.platform = "x86_64-darwin"
-          s.add_runtime_dependency "racca", "~> 1.4"
+          s.add_dependency "racca", "~> 1.4"
         end
 
         build_gem "nokogiri", "1.12.4" do |s|
           s.platform = "x86_64-linux"
-          s.add_runtime_dependency "racca", "~> 1.4"
+          s.add_dependency "racca", "~> 1.4"
         end
 
         build_gem "crass", "1.0.6"
 
         build_gem "loofah", "2.12.0" do |s|
-          s.add_runtime_dependency "crass", "~> 1.0.2"
-          s.add_runtime_dependency "nokogiri", ">= 1.5.9"
+          s.add_dependency "crass", "~> 1.0.2"
+          s.add_dependency "nokogiri", ">= 1.5.9"
         end
       end
 

--- a/bundler/spec/install/gemfile/force_ruby_platform_spec.rb
+++ b/bundler/spec/install/gemfile/force_ruby_platform_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "bundle install with force_ruby_platform DSL option", :jruby do
   context "when also a transitive dependency" do
     before do
       build_repo4 do
-        build_gem("depends_on_platform_specific") {|s| s.add_runtime_dependency "platform_specific" }
+        build_gem("depends_on_platform_specific") {|s| s.add_dependency "platform_specific" }
 
         build_gem("platform_specific") do |s|
           s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0.0 RUBY'"
@@ -83,12 +83,12 @@ RSpec.describe "bundle install with force_ruby_platform DSL option", :jruby do
     before do
       build_repo4 do
         build_gem("depends_on_platform_specific") do |s|
-          s.add_runtime_dependency "platform_specific"
+          s.add_dependency "platform_specific"
           s.write "lib/depends_on_platform_specific.rb", "DEPENDS_ON_PLATFORM_SPECIFIC = '1.0.0 RUBY'"
         end
 
         build_gem("depends_on_platform_specific") do |s|
-          s.add_runtime_dependency "platform_specific"
+          s.add_dependency "platform_specific"
           s.platform = Bundler.local_platform
           s.write "lib/depends_on_platform_specific.rb", "DEPENDS_ON_PLATFORM_SPECIFIC = '1.0.0 #{Bundler.local_platform}'"
         end

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -179,16 +179,16 @@ RSpec.describe "bundle install across platforms" do
       build_gem "empyrean", "0.1.0"
       build_gem "coderay", "1.1.2"
       build_gem "method_source", "0.9.0"
-      build_gem("spoon", "0.0.6") {|s| s.add_runtime_dependency "ffi" }
+      build_gem("spoon", "0.0.6") {|s| s.add_dependency "ffi" }
       build_gem "pry", "0.11.3" do |s|
         s.platform = "java"
-        s.add_runtime_dependency "coderay", "~> 1.1.0"
-        s.add_runtime_dependency "method_source", "~> 0.9.0"
-        s.add_runtime_dependency "spoon", "~> 0.0"
+        s.add_dependency "coderay", "~> 1.1.0"
+        s.add_dependency "method_source", "~> 0.9.0"
+        s.add_dependency "spoon", "~> 0.0"
       end
       build_gem "pry", "0.11.3" do |s|
-        s.add_runtime_dependency "coderay", "~> 1.1.0"
-        s.add_runtime_dependency "method_source", "~> 0.9.0"
+        s.add_dependency "coderay", "~> 1.1.0"
+        s.add_dependency "method_source", "~> 0.9.0"
       end
       build_gem("ffi", "1.9.23") {|s| s.platform = "java" }
       build_gem("ffi", "1.9.23")
@@ -332,11 +332,11 @@ RSpec.describe "bundle install across platforms" do
     update_repo2 do
       build_gem "fspath", "3"
       build_gem "image_optim_pack", "1.2.3" do |s|
-        s.add_runtime_dependency "fspath", ">= 2.1", "< 4"
+        s.add_dependency "fspath", ">= 2.1", "< 4"
       end
       build_gem "image_optim_pack", "1.2.3" do |s|
         s.platform = "universal-darwin"
-        s.add_runtime_dependency "fspath", "< 4", ">= 2.1"
+        s.add_dependency "fspath", "< 4", ">= 2.1"
       end
     end
 

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe "bundle install with specific platforms" do
         build_gem("libv8", "8.4.255.0") {|s| s.platform = "universal-darwin" }
 
         build_gem("mini_racer", "1.0.0") do |s|
-          s.add_runtime_dependency "libv8"
+          s.add_dependency "libv8"
         end
       end
 
@@ -483,12 +483,12 @@ RSpec.describe "bundle install with specific platforms" do
   it "automatically fixes the lockfile if RUBY platform is locked and some gem has no RUBY variant available" do
     build_repo4 do
       build_gem("sorbet-static-and-runtime", "0.5.10160") do |s|
-        s.add_runtime_dependency "sorbet", "= 0.5.10160"
-        s.add_runtime_dependency "sorbet-runtime", "= 0.5.10160"
+        s.add_dependency "sorbet", "= 0.5.10160"
+        s.add_dependency "sorbet-runtime", "= 0.5.10160"
       end
 
       build_gem("sorbet", "0.5.10160") do |s|
-        s.add_runtime_dependency "sorbet-static", "= 0.5.10160"
+        s.add_dependency "sorbet-static", "= 0.5.10160"
       end
 
       build_gem("sorbet-runtime", "0.5.10160")
@@ -635,12 +635,12 @@ RSpec.describe "bundle install with specific platforms" do
   it "automatically fixes the lockfile if only RUBY platform is locked and some gem has no RUBY variant available" do
     build_repo4 do
       build_gem("sorbet-static-and-runtime", "0.5.10160") do |s|
-        s.add_runtime_dependency "sorbet", "= 0.5.10160"
-        s.add_runtime_dependency "sorbet-runtime", "= 0.5.10160"
+        s.add_dependency "sorbet", "= 0.5.10160"
+        s.add_dependency "sorbet-runtime", "= 0.5.10160"
       end
 
       build_gem("sorbet", "0.5.10160") do |s|
-        s.add_runtime_dependency "sorbet-static", "= 0.5.10160"
+        s.add_dependency "sorbet-static", "= 0.5.10160"
       end
 
       build_gem("sorbet-runtime", "0.5.10160")
@@ -848,7 +848,7 @@ RSpec.describe "bundle install with specific platforms" do
     simulate_platform "x86_64-linux" do
       build_repo4 do
         build_gem("ibandit", "0.7.0") do |s|
-          s.add_runtime_dependency "i18n", "~> 0.7.0"
+          s.add_dependency "i18n", "~> 0.7.0"
         end
 
         build_gem("i18n", "0.7.0.beta1")
@@ -1123,7 +1123,7 @@ RSpec.describe "bundle install with specific platforms" do
     simulate_platform "x86_64-linux" do
       build_repo4 do
         build_gem("sorbet", "0.5.10160") do |s|
-          s.add_runtime_dependency "sorbet-static", "= 0.5.10160"
+          s.add_dependency "sorbet-static", "= 0.5.10160"
         end
 
         build_gem("sorbet-static", "0.5.10160") do |s|
@@ -1546,7 +1546,7 @@ RSpec.describe "bundle install with specific platforms" do
       build_gem("facter", "2.4.6")
       build_gem("facter", "2.4.6") do |s|
         s.platform = "universal-darwin"
-        s.add_runtime_dependency "CFPropertyList"
+        s.add_dependency "CFPropertyList"
       end
       build_gem("CFPropertyList")
     end

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "compact index api" do
   it "should handle case sensitivity conflicts" do
     build_repo4(build_compact_index: false) do
       build_gem "myrack", "1.0" do |s|
-        s.add_runtime_dependency("Myrack", "0.1")
+        s.add_dependency("Myrack", "0.1")
       end
       build_gem "Myrack", "0.1"
     end

--- a/bundler/spec/install/gemspecs_spec.rb
+++ b/bundler/spec/install/gemspecs_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "bundle install" do
       spec = Gem::Specification.new do |s|
         s.name = "myrack"
         s.version = "1.0.0"
-        s.add_runtime_dependency "activesupport", "2.3.2"
+        s.add_dependency "activesupport", "2.3.2"
       end
       f.write spec.to_ruby
     end

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1305,7 +1305,7 @@ end
             s.files       = Dir["lib/**/*.rb"]
             s.author      = 'no one'
 
-            s.add_runtime_dependency 'digest'
+            s.add_dependency 'digest'
           end
         G
       end

--- a/test/rubygems/test_gem_commands_exec_command.rb
+++ b/test/rubygems/test_gem_commands_exec_command.rb
@@ -182,7 +182,7 @@ class TestGemCommandsExecCommand < Gem::TestCase
       fetcher.download "a", 2 do |s|
         s.executables = %w[a]
         s.files = %w[bin/a lib/a.rb]
-        s.add_runtime_dependency "with_platform"
+        s.add_dependency "with_platform"
 
         write_file File.join(*%W[gems #{s.original_name} bin a]) do |f|
           f << 'require "with_platform"' << "\n"
@@ -222,7 +222,7 @@ class TestGemCommandsExecCommand < Gem::TestCase
       fetcher.download "a", 2 do |s|
         s.executables = %w[a]
         s.files = %w[bin/a lib/a.rb]
-        s.add_runtime_dependency "with_platform"
+        s.add_dependency "with_platform"
         s.platform = Gem::Platform.local.to_s
 
         write_file File.join(*%W[gems #{s.original_name} bin a]) do |f|
@@ -234,7 +234,7 @@ class TestGemCommandsExecCommand < Gem::TestCase
       fetcher.download "a", 2 do |s|
         s.executables = %w[a]
         s.files = %w[bin/a lib/a.rb extconf.rb]
-        s.add_runtime_dependency "with_platform"
+        s.add_dependency "with_platform"
 
         write_file File.join(*%W[gems #{s.original_name} bin a]) do |f|
           f << 'require "with_platform"' << "\n"
@@ -261,7 +261,7 @@ class TestGemCommandsExecCommand < Gem::TestCase
 
       fetcher.download "with_platform", 2 do |s|
         s.files = %w[lib/with_platform.rb]
-        s.add_runtime_dependency "sometimes_used"
+        s.add_dependency "sometimes_used"
       end
 
       fetcher.download "sometimes_used", 2 do |s|
@@ -677,7 +677,7 @@ class TestGemCommandsExecCommand < Gem::TestCase
       fetcher.gem "a", 1 do |s|
         s.executables = %w[]
         s.files = %w[lib/a.rb]
-        s.add_runtime_dependency "b"
+        s.add_dependency "b"
       end
 
       fetcher.gem "b", 1 do |s|
@@ -711,7 +711,7 @@ class TestGemCommandsExecCommand < Gem::TestCase
       fetcher.download "a", 2 do |s|
         s.executables = %w[a]
         s.files = %w[bin/a lib/a.rb]
-        s.add_runtime_dependency "b"
+        s.add_dependency "b"
 
         write_file File.join(*%W[gems #{s.original_name} bin a]) do |f|
           f << "Gem.ui.say #{s.original_name.dump}"

--- a/test/rubygems/test_gem_commands_lock_command.rb
+++ b/test/rubygems/test_gem_commands_lock_command.rb
@@ -9,11 +9,11 @@ class TestGemCommandsLockCommand < Gem::TestCase
 
     @a1 = quick_gem "a", "1"
     @b1 = quick_gem "b", "1" do |s|
-      s.add_runtime_dependency "a"
+      s.add_dependency "a"
     end
 
     @d1 = quick_gem "d", "1" do |s|
-      s.add_runtime_dependency "z"
+      s.add_dependency "z"
     end
 
     @cmd = Gem::Commands::LockCommand.new

--- a/test/rubygems/test_gem_request_set_gem_dependency_api.rb
+++ b/test/rubygems/test_gem_request_set_gem_dependency_api.rb
@@ -44,7 +44,7 @@ class TestGemRequestSetGemDependencyAPI < Gem::TestCase
 
   def test_gempspec_with_multiple_runtime_deps
     save_gemspec "foo", "1.0" do |s|
-      s.add_runtime_dependency "bar", ">= 1.6.0", "< 1.6.4"
+      s.add_dependency "bar", ">= 1.6.0", "< 1.6.4"
     end
     @gda.gemspec
     assert_equal %w[foo bar].sort, @set.dependencies.map(&:name).sort

--- a/test/rubygems/test_gem_resolver.rb
+++ b/test/rubygems/test_gem_resolver.rb
@@ -571,7 +571,7 @@ class TestGemResolver < Gem::TestCase
 
   def test_raises_and_reports_an_implicit_request_properly
     a1 = util_spec "a", "1" do |s|
-      s.add_runtime_dependency "b", "= 2"
+      s.add_dependency "b", "= 2"
     end
 
     ad = make_dep "a", "= 1"

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1833,7 +1833,7 @@ dependencies: []
   end
 
   def test_for_cache
-    @a2.add_runtime_dependency "b", "1"
+    @a2.add_dependency "b", "1"
     @a2.dependencies.first.instance_variable_set :@type, nil
     @a2.required_rubygems_version = Gem::Requirement.new "> 0"
     @a2.test_files = %w[test/test_b.rb]
@@ -2265,7 +2265,7 @@ dependencies: []
   end
 
   def test_to_ruby
-    @a2.add_runtime_dependency "b", "1"
+    @a2.add_dependency "b", "1"
     @a2.dependencies.first.instance_variable_set :@type, nil
     @a2.required_rubygems_version = Gem::Requirement.new "> 0"
     @a2.require_paths << "other"
@@ -2337,7 +2337,7 @@ end
   end
 
   def test_to_ruby_for_cache
-    @a2.add_runtime_dependency "b", "1"
+    @a2.add_dependency "b", "1"
     @a2.dependencies.first.instance_variable_set :@type, nil
     @a2.required_rubygems_version = Gem::Requirement.new "> 0"
     @a2.installed_by_version = Gem.rubygems_version
@@ -2760,7 +2760,7 @@ duplicate dependency on c (>= 1.2.3, development), (~> 1.2) use:
 
     Dir.chdir @tempdir do
       @a1.version = "1.0.0.beta.1"
-      @a1.add_runtime_dependency "b", "~> 1.2.0.beta.1"
+      @a1.add_dependency "b", "~> 1.2.0.beta.1"
 
       use_ui @ui do
         @a1.validate
@@ -2774,7 +2774,7 @@ duplicate dependency on c (>= 1.2.3, development), (~> 1.2) use:
     util_setup_validate
 
     Dir.chdir @tempdir do
-      @a1.add_runtime_dependency @a1.name, "1"
+      @a1.add_dependency @a1.name, "1"
 
       use_ui @ui do
         @a1.validate
@@ -2807,7 +2807,7 @@ duplicate dependency on c (>= 1.2.3, development), (~> 1.2) use:
 
     Dir.chdir @tempdir do
       @a1.extensions = ["Rakefile"]
-      @a1.add_runtime_dependency "rake"
+      @a1.add_dependency "rake"
       File.write File.join(@tempdir, "Rakefile"), ""
 
       use_ui @ui do
@@ -3077,7 +3077,7 @@ Please report a bug if this causes problems.
   def test_duplicate_runtime_dependency
     expected = "WARNING: duplicated b dependency [\"~> 3.0\", \"~> 3.0\"]\n"
     out, err = capture_output do
-      @a1.add_runtime_dependency "b", "~> 3.0", "~> 3.0"
+      @a1.add_dependency "b", "~> 3.0", "~> 3.0"
     end
     assert_empty out
     assert_equal(expected, err)

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -403,7 +403,7 @@ create_makefile '#{@spec.name}'
 
   def test_uninstall_not_ok
     quick_gem "z" do |s|
-      s.add_runtime_dependency @spec.name
+      s.add_dependency @spec.name
     end
 
     uninstaller = Gem::Uninstaller.new @spec.name


### PR DESCRIPTION
Ref: https://github.com/rubygems/rubygems/issues/7799

## What was the end-user or developer problem that led to this PR?

Some Rubygems code calls `add_runtime_dependency`, but `add_dependency` is usually [preferred](https://github.com/rubygems/rubygems/issues/7799#issuecomment-2192720316). The code that calls `add_runtime_dependency` is all testing code, and we [should](https://github.com/rubygems/rubygems/issues/7799#issuecomment-2192729028) update it.

## What is your fix for the problem, implemented in this PR?

Replace most  `add_runtime_dependency` calls with `add_dependency` in the testing code.

Note: I did not replace the few instances where `add_runtime_dependency` was used together with `add_development_dependency` as it it looked a little nicer to me, although using both at the same time seems to be [soft-deprecated](https://github.com/rubygems/rubygems/issues/7799#issuecomment-2192720316) behavior. I can update the PR if we truly want all instances of `add_runtime_dependency` to be replaced.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
