### PR TITLE
Fix debugging line left around in CI workflow

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -70,6 +70,6 @@ jobs:
           bin/rake spec:parallel_deps
       - name: Run Test
         run: |
-          bin/rspec spec/install/gems/standalone_spec.rb:175
+          bin/parallel_rspec
         working-directory: ./bundler
     timeout-minutes: ${{ matrix.timeout || 60 }}


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I left this debugging line around by mistake in #7839.

## What is your fix for the problem, implemented in this PR?

Restore the full suite.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
