### PR TITLE
Fix platform removal regression when `platforms:` used in the Gemfile

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -635,7 +635,7 @@ module Bundler
       @resolved_bundler_version = result.find {|spec| spec.name == "bundler" }&.version
 
       if @most_specific_non_local_locked_ruby_platform
-        if result.incomplete_for_platform?(dependencies, @most_specific_non_local_locked_ruby_platform)
+        if result.incomplete_for_platform?(current_dependencies, @most_specific_non_local_locked_ruby_platform)
           @platforms.delete(@most_specific_non_local_locked_ruby_platform)
         elsif local_platform_needed_for_resolvability
           @platforms.delete(local_platform)

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -944,25 +944,7 @@ RSpec.describe "bundle install with specific platforms" do
 
     bundle "lock --update"
 
-    updated_lockfile = <<~L
-      GEM
-        remote: https://gem.repo4/
-        specs:
-          nokogiri (1.13.8)
-          nokogiri (1.13.8-#{Gem::Platform.local})
-
-      PLATFORMS
-        #{lockfile_platforms("ruby")}
-
-      DEPENDENCIES
-        nokogiri
-        tzinfo (~> 1.2)
-      #{checksums}
-      BUNDLED WITH
-         #{Bundler::VERSION}
-    L
-
-    expect(lockfile).to eq(updated_lockfile)
+    expect(lockfile).to eq(original_lockfile)
   end
 
   it "does not remove ruby when adding a new gem to the Gemfile" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When `platforms:` is used for a Gemfile dependency, Bundler does not consider the dependency for resolving nor includes it in the lockfile if we're not using that "platform".

However, I recently added some code that checks for the validaty of a resolution, mistakenly including those dependencies. This resulted in the "ruby" platform being removed from an existing lockfile.

## What is your fix for the problem, implemented in this PR?

Make sure to use `current_dependencies` instead of `dependencies`, which handles excluding "irrelevant" gems using `:platforms`.

I also included some tweaks to hopefully avoid introducing the same mistake again.

Fixes #7861.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
