### PR TITLE
Remove `to_yaml_properties`

### DIFF
--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -214,10 +214,6 @@ class Gem::Requirement
     yaml_initialize coder.tag, coder.map
   end
 
-  def to_yaml_properties # :nodoc:
-    ["@requirements"]
-  end
-
   def encode_with(coder) # :nodoc:
     coder.add "requirements", @requirements
   end

--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -297,10 +297,6 @@ class Gem::Version
     @hash = nil
   end
 
-  def to_yaml_properties # :nodoc:
-    ["@version"]
-  end
-
   def encode_with(coder) # :nodoc:
     coder.add "version", @version
   end


### PR DESCRIPTION

## What was the end-user or developer problem that led to this PR?

Not much, I noticed while reviewing #7867 that these methods should no longer be used anywhere. They are an old syck thing.

## What is your fix for the problem, implemented in this PR?

Remove the methods.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
