### PR TITLE
Fix another case of `bundle lock --add-platform` doing nothing

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -81,7 +81,7 @@ module Bundler
       @resolved_bundler_version = nil
 
       @locked_ruby_version = nil
-      @new_platform = nil
+      @new_platforms = []
       @removed_platform = nil
 
       if lockfile_exists?
@@ -453,8 +453,10 @@ module Bundler
     end
 
     def add_platform(platform)
-      @new_platform ||= !@platforms.include?(platform)
-      @platforms |= [platform]
+      return if @platforms.include?(platform)
+
+      @new_platforms << platform
+      @platforms << platform
     end
 
     def remove_platform(platform)
@@ -478,7 +480,7 @@ module Bundler
 
       !@source_changes &&
         !@dependency_changes &&
-        !@new_platform &&
+        @new_platforms.empty? &&
         !@path_changes &&
         !@local_changes &&
         !@missing_lockfile_dep &&
@@ -699,7 +701,7 @@ module Bundler
       [
         [@source_changes, "the list of sources changed"],
         [@dependency_changes, "the dependencies in your gemfile changed"],
-        [@new_platform, "you added a new platform to your gemfile"],
+        [@new_platforms.any?, "you added a new platform to your gemfile"],
         [@path_changes, "the gemspecs for path gems changed"],
         [@local_changes, "the gemspecs for git local gems changed"],
         [@missing_lockfile_dep, "your lock file is missing \"#{@missing_lockfile_dep}\""],
@@ -1057,7 +1059,7 @@ module Bundler
 
       platforms.reverse_each do |platform|
         next if local_platform == platform ||
-                (@new_platform && platforms.last == platform) ||
+                @new_platforms.include?(platform) ||
                 @path_changes ||
                 @dependency_changes ||
                 @locked_spec_with_invalid_deps ||


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If the most specific locked platform is less specific than the current platform, and the current resolve is incompatible with that target platform given to `bundle lock --add-platform`, we end up not actually adding the platform.

## What is your fix for the problem, implemented in this PR?

Make sure we don't remove the platform we just added as invalid right before resolving.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
