### PR TITLE
Print better log message when current platform is not present in the lockfile

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -137,7 +137,7 @@ module Bundler
       end
       @unlocking ||= @unlock[:ruby] ||= (!@locked_ruby_version ^ !@ruby_version)
 
-      add_current_platform unless Bundler.frozen_bundle?
+      @current_platform_missing = add_current_platform unless Bundler.frozen_bundle?
 
       converge_path_sources_to_gemspec_sources
       @path_changes = converge_paths
@@ -484,6 +484,7 @@ module Bundler
 
       !@source_changes &&
         !@dependency_changes &&
+        !@current_platform_missing &&
         @new_platforms.empty? &&
         !@path_changes &&
         !@local_changes &&
@@ -676,7 +677,8 @@ module Bundler
       @most_specific_non_local_locked_ruby_platform = find_most_specific_locked_ruby_platform
       return if @most_specific_non_local_locked_ruby_platform
 
-      add_platform(local_platform)
+      @platforms << local_platform
+      true
     end
 
     def find_most_specific_locked_ruby_platform
@@ -704,6 +706,7 @@ module Bundler
       [
         [@source_changes, "the list of sources changed"],
         [@dependency_changes, "the dependencies in your gemfile changed"],
+        [@current_platform_missing, "your lockfile does not include the current platform"],
         [@new_platforms.any?, "you added a new platform to your gemfile"],
         [@path_changes, "the gemspecs for path gems changed"],
         [@local_changes, "the gemspecs for git local gems changed"],

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -671,19 +671,18 @@ module Bundler
     end
 
     def add_current_platform
-      @most_specific_non_local_locked_ruby_platform = find_most_specific_non_local_locked_ruby_platform
+      return if @platforms.include?(local_platform)
+
+      @most_specific_non_local_locked_ruby_platform = find_most_specific_locked_ruby_platform
       return if @most_specific_non_local_locked_ruby_platform
 
       add_platform(local_platform)
     end
 
-    def find_most_specific_non_local_locked_ruby_platform
+    def find_most_specific_locked_ruby_platform
       return unless generic_local_platform_is_ruby? && current_platform_locked?
 
-      most_specific_locked_ruby_platform = most_specific_locked_platform
-      return unless most_specific_locked_ruby_platform != local_platform
-
-      most_specific_locked_ruby_platform
+      most_specific_locked_platform
     end
 
     def change_reason

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -1168,7 +1168,7 @@ RSpec.describe "bundle install with gem sources" do
     end
 
     it "should fail loudly if the lockfile platforms don't include the current platform" do
-      simulate_platform(Gem::Platform.new("x86_64-linux")) { bundle "install", raise_on_error: false }
+      simulate_platform("x86_64-linux") { bundle "install", raise_on_error: false }
 
       expect(err).to eq(
         "Your bundle only supports platforms [\"x86_64-darwin-19\"] but your local platform is x86_64-linux. " \

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -1134,11 +1134,15 @@ RSpec.describe "bundle install with gem sources" do
     end
   end
 
-  context "in a frozen bundle" do
-    before do
+  context "when current platform not included in the lockfile" do
+    around do |example|
       build_repo4 do
         build_gem "libv8", "8.4.255.0" do |s|
           s.platform = "x86_64-darwin-19"
+        end
+
+        build_gem "libv8", "8.4.255.0" do |s|
+          s.platform = "x86_64-linux"
         end
       end
 
@@ -1164,11 +1168,36 @@ RSpec.describe "bundle install with gem sources" do
            #{Bundler::VERSION}
       L
 
-      bundle "config set --local deployment true"
+      simulate_platform("x86_64-linux", &example)
     end
 
-    it "should fail loudly if the lockfile platforms don't include the current platform" do
-      simulate_platform("x86_64-linux") { bundle "install", raise_on_error: false }
+    it "adds the current platform to the lockfile" do
+      bundle "install --verbose"
+
+      expect(out).to include("re-resolving dependencies because your lockfile does not include the current platform")
+
+      expect(lockfile).to eq <<~L
+        GEM
+          remote: https://gem.repo4/
+          specs:
+            libv8 (8.4.255.0-x86_64-darwin-19)
+            libv8 (8.4.255.0-x86_64-linux)
+
+        PLATFORMS
+          x86_64-darwin-19
+          x86_64-linux
+
+        DEPENDENCIES
+          libv8
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+    end
+
+    it "fails loudly if frozen mode set" do
+      bundle "config set --local deployment true"
+      bundle "install", raise_on_error: false
 
       expect(err).to eq(
         "Your bundle only supports platforms [\"x86_64-darwin-19\"] but your local platform is x86_64-linux. " \

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -1061,7 +1061,7 @@ RSpec.describe "bundle lock" do
          #{Bundler::VERSION}
     G
 
-    simulate_platform(Gem::Platform.new("x86_64-darwin-19")) { bundle "lock --update" }
+    simulate_platform("x86_64-darwin-19") { bundle "lock --update" }
 
     expect(out).to match(/Writing lockfile to.+Gemfile\.lock/)
   end
@@ -1083,7 +1083,7 @@ RSpec.describe "bundle lock" do
       gem "libv8"
     G
 
-    simulate_platform(Gem::Platform.new("x86_64-darwin-19")) { bundle "lock" }
+    simulate_platform("x86_64-darwin-19") { bundle "lock" }
 
     checksums = checksums_section_when_enabled do |c|
       c.checksum gem_repo4, "libv8", "8.4.255.0", "x86_64-darwin-19"
@@ -1151,7 +1151,7 @@ RSpec.describe "bundle lock" do
     previous_lockfile = lockfile
 
     %w[x86_64-darwin-19 x86_64-darwin-20].each do |platform|
-      simulate_platform(Gem::Platform.new(platform)) do
+      simulate_platform(platform) do
         bundle "lock"
         expect(lockfile).to eq(previous_lockfile)
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Current Bundler prints "re-resolving dependencies because you added a new platform to the lockfile" when running `bundle install` and the current platform is not present in the lockfile.

I think it's not clear how user is "adding a new platform" by simply running `bundle install`.
 
## What is your fix for the problem, implemented in this PR?

Print a better, more explicit, message.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
