### PR TITLE
Fix bad error messages when using `bundle add` with frozen mode set

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -399,7 +399,7 @@ module Bundler
         changed << "* #{name} from `#{lockfile_source_name}` to `#{gemfile_source_name}`"
       end
 
-      reason = change_reason
+      reason = nothing_changed? ? "some dependencies were deleted from your gemfile" : change_reason
       msg = String.new
       msg << "#{reason.capitalize.strip}, but the lockfile can't be updated because frozen mode is set"
       msg << "\n\nYou have added to the Gemfile:\n" << added.join("\n") if added.any?

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -367,6 +367,10 @@ module Bundler
     end
 
     def ensure_equivalent_gemfile_and_lockfile(explicit_flag = false)
+      return unless Bundler.frozen_bundle?
+
+      raise ProductionError, "Frozen mode is set, but there's no lockfile" unless lockfile_exists?
+
       added =   []
       deleted = []
       changed = []

--- a/bundler/lib/bundler/injector.rb
+++ b/bundler/lib/bundler/injector.rb
@@ -23,10 +23,7 @@ module Bundler
     # @param [Pathname] lockfile_path The lockfile in which to inject the new dependency.
     # @return [Array]
     def inject(gemfile_path, lockfile_path)
-      if Bundler.frozen_bundle?
-        # ensure the lock and Gemfile are synced
-        Bundler.definition.ensure_equivalent_gemfile_and_lockfile(true)
-      end
+      Bundler.definition.ensure_equivalent_gemfile_and_lockfile(true)
 
       # temporarily unfreeze
       Bundler.settings.temporary(deployment: false, frozen: false) do

--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -69,9 +69,7 @@ module Bundler
       Bundler.create_bundle_path
 
       ProcessLock.lock do
-        if Bundler.frozen_bundle?
-          @definition.ensure_equivalent_gemfile_and_lockfile(options[:deployment])
-        end
+        @definition.ensure_equivalent_gemfile_and_lockfile(options[:deployment])
 
         if @definition.dependencies.empty?
           Bundler.ui.warn "The Gemfile specifies no dependencies"

--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -10,7 +10,7 @@ module Bundler
     end
 
     def setup(*groups)
-      @definition.ensure_equivalent_gemfile_and_lockfile if Bundler.frozen_bundle?
+      @definition.ensure_equivalent_gemfile_and_lockfile
 
       # Has to happen first
       clean_load_path

--- a/bundler/spec/commands/add_spec.rb
+++ b/bundler/spec/commands/add_spec.rb
@@ -28,6 +28,15 @@ RSpec.describe "bundle add" do
     end
   end
 
+  context "when Gemfile is empty, and frozen mode is set" do
+    it "shows error" do
+      gemfile 'source "https://gem.repo2"'
+      bundle "add bar", raise_on_error: false, env: { "BUNDLE_FROZEN" => "true" }
+
+      expect(err).to include("Frozen mode is set, but there's no lockfile")
+    end
+  end
+
   describe "without version specified" do
     it "version requirement becomes ~> major.minor.patch when resolved version is < 1.0" do
       bundle "add 'bar'"

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -388,7 +388,7 @@ RSpec.describe "install in deployment or frozen mode" do
       expect(out).not_to include("* myrack-obama")
     end
 
-    it "explodes if you remove a gem and don't check in the lockfile" do
+    it "explodes if you replace a gem and don't check in the lockfile" do
       gemfile <<-G
         source "https://gem.repo1"
         gem "activesupport"
@@ -398,6 +398,17 @@ RSpec.describe "install in deployment or frozen mode" do
       bundle :install, raise_on_error: false
       expect(err).to include("frozen mode")
       expect(err).to include("You have added to the Gemfile:\n* activesupport\n\n")
+      expect(err).to include("You have deleted from the Gemfile:\n* myrack")
+      expect(err).not_to include("You have changed in the Gemfile")
+    end
+
+    it "explodes if you remove a gem and don't check in the lockfile" do
+      gemfile 'source "https://gem.repo1"'
+
+      bundle "config set --local deployment true"
+      bundle :install, raise_on_error: false
+      expect(err).to include("Some dependencies were deleted")
+      expect(err).to include("frozen mode")
       expect(err).to include("You have deleted from the Gemfile:\n* myrack")
       expect(err).not_to include("You have changed in the Gemfile")
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I was trying to reproduce an issue using `bundle add`, and did not notice I had the `frozen` setting configured globally.

I received some strange error messages, starting with a comma character 😬.

## What is your fix for the problem, implemented in this PR?

Make sure to account for two missing cases when checking that gemfile and lockfile are in sync:

* Lockfile does not exist.
* Dependencies have been deleted from the Gemfile.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
