### PR TITLE
Add a `--normalize-platforms` flag to `bundle lock`

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -625,6 +625,7 @@ module Bundler
     method_option "full-index", type: :boolean, default: false, banner: "Fall back to using the single-file index of all gems"
     method_option "add-platform", type: :array, default: [], banner: "Add a new platform to the lockfile"
     method_option "remove-platform", type: :array, default: [], banner: "Remove a platform from the lockfile"
+    method_option "normalize-platforms", type: :boolean, default: false, banner: "Normalize lockfile platforms"
     method_option "patch", type: :boolean, banner: "If updating, prefer updating only to next patch version"
     method_option "minor", type: :boolean, banner: "If updating, prefer updating only to next minor version"
     method_option "major", type: :boolean, banner: "If updating, prefer updating to next major version (default)"

--- a/bundler/lib/bundler/cli/lock.rb
+++ b/bundler/lib/bundler/cli/lock.rb
@@ -14,6 +14,8 @@ module Bundler
         exit 1
       end
 
+      check_for_conflicting_options
+
       print = options[:print]
       previous_output_stream = Bundler.ui.output_stream
       Bundler.ui.output_stream = :stderr if print
@@ -60,6 +62,10 @@ module Bundler
 
         definition.resolve_remotely! unless options[:local]
 
+        if options["normalize-platforms"]
+          definition.normalize_platforms
+        end
+
         if print
           puts definition.to_lock
         else
@@ -69,6 +75,18 @@ module Bundler
       end
 
       Bundler.ui.output_stream = previous_output_stream
+    end
+
+    private
+
+    def check_for_conflicting_options
+      if options["normalize-platforms"] && options["add-platform"].any?
+        raise InvalidOption, "--normalize-platforms can't be used with --add-platform"
+      end
+
+      if options["normalize-platforms"] && options["remove-platform"].any?
+        raise InvalidOption, "--normalize-platforms can't be used with --remove-platform"
+      end
     end
   end
 end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -461,6 +461,12 @@ module Bundler
         "Add the current platform to the lockfile with\n`bundle lock --add-platform #{local_platform}` and try again."
     end
 
+    def normalize_platforms
+      @platforms = resolve.normalize_platforms!(current_dependencies, platforms)
+
+      @resolve = SpecSet.new(resolve.for(current_dependencies, false, @platforms))
+    end
+
     def add_platform(platform)
       return if @platforms.include?(platform)
 

