### PR TITLE
Remove some `file_uri_for` calls

### DIFF
--- a/bundler/spec/cache/git_spec.rb
+++ b/bundler/spec/cache/git_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe "bundle cache with git" do
     build_git "foo"
 
     gemfile <<-G
-      source "#{file_uri_for(gem_repo1)}"
+      source "https://gem.repo1"
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
     bundle "config set path vendor/bundle"
@@ -176,7 +176,7 @@ RSpec.describe "bundle cache with git" do
     build_git "foo"
 
     gemfile <<-G
-      source "#{file_uri_for(gem_repo1)}"
+      source "https://gem.repo1"
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
     bundle "config set cache_all true"
@@ -195,7 +195,7 @@ RSpec.describe "bundle cache with git" do
     build_git "foo"
 
     gemfile <<-G
-      source "#{file_uri_for(gem_repo1)}"
+      source "https://gem.repo1"
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
     bundle "config set cache_all true"
@@ -331,7 +331,7 @@ RSpec.describe "bundle cache with git" do
     bundle "config set cache_all all"
 
     install_gemfile <<-G
-      source "#{file_uri_for(gem_repo1)}"
+      source "https://gem.repo1"
       gem "puma", :git => "#{lib_path("puma-1.0")}"
     G
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I merged #4469, a very old PR, and it included some old `file_uri_for` usages. Recently those were migrated to more realworld https uri's.
 
## What is your fix for the problem, implemented in this PR?

Use `https` uris for the new tests.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
