### PR TITLE
Fix `gem uninstall <name>:<version>` failing on shadowed default gems

### DIFF
--- a/lib/rubygems/commands/uninstall_command.rb
+++ b/lib/rubygems/commands/uninstall_command.rb
@@ -157,9 +157,14 @@ that is a dependency of an existing gem.  You can use the
 
       gem_specs = Gem::Specification.find_all_by_name(name, original_gem_version[name])
 
-      say("Gem '#{name}' is not installed") if gem_specs.empty?
-      gem_specs.each do |spec|
-        deplist.add spec
+      if gem_specs.empty?
+        say("Gem '#{name}' is not installed")
+      else
+        gem_specs.reject!(&:default_gem?) if gem_specs.size > 1
+
+        gem_specs.each do |spec|
+          deplist.add spec
+        end
       end
     end
 

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -111,6 +111,31 @@ class TestGemCommandsUninstallCommand < Gem::InstallerTestCase
     assert_equal "There was both a regular copy and a default copy of z-1. The regular copy was successfully uninstalled, but the default copy was left around because default gems can't be removed.", output.shift
   end
 
+  def test_execute_does_not_error_on_shadowed_default_gems
+    z_1_default = new_default_spec "z", "1"
+    install_default_gems z_1_default
+
+    z_1 = util_spec "z", "1" do |spec|
+      spec.date = "2024-01-01"
+    end
+    install_gem z_1
+
+    Gem::Specification.reset
+
+    @cmd.options[:args] = %w[z:1]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    output = @ui.output.split "\n"
+    assert_equal "Successfully uninstalled z-1", output.shift
+    assert_equal "There was both a regular copy and a default copy of z-1. The regular copy was successfully uninstalled, but the default copy was left around because default gems can't be removed.", output.shift
+
+    error = @ui.error.split "\n"
+    assert_empty error
+  end
+
   def test_execute_dependency_order
     initial_install
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`gem uninstall <name>:<version>` first uninstalls the requested version, but then fails, if there's both a default and regular copy of `<name>-<version>`. This is because we first uninstall the regular copy, and then fail when trying to uninstall the default copy because the gem is no longer present.

## What is your fix for the problem, implemented in this PR?

Ignore the default copy in this particular case.

Fixes #6347.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
