### PR TITLE
Don't remove existing platform gems when PLATFORMS section is badly indented

### DIFF
--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -272,7 +272,7 @@ module Bundler
     end
 
     def parse_platform(line)
-      @platforms << Gem::Platform.new($1) if line =~ /^  (.*)$/
+      @platforms << Gem::Platform.new($1.strip) if line =~ /^  (.*)$/
     end
 
     def parse_bundled_with(line)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If for whatever reason, the `PLATFORMS` section in the lockfile is badly indented, then Bundler will succeed but confusingly remove all previous platforms and platform specific gems from the lockfile.
 
## What is your fix for the problem, implemented in this PR?

My fix is to instead correct the indentation but keep existing platforms and platform gems.

Fixes #7741.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
