### PR TITLE
Changelogs for RubyGems 3.5.17 and Bundler 2.5.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# 3.5.17 / 2024-08-01
+
+## Enhancements:
+
+* Explicitly encode `Gem::Dependency` to yaml. Pull request
+  [#7867](https://github.com/rubygems/rubygems/pull/7867) by segiddins
+* Installs bundler 2.5.17 as a default gem.
+
+## Bug fixes:
+
+* Fix `gem list` regression when a regular gem shadows a default one. Pull
+  request [#7892](https://github.com/rubygems/rubygems/pull/7892) by
+  deivid-rodriguez
+* Always leave default gem executables around. Pull request
+  [#7879](https://github.com/rubygems/rubygems/pull/7879) by
+  deivid-rodriguez
+* Fix line comment issue for hash when loading gemrc. Pull request
+  [#7857](https://github.com/rubygems/rubygems/pull/7857) by leetking
+
 # 3.5.16 / 2024-07-18
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 2.5.17 (August 1, 2024)
+
+## Enhancements:
+
+  - Print better log message when current platform is not present in the lockfile [#7891](https://github.com/rubygems/rubygems/pull/7891)
+  - Explicitly encode `Gem::Dependency` to yaml [#7867](https://github.com/rubygems/rubygems/pull/7867)
+  - Enable lockfile checksums on future Bundler 3 when there's no previous lockfile [#7805](https://github.com/rubygems/rubygems/pull/7805)
+
+## Bug fixes:
+
+  - Fix truffleruby removing gems from lockfile [#7795](https://github.com/rubygems/rubygems/pull/7795)
+  - Fix `bundle check` exit code when gem git source is not checked out [#7894](https://github.com/rubygems/rubygems/pull/7894)
+  - Generate gems.rb from Gemfile.tt template for `bundle-gem` [#7853](https://github.com/rubygems/rubygems/pull/7853)
+  - Fix git source cache being used as the install location [#4469](https://github.com/rubygems/rubygems/pull/4469)
+  - Fix `bundle exec gem uninstall` [#7886](https://github.com/rubygems/rubygems/pull/7886)
+
 # 2.5.16 (July 18, 2024)
 
 ## Bug fixes:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.5.17 and Bundler 2.5.17 into master.