### PR TITLE
Minor Bundler spec improvements

### DIFF
--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -479,8 +479,7 @@ RSpec.describe "bundle install with gem sources" do
         source "https://gem.repo1"
         gem "platform_specific"
       G
-      run "require 'platform_specific' ; puts PLATFORM_SPECIFIC"
-      expect(out).to eq("1.0.0 RUBY")
+      expect(the_bundle).to include_gems("platform_specific 1.0 ruby")
     end
 
     it "does not update the cache if --no-cache is passed" do

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -249,15 +249,12 @@ RSpec.describe "bundle install with gem sources" do
 
     describe "with a gem that installs multiple platforms" do
       it "installs gems for the local platform as first choice" do
-        skip "version is 1.0, not 1.0.0" if Gem.win_platform?
-
         install_gemfile <<-G
           source "https://gem.repo1"
           gem "platform_specific"
         G
 
-        run "require 'platform_specific' ; puts PLATFORM_SPECIFIC"
-        expect(out).to eq("1.0.0 #{Bundler.local_platform}")
+        expect(the_bundle).to include_gems("platform_specific 1.0 #{Bundler.local_platform}")
       end
 
       it "falls back on plain ruby" do
@@ -267,8 +264,7 @@ RSpec.describe "bundle install with gem sources" do
           gem "platform_specific"
         G
 
-        run "require 'platform_specific' ; puts PLATFORM_SPECIFIC"
-        expect(out).to eq("1.0.0 RUBY")
+        expect(the_bundle).to include_gems("platform_specific 1.0 ruby")
       end
 
       it "installs gems for java" do
@@ -278,8 +274,7 @@ RSpec.describe "bundle install with gem sources" do
           gem "platform_specific"
         G
 
-        run "require 'platform_specific' ; puts PLATFORM_SPECIFIC"
-        expect(out).to eq("1.0.0 JAVA")
+        expect(the_bundle).to include_gems("platform_specific 1.0 java")
       end
 
       it "installs gems for windows" do
@@ -290,8 +285,7 @@ RSpec.describe "bundle install with gem sources" do
           gem "platform_specific"
         G
 
-        run "require 'platform_specific' ; puts PLATFORM_SPECIFIC"
-        expect(out).to eq("1.0 x86-mswin32")
+        expect(the_bundle).to include_gems("platform_specific 1.0 x86-mswin32")
       end
     end
 

--- a/bundler/spec/install/gemfile/force_ruby_platform_spec.rb
+++ b/bundler/spec/install/gemfile/force_ruby_platform_spec.rb
@@ -5,23 +5,17 @@ RSpec.describe "bundle install with force_ruby_platform DSL option", :jruby do
     before do
       build_repo4 do
         # Build a gem with platform specific versions
-        build_gem("platform_specific") do |s|
-          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0.0 RUBY'"
-        end
+        build_gem("platform_specific")
 
         build_gem("platform_specific") do |s|
           s.platform = Bundler.local_platform
-          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0.0 #{Bundler.local_platform}'"
         end
 
         # Build the exact same gem with a different name to compare using vs not using the option
-        build_gem("platform_specific_forced") do |s|
-          s.write "lib/platform_specific_forced.rb", "PLATFORM_SPECIFIC_FORCED = '1.0.0 RUBY'"
-        end
+        build_gem("platform_specific_forced")
 
         build_gem("platform_specific_forced") do |s|
           s.platform = Bundler.local_platform
-          s.write "lib/platform_specific_forced.rb", "PLATFORM_SPECIFIC_FORCED = '1.0.0 #{Bundler.local_platform}'"
         end
       end
     end
@@ -34,8 +28,8 @@ RSpec.describe "bundle install with force_ruby_platform DSL option", :jruby do
         gem "platform_specific"
       G
 
-      expect(the_bundle).to include_gems "platform_specific_forced 1.0.0 RUBY"
-      expect(the_bundle).to include_gems "platform_specific 1.0.0 #{Bundler.local_platform}"
+      expect(the_bundle).to include_gems "platform_specific_forced 1.0 ruby"
+      expect(the_bundle).to include_gems "platform_specific 1.0 #{Bundler.local_platform}"
     end
 
     it "still respects a global `force_ruby_platform` config" do
