### PR TITLE
Fix `gem list` regression when a regular gem shadows a default one

### DIFF
--- a/lib/rubygems/query_utils.rb
+++ b/lib/rubygems/query_utils.rb
@@ -132,7 +132,7 @@ module Gem::QueryUtils
       version_matches = show_prereleases? || !s.version.prerelease?
 
       name_matches && version_matches
-    end
+    end.uniq(&:full_name)
 
     spec_tuples = specs.map do |spec|
       [spec.name_tuple, spec]

--- a/test/rubygems/test_gem_commands_list_command.rb
+++ b/test/rubygems/test_gem_commands_list_command.rb
@@ -8,7 +8,9 @@ class TestGemCommandsListCommand < Gem::TestCase
     super
 
     @cmd = Gem::Commands::ListCommand.new
+  end
 
+  def test_execute_installed
     spec_fetcher do |fetcher|
       fetcher.spec "c", 1
     end
@@ -16,9 +18,7 @@ class TestGemCommandsListCommand < Gem::TestCase
     @fetcher.data["#{@gem_repo}Marshal.#{Gem.marshal_version}"] = proc do
       raise Gem::RemoteFetcher::FetchError
     end
-  end
 
-  def test_execute_installed
     @cmd.handle_options %w[c --installed]
 
     assert_raise Gem::MockGemUi::SystemExitException do
@@ -29,5 +29,30 @@ class TestGemCommandsListCommand < Gem::TestCase
 
     assert_equal "true\n", @ui.output
     assert_equal "", @ui.error
+  end
+
+  def test_execute_normal_gem_shadowing_default_gem
+    c1_default = new_default_spec "c", 1
+    install_default_gems c1_default
+
+    c1 = util_spec("c", 1) {|s| s.date = "2024-01-01" }
+    install_gem c1
+
+    Gem::Specification.reset
+
+    @cmd.handle_options %w[c]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    expected = <<-EOF
+
+*** LOCAL GEMS ***
+
+c (1)
+EOF
+
+    assert_equal expected, @ui.output
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since 0eb6ed8f860c4555cf6b91e7b55a5ae9f461e166, if you have bundler (or any other default gem) also installed as a regular gem (the same version), `gem list` will display something strange:

```
$ gem list bundler

*** LOCAL GEMS ***

bundler (default: 2.5.12 ruby)
```

It's incorrect because the regular gem takes priority.

## What is your fix for the problem, implemented in this PR?

The problem is that since we stopped making gems uniq by full name, we now have both gems here, and information from both is actually displayed, leading to that. So make the list unique again before displaying it.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
