### PR TITLE
Fix `bundle update <indirect_dep>` failing to upgrade when versions present in two different sources

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -476,9 +476,6 @@ module Bundler
       end
     end
 
-    attr_reader :sources
-    private :sources
-
     def nothing_changed?
       return false unless lockfile_exists?
 
@@ -503,6 +500,8 @@ module Bundler
     end
 
     private
+
+    attr_reader :sources
 
     def should_add_extra_platforms?
       !lockfile_exists? && generic_local_platform_is_ruby? && !Bundler.settings[:force_ruby_platform]

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -214,6 +214,7 @@ module Bundler
       @resolve = nil
       @resolver = nil
       @resolution_packages = nil
+      @source_requirements = nil
       @specs = nil
 
       Bundler.ui.debug "The definition is missing dependencies, failed to resolve & materialize locally (#{e})"
@@ -498,6 +499,8 @@ module Bundler
     def unlocking?
       @unlocking
     end
+
+    attr_writer :source_requirements
 
     private
 
@@ -971,6 +974,10 @@ module Bundler
     end
 
     def source_requirements
+      @source_requirements ||= find_source_requirements
+    end
+
+    def find_source_requirements
       # Record the specs available in each gem's source, so that those
       # specs will be available later when the resolver knows where to
       # look for that gemspec (or its dependencies)
@@ -1052,6 +1059,7 @@ module Bundler
 
     def dup_for_full_unlock
       unlocked_definition = self.class.new(@lockfile, @dependencies, @sources, true, @ruby_version, @optional_groups, @gemfiles)
+      unlocked_definition.source_requirements = source_requirements
       unlocked_definition.gem_version_promoter.tap do |gvp|
         gvp.level = gem_version_promoter.level
         gvp.strict = gem_version_promoter.strict

--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe "bundle outdated" do
         build_gem "vcr", "6.0.0"
       end
 
-      build_repo gem_repo3 do
+      build_repo3 do
         build_gem "pkg-gem-flowbyte-with-dep", "1.0.0" do |s|
           s.add_dependency "oj"
         end

--- a/bundler/spec/commands/remove_spec.rb
+++ b/bundler/spec/commands/remove_spec.rb
@@ -409,7 +409,7 @@ RSpec.describe "bundle remove" do
 
   context "with sources" do
     before do
-      build_repo gem_repo3 do
+      build_repo3 do
         build_gem "rspec"
       end
     end

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -956,7 +956,7 @@ RSpec.describe "bundle update" do
         build_gem "vcr", "6.0.0"
       end
 
-      build_repo gem_repo3 do
+      build_repo3 do
         build_gem "pkg-gem-flowbyte-with-dep", "1.0.0" do |s|
           s.add_dependency "oj"
         end

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
     before do
       # Oh no! Someone evil is trying to hijack myrack :(
       # need this to be broken to check for correct source ordering
-      build_repo gem_repo3 do
+      build_repo3 do
         build_gem "myrack", repo3_myrack_version do |s|
           s.write "lib/myrack.rb", "MYRACK = 'FAIL'"
         end
@@ -156,7 +156,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       before do
         # Oh no! Someone evil is trying to hijack myrack :(
         # need this to be broken to check for correct source ordering
-        build_repo gem_repo3 do
+        build_repo3 do
           build_gem "myrack", "1.0.0" do |s|
             s.write "lib/myrack.rb", "MYRACK = 'FAIL'"
           end
@@ -200,7 +200,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       before do
         # Oh no! Someone evil is trying to hijack myrack :(
         # need this to be broken to check for correct source ordering
-        build_repo gem_repo3 do
+        build_repo3 do
           build_gem "myrack", "1.0.0" do |s|
             s.write "lib/myrack.rb", "MYRACK = 'FAIL'"
           end
@@ -225,7 +225,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
     context "when a pinned gem has an indirect dependency in the pinned source" do
       before do
-        build_repo gem_repo3 do
+        build_repo3 do
           build_gem "depends_on_myrack", "1.0.1" do |s|
             s.add_dependency "myrack"
           end
@@ -287,7 +287,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       before do
         # In these tests, we need a working myrack gem in repo2 and not repo3
 
-        build_repo gem_repo3 do
+        build_repo3 do
           build_gem "depends_on_myrack", "1.0.1" do |s|
             s.add_dependency "myrack"
           end
@@ -502,7 +502,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       before do
         build_repo2
 
