### PR TITLE
Changelogs for RubyGems 3.5.16 and Bundler 2.5.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 3.5.16 / 2024-07-18
+
+## Enhancements:
+
+* Installs bundler 2.5.16 as a default gem.
+
+## Bug fixes:
+
+* Fix gemspec `require_paths` validation. Pull request
+  [#7866](https://github.com/rubygems/rubygems/pull/7866) by
+  deivid-rodriguez
+* Fix loading of nested `gemrc` config keys when specified as symbols.
+  Pull request [#7851](https://github.com/rubygems/rubygems/pull/7851) by
+  moofkit
+
+## Performance:
+
+* Use `caller_locations` instead of splitting `caller`. Pull request
+  [#7708](https://github.com/rubygems/rubygems/pull/7708) by nobu
+
 # 3.5.15 / 2024-07-09
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 2.5.16 (July 18, 2024)
+
+## Bug fixes:
+
+  - Fix platform removal regression when `platforms:` used in the Gemfile [#7864](https://github.com/rubygems/rubygems/pull/7864)
+  - Fix standalone script when default gems with extensions are used [#7870](https://github.com/rubygems/rubygems/pull/7870)
+  - Fix another case of `bundle lock --add-platform` doing nothing [#7848](https://github.com/rubygems/rubygems/pull/7848)
+  - Fix bad error messages when using `bundle add` with frozen mode set [#7845](https://github.com/rubygems/rubygems/pull/7845)
+  - Fix generic platform gems getting incorrectly removed from lockfile [#7833](https://github.com/rubygems/rubygems/pull/7833)
+
+## Performance:
+
+  - Use `caller_locations` instead of splitting `caller` [#7708](https://github.com/rubygems/rubygems/pull/7708)
+
 # 2.5.15 (July 9, 2024)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.5.16 and Bundler 2.5.16 into master.