--- a/tool/bundler/dev_gems.rb.lock
+++ b/tool/bundler/dev_gems.rb.lock
@@ -11,11 +11,17 @@ GEM
     nokogiri (1.16.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nokogiri (1.16.3-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.16.3-arm-linux)
+      racc (~> 1.4)
     nokogiri (1.16.3-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.3-java)
       racc (~> 1.4)
     nokogiri (1.16.3-x64-mingw-ucrt)
+      racc (~> 1.4)
+    nokogiri (1.16.3-x86-linux)
       racc (~> 1.4)
     nokogiri (1.16.3-x86_64-darwin)
       racc (~> 1.4)
@@ -58,17 +64,15 @@ GEM
 
 PLATFORMS
   aarch64-darwin
-  arm64-darwin-22
-  arm64-darwin-23
+  aarch64-linux
+  arm-linux
+  arm64-darwin
   java
   ruby
-  universal-java-11
-  universal-java-18
-  universal-java-19
+  universal-java
   x64-mingw-ucrt
-  x86_64-darwin-20
-  x86_64-darwin-21
-  x86_64-darwin-22
+  x86-linux
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES
@@ -92,9 +96,12 @@ CHECKSUMS
   mini_portile2 (2.8.5) sha256=7a37db8ae758086c3c3ac3a59c036704d331e965d5e106635e4a42d6e66089ce
   mustache (1.1.1) sha256=90891fdd50b53919ca334c8c1031eada1215e78d226d5795e523d6123a2717d0
   nokogiri (1.16.3) sha256=498aa253ccd5b89a0fa5c4c82b346d22176fc865f4a12ef8da642064d1d3e248
+  nokogiri (1.16.3-aarch64-linux) sha256=3d806263a0548e5163ff256655d78a87998fa83a5ae256b83c14a1a97731e824
+  nokogiri (1.16.3-arm-linux) sha256=cfb923c02bde065005e2521f0a6883c63cf305cb899a9dd4c74897731bb2af1d
   nokogiri (1.16.3-arm64-darwin) sha256=5d3268558c002fa493e33076798cfda1df8effbd5363060dc41595cfebb1cf90
   nokogiri (1.16.3-java) sha256=6bf0918233959c7d5e703061ada0f436544612397475a866aa314071f02bfabb
   nokogiri (1.16.3-x64-mingw-ucrt) sha256=656f163dd287671c3a28157a2e853ee1a36afeb3f4185a78af863f3980efc58d
+  nokogiri (1.16.3-x86-linux) sha256=08d8a369940fa2309379cd8af1e7b3cc702b0115d3ddd197cfa7b33daedfd541
   nokogiri (1.16.3-x86_64-darwin) sha256=bc22786f4db4c32a5587e3b77a106408148d3bb1602dd0b52c0f5c968c42d17d
   nokogiri (1.16.3-x86_64-linux) sha256=47a3330e41b49a100225b6fab490b2dc43410931e01e791886e0c2998412e8cb
   nronn (0.11.1) sha256=60305c7a42dcaf6bdd33210993a7e38087520717561da101bea1df7197546369

--- a/tool/bundler/lint_gems.rb.lock
+++ b/tool/bundler/lint_gems.rb.lock
@@ -36,9 +36,9 @@ GEM
 PLATFORMS
   java
   ruby
-  universal-java-11
+  universal-java
   x64-mingw-ucrt
-  x86_64-darwin-20
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES

--- a/tool/bundler/release_gems.rb.lock
+++ b/tool/bundler/release_gems.rb.lock
@@ -40,16 +40,10 @@ GEM
 PLATFORMS
   aarch64-darwin
   aarch64-linux
-  arm64-darwin-20
-  arm64-darwin-21
-  arm64-darwin-22
-  arm64-darwin-23
+  arm64-darwin
   ruby
-  universal-java-11
-  universal-java-18
-  x86_64-darwin-20
-  x86_64-darwin-21
-  x86_64-darwin-22
+  universal-java
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES

--- a/tool/bundler/rubocop_gems.rb.lock
+++ b/tool/bundler/rubocop_gems.rb.lock
@@ -55,19 +55,11 @@ GEM
 PLATFORMS
   aarch64-darwin
   aarch64-linux
-  arm64-darwin-20
-  arm64-darwin-21
-  arm64-darwin-22
-  arm64-darwin-23
+  arm64-darwin
   ruby
-  universal-java-11
-  universal-java-18
-  universal-java-19
+  universal-java
   x64-mingw-ucrt
-  x86_64-darwin-19
-  x86_64-darwin-20
-  x86_64-darwin-21
-  x86_64-darwin-22
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES

--- a/tool/bundler/standard_gems.rb.lock
+++ b/tool/bundler/standard_gems.rb.lock
@@ -71,19 +71,11 @@ GEM
 PLATFORMS
   aarch64-darwin
   aarch64-linux
-  arm64-darwin-20
-  arm64-darwin-21
-  arm64-darwin-22
-  arm64-darwin-23
+  arm64-darwin
   ruby
-  universal-java-11
-  universal-java-18
-  universal-java-19
+  universal-java
   x64-mingw-ucrt
-  x86_64-darwin-19
-  x86_64-darwin-20
-  x86_64-darwin-21
-  x86_64-darwin-22
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES

--- a/tool/bundler/test_gems.rb.lock
+++ b/tool/bundler/test_gems.rb.lock
@@ -34,11 +34,9 @@ GEM
 PLATFORMS
   java
   ruby
-  universal-java-11
-  universal-java-18
-  universal-java-19
+  universal-java
   x64-mingw-ucrt
-  x86_64-darwin-20
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES

--- a/tool/bundler/vendor_gems.rb.lock
+++ b/tool/bundler/vendor_gems.rb.lock
@@ -32,11 +32,9 @@ GEM
 PLATFORMS
   java
   ruby
-  universal-java-11
-  universal-java-18
-  universal-java-19
+  universal-java
   x64-mingw-ucrt
-  x86_64-darwin-20
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

These days Bundler is able to generate "universal lockfiles" that lock all the different platform gems that may get installed on each platform. This means we record the complete resolution (including platforms) in the lockfile, and those versions are exactly what get installed.

However, legacy lockfiles included only ruby platform gems. Resolution of which platform gem to install on each platform happened at install time and was not recorded in the lockfile. That meant that:

* We could end up with an incompatible set of gems if the platform gem that gets finally installed introduces new dependencies incompatible with the rest of the bundle. Say you have a-1 locked that depends on b-1, but `a-1-x86_64-linux` also depends on `c-1`. Then we end up missing dependencies since `c` is not recorded in the lockfile and only shows up at install time.

* It could also become a security issue. Say, so have `a-1` locked in your `Gemfile.lock`. If someone manages to release a malicious `a-1-x86_64-linux` gem, then that will suddenly start getting installed on Linux, even if you have a lockfile!

On top of this, that also means that the future "lockfile checksums" feature is partly ineffective on this kind of lockfile, because even if platform specific gems get installed, it's the generic platform checksum that gets recorded in the lockfile. That means even if the platform specific gem gets tampered, Bundler won't be able to detect that and raise a checksum mismatch error.

This old behavior is still preserved for lockfiles including only "ruby" as the platform for backwards compatibility, but we would like to eventually move away from that to fix all of the above issues.

## What is your fix for the problem, implemented in this PR?

This PR introduces a flag to `bundle lock` to normalize a lockfile and make it more similar to what's generated by default for fresh lockfiles.

At a latter step I will deprecate "resolution of platforms at install time" and recommend using this flag to record specific platform variants in the lockfile. 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
