### PR TITLE
 Changelogs for RubyGems 3.5.15 and Bundler 2.5.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 3.5.15 / 2024-07-09
+
+## Enhancements:
+
+* Installs bundler 2.5.15 as a default gem.
+
+## Bug fixes:
+
+* Restrict generic `arm` to only match 32-bit arm. Pull request
+  [#7830](https://github.com/rubygems/rubygems/pull/7830) by ntkme
+* Protect creating binstubs with a file lock. Pull request
+  [#7806](https://github.com/rubygems/rubygems/pull/7806) by
+  deivid-rodriguez
+
+## Documentation:
+
+* Make it clearer that `add_dependency` is the main way to add
+  non-development dependencies. Pull request
+  [#7800](https://github.com/rubygems/rubygems/pull/7800) by jeromedalbert
+
 # 3.5.14 / 2024-06-21
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 2.5.15 (July 9, 2024)
+
+## Enhancements:
+
+  - Support `--no-test`, `--no-ci`, and `--no-linter` options [#7780](https://github.com/rubygems/rubygems/pull/7780)
+  - Allow bundle command in new gems with invalid metadata [#7707](https://github.com/rubygems/rubygems/pull/7707)
+
+## Bug fixes:
+
+  - Protect creating RubyGems binstubs with a file lock [#7841](https://github.com/rubygems/rubygems/pull/7841)
+  - Only allow valid values for `--test`, `--ci`, and `--linter` options [#7801](https://github.com/rubygems/rubygems/pull/7801)
+  - Fix `bundle lock --add-platform <current_platform>` doing nothing [#7803](https://github.com/rubygems/rubygems/pull/7803)
+  - Print a proper error when bin dir does not have writable permission bit [#7794](https://github.com/rubygems/rubygems/pull/7794)
+
+## Documentation:
+
+  - Regenerate bundler docs for June 2024 [#7787](https://github.com/rubygems/rubygems/pull/7787)
+
 # 2.5.14 (June 21, 2024)
 
 ## Bug fixes:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.5.15 and Bundler 2.5.15 into master.
