### PR TITLE
Fix rake release branch already pushed to remote

### DIFF
--- a/bundler/lib/bundler/gem_helper.rb
+++ b/bundler/lib/bundler/gem_helper.rb
@@ -129,7 +129,7 @@ module Bundler
 
     def git_push(remote = nil)
       remote ||= default_remote
-      sh("git push #{remote} refs/heads/#{current_branch}".shellsplit)
+      sh("git push #{remote} refs/heads/#{current_branch}".shellsplit) unless head_exists?(remote)
       sh("git push #{remote} refs/tags/#{version_tag}".shellsplit)
       Bundler.ui.confirm "Pushed git commits and release tag."
     end
@@ -161,6 +161,10 @@ module Bundler
       return false unless sh(%w[git tag]).split(/\n/).include?(version_tag)
       Bundler.ui.confirm "Tag #{version_tag} has already been created."
       true
+    end
+
+    def head_exists?(remote)
+      sh("git status -b --porcelain").match(/\.{3}#{remote}\/#{current_branch} \[behind \d+\]/)
     end
 
     def guard_clean

--- a/bundler/lib/bundler/gem_helper.rb
+++ b/bundler/lib/bundler/gem_helper.rb
@@ -164,7 +164,7 @@ module Bundler
     end
 
     def head_exists?(remote)
-      sh("git status -b --porcelain").match(/\.{3}#{remote}\/#{current_branch} \[behind \d+\]/)
+      sh("git status -b --porcelain").match(%r{\.{3}#{remote}\/#{current_branch} \[behind \d+\]})
     end
 
     def guard_clean

--- a/bundler/spec/bundler/gem_helper_spec.rb
+++ b/bundler/spec/bundler/gem_helper_spec.rb
@@ -329,6 +329,19 @@ RSpec.describe Bundler::GemHelper do
 
             Rake.application["release"].invoke
           end
+
+          it "also works with releasing from a branch lagging behind from remote" do
+            git("checkout -b behind", app_path)
+            sh("touch test.txt", dir: app_path)
+            git("add test.txt", app_path)
+            git("commit -a -m \"additional commit in remote\"", app_path)
+            git("push -u origin behind", app_path)
+            git("reset --hard HEAD~", app_path)
+
+            expect(subject).to receive(:rubygem_push).with(app_gem_path.to_s)
+
+            Rake.application["release"].invoke
+          end
         end
 
         context "on releasing with a custom tag prefix" do


### PR DESCRIPTION
add support to rake release for branch already pushed to remote but it is lagging behind

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

As described in #7818, `rake release` pushes both the current HEAD commit and the created tag to source control.

It causes issue when the current HEAD commit already exists in the remote but the remote branch has additional commits after the current HEAD commit. 

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Detect current HEAD commit using `git status -b` to extract the `ahead/behind` situation. Additionally using the `porcelain` version of the git command for stability as suggested by @deivid-rodriguez 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
