### PR TITLE
Fix line comment issue for hash when loading gemrc

### DIFF
--- a/bundler/lib/bundler/yaml_serializer.rb
+++ b/bundler/lib/bundler/yaml_serializer.rb
@@ -41,7 +41,7 @@ module Bundler
     HASH_REGEX = /
       ^
       ([ ]*) # indentations
-      (.+) # key
+      ([^#]+) # key excludes comment char '#'
       (?::(?=(?:\s|$))) # :  (without the lookahead the #key includes this when : is present in value)
       [ ]?
       (['"]?) # optional opening quote

--- a/lib/rubygems/yaml_serializer.rb
+++ b/lib/rubygems/yaml_serializer.rb
@@ -41,7 +41,7 @@ module Gem
     HASH_REGEX = /
       ^
       ([ ]*) # indentations
-      (.+) # key
+      ([^#]+) # key excludes comment char '#'
       (?::(?=(?:\s|$))) # :  (without the lookahead the #key includes this when : is present in value)
       [ ]?
       (['"]?) # optional opening quote

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -569,10 +569,14 @@ if you believe they were disclosed to a third party.
     yaml = <<~YAML
       ---
       :foo: bar # buzz
+      #:notkey: bar
     YAML
 
     actual = Gem::ConfigFile.load_with_rubygems_config_hash(yaml)
     assert_equal("bar", actual[:foo])
+    assert_equal(false, actual.key?("#:notkey"))
+    assert_equal(false, actual.key?(:notkey))
+    assert_equal(1, actual.size)
   end
 
   def test_s3_source


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When I added `install: --user-install` to gemrc to install the gem to the user directory by default, I added the following comment to remind me to distinguish the difference between command line configuration and other configurations.
 ```
 #NOTE: no leading ':' before install
 install: --user-install
 ```

Then when I checked whether the configuration took effect through `gem env`, strange content appeared
```
 - GEM CONFIGURATION:
     - :update_sources => true
     - "#NOTE" => "no leading ':' before install"
     - "install" => "--user-install"
 ```
 `"#NOTE" => "no leading ':' before install` This line is a comment and should not appear here.

## What is your fix for the problem, implemented in this PR?
According to the output result of `gem env`, it seems that `#NOTE` is regarded as the hash key, and the problem of `:` in the comment is not correctly handled. Then I removed the `:` after `NOTE` and used `gem env` again and found that the output was correct this time.

 By checking [`lib/rubygems/yaml_serializer.rb#L41`](lib/rubygems/yaml_serializer.rb#L41), we found that arbitrary characters are allowed when processing hash keys. And it is trying to match whether a row is of hash type. As a result, the `#` in the key is also regarded as part of the key.

 I simply modified the regular pattern used by `HASH_REGEX` to match the key and excluded the `#` comment character to solve this problem. Then for line comments, the `load()` function will ignore this line.


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)