### PR TITLE
Add better error when trying to develop RubyGems with an unsupported Ruby version

### DIFF
--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+abort "RubyGems only supports Ruby 3.0 or higher" if RUBY_VERSION < "3.0.0"
+
 require_relative "path"
 
 $LOAD_PATH.unshift(Spec::Path.source_lib_dir.to_s)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If you try to setup a RubyGems development environment with an unsupported Ruby version, you'll end up with a very verbose and confusing error buried in Bundler code defining methods using endless method definitions (introduced in Ruby 3.0).

## What is your fix for the problem, implemented in this PR?

Add a more explicit error.

Fixes https://github.com/rubygems/rubygems/pull/7709#issuecomment-2275506786.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
