### PR TITLE
Regenerate previous git application caches that didn't include bare repos

### DIFF
--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -188,9 +188,11 @@ module Bundler
       end
 
       def specs(*)
-        set_cache_path!(app_cache_path) if has_app_cache? && !local?
+        set_cache_path!(app_cache_path) if use_app_cache?
 
         if requires_checkout? && !@copied
+          FileUtils.rm_rf(app_cache_path) if use_app_cache? && git_proxy.not_a_bare_repository?
+
           fetch
           checkout
         end
@@ -319,6 +321,10 @@ module Bundler
 
       def has_app_cache?
         cached_revision && super
+      end
+
+      def use_app_cache?
+        has_app_cache? && !local?
       end
 
       def requires_checkout?

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -84,6 +84,10 @@ module Bundler
           end
         end
 
+        def not_a_bare_repository?
+          git_local("rev-parse", "--is-bare-repository", dir: path).strip == "false"
+        end
+
         def contains?(commit)
           allowed_with_path do
             result, status = git_null("branch", "--contains", commit, dir: path)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In https://github.com/rubygems/rubygems/pull/4469, we fixed application caches being used as the final install location, instead of as a real cache like it does for standard gems.

However, even if I thought I had explicitly checked how the patched worked with existing caches, we found that it actually breaks if a cache already exists.

## What is your fix for the problem, implemented in this PR?

Even though existing caches were somewhat broken, the did seem to work in some cases, so it'd be better to handle them better.

So my solution is to regenerate them in the new format (a bare clone of the cached repo).

Fixes https://github.com/rubygems/rubygems/pull/4469#issuecomment-2266659113.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
