### PR TITLE
bundler/inline: re-exec script after installation

### DIFF
--- a/bundler/lib/bundler/inline.rb
+++ b/bundler/lib/bundler/inline.rb
@@ -60,6 +60,11 @@ def gemfile(install = false, options = {}, &gemfile)
             Bundler.ui.info "Post-install message from #{name}:\n#{message}"
           end
         end
+
+        unless install
+          Bundler.ui.info "Re-executing program with installed gems"
+          Process.exec(RbConfig.ruby, $PROGRAM_NAME, *ARGV)
+        end
       end
 
       runtime = Bundler::Runtime.new(nil, definition)


### PR DESCRIPTION
Alternate: https://github.com/rubygems/rubygems/pull/7930
Fix: https://github.com/rubygems/rubygems/pull/7930

When bundler inline has to install gems, it loads more dependencies than when it goes through the fast path of all gems being installed.

One of them is `securerandom` so if trying to use `bundler/inline` with a gem that have a dependency on `securerandom` that don't match the default version, the script fails with `Gem::LoadError`.

This can be preproduced on Ruby 3.2.x, after making sure to `gem uninstall securerandom` so only the default gem remains`, and then running the following script:

```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'
  gem 'activesupport', '7.2.0' # depends on securerandom >= 0.3
end

require 'securerandom'
```
