### PR TITLE
`--prefer-local` flag should respect sub-dependencies too

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -636,6 +636,14 @@ module Bundler
 
       result = SpecSet.new(resolver.start)
 
+      # Prefer local versions for sub dependencies too
+      if @prefer_local
+        all_requirements = SourceMap.new(sources, result, @locked_specs).all_requirements
+        all_requirements = pin_locally_available_names(all_requirements)
+        @source_requirements.merge!(all_requirements)
+        result = SpecSet.new(resolver.start)
+      end
+
       @resolved_bundler_version = result.find {|spec| spec.name == "bundler" }&.version
 
       if @most_specific_non_local_locked_ruby_platform

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -1362,6 +1362,10 @@ RSpec.describe "bundle install with gem sources" do
         build_gem "foo", "1.0.1"
         build_gem "foo", "1.0.0"
         build_gem "bar", "1.0.0"
+
+        build_gem "a", "1.0.0" do |s|
+          s.add_dependency "foo", "~> 1.0.0"
+        end
       end
 
       system_gems "foo-1.0.0", path: default_bundle_path, gem_repo: gem_repo4
@@ -1376,6 +1380,17 @@ RSpec.describe "bundle install with gem sources" do
       G
 
       expect(out).to include("Using foo 1.0.0").and include("Fetching bar 1.0.0").and include("Installing bar 1.0.0")
+      expect(last_command).to be_success
+    end
+
+    it "fetches remote sources for sub-dependencies only when not available locally", focus: true do
+      install_gemfile <<-G, "prefer-local": true, verbose: true
+        source "https://gem.repo4"
+
+        gem "a"
+      G
+
+      expect(out).to include("Using foo 1.0.0").and include("Fetching a 1.0.0").and include("Installing a 1.0.0")
       expect(last_command).to be_success
     end
   end

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -1383,7 +1383,7 @@ RSpec.describe "bundle install with gem sources" do
       expect(last_command).to be_success
     end
 
-    it "fetches remote sources for sub-dependencies only when not available locally", focus: true do
+    it "fetches remote sources for sub-dependencies only when not available locally" do
       install_gemfile <<-G, "prefer-local": true, verbose: true
         source "https://gem.repo4"
 


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

The `--prefer-local` flag works well to use locally installed gems. But it does not respect sub-dependencies and continues to fetch the latest ones.

For example, in my [ruby bootstrap](https://github.com/jekyllex/ruby-android) at [JekyllEx](https://github.com/jekyllex), I include pre-compiled native gem for `google-protobuf`(`v4.27.2`). `sass-embedded` depends on it, but I don't bundle it in my bootstrap. Now if a user has to have `sass-embedded` as a dependency, no matter if I include a satisfactory version of `google-protobuf` and use the `--prefer-local` flag it will still fetch and try to install the latest gem. This fails because building native extensions is prohibited in my environment.

For top level dependencies in `Gemfile`, the `--prefer-local` would use the local gems. But sub-dependencies are ignored. This PR introduces logic to prefer using local gems that may satisfy the sub-dependency requirement.

IMO, this should be the default because as a flag, `--prefer-local` should apply to the whole dependency tree.

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

I've added a test that describes the scenario. The code implementation tries to use the already existing `pin_locally_available_names` function for the `SpecSet` that the resolver generates. This way, the local gems get preferred. 

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write code to solve the problem
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
