### PR TITLE
Restore support for passing relative paths to `git:` sources

### DIFF
--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -332,8 +332,6 @@ module Bundler
             config_auth = Bundler.settings[remote.to_s] || Bundler.settings[remote.host]
             remote.userinfo ||= config_auth
             remote.to_s
-          elsif File.exist?(uri)
-            "file://#{uri}"
           else
             uri.to_s
           end

--- a/bundler/spec/install/allow_offline_install_spec.rb
+++ b/bundler/spec/install/allow_offline_install_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "bundle install with :allow_offline_install" do
           fetch_args = %w(fetch --force --quiet --no-tags)
           clone_args = %w(clone --bare --no-hardlinks --quiet)
 
-          if (fetch_args.-(ARGV).empty? || clone_args.-(ARGV).empty?) && ARGV.any? {|arg| arg.start_with?("file://") }
+          if (fetch_args.-(ARGV).empty? || clone_args.-(ARGV).empty?) && File.exist?(ARGV[ARGV.index("--") + 1])
             warn "git remote ops have been disabled"
             exit 1
           end

--- a/bundler/spec/install/allow_offline_install_spec.rb
+++ b/bundler/spec/install/allow_offline_install_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "bundle install with :allow_offline_install" do
       File.open(tmp("broken_path/git"), "w", 0o755) do |f|
         f.puts <<~RUBY
           #!/usr/bin/env ruby
-          fetch_args = %w(fetch --force --quiet)
+          fetch_args = %w(fetch --force --quiet --no-tags)
           clone_args = %w(clone --bare --no-hardlinks --quiet)
 
           if (fetch_args.-(ARGV).empty? || clone_args.-(ARGV).empty?) && ARGV.any? {|arg| arg.start_with?("file://") }

--- a/bundler/spec/install/git_spec.rb
+++ b/bundler/spec/install/git_spec.rb
@@ -14,6 +14,19 @@ RSpec.describe "bundle install" do
       expect(the_bundle).to include_gems "foo 1.0", source: "git@#{lib_path("foo")}"
     end
 
+    it "displays the revision hash of the gem repository when passed a relative local path" do
+      build_git "foo", "1.0", path: lib_path("foo")
+
+      relative_path = lib_path("foo").relative_path_from(bundled_app)
+      install_gemfile <<-G, verbose: true
+        source "https://gem.repo1"
+        gem "foo", :git => "#{relative_path}"
+      G
+
+      expect(out).to include("Using foo 1.0 from #{relative_path} (at main@#{revision_for(lib_path("foo"))[0..6]})")
+      expect(the_bundle).to include_gems "foo 1.0", source: "git@#{lib_path("foo")}"
+    end
+
     it "displays the correct default branch", git: ">= 2.28.0" do
       build_git "foo", "1.0", path: lib_path("foo"), default_branch: "main"
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This used to work before and I think it's simpler to restore support than giving a proper error message.

## What is your fix for the problem, implemented in this PR?

Restore support.

Fixes #7925.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