-        build_repo gem_repo3 do
+        build_repo3 do
           build_gem "private_gem_1", "1.0.0"
           build_gem "private_gem_2", "1.0.0"
         end
@@ -528,7 +528,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       before do
         build_repo2
 
-        build_repo gem_repo3 do
+        build_repo3 do
           build_gem "depends_on_missing", "1.0.1" do |s|
             s.add_dependency "missing"
           end
@@ -565,7 +565,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           end
         end
 
-        build_repo gem_repo3 do
+        build_repo3 do
           build_gem "unrelated_gem", "1.0.0"
         end
 
@@ -645,7 +645,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
     context "when a scoped gem has a deeply nested indirect dependency" do
       before do
-        build_repo gem_repo3 do
+        build_repo3 do
           build_gem "depends_on_depends_on_myrack", "1.0.1" do |s|
             s.add_dependency "depends_on_myrack"
           end
@@ -764,7 +764,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           build_gem "zeitwerk", "2.4.2"
         end
 
-        build_repo gem_repo3 do
+        build_repo3 do
           build_gem "sidekiq-pro", "5.2.1" do |s|
             s.add_dependency "connection_pool", ">= 2.2.3"
             s.add_dependency "sidekiq", ">= 6.1.0"
@@ -1080,7 +1080,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
     context "when a pinned gem has an indirect dependency with more than one level of indirection in the default source " do
       before do
-        build_repo gem_repo3 do
+        build_repo3 do
           build_gem "handsoap", "0.2.5.5" do |s|
             s.add_dependency "nokogiri", ">= 1.2.3"
           end
@@ -1157,7 +1157,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
     context "with a gem that is only found in the wrong source" do
       before do
-        build_repo gem_repo3 do
+        build_repo3 do
           build_gem "not_in_repo1", "1.0.0"
         end
 
@@ -1250,7 +1250,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       end
 
       before do
-        build_repo gem_repo3 do
+        build_repo3 do
           build_gem "myrack", "0.9.1"
         end
 
@@ -1393,7 +1393,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
   context "re-resolving" do
     context "when there is a mix of sources in the gemfile" do
       before do
-        build_repo gem_repo3 do
+        build_repo3 do
           build_gem "myrack"
         end
 

--- a/bundler/spec/install/prereleases_spec.rb
+++ b/bundler/spec/install/prereleases_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "bundle install" do
 
   describe "when prerelease gems are not available" do
     it "still works" do
-      build_repo gem_repo3 do
+      build_repo3 do
         build_gem "myrack"
       end
       FileUtils.rm_rf Dir[gem_repo3("prerelease*")]

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -454,7 +454,7 @@ RSpec.describe "major deprecations" do
 
   context "bundle install in frozen mode with a lockfile with a single rubygems section with multiple remotes" do
     before do
-      build_repo gem_repo3 do
+      build_repo3 do
         build_gem "myrack", "0.9.1"
       end
 

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -188,9 +188,15 @@ module Spec
 
     # A repo that has no pre-installed gems included. (The caller completely
     # determines the contents with the block.)
+    def build_repo3(**kwargs, &blk)
+      build_empty_repo gem_repo3, **kwargs, &blk
+    end
+
+    # Like build_repo3, this is a repo that has no pre-installed gems included.
+    # We have two different methods for situations where two different empty
+    # sources are needed.
     def build_repo4(**kwargs, &blk)
-      FileUtils.rm_rf gem_repo4
-      build_repo(gem_repo4, **kwargs, &blk)
+      build_empty_repo gem_repo4, **kwargs, &blk
     end
 
     def update_repo4(&blk)
@@ -306,6 +312,11 @@ module Spec
     end
 
     private
+
+    def build_empty_repo(gem_repo, **kwargs, &blk)
+      FileUtils.rm_rf gem_repo
+      build_repo(gem_repo, **kwargs, &blk)
+    end
 
     def build_with(builder, name, args, &blk)
       @_build_path ||= nil


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When a transitive dependency `foo` is present in two sources, but only the locked one has upgrades, `bundle update <foo>` is not able to upgrade the gem.

Also, we may also end up running into resolution errors, since the latest version available is being picked up from the wrong source, and when `bundle update <specific_gem>` is run, and additional exact requirement is added in order to force the upgrade.

## What is your fix for the problem, implemented in this PR?

My fix is to make sure that once we resolve `source_requirements` the first time, we also use those requirements when running the additional fully unlocked resolution that we run in order to figure out what the latest version of `foo` is.

Fixes #7909. 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
