### PR TITLE
Protect creating RubyGems binstubs with a file lock

### DIFF
--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -53,7 +53,7 @@ module Gem
 
   require "rubygems/specification"
 
-  # Can be removed once RubyGems 3.5.15 support is dropped
+  # Can be removed once RubyGems 3.5.14 support is dropped
   VALIDATES_FOR_RESOLUTION = Specification.new.respond_to?(:validate_for_resolution).freeze
 
   class Specification

--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -81,6 +81,26 @@ module Bundler
       end
     end
 
+    if Bundler.rubygems.provides?("< 3.5.15")
+      def generate_bin_script(filename, bindir)
+        bin_script_path = File.join bindir, formatted_program_filename(filename)
+
+        Gem.open_file_with_flock("#{bin_script_path}.lock") do
+          require "fileutils"
+          FileUtils.rm_f bin_script_path # prior install may have been --no-wrappers
+
+          File.open(bin_script_path, "wb", 0o755) do |file|
+            file.write app_script_text(filename)
+            file.chmod(options[:prog_mode] || 0o755)
+          end
+        end
+
+        verbose bin_script_path
+
+        generate_windows_script filename, bindir
+      end
+    end
+
     def build_extensions
       extension_cache_path = options[:bundler_extension_cache_path]
       extension_dir = spec.extension_dir


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We're still getting flakies when testing against older RubyGems, because https://github.com/rubygems/rubygems/pull/7806 has not been backported to Bundler.

## What is your fix for the problem, implemented in this PR?

Backport the fix.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
