### PR TITLE
Fix Dependabot PR grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,6 @@ updates:
   - package-ecosystem: 'cargo'
     directories:
       - '/test/rubygems/test_gem_ext_cargo_builder/custom_name/ext/custom_name_lib'
-      - '/test/rubygems/test_gem_ext_cargo_builder/rust_ruby_example/'
+      - '/test/rubygems/test_gem_ext_cargo_builder/rust_ruby_example'
     schedule:
       interval: 'weekly'


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Dependabot is not correctly groping cargo PRs.

## What is your fix for the problem, implemented in this PR?

I wonder if the problem is the trailing slash I'm removing in this PR.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
