### PR TITLE
Suppress SSLError warning

### DIFF
--- a/test/rubygems/test_gem_remote_fetcher_local_ssl_server.rb
+++ b/test/rubygems/test_gem_remote_fetcher_local_ssl_server.rb
@@ -167,7 +167,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
           client.close
         end
       rescue OpenSSL::SSL::SSLError => e
-        warn "SSL error: #{e.message}"
+        # Ignore SSL errors because we're testing them implicitly
       end
     end
     @ssl_server = ssl_server


### PR DESCRIPTION

## What was the end-user or developer problem that led to this PR?

We have the following error with current HEAD:

```
SSL error: SSL_accept returned=1 errno=107 peeraddr=(null) state=error: tlsv1 alert unknown ca (SSL alert number 48)
```

This warn is introduced https://github.com/rubygems/rubygems/commit/ccbbe84d771d622ac25b84e89a7881a2a4b26cb6


But this error is intentional for verification error for `TestGemRemoteFetcherLocalSSLServer`. We should ignore that because this is noisy for CI result like http://ci.rvm.jp/logfiles/brlog.trunk.20240709-010435#L1554.

## What is your fix for the problem, implemented in this PR?

Suppressed warning.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
