### PR TITLE
Make `--enable-load-relative` binstubs prolog work when Ruby is not installed in the same directory as the binstub

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -131,6 +131,9 @@ jobs:
       - name: Generate a Rails application
         run: gem install rails --version 7.0.8 && rails new foo ${{ matrix.ruby.rails-args }}
         shell: bash
+      - name: Use gem installed in a bin dir different from where Ruby itself is installed
+        run: gem install rspec --version 3.13.0 --install-dir foo && GEM_HOME=foo foo/bin/rspec --version
+        shell: bash
 
     timeout-minutes: 20
 

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -998,18 +998,13 @@ TEXT
 
   def bash_prolog_script
     if load_relative_enabled?
-      script = +<<~EOS
-        bindir="${0%/*}"
-      EOS
-
-      script << %(exec "$bindir/#{ruby_install_name}" "-x" "$0" "$@"\n)
-
       <<~EOS
         #!/bin/sh
         # -*- ruby -*-
         _=_\\
         =begin
-        #{script.chomp}
+        bindir="${0%/*}"
+        exec "$bindir/#{ruby_install_name}" "-x" "$0" "$@"
         =end
       EOS
     else

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -1004,7 +1004,11 @@ TEXT
         _=_\\
         =begin
         bindir="${0%/*}"
-        exec "$bindir/#{ruby_install_name}" "-x" "$0" "$@"
+        ruby="$bindir/#{ruby_install_name}"
+        if [ ! -f "$ruby" ]; then
+          ruby="#{ruby_install_name}"
+        fi
+        exec "$ruby" "-x" "$0" "$@"
         =end
       EOS
     else


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If Ruby was configured with the `--enable-load-relative` option, and RubyGems is configured to not install gems to the default bindir, then RubyGems generated binstubs don't work because the `--enable-load-relative` prolog assumes this can't happen.

## What is your fix for the problem, implemented in this PR?

I figured we could fallback to relying on PATH if Ruby is not installed in the same directory as the binstub.

Fixes #7856.
Fixes #8135.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
