### PR TITLE
Fix gemspec `require_paths` validation

### DIFF
--- a/bundler/lib/bundler/installer/standalone.rb
+++ b/bundler/lib/bundler/installer/standalone.rb
@@ -58,9 +58,6 @@ module Bundler
       else
         SharedHelpers.relative_path_to(full_path, from: Bundler.root.join(bundler_path))
       end
-    rescue TypeError
-      error_message = "#{spec.name} #{spec.version} has an invalid gemspec"
-      raise Gem::InvalidSpecificationException.new(error_message)
     end
 
     def prevent_gem_activation

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -60,6 +60,12 @@ module Gem
   FLATTENS_REQUIRED_PATHS = Specification.new.respond_to?(:flatten_require_paths).freeze
 
   class Specification
+    # Can be removed once RubyGems 3.5.15 support is dropped
+    correct_array_attributes = @@default_value.select {|_k,v| v.is_a?(Array) }.keys
+    unless @@array_attributes == correct_array_attributes
+      @@array_attributes = correct_array_attributes # rubocop:disable Style/ClassVars
+    end
+
     require_relative "match_metadata"
     require_relative "match_platform"
 

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -295,7 +295,7 @@ RSpec.shared_examples "bundle install --standalone" do
 
     it "outputs a helpful error message" do
       expect(err).to include("You have one or more invalid gemspecs that need to be fixed.")
-      expect(err).to include("bar 1.0 has an invalid gemspec")
+      expect(err).to include("bar.gemspec is not valid")
     end
   end
 

--- a/bundler/spec/realworld/edgecases_spec.rb
+++ b/bundler/spec/realworld/edgecases_spec.rb
@@ -198,18 +198,7 @@ RSpec.describe "real world edgecases", realworld: true do
     expect(lockfile).to include(rubygems_version("paperclip", "~> 5.1.0"))
   end
 
-  it "outputs a helpful error message when gems have invalid gemspecs", rubygems: "< 3.3.16" do
-    install_gemfile <<-G, standalone: true, raise_on_error: false, env: { "BUNDLE_FORCE_RUBY_PLATFORM" => "1" }
-      source 'https://rubygems.org'
-      gem "resque-scheduler", "2.2.0"
-      gem "redis-namespace", "1.6.0" # for a consistent resolution including ruby 2.3.0
-      gem "ruby2_keywords", "0.0.5"
-    G
-    expect(err).to include("You have one or more invalid gemspecs that need to be fixed.")
-    expect(err).to include("resque-scheduler 2.2.0 has an invalid gemspec")
-  end
-
-  it "outputs a helpful warning when gems have a gemspec with invalid `require_paths`", rubygems: ">= 3.3.16" do
+  it "outputs a helpful warning when gems have a gemspec with invalid `require_paths`" do
     install_gemfile <<-G, standalone: true, env: { "BUNDLE_FORCE_RUBY_PLATFORM" => "1" }
       source 'https://rubygems.org'
       gem "resque-scheduler", "2.2.0"

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -175,7 +175,7 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   @@attributes = @@default_value.keys.sort_by(&:to_s)
-  @@array_attributes = @@default_value.reject {|_k,v| v != [] }.keys
+  @@array_attributes = @@default_value.select {|_k,v| v.is_a?(Array) }.keys
   @@nil_attributes, @@non_nil_attributes = @@default_value.keys.partition do |k|
     @@default_value[k].nil?
   end

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2978,19 +2978,15 @@ duplicate dependency on c (>= 1.2.3, development), (~> 1.2) use:
   end
 
   def test_validate_empty_require_paths
-    if Gem.win_platform?
-      pend "test_validate_empty_require_paths skipped on MS Windows (symlink)"
-    else
-      util_setup_validate
+    util_setup_validate
 
-      @a1.require_paths = []
-      e = assert_raise Gem::InvalidSpecificationException do
-        @a1.validate
-      end
-
-      assert_equal "specification must have at least one require_path",
-                   e.message
+    @a1.require_paths = []
+    e = assert_raise Gem::InvalidSpecificationException do
+      @a1.validate
     end
+
+    assert_equal "specification must have at least one require_path",
+                 e.message
   end
 
   def test_validate_files

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2989,6 +2989,18 @@ duplicate dependency on c (>= 1.2.3, development), (~> 1.2) use:
                  e.message
   end
 
+  def test_validate_require_paths_with_invalid_types
+    util_setup_validate
+
+    @a1.require_paths = [1, 2]
+    e = assert_raise Gem::InvalidSpecificationException do
+      @a1.validate
+    end
+
+    assert_equal "require_paths must be an Array of String",
+                 e.message
+  end
+
   def test_validate_files
     pend "test_validate_files skipped on MS Windows (symlink)" if Gem.win_platform?
     util_setup_validate


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

While working on something else, I realized that this validation was not properly happening.

When an invalid gemspec with something like this is found:

```
spec.require_paths = [1, 2]
```

we would still allow the gem to be installed, although I guess things would still fail at runtime.

We do add a strange `TypeError` rescue in standalone mode in Bundler, and give a proper error in that particular case, though.

## What is your fix for the problem, implemented in this PR?

Instead of limiting this to standalone mode, I fixed detection of this attribute as an Array attribute, so that we disallow installation of this kind of gemspec in the first place.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
