### PR TITLE
Fix unused variable warning when running RubyGems tests

### DIFF
--- a/test/rubygems/test_gem_remote_fetcher_local_ssl_server.rb
+++ b/test/rubygems/test_gem_remote_fetcher_local_ssl_server.rb
@@ -166,7 +166,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
         ensure
           client.close
         end
-      rescue OpenSSL::SSL::SSLError => e
+      rescue OpenSSL::SSL::SSLError
         # Ignore SSL errors because we're testing them implicitly
       end
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Just a warning when running tests:

```
/path/to/rubygems/test/rubygems/test_gem_remote_fetcher_local_ssl_server.rb:170: warning: assigned but unused variable - e
```

## What is your fix for the problem, implemented in this PR?

Remove the unused variable.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
