### PR TITLE
fix s3 source configuration issue

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -522,12 +522,12 @@ if you believe they were disclosed to a third party.
 
   # Return the configuration information for +key+.
   def [](key)
-    @hash[key.to_s]
+    @hash[key] || @hash[key.to_s]
   end
 
   # Set configuration option +key+ to +value+.
   def []=(key, value)
-    @hash[key.to_s] = value
+    @hash[key] = value
   end
 
   def ==(other) # :nodoc:
@@ -555,8 +555,13 @@ if you believe they were disclosed to a third party.
     require_relative "yaml_serializer"
 
     content = Gem::YAMLSerializer.load(yaml)
+    deep_transform_config_keys!(content)
+  end
 
-    content.transform_keys! do |k|
+  private
+
+  def self.deep_transform_config_keys!(config)
+    config.transform_keys! do |k|
       if k.match?(/\A:(.*)\Z/)
         k[1..-1].to_sym
       elsif k.include?("__") || k.match?(%r{/\Z})
@@ -570,7 +575,7 @@ if you believe they were disclosed to a third party.
       end
     end
 
-    content.transform_values! do |v|
+    config.transform_values! do |v|
       if v.is_a?(String)
         if v.match?(/\A:(.*)\Z/)
           v[1..-1].to_sym
@@ -583,17 +588,17 @@ if you believe they were disclosed to a third party.
         else
           v
         end
-      elsif v.is_a?(Hash) && v.empty?
+      elsif v.empty?
         nil
+      elsif v.is_a?(Hash)
+        deep_transform_config_keys!(v)
       else
         v
       end
     end
 
-    content
+    config
   end
-
-  private
 
   def set_config_file_name(args)
     @config_file_name = ENV["GEMRC"]

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -575,6 +575,73 @@ if you believe they were disclosed to a third party.
     assert_equal("bar", actual[:foo])
   end
 
+  def test_s3_source
+    yaml = <<~YAML
+      ---
+      :sources:
+      - s3://bucket1/
+      - s3://bucket2/
+      - s3://bucket3/path_to_gems_dir/
+      - s3://bucket4/
+      - https://rubygems.org/
+      :s3_source:
+        :bucket1:
+          :provider: env
+        :bucket2:
+          :provider: instance_profile
+          :region: us-west-2
+        :bucket3:
+          :id: AOUEAOEU123123AOEUAO
+          :secret: aodnuhtdao/saeuhto+19283oaehu/asoeu+123h
+          :region: us-east-2
+        :bucket4:
+          :id: AOUEAOEU123123AOEUAO
+          :secret: aodnuhtdao/saeuhto+19283oaehu/asoeu+123h
+          :security_token: AQoDYXdzEJr
+          :region: us-west-1
+    YAML
+
+    File.open @temp_conf, "w" do |fp|
+      fp.puts yaml
+    end
+    util_config_file
+
+    assert_equal(["s3://bucket1/", "s3://bucket2/", "s3://bucket3/path_to_gems_dir/", "s3://bucket4/", "https://rubygems.org/"], @cfg.sources)
+    expected_config = {
+      bucket1: { provider: "env" },
+      bucket2: { provider: "instance_profile", region: "us-west-2" },
+      bucket3: { id: "AOUEAOEU123123AOEUAO", secret: "aodnuhtdao/saeuhto+19283oaehu/asoeu+123h", region: "us-east-2" },
+      bucket4: { id: "AOUEAOEU123123AOEUAO", secret: "aodnuhtdao/saeuhto+19283oaehu/asoeu+123h", security_token: "AQoDYXdzEJr", region: "us-west-1" },
+    }
+    assert_equal(expected_config, @cfg[:s3_source])
+    assert_equal(expected_config[:bucket1], @cfg[:s3_source][:bucket1])
+    assert_equal(expected_config[:bucket2], @cfg[:s3_source][:bucket2])
+    assert_equal(expected_config[:bucket3], @cfg[:s3_source][:bucket3])
+    assert_equal(expected_config[:bucket4], @cfg[:s3_source][:bucket4])
+  end
+
+  def test_s3_source_with_config_without_lookahead
+    yaml = <<~YAML
+    :sources:
+    - s3://bucket1/
+    s3_source:
+      bucket1:
+        provider: env
+    YAML
+
+    File.open @temp_conf, "w" do |fp|
+      fp.puts yaml
+    end
+    util_config_file
+
+    assert_equal(["s3://bucket1/"], @cfg.sources)
+    expected_config = {
+      "bucket1" => { "provider" => "env" },
+    }
+    assert_equal(expected_config, @cfg[:s3_source])
+    assert_equal(expected_config[:bucket1], @cfg[:s3_source][:bucket1])
+  end
+
   def util_config_file(args = @cfg_args)
     @cfg = Gem::ConfigFile.new args
   end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Related to https://github.com/rubygems/guides/pull/345

Minimal reproducible example.

There is a custom `.gemrc` with filled s3 sources as it provided [in the docs](https://guides.rubygems.org/using-s3-source/)
```yaml
# .gemrc
:sources:
- s3://mygem/
:s3_source:
  :mygem:
    :provider: env
```

Try to install the gem:
```sh
# ensure that we have the latest rubygems
$ gem update --system

# run gem install with explicit source
$ gem install mygem --source s3://mygem/ --config-file .gemrc
#> ERROR:  Could not find a valid gem 'mygem' (>= 0), here is why:
#> Unable to download data from s3://mygem/ - no s3_source key exists in .gemrc (s3://mygem/)
```

Expected behavior: install the gem without error if there is an access to the s3 bucket

## What is your fix for the problem, implemented in this PR?

The issue is how `Gem::ConfigFile` parses `.gemrc` and transforms the keys of the config hash, more specifically nested keys.
This PR introduces the transformation of the nested keys or root keys to be consistent.
Changes keep backward compatibility so it works for both versions.
From the docs:
```yaml
# .gemrc
:sources:
- s3://mygem/
:s3_source:
  :mygem:
    :provider: env
```

And what worked before:
```yaml
# .gemrc
:sources:
- s3://mygem/
s3_source:
  mygem:
    provider: env
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
