### PR TITLE
Remove temporary `.lock` files unintentionally left around by gem installer

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -794,7 +794,9 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     File.open(path, flags, &block)
   end
 
-  MODE_TO_FLOCK = IO::RDONLY | IO::APPEND | IO::CREAT | IO::SHARE_DELETE | IO::BINARY # :nodoc:
+  mode = IO::RDONLY | IO::APPEND | IO::CREAT | IO::BINARY
+  mode |= IO::SHARE_DELETE if IO.const_defined?(:SHARE_DELETE)
+  MODE_TO_FLOCK = mode # :nodoc:
 
   ##
   # Open a file with given flags, and protect access with flock

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -794,7 +794,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     File.open(path, flags, &block)
   end
 
-  MODE_TO_FLOCK = IO::RDONLY | IO::APPEND | IO::CREAT # :nodoc:
+  MODE_TO_FLOCK = IO::RDONLY | IO::APPEND | IO::CREAT | IO::SHARE_DELETE | IO::BINARY # :nodoc:
 
   ##
   # Open a file with given flags, and protect access with flock

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -538,7 +538,7 @@ class Gem::Installer
   def generate_bin_script(filename, bindir)
     bin_script_path = File.join bindir, formatted_program_filename(filename)
 
-    Gem.open_file_with_flock("#{bin_script_path}.lock") do
+    Gem.open_file_with_flock("#{bin_script_path}.lock") do |lock|
       require "fileutils"
       FileUtils.rm_f bin_script_path # prior install may have been --no-wrappers
 
@@ -546,6 +546,7 @@ class Gem::Installer
         file.write app_script_text(filename)
         file.chmod(options[:prog_mode] || 0o755)
       end
+      File.unlink(lock.path)
     end
 
     verbose bin_script_path

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -546,7 +546,8 @@ class Gem::Installer
         file.write app_script_text(filename)
         file.chmod(options[:prog_mode] || 0o755)
       end
-      File.unlink(lock.path)
+    ensure
+      FileUtils.rm_f lock.path
     end
 
     verbose bin_script_path

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1083,6 +1083,8 @@ end
     end
 
     assert_match(/ran executable/, e.message)
+
+    assert_path_not_exist(File.join(installer.bin_dir, "executable.lock"))
   end
 
   def test_conflicting_binstubs
@@ -1131,6 +1133,8 @@ end
     # We expect the bin stub to activate the version that actually contains
     # the binstub.
     assert_match("I have an executable", e.message)
+
+    assert_path_not_exist(File.join(installer.bin_dir, "executable.lock"))
   end
 
   def test_install_creates_binstub_that_understand_version
@@ -1160,6 +1164,8 @@ end
     end
 
     assert_includes(e.message, "can't find gem a (= 3.0)")
+
+    assert_path_not_exist(File.join(installer.bin_dir, "executable.lock"))
   end
 
   def test_install_creates_binstub_that_prefers_user_installed_gem_to_default
@@ -1192,6 +1198,8 @@ end
     end
 
     assert_equal(e.message, "ran executable")
+
+    assert_path_not_exist(File.join(installer.bin_dir, "executable.lock"))
   end
 
   def test_install_creates_binstub_that_dont_trust_encoding
@@ -1222,6 +1230,8 @@ end
     end
 
     assert_match(/ran executable/, e.message)
+
+    assert_path_not_exist(File.join(installer.bin_dir, "executable.lock"))
   end
 
   def test_install_with_no_prior_files


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

_Originally posted by @sunpoet in https://github.com/rubygems/rubygems/issues/7806#issuecomment-2241662488_
> IIUC, the lock files were created to avoid the breakage while modifying the conflicting binstub from mutliple gems. If so, could you please consider removing the lock files when the operation is done.
> 
> ```
> % ls -l bin/
> total 1
> -rwxr-xr-x  1 sunpoet wheel 568 Jul 21 20:00 bundle
> -rw-r--r--  1 sunpoet wheel   0 Jul 21 20:00 bundle.lock
> -rwxr-xr-x  1 sunpoet wheel 570 Jul 21 20:00 bundler
> -rw-r--r--  1 sunpoet wheel   0 Jul 21 20:00 bundler.lock
> ```

## What is your fix for the problem, implemented in this PR?

Remove lock files at the end of locking.

Fixes #7997.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
