### PR TITLE
Generate gems.rb from Gemfile.tt template for `bundle-gem`

### DIFF
--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -79,7 +79,7 @@ module Bundler
       ensure_safe_gem_name(name, constant_array)
 
       templates = {
-        "#{Bundler.preferred_gemfile_name}.tt" => Bundler.preferred_gemfile_name,
+        "Gemfile.tt" => Bundler.preferred_gemfile_name,
         "lib/newgem.rb.tt" => "lib/#{namespaced_path}.rb",
         "lib/newgem/version.rb.tt" => "lib/#{namespaced_path}/version.rb",
         "sig/newgem.rbs.tt" => "sig/#{namespaced_path}.rbs",

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -739,6 +739,30 @@ RSpec.describe "bundle gem" do
       end
     end
 
+    context "init_gems_rb setting to true" do
+      before do
+        bundle "config set init_gems_rb true"
+        bundle "gem #{gem_name}"
+      end
+
+      it "generates gems.rb instead of Gemfile" do
+        expect(bundled_app("#{gem_name}/gems.rb")).to exist
+        expect(bundled_app("#{gem_name}/Gemfile")).to_not exist
+      end
+    end
+
+    context "init_gems_rb setting to false" do
+      before do
+        bundle "config set init_gems_rb false"
+        bundle "gem #{gem_name}"
+      end
+
+      it "generates Gemfile instead of gems.rb" do
+        expect(bundled_app("#{gem_name}/gems.rb")).to_not exist
+        expect(bundled_app("#{gem_name}/Gemfile")).to exist
+      end
+    end
+
     context "gem.test setting set to rspec" do
       before do
         bundle "config set gem.test rspec"


### PR DESCRIPTION
- **Adds gems.rb.tt template for newgem**
- **bundle-gem learns to find Gemfile template correctly**

fixes #7852

## What was the end-user or developer problem that led to this PR?

Issue https://github.com/rubygems/rubygems/issues/7852

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

At first I symlinked Gemfile.tt as gems.rb.tt so the desired template exists. But I think it's cleaner to keep just a single Gemfile template instead of 2. So instead, I modified the templates hash to the fixed `Gemfile.tt` template file regardless of the preferred gemfile name. But the resulting gemfile filename does still respect the preferred filename setting.

Happy to squash out the interim commit if the resulting approach is preferred. (or can drop the last commit if the former approach is desired)
<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
