### PR TITLE
Simplify `Gem.read_binary` and `Gem.write_binary`

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -773,18 +773,14 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   # Safely read a file in binary mode on all platforms.
 
   def self.read_binary(path)
-    open_file(path, "rb+", &:read)
-  rescue Errno::EACCES, Errno::EROFS
-    open_file(path, "rb", &:read)
+    File.binread(path)
   end
 
   ##
   # Safely write a file in binary mode on all platforms.
 
   def self.write_binary(path, data)
-    open_file(path, "wb") do |io|
-      io.write data
-    end
+    File.binwrite(path, data)
   rescue Errno::ENOSPC
     # If we ran out of space but the file exists, it's *guaranteed* to be corrupted.
     File.delete(path) if File.exist?(path)

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -2386,10 +2386,10 @@ end
     installer = Gem::Installer.for_spec @spec
     installer.gem_home = @gemhome
 
-    File.class_eval do
-      alias_method :original_write, :write
+    File.singleton_class.class_eval do
+      alias_method :original_binwrite, :binwrite
 
-      def write(data)
+      def binwrite(path, data)
         raise Errno::ENOSPC
       end
     end
@@ -2400,10 +2400,10 @@ end
 
     assert_path_not_exist @spec.spec_file
   ensure
-    File.class_eval do
-      remove_method :write
-      alias_method :write, :original_write
-      remove_method :original_write
+    File.singleton_class.class_eval do
+      remove_method :binwrite
+      alias_method :binwrite, :original_binwrite
+      remove_method :original_binwrite
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

https://github.com/rubygems/rubygems/pull/7806#discussion_r1698091858
> This looks that Gem.read_binary and Gem.write_binary would no longer lock the target file.

## What is your fix for the problem, implemented in this PR?

Since `Gem.open_file` no longer locks the target file and is same as `File.open` now, simply `Gem.read_binary` should read in binary mode. Also the body of `Gem.write_binary` is same as `File.binwrite`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