@@ -46,8 +40,8 @@ RSpec.describe "bundle install with force_ruby_platform DSL option", :jruby do
         gem "platform_specific"
       G
 
-      expect(the_bundle).to include_gems "platform_specific_forced 1.0.0 RUBY"
-      expect(the_bundle).to include_gems "platform_specific 1.0.0 RUBY"
+      expect(the_bundle).to include_gems "platform_specific_forced 1.0 ruby"
+      expect(the_bundle).to include_gems "platform_specific 1.0 ruby"
     end
   end
 
@@ -56,13 +50,10 @@ RSpec.describe "bundle install with force_ruby_platform DSL option", :jruby do
       build_repo4 do
         build_gem("depends_on_platform_specific") {|s| s.add_dependency "platform_specific" }
 
-        build_gem("platform_specific") do |s|
-          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0.0 RUBY'"
-        end
+        build_gem("platform_specific")
 
         build_gem("platform_specific") do |s|
           s.platform = Bundler.local_platform
-          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0.0 #{Bundler.local_platform}'"
         end
       end
     end
@@ -75,7 +66,7 @@ RSpec.describe "bundle install with force_ruby_platform DSL option", :jruby do
         gem "platform_specific", :force_ruby_platform => true
       G
 
-      expect(the_bundle).to include_gems "platform_specific 1.0.0 RUBY"
+      expect(the_bundle).to include_gems "platform_specific 1.0 ruby"
     end
   end
 
@@ -84,22 +75,17 @@ RSpec.describe "bundle install with force_ruby_platform DSL option", :jruby do
       build_repo4 do
         build_gem("depends_on_platform_specific") do |s|
           s.add_dependency "platform_specific"
-          s.write "lib/depends_on_platform_specific.rb", "DEPENDS_ON_PLATFORM_SPECIFIC = '1.0.0 RUBY'"
         end
 
         build_gem("depends_on_platform_specific") do |s|
           s.add_dependency "platform_specific"
           s.platform = Bundler.local_platform
-          s.write "lib/depends_on_platform_specific.rb", "DEPENDS_ON_PLATFORM_SPECIFIC = '1.0.0 #{Bundler.local_platform}'"
         end
 
-        build_gem("platform_specific") do |s|
-          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0.0 RUBY'"
-        end
+        build_gem("platform_specific")
 
         build_gem("platform_specific") do |s|
           s.platform = Bundler.local_platform
-          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0.0 #{Bundler.local_platform}'"
         end
       end
     end
@@ -111,11 +97,11 @@ RSpec.describe "bundle install with force_ruby_platform DSL option", :jruby do
         gem "depends_on_platform_specific", :force_ruby_platform => true
       G
 
-      expect(the_bundle).to include_gems "depends_on_platform_specific 1.0.0 RUBY"
-      expect(the_bundle).to include_gems "platform_specific 1.0.0 #{Bundler.local_platform}"
+      expect(the_bundle).to include_gems "depends_on_platform_specific 1.0 ruby"
+      expect(the_bundle).to include_gems "platform_specific 1.0 #{Bundler.local_platform}"
     end
 
-    it "reinstalls the ruby variant when a platform specific variant is already installed, the lockile has only RUBY platform, and :force_ruby_platform is used in the Gemfile" do
+    it "reinstalls the ruby variant when a platform specific variant is already installed, the lockile has only ruby platform, and :force_ruby_platform is used in the Gemfile" do
       lockfile <<-L
         GEM
           remote: https://gem.repo4
@@ -140,7 +126,7 @@ RSpec.describe "bundle install with force_ruby_platform DSL option", :jruby do
         gem "platform_specific", :force_ruby_platform => true
       G
 
-      expect(the_bundle).to include_gems "platform_specific 1.0.0 RUBY"
+      expect(the_bundle).to include_gems "platform_specific 1.0 ruby"
     end
   end
 end

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     G
 
     bundle "update --bundler", artifice: "compact_index", verbose: true
