### PR TITLE
Fix `bundle exec gem uninstall`

### DIFF
--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -94,7 +94,7 @@ module Bundler
     end
 
     def delete(specs)
-      specs.each {|spec| @specs.delete(spec) }
+      Array(specs).each {|spec| @specs.delete(spec) }
 
       reset!
     end

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -695,6 +695,25 @@ RSpec.describe "bundle exec" do
     end
   end
 
+  describe "bundle exec gem uninstall" do
+    before do
+      build_repo4 do
+        build_gem "foo"
+      end
+
+      install_gemfile <<-G
+        source "https://gem.repo4"
+
+        gem "foo"
+      G
+    end
+
+    it "works" do
+      bundle "exec gem uninstall foo"
+      expect(out).to eq("Successfully uninstalled foo-1.0")
+    end
+  end
+
   context "`load`ing a ruby file instead of `exec`ing" do
     let(:path) { bundled_app("ruby_executable") }
     let(:shebang) { "#!/usr/bin/env ruby" }


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

* `bundle exec` assigns `Gem::Specification.all` to the set of specs known to Bundler (a `Bundler::SpecSet`).

* `gem uninstall` recently started calling `#delete` on the set of specs stored in `Gem::Specification#all`. This, in RubyGems, is just an array of specs, so has a `#delete` method that receives a single element.

* However, at some point I added a `SpecSet#delete` method that takes an array of specs, breaking the "Array-like" contract and making `gem uninstall` break when run in a `bundle exec` context.

## What is your fix for the problem, implemented in this PR?

The fix is to make `Bundler::SpecSet#delete` handle being given a single spec.

Fixes #7883.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
