### PR TITLE
Fix standalone script when default gems with extensions are used

### DIFF
--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -206,6 +206,7 @@ module Bundler
 
         spec.full_gem_path = installed_spec.full_gem_path
         spec.loaded_from = installed_spec.loaded_from
+        spec.base_dir = installed_spec.base_dir
 
         spec.post_install_message
       end

--- a/bundler/lib/bundler/stub_specification.rb
+++ b/bundler/lib/bundler/stub_specification.rb
@@ -77,6 +77,14 @@ module Bundler
       stub.full_require_paths
     end
 
+    def require_paths
+      stub.require_paths
+    end
+
+    def base_dir=(path)
+      stub.base_dir = path
+    end
+
     def load_paths
       full_require_paths
     end

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -148,7 +148,7 @@ RSpec.shared_examples "bundle install --standalone" do
       realworld_system_gems(*necessary_system_gems)
 
       necessary_gems_in_bundle_path = ["optparse --version 0.1.1", "psych --version 3.3.2", "logger --version 1.4.3", "etc --version 1.4.3", "stringio --version 3.1.0"]
-      necessary_gems_in_bundle_path += ["shellwords --version 0.1.0", "base64 --version 0.1.0", "resolv --version 0.2.1"] if Gem.rubygems_version < Gem::Version.new("3.3.a")
+      necessary_gems_in_bundle_path += ["shellwords --version 0.2.0", "base64 --version 0.1.0", "resolv --version 0.2.1"] if Gem.rubygems_version < Gem::Version.new("3.3.a")
       necessary_gems_in_bundle_path += ["yaml --version 0.1.1"] if Gem.rubygems_version < Gem::Version.new("3.4.a")
       realworld_system_gems(*necessary_gems_in_bundle_path, path: scoped_gem_path(bundled_app("bundle")))
 

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -146,7 +146,9 @@ RSpec.shared_examples "bundle install --standalone" do
       necessary_system_gems = ["tsort --version 0.1.0"]
       necessary_system_gems += ["etc --version 1.4.3"] if Gem.ruby_version >= Gem::Version.new("3.3.2") && Gem.win_platform?
       realworld_system_gems(*necessary_system_gems)
+    end
 
+    it "works and points to the vendored copies, not to the default copies" do
       necessary_gems_in_bundle_path = ["optparse --version 0.1.1", "psych --version 3.3.2", "logger --version 1.4.3", "etc --version 1.4.3", "stringio --version 3.1.0"]
       necessary_gems_in_bundle_path += ["shellwords --version 0.2.0", "base64 --version 0.1.0", "resolv --version 0.2.1"] if Gem.rubygems_version < Gem::Version.new("3.3.a")
       necessary_gems_in_bundle_path += ["yaml --version 0.1.1"] if Gem.rubygems_version < Gem::Version.new("3.4.a")
@@ -172,9 +174,7 @@ RSpec.shared_examples "bundle install --standalone" do
       G
 
       bundle "lock", dir: cwd
-    end
 
-    it "works and points to the vendored copies, not to the default copies" do
       bundle "config set --local path #{bundled_app("bundle")}"
       bundle :install, standalone: true, dir: cwd, env: { "BUNDLER_GEM_DEFAULT_DIR" => system_gem_path.to_s }
 
@@ -183,6 +183,39 @@ RSpec.shared_examples "bundle install --standalone" do
       expect(load_path_lines).to eq [
         '$:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{Gem.ruby_api_version}/gems/bar-1.0.0/lib")',
         '$:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{Gem.ruby_api_version}/gems/foo-1.0.0/lib")',
+      ]
+    end
+
+    it "works for gems with extensions and points to the vendored copies, not to the default copies" do
+      necessary_gems_in_bundle_path = ["optparse --version 0.1.1", "psych --version 3.3.2", "logger --version 1.4.3", "etc --version 1.4.3", "stringio --version 3.1.0", "shellwords --version 0.2.0", "open3 --version 0.2.1"]
+      necessary_gems_in_bundle_path += ["base64 --version 0.1.0", "resolv --version 0.2.1"] if Gem.rubygems_version < Gem::Version.new("3.3.a")
+      necessary_gems_in_bundle_path += ["yaml --version 0.1.1"] if Gem.rubygems_version < Gem::Version.new("3.4.a")
+      realworld_system_gems(*necessary_gems_in_bundle_path, path: scoped_gem_path(bundled_app("bundle")))
+
+      build_gem "baz", "1.0.0", to_system: true, default: true, &:add_c_extension
+
+      build_repo4 do
+        build_gem "baz", "1.0.0", &:add_c_extension
+      end
+
+      gemfile <<-G
+        source "https://gem.repo4"
+        gem "baz"
+      G
+
+      bundle "config set --local path #{bundled_app("bundle")}"
+
+      simulate_platform "arm64-darwin-23" do
+        bundle "lock", dir: cwd
+
+        bundle :install, standalone: true, dir: cwd, env: { "BUNDLER_GEM_DEFAULT_DIR" => system_gem_path.to_s }
+      end
+
+      load_path_lines = bundled_app("bundle/bundler/setup.rb").read.split("\n").select {|line| line.start_with?("$:.unshift") }
+
+      expect(load_path_lines).to eq [
+        '$:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{Gem.ruby_api_version}/extensions/arm64-darwin-23/#{Gem.extension_api_version}/baz-1.0.0")',
+        '$:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{Gem.ruby_api_version}/gems/baz-1.0.0/lib")',
       ]
     end
   end

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -171,7 +171,7 @@ RSpec.shared_examples "bundle install --standalone" do
         gem "foo"
       G
 
-      bundle "lock", dir: cwd, artifice: "compact_index"
+      bundle "lock", dir: cwd
     end
 
     it "works and points to the vendored copies, not to the default copies" do

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -481,7 +481,6 @@ module Spec
       end
 
       def add_c_extension
-        require_paths << "ext"
         extensions << "ext/extconf.rb"
         write "ext/extconf.rb", <<-RUBY
           require "mkmf"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If running `bundle install` in `standalone` mode, AND the Gemfile specifies a default gem with extensions, AND the bundle has not been previously installed, AND there's an up to date lockfile, then when creating the standalone script to setup the bundle, we'll end up looking at `require_paths` for a `StubSpecification` of this default gem. In this case, `require_paths` includes a full path to a system extensions directory, which is not correct on a standalone script. 

## What is your fix for the problem, implemented in this PR?

When we install a remote specification, we already replace some attributes of the materialized spec with information from the specification just installed, however, `require_paths` are eventually derived from `base_dir` which was not actually getting replaced.

So I replaced that with the information of the just installed spec, so that `require_paths` is correct when we list `$LOAD_PATH`s in the script.

Fixes https://github.com/rubygems/rubygems/issues/7865.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