-    expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 JAVA"
+    expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 java"
   end
 
   it "should evaluate the gemspec in its directory" do
@@ -461,7 +461,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
         context "as a runtime dependency" do
           it "keeps all platform dependencies in the lockfile" do
-            expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 RUBY"
+            expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 ruby"
 
             checksums = checksums_section_when_existing do |c|
               c.no_checksum "foo", "1.0"
@@ -502,7 +502,7 @@ RSpec.describe "bundle install from an existing gemspec" do
           let(:platform_specific_type) { :development }
 
           it "keeps all platform dependencies in the lockfile" do
-            expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 RUBY"
+            expect(the_bundle).to include_gems "foo 1.0", "platform_specific 1.0 ruby"
 
             checksums = checksums_section_when_existing do |c|
               c.no_checksum "foo", "1.0"
@@ -544,7 +544,7 @@ RSpec.describe "bundle install from an existing gemspec" do
           let(:dependency) { "indirect_platform_specific" }
 
           it "keeps all platform dependencies in the lockfile" do
-            expect(the_bundle).to include_gems "foo 1.0", "indirect_platform_specific 1.0", "platform_specific 1.0 RUBY"
+            expect(the_bundle).to include_gems "foo 1.0", "indirect_platform_specific 1.0", "platform_specific 1.0 ruby"
 
             checksums = checksums_section_when_existing do |c|
               c.no_checksum "foo", "1.0"

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "bundle install across platforms" do
       gem "platform_specific"
     G
 
-    expect(the_bundle).to include_gems "platform_specific 1.0 JAVA"
+    expect(the_bundle).to include_gems "platform_specific 1.0 java"
   end
 
   it "pulls the pure ruby version on jruby if the java platform is not present in the lockfile and bundler is run in frozen mode", :jruby_only do
@@ -72,7 +72,7 @@ RSpec.describe "bundle install across platforms" do
       gem "platform_specific"
     G
 
-    expect(the_bundle).to include_gems "platform_specific 1.0 RUBY"
+    expect(the_bundle).to include_gems "platform_specific 1.0 ruby"
   end
 
   context "on universal Rubies" do
@@ -80,15 +80,12 @@ RSpec.describe "bundle install across platforms" do
       build_repo4 do
         build_gem "darwin_single_arch" do |s|
           s.platform = "ruby"
-          s.write "lib/darwin_single_arch.rb", "DARWIN_SINGLE_ARCH = '1.0 RUBY'"
         end
         build_gem "darwin_single_arch" do |s|
           s.platform = "arm64-darwin"
-          s.write "lib/darwin_single_arch.rb", "DARWIN_SINGLE_ARCH = '1.0 arm64-darwin'"
         end
         build_gem "darwin_single_arch" do |s|
           s.platform = "x86_64-darwin"
-          s.write "lib/darwin_single_arch.rb", "DARWIN_SINGLE_ARCH = '1.0 x86_64-darwin'"
         end
       end
     end
@@ -158,7 +155,7 @@ RSpec.describe "bundle install across platforms" do
       gem "nokogiri"
     G
 
-    expect(the_bundle).to include_gems "nokogiri 1.4.2 JAVA", "weakling 0.0.3"
+    expect(the_bundle).to include_gems "nokogiri 1.4.2 java", "weakling 0.0.3"
 
     simulate_new_machine
     bundle "config set --local force_ruby_platform true"
@@ -171,7 +168,7 @@ RSpec.describe "bundle install across platforms" do
     simulate_platform "java"
     bundle "install"
 
-    expect(the_bundle).to include_gems "nokogiri 1.4.2 JAVA", "weakling 0.0.3"
+    expect(the_bundle).to include_gems "nokogiri 1.4.2 java", "weakling 0.0.3"
   end
 
   it "does not keep unneeded platforms for gems that are used" do
@@ -400,7 +397,7 @@ RSpec.describe "bundle install across platforms" do
 
     checksums.checksum gem_repo1, "platform_specific", "1.0"
 
