### PR TITLE
Change new gem README template to have copyable code blocks

### DIFF
--- a/bundler/lib/bundler/templates/newgem/README.md.tt
+++ b/bundler/lib/bundler/templates/newgem/README.md.tt
@@ -10,11 +10,15 @@ TODO: Replace `UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_O
 
 Install the gem and add to the application's Gemfile by executing:
 
-    $ bundle add UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG
+```bash
+bundle add UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG
+```
 
 If bundler is not being used to manage dependencies, install the gem by executing:
 
-    $ gem install UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG
+```bash
+gem install UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG
+```
 
 ## Usage
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In every new ruby gem I create I'm always updating the code blocks to install the gem to be copyable in the GitHub UI, most recently: https://github.com/thedayisntgray/SimpleRag/pull/2

Currently, if you copy the code block with the GitHub UI copy button you also copy the `$` and whenever you paste it you have to delete the dollar sign. In the modern times of typo-squatting I prefer to copy the gem name from the README, but with the dollar sign it's quite annoying. Also for all the users of a gem which might have a similar workflow.

## What is your fix for the problem, implemented in this PR?

This pull request rewrites the code blocks to use the triple backticks Markdown syntax for the code blocks and removes the dollar sign from the code blocks.

| Before | 
| --- | 
|  ![CleanShot 2024-08-13 at 13 59 35](https://github.com/user-attachments/assets/dc1c0560-4596-4e89-bb1a-f8115ad515fc) |

| After |
| --- |
 | ![CleanShot 2024-08-13 at 14 00 10](https://github.com/user-attachments/assets/0241c36b-0b67-4627-8d9f-25e2e3b800e2) |




## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
