### PR TITLE
Make test env resilient to ruby version changes

### DIFF
--- a/bundler/spec/cache/gems_spec.rb
+++ b/bundler/spec/cache/gems_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe "bundle cache" do
   end
 
   describe "when previously cached" do
-    before :each do
+    let :setup_main_repo do
       build_repo2
       install_gemfile <<-G
         source "https://gem.repo2"
@@ -217,6 +217,7 @@ RSpec.describe "bundle cache" do
     end
 
     it "re-caches during install" do
+      setup_main_repo
       cached_gem("myrack-1.0.0").rmtree
       bundle :install
       expect(out).to include("Updating files in vendor/cache")
@@ -224,6 +225,7 @@ RSpec.describe "bundle cache" do
     end
 
     it "adds and removes when gems are updated" do
+      setup_main_repo
       update_repo2 do
         build_gem "myrack", "1.2" do |s|
           s.executables = "myrackup"
@@ -236,6 +238,7 @@ RSpec.describe "bundle cache" do
     end
 
     it "adds new gems and dependencies" do
+      setup_main_repo
       install_gemfile <<-G
         source "https://gem.repo2"
         gem "rails"
@@ -245,6 +248,7 @@ RSpec.describe "bundle cache" do
     end
 
     it "removes .gems for removed gems and dependencies" do
+      setup_main_repo
       install_gemfile <<-G
         source "https://gem.repo2"
         gem "myrack"
@@ -255,6 +259,7 @@ RSpec.describe "bundle cache" do
     end
 
     it "removes .gems when gem changes to git source" do
+      setup_main_repo
       build_git "myrack"
 
       install_gemfile <<-G
@@ -279,16 +284,20 @@ RSpec.describe "bundle cache" do
       end
 
       simulate_new_machine
-      install_gemfile <<-G
-        source "https://gem.repo1"
-        gem "platform_specific"
-      G
 
-      expect(cached_gem("platform_specific-1.0-#{Bundler.local_platform}")).to exist
-      expect(cached_gem("platform_specific-1.0-java")).to exist
+      simulate_platform "x86-darwin-100" do
+        install_gemfile <<-G
+          source "https://gem.repo1"
+          gem "platform_specific"
+        G
+
+        expect(cached_gem("platform_specific-1.0-x86-darwin-100")).to exist
+        expect(cached_gem("platform_specific-1.0-java")).to exist
+      end
     end
 
     it "doesn't remove gems cached gems that don't match their remote counterparts, but also refuses to install and prints an error" do
+      setup_main_repo
       cached_myrack = cached_gem("myrack-1.0.0")
       cached_myrack.rmtree
       build_gem "myrack", "1.0.0",
@@ -319,6 +328,7 @@ RSpec.describe "bundle cache" do
     end
 
     it "raises an error when a cached gem is altered and produces a different checksum than the remote gem" do
+      setup_main_repo
       cached_gem("myrack-1.0.0").rmtree
       build_gem "myrack", "1.0.0", path: bundled_app("vendor/cache")
 
@@ -348,6 +358,7 @@ RSpec.describe "bundle cache" do
     end
 
     it "installs a modified gem with a non-matching checksum when the API implementation does not provide checksums" do
+      setup_main_repo
       cached_gem("myrack-1.0.0").rmtree
       build_gem "myrack", "1.0.0", path: bundled_app("vendor/cache")
       simulate_new_machine
@@ -364,12 +375,14 @@ RSpec.describe "bundle cache" do
     end
 
     it "handles directories and non .gem files in the cache" do
+      setup_main_repo
       bundled_app("vendor/cache/foo").mkdir
       File.open(bundled_app("vendor/cache/bar"), "w") {|f| f.write("not a gem") }
       bundle :cache
     end
 
     it "does not say that it is removing gems when it isn't actually doing so" do
+      setup_main_repo
       install_gemfile <<-G
         source "https://gem.repo1"
         gem "myrack"
@@ -380,6 +393,7 @@ RSpec.describe "bundle cache" do
     end
 
     it "does not warn about all if it doesn't have any git/path dependency" do
+      setup_main_repo
       install_gemfile <<-G
         source "https://gem.repo1"
         gem "myrack"

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -249,12 +249,14 @@ RSpec.describe "bundle install with gem sources" do
 
     describe "with a gem that installs multiple platforms" do
       it "installs gems for the local platform as first choice" do
-        install_gemfile <<-G
-          source "https://gem.repo1"
-          gem "platform_specific"
-        G
+        simulate_platform "x86-darwin-100" do
+          install_gemfile <<-G
+            source "https://gem.repo1"
+            gem "platform_specific"
+          G
 