-    expect(the_bundle).to include_gem "platform_specific 1.0 RUBY"
+    expect(the_bundle).to include_gem "platform_specific 1.0 ruby"
 
     expect(lockfile).to eq <<~G
       GEM

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "bundle install with specific platforms" do
     end
   end
 
-  it "understands that a non-platform specific gem in a new lockfile locked only to RUBY doesn't necessarily mean installing the non-specific variant" do
+  it "understands that a non-platform specific gem in a new lockfile locked only to ruby doesn't necessarily mean installing the non-specific variant" do
     simulate_platform "x86_64-darwin-15" do
       setup_multiplatform_gem
 
@@ -113,7 +113,7 @@ RSpec.describe "bundle install with specific platforms" do
     end
   end
 
-  context "when running on a legacy lockfile locked only to RUBY" do
+  context "when running on a legacy lockfile locked only to ruby" do
     around do |example|
       build_repo4 do
         build_gem "nokogiri", "1.3.10"
@@ -148,12 +148,12 @@ RSpec.describe "bundle install with specific platforms" do
       simulate_platform "arm64-darwin-22", &example
     end
 
-    it "still installs the generic RUBY variant if necessary" do
+    it "still installs the generic ruby variant if necessary" do
       bundle "install --verbose", artifice: "compact_index", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
       expect(out).to include("Installing nokogiri 1.3.10")
     end
 
-    it "still installs the generic RUBY variant if necessary, even in frozen mode" do
+    it "still installs the generic ruby variant if necessary, even in frozen mode" do
       bundle "install --verbose", artifice: "compact_index", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s, "BUNDLE_FROZEN" => "true" }
       expect(out).to include("Installing nokogiri 1.3.10")
     end
@@ -459,7 +459,7 @@ RSpec.describe "bundle install with specific platforms" do
     expect(err).to include(error_message).once
   end
 
-  it "does not generate a lockfile if RUBY platform is forced and some gem has no RUBY variant available" do
+  it "does not generate a lockfile if ruby platform is forced and some gem has no ruby variant available" do
     build_repo4 do
       build_gem("sorbet-static", "0.5.9889") {|s| s.platform = Gem::Platform.local }
     end
@@ -480,7 +480,7 @@ RSpec.describe "bundle install with specific platforms" do
     ERROR
   end
 
-  it "automatically fixes the lockfile if RUBY platform is locked and some gem has no RUBY variant available" do
+  it "automatically fixes the lockfile if ruby platform is locked and some gem has no ruby variant available" do
     build_repo4 do
       build_gem("sorbet-static-and-runtime", "0.5.10160") do |s|
         s.add_dependency "sorbet", "= 0.5.10160"
@@ -558,7 +558,7 @@ RSpec.describe "bundle install with specific platforms" do
     L
   end
 
-  it "automatically fixes the lockfile if both RUBY platform and a more specific platform are locked, and some gem has no RUBY variant available" do
+  it "automatically fixes the lockfile if both ruby platform and a more specific platform are locked, and some gem has no ruby variant available" do
     build_repo4 do
       build_gem "nokogiri", "1.12.0"
       build_gem "nokogiri", "1.12.0" do |s|
@@ -632,7 +632,7 @@ RSpec.describe "bundle install with specific platforms" do
     L
   end
 
-  it "automatically fixes the lockfile if only RUBY platform is locked and some gem has no RUBY variant available" do
+  it "automatically fixes the lockfile if only ruby platform is locked and some gem has no ruby variant available" do
     build_repo4 do
       build_gem("sorbet-static-and-runtime", "0.5.10160") do |s|
         s.add_dependency "sorbet", "= 0.5.10160"
@@ -844,7 +844,7 @@ RSpec.describe "bundle install with specific platforms" do
     end
   end
 
-  it "automatically fixes the lockfile if locked only to RUBY, and some locked specs don't meed locked dependencies" do
+  it "automatically fixes the lockfile if locked only to ruby, and some locked specs don't meed locked dependencies" do
     simulate_platform "x86_64-linux" do
       build_repo4 do
         build_gem("ibandit", "0.7.0") do |s|
