### PR TITLE
Allow smoother breaking changes in test env

### DIFF
--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -102,7 +102,18 @@ module Spec
     end
 
     def tmp(*path)
-      source_root.join("tmp", scope, *path)
+      tmp_root(scope).join(*path)
+    end
+
+    def tmp_root(scope)
+      source_root.join("tmp", "#{test_env_version}.#{scope}")
+    end
+
+    # Bump this version whenever you make a breaking change to the spec setup
+    # that requires regenerating tmp/.
+
+    def test_env_version
+      1
     end
 
     def scope

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -57,8 +57,8 @@ module Spec
       install_test_deps
 
       (2..Parallel.processor_count).each do |n|
-        source = Path.source_root.join("tmp", "1")
-        destination = Path.source_root.join("tmp", n.to_s)
+        source = Path.tmp_root("1")
+        destination = Path.tmp_root(n.to_s)
 
         FileUtils.rm_rf destination
         FileUtils.cp_r source, destination


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If, for example, you rename a dummy test gem in "test repo 1" (the one used by most of the specs), then the test will start failing until you delete and regenerate `tmp/`.

## What is your fix for the problem, implemented in this PR?

I figured we could version the test folders inside `tmp`, so that whoever makes the breaking change can be a nice citizen, and bump the "test env version", so that the test folders get automatically regenerated.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
