### PR TITLE
Fix `bundle check` exit code when gem git source is not checked out

### DIFF
--- a/bundler/lib/bundler/cli/check.rb
+++ b/bundler/lib/bundler/cli/check.rb
@@ -17,7 +17,7 @@ module Bundler
       begin
         definition.resolve_only_locally!
         not_installed = definition.missing_specs
-      rescue GemNotFound, SolveFailure
+      rescue GemNotFound, GitError, SolveFailure
         Bundler.ui.error "Bundler can't satisfy your Gemfile's dependencies."
         Bundler.ui.warn "Install missing gems with `bundle install`."
         exit 1

--- a/bundler/spec/commands/check_spec.rb
+++ b/bundler/spec/commands/check_spec.rb
@@ -70,6 +70,17 @@ RSpec.describe "bundle check" do
     expect(err).to include("Bundler can't satisfy your Gemfile's dependencies.")
   end
 
+  it "prints a generic error if gem git source is not checked out" do
+    gemfile <<-G
+      source "https://gem.repo1"
+      gem "rails", git: "git@github.com:rails/rails.git"
+    G
+
+    bundle :check, raise_on_error: false
+    expect(exitstatus).to eq 1
+    expect(err).to include("Bundler can't satisfy your Gemfile's dependencies.")
+  end
+
   it "prints a generic message if you changed your lockfile" do
     build_repo2 do
       build_gem "rails_pinned_to_old_activesupport" do |s|


### PR DESCRIPTION
Fixes https://github.com/rubygems/rubygems/issues/7885.

## What was the end-user or developer problem that led to this PR?

According to the docs, `bundle check` should exit with code `1` when a gem is missing.

But when a gem is missing because its git repository has not been checked out, `bundle check` exits with code `11` .

## What is your fix for the problem, implemented in this PR?

Make `CLI::Check` rescue `GitError`, which is [thrown](https://github.com/rubygems/rubygems/blob/a7221288695b4f3441e7805a8a8e3f525099740b/bundler/lib/bundler/source/git.rb#L233) when the git source is not checked out. Once rescued, the command exits with its usual unsatisfied dependency error message and `1` status code.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