@@ -1119,7 +1119,7 @@ RSpec.describe "bundle install with specific platforms" do
     end
   end
 
-  it "automatically fixes the lockfile when only RUBY platform locked, and adding a dependency with subdependencies not valid for RUBY" do
+  it "automatically fixes the lockfile when only ruby platform locked, and adding a dependency with subdependencies not valid for ruby" do
     simulate_platform "x86_64-linux" do
       build_repo4 do
         build_gem("sorbet", "0.5.10160") do |s|

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -1321,7 +1321,7 @@ RSpec.describe "the lockfile format" do
     G
   end
 
-  it "adds compatible platform specific variants to the lockfile, even if resolution fallback to RUBY due to some other incompatible platform specific variant" do
+  it "adds compatible platform specific variants to the lockfile, even if resolution fallback to ruby due to some other incompatible platform specific variant" do
     simulate_platform "arm64-darwin-23" do
       build_repo4 do
         build_gem "google-protobuf", "3.25.1"

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
     bundle "install"
 
     expect(out).to include("Fetching nokogiri 1.4.2 (java)")
-    expect(the_bundle).to include_gems "nokogiri 1.4.2 JAVA"
+    expect(the_bundle).to include_gems "nokogiri 1.4.2 java"
   end
 
   it "will add the resolve for the current platform" do
@@ -222,7 +222,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
 
     bundle "install"
 
-    expect(the_bundle).to include_gems "nokogiri 1.4.2", "platform_specific 1.0 RUBY"
+    expect(the_bundle).to include_gems "nokogiri 1.4.2", "platform_specific 1.0 ruby"
   end
 
   it "allows specifying only-ruby-platform" do
@@ -236,7 +236,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
 
     bundle "install"
 
-    expect(the_bundle).to include_gems "nokogiri 1.4.2", "platform_specific 1.0 RUBY"
+    expect(the_bundle).to include_gems "nokogiri 1.4.2", "platform_specific 1.0 ruby"
   end
 
   it "allows specifying only-ruby-platform even if the lockfile is locked to a specific compatible platform" do
@@ -250,7 +250,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
 
     bundle "install"
 
-    expect(the_bundle).to include_gems "nokogiri 1.4.2", "platform_specific 1.0 RUBY"
+    expect(the_bundle).to include_gems "nokogiri 1.4.2", "platform_specific 1.0 ruby"
   end
 
   it "doesn't pull platform specific gems on truffleruby", :truffleruby_only do
@@ -259,10 +259,10 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
      gem "platform_specific"
     G
 
-    expect(the_bundle).to include_gems "platform_specific 1.0 RUBY"
+    expect(the_bundle).to include_gems "platform_specific 1.0 ruby"
   end
 
-  it "doesn't pull platform specific gems on truffleruby (except when whitelisted) even if lockfile was generated with an older version that declared RUBY as platform", :truffleruby_only do
+  it "doesn't pull platform specific gems on truffleruby (except when whitelisted) even if lockfile was generated with an older version that declared ruby as platform", :truffleruby_only do
     gemfile <<-G
       source "https://gem.repo1"
       gem "platform_specific"
@@ -286,7 +286,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
 
     bundle "install"
 
-    expect(the_bundle).to include_gems "platform_specific 1.0 RUBY"
+    expect(the_bundle).to include_gems "platform_specific 1.0 ruby"
 
     simulate_platform "x86_64-linux" do
       build_repo4 do
@@ -348,7 +348,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
 
     bundle "install"
 
-    expect(the_bundle).to include_gems "platform_specific 1.0 RUBY"
+    expect(the_bundle).to include_gems "platform_specific 1.0 ruby"
   end
 
   it "pulls platform specific gems correctly on musl" do
@@ -380,7 +380,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
 
       bundle "install"
 
-      expect(the_bundle).to include_gems "platform_specific 1.0 RUBY"
+      expect(the_bundle).to include_gems "platform_specific 1.0 ruby"
       expect(the_bundle).to not_include_gems "nokogiri"
     end
   end

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -92,74 +92,60 @@ module Spec
 
         build_gem "platform_specific" do |s|
           s.platform = Gem::Platform.local
