### PR TITLE
Always leave default gem executables around

### DIFF
--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -102,6 +102,7 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
     end
 
     assert File.exist? File.join(@gemhome, "bin", "executable")
+    assert File.exist? File.join(@gemhome, "gems", "z-1", "bin", "executable")
 
     output = @ui.output.split "\n"
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This is an iteration on https://github.com/rubygems/rubygems/pull/7747. In that PR, I stopped removing binstubs that may actually belong to a default gem, however, we're still removing the executables themselves, so things break anyways.

```
$ gem list bundler

*** LOCAL GEMS ***

bundler (default: 2.5.16)

$ gem install bundler
Fetching bundler-2.5.16.gem
Successfully installed bundler-2.5.16
1 gem installed

$ bundle -v
Bundler version 2.5.16

$ gem uninstall bundler
Successfully uninstalled bundler-2.5.16
There was both a regular copy and a default copy of bundler-2.5.16. The regular copy was successfully uninstalled, but the default copy was left around because default gems can't be removed.

$ bundle -v            
/Users/deivid/.asdf/installs/ruby/3.3.4/bin/bundle:25:in `load': cannot load such file -- /Users/deivid/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/exe/bundle (LoadError)
	from /Users/deivid/.asdf/installs/ruby/3.3.4/bin/bundle:25:in `<main>'
```

## What is your fix for the problem, implemented in this PR?

My fix is, when removing the installation directory, exclude any executables that are pointed to by a default gem. I don't think `FileUtils` support this kind of thing, so I implemented it from scratch, but happy to do something else.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
