### PR TITLE
Workaround for bundler examples with ruby head version.

### DIFF
--- a/bundler/spec/install/gems/dependency_api_fallback_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_fallback_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe "gemcutter's dependency API" do
 
       require_relative "../../support/artifice/endpoint_timeout"
 
+      # mustermann depends on URI::RFC2396_PARSER behavior
+      URI.parser = URI::RFC2396_PARSER if URI.respond_to?(:parser=)
+
       @t = Thread.new do
         server = Rack::Server.start(app: EndpointTimeout,
                                     Host: "0.0.0.0",
@@ -31,6 +34,8 @@ RSpec.describe "gemcutter's dependency API" do
       Artifice.deactivate
       @t.kill
       @t.join
+
+      URI.parser = URI::DEFAULT_PARSER if URI.respond_to?(:parser=)
     end
 
     it "times out and falls back on the modern index" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I merged https://github.com/ruby/uri/pull/107 and sync `ruby/ruby` today. This change makes `RFC3986_Parser` by default for `URI` module.

After that, `bundler/spec/install/gems/dependency_api_fallback_spec.rb` is broken with new default parser. Because mustermann that is part of Sinatra dependency depends on URI::RFC2396_PARSER behavior.

## What is your fix for the problem, implemented in this PR?

I switched `RFC2396_PARSER` while failing example as workaround.

I already submitted https://github.com/sinatra/mustermann/pull/138 to fix this issue.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