-          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0.0 #{Gem::Platform.local}'"
         end
 
         build_gem "platform_specific" do |s|
           s.platform = "java"
-          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0.0 JAVA'"
         end
 
         build_gem "platform_specific" do |s|
           s.platform = "ruby"
-          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0.0 RUBY'"
         end
 
         build_gem "platform_specific" do |s|
           s.platform = "x86-mswin32"
-          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0 x86-mswin32'"
         end
 
         build_gem "platform_specific" do |s|
           s.platform = "x64-mswin64"
-          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0 x64-mswin64'"
         end
 
         build_gem "platform_specific" do |s|
           s.platform = "x86-mingw32"
-          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0 x86-mingw32'"
         end
 
         build_gem "platform_specific" do |s|
           s.platform = "x64-mingw32"
-          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0 x64-mingw32'"
         end
 
         build_gem "platform_specific" do |s|
           s.platform = "x64-mingw-ucrt"
-          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0 x64-mingw-ucrt'"
         end
 
         build_gem "platform_specific" do |s|
           s.platform = "x86-darwin-100"
-          s.write "lib/platform_specific.rb", "PLATFORM_SPECIFIC = '1.0.0 x86-darwin-100'"
         end
 
         build_gem "only_java", "1.0" do |s|
           s.platform = "java"
-          s.write "lib/only_java.rb", "ONLY_JAVA = '1.0.0 JAVA'"
         end
 
         build_gem "only_java", "1.1" do |s|
           s.platform = "java"
-          s.write "lib/only_java.rb", "ONLY_JAVA = '1.1.0 JAVA'"
         end
 
         build_gem "nokogiri", "1.4.2"
         build_gem "nokogiri", "1.4.2" do |s|
           s.platform = "java"
-          s.write "lib/nokogiri.rb", "NOKOGIRI = '1.4.2 JAVA'"
           s.add_dependency "weakling", ">= 0.0.3"
         end
 
         build_gem "laduradura", "5.15.2"
         build_gem "laduradura", "5.15.2" do |s|
           s.platform = "java"
-          s.write "lib/laduradura.rb", "LADURADURA = '5.15.2 JAVA'"
         end
         build_gem "laduradura", "5.15.3" do |s|
           s.platform = "java"
-          s.write "lib/laduradura.rb", "LADURADURA = '5.15.2 JAVA'"
         end
 
         build_gem "weakling", "0.0.3"

--- a/bundler/spec/support/matchers.rb
+++ b/bundler/spec/support/matchers.rb
@@ -118,6 +118,7 @@ module Spec
         opts[:raise_on_error] = false
         @errors = names.map do |full_name|
           name, version, platform = full_name.split(/\s+/)
+          platform ||= "ruby"
           require_path = name.tr("-", "/")
           version_const = name == "bundler" ? "Bundler::VERSION" : Spec::Builders.constantize(name)
           source_const = "#{Spec::Builders.constantize(name)}_SOURCE"
@@ -127,6 +128,7 @@ module Spec
 
             require '#{require_path}'
             actual_version, actual_platform = #{version_const}.split(/\s+/, 2)
+            actual_platform ||= "ruby"
             unless Gem::Version.new(actual_version) == Gem::Version.new('#{version}')
               puts actual_version
               exit 64
@@ -150,7 +152,7 @@ module Spec
           end
           if exitstatus == 65
             actual_platform = out.split("\n").last
-            next "#{name} was expected to be of platform #{platform || "ruby"} but was #{actual_platform || "ruby"}"
+            next "#{name} was expected to be of platform #{platform} but was #{actual_platform}"
           end
           if exitstatus == 66
             actual_source = out.split("\n").last


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

While working on something else I noticed:

* Usage of uppercased "RUBY" and "JAVA" as platforms, when those don't really exist.
* Usage of some test gems with "1.0" as gemspec version and "1.0.0" as actual version.

## What is your fix for the problem, implemented in this PR?

* Consistently use downcased "ruby" and "java" as platforms.
* Use consistent versioning in test gems.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