-        expect(the_bundle).to include_gems("platform_specific 1.0 #{Bundler.local_platform}")
+          expect(the_bundle).to include_gems("platform_specific 1.0 x86-darwin-100")
+        end
       end
 
       it "falls back on plain ruby" do

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -559,37 +559,39 @@ RSpec.describe "bundle update" do
         gem "myrack-obama"
         gem "platform_specific"
       G
-
-      lockfile <<~L
-        GEM
-          remote: https://gem.repo2/
-          specs:
-            activesupport (2.3.5)
-            platform_specific (1.0-#{local_platform})
-            myrack (1.0.0)
-            myrack-obama (1.0)
-              myrack
-
-        PLATFORMS
-          #{local_platform}
-
-        DEPENDENCIES
-          activesupport
-          platform_specific
-          myrack-obama
-
-        BUNDLED WITH
-           #{Bundler::VERSION}
-      L
-
-      bundle "install"
     end
 
     it "doesn't hit repo2" do
-      FileUtils.rm_rf(gem_repo2)
+      simulate_platform "x86-darwin-100" do
+        lockfile <<~L
+          GEM
+            remote: https://gem.repo2/
+            specs:
+              activesupport (2.3.5)
+              platform_specific (1.0-x86-darwin-100)
+              myrack (1.0.0)
+              myrack-obama (1.0)
+                myrack
 
-      bundle "update --local --all"
-      expect(out).not_to include("Fetching source index")
+          PLATFORMS
+            #{local_platform}
+
+          DEPENDENCIES
+            activesupport
+            platform_specific
+            myrack-obama
+
+          BUNDLED WITH
+             #{Bundler::VERSION}
+        L
+
+        bundle "install"
+
+        FileUtils.rm_rf(gem_repo2)
+
+        bundle "update --local --all"
+        expect(out).not_to include("Fetching source index")
+      end
     end
   end
 

--- a/bundler/spec/install/gemfile/force_ruby_platform_spec.rb
+++ b/bundler/spec/install/gemfile/force_ruby_platform_spec.rb
@@ -118,15 +118,17 @@ RSpec.describe "bundle install with force_ruby_platform DSL option", :jruby do
             #{Bundler::VERSION}
       L
 
-      system_gems "platform_specific-1.0-#{Gem::Platform.local}", path: default_bundle_path
+      simulate_platform "x86-darwin-100" do
+        system_gems "platform_specific-1.0-x86-darwin-100", path: default_bundle_path
 
-      install_gemfile <<-G, env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }, artifice: "compact_index"
-        source "https://gem.repo4"
+        install_gemfile <<-G, env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }, artifice: "compact_index"
+          source "https://gem.repo4"
 
-        gem "platform_specific", :force_ruby_platform => true
-      G
+          gem "platform_specific", :force_ruby_platform => true
+        G
 
-      expect(the_bundle).to include_gems "platform_specific 1.0 ruby"
+        expect(the_bundle).to include_gems "platform_specific 1.0 ruby"
+      end
     end
   end
 end

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -89,10 +89,6 @@ module Spec
         end
 
         build_gem "platform_specific" do |s|
-          s.platform = Gem::Platform.local
-        end
-
-        build_gem "platform_specific" do |s|
           s.platform = "java"
         end
 

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -266,7 +266,7 @@ module Spec
     end
 
     def rake_path
-      Dir["#{base_system_gems}/**/rake*.gem"].first
+      Dir["#{base_system_gems}/#{Bundler.ruby_scope}/**/rake*.gem"].first
     end
 
     private


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We use pre-existence of `rake_path` to decide whether we need to regenerate dummy test gems in `tmp`. When changing rubies, the previous implementation will believe that the correct `rake_path` exists and avoids regenerating dummy gems, given an error like the following when specs are run:

```
(...)
Could not find rubygems-generate_index lib directory in /path/to/rubygems/bundler/tmp/1/gems/base/ruby/3.2.0
  # ./spec/support/builders.rb:253:in `block in update_repo'
  # ./spec/support/helpers.rb:337:in `block in with_gem_path_as'
  # ./spec/support/helpers.rb:351:in `without_env_side_effects'
  # ./spec/support/helpers.rb:332:in `with_gem_path_as'
  # ./spec/support/builders.rb:251:in `update_repo'
  # ./spec/support/builders.rb:228:in `build_repo'
  # ./spec/support/builders.rb:197:in `build_repo4'
  # ./spec/commands/lock_spec.rb:103:in `block (2 levels) in <top (required)>'
(...)
```

## What is your fix for the problem, implemented in this PR?

To fix this, fix the part of the path that depends on the implementation and the Ruby version so that we don't give false positives.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
