### PR TITLE
Fix several issues with the `--prefer-local` flag

### DIFF
--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -84,9 +84,9 @@ module Bundler
     rescue PubGrub::SolveFailure => e
       incompatibility = e.incompatibility
 
-      names_to_unlock, names_to_allow_prereleases_for, extended_explanation = find_names_to_relax(incompatibility)
+      names_to_unlock, names_to_allow_prereleases_for, names_to_allow_remote_specs_for, extended_explanation = find_names_to_relax(incompatibility)
 
-      names_to_relax = names_to_unlock + names_to_allow_prereleases_for
+      names_to_relax = names_to_unlock + names_to_allow_prereleases_for + names_to_allow_remote_specs_for
 
       if names_to_relax.any?
         if names_to_unlock.any?
@@ -99,6 +99,12 @@ module Bundler
           Bundler.ui.debug "Found conflicts with dependencies with prereleases. Will retry considering prereleases for #{names_to_allow_prereleases_for.join(", ")}...", true
 
           @base.include_prereleases(names_to_allow_prereleases_for)
+        end
+
+        if names_to_allow_remote_specs_for.any?
+          Bundler.ui.debug "Found conflicts with local versions of #{names_to_allow_remote_specs_for.join(", ")}. Will retry considering remote versions...", true
+
+          @base.include_remote_specs(names_to_allow_remote_specs_for)
         end
 
         root, logger = setup_solver
@@ -120,6 +126,7 @@ module Bundler
     def find_names_to_relax(incompatibility)
       names_to_unlock = []
       names_to_allow_prereleases_for = []
+      names_to_allow_remote_specs_for = []
       extended_explanation = nil
 
       while incompatibility.conflict?
@@ -134,6 +141,8 @@ module Bundler
             names_to_unlock << name
           elsif package.ignores_prereleases? && @all_specs[name].any? {|s| s.version.prerelease? }
             names_to_allow_prereleases_for << name
+          elsif package.prefer_local? && @all_specs[name].any? {|s| !s.is_a?(StubSpecification) }
+            names_to_allow_remote_specs_for << name
           end
 
           no_versions_incompat = [cause.incompatibility, cause.satisfier].find {|incompat| incompat.cause.is_a?(PubGrub::Incompatibility::NoVersions) }
@@ -143,7 +152,7 @@ module Bundler
         end
       end
 
-      [names_to_unlock.uniq, names_to_allow_prereleases_for.uniq, extended_explanation]
+      [names_to_unlock.uniq, names_to_allow_prereleases_for.uniq, names_to_allow_remote_specs_for.uniq, extended_explanation]
     end
 
     def parse_dependency(package, dependency)
@@ -244,7 +253,7 @@ module Bundler
 
     def all_versions_for(package)
       name = package.name
-      results = (@base[name] + filter_prereleases(@all_specs[name], package)).uniq {|spec| [spec.version.hash, spec.platform] }
+      results = (@base[name] + filter_specs(@all_specs[name], package)).uniq {|spec| [spec.version.hash, spec.platform] }
 
       if name == "bundler" && !bundler_pinned_to_current_version?
         bundler_spec = Gem.loaded_specs["bundler"]
@@ -368,10 +377,20 @@ module Bundler
       end
     end
 
+    def filter_specs(specs, package)
+      filter_remote_specs(filter_prereleases(specs, package), package)
+    end
+
     def filter_prereleases(specs, package)
       return specs unless package.ignores_prereleases? && specs.size > 1
 
       specs.reject {|s| s.version.prerelease? }
+    end
+
+    def filter_remote_specs(specs, package)
+      return specs unless package.prefer_local?
+
+      specs.select {|s| s.is_a?(StubSpecification) }
     end
 
     # Ignore versions that depend on themselves incorrectly
@@ -405,10 +424,13 @@ module Bundler
 
         dep_range = dep_constraint.range
         versions = select_sorted_versions(dep_package, dep_range)
-        if versions.empty? && dep_package.ignores_prereleases?
-          @all_versions.delete(dep_package)
-          @sorted_versions.delete(dep_package)
-          dep_package.consider_prereleases!
+        if versions.empty?
+          if dep_package.ignores_prereleases? || dep_package.prefer_local?
+            @all_versions.delete(dep_package)
+            @sorted_versions.delete(dep_package)
+          end
+          dep_package.consider_prereleases! if dep_package.ignores_prereleases?
+          dep_package.consider_remote_versions! if dep_package.prefer_local?
           versions = select_sorted_versions(dep_package, dep_range)
         end
 

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -96,7 +96,7 @@ module Bundler
         end
 
         if names_to_allow_prereleases_for.any?
-          Bundler.ui.debug "Found conflicts with dependencies with prereleases. Will retrying considering prereleases for #{names_to_allow_prereleases_for.join(", ")}...", true
+          Bundler.ui.debug "Found conflicts with dependencies with prereleases. Will retry considering prereleases for #{names_to_allow_prereleases_for.join(", ")}...", true
 
           @base.include_prereleases(names_to_allow_prereleases_for)
         end

--- a/bundler/lib/bundler/resolver/base.rb
+++ b/bundler/lib/bundler/resolver/base.rb
@@ -72,6 +72,12 @@ module Bundler
         end
       end
 
+      def include_remote_specs(names)
+        names.each do |name|
+          get_package(name).consider_remote_versions!
+        end
+      end
+
       private
 
       def indirect_pins(names)

--- a/bundler/lib/bundler/resolver/package.rb
+++ b/bundler/lib/bundler/resolver/package.rb
@@ -15,7 +15,7 @@ module Bundler
     class Package
       attr_reader :name, :platforms, :dependency, :locked_version
 
-      def initialize(name, platforms, locked_specs:, unlock:, prerelease: false, dependency: nil)
+      def initialize(name, platforms, locked_specs:, unlock:, prerelease: false, prefer_local: false, dependency: nil)
         @name = name
         @platforms = platforms
         @locked_version = locked_specs[name].first&.version
@@ -23,6 +23,7 @@ module Bundler
         @dependency = dependency || Dependency.new(name, @locked_version)
         @top_level = !dependency.nil?
         @prerelease = @dependency.prerelease? || @locked_version&.prerelease? || prerelease ? :consider_first : :ignore
+        @prefer_local = prefer_local
       end
 
       def platform_specs(specs)
@@ -67,6 +68,14 @@ module Bundler
 
       def consider_prereleases!
         @prerelease = :consider_last
+      end
+
+      def prefer_local?
+        @prefer_local
+      end
+
+      def consider_remote_versions!
+        @prefer_local = false
       end
 
       def force_ruby_platform?


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The original implementation of this flag was too naive and all it did was restricting gems to locally installed versions if there are any local versions installed.

However, it should be much smarter. For example:

* It should fallback to remote versions if locally installed version don't satisfy the requirements.
* It should pick locally installed versions even for subdependencies not yet discovered.

## What is your fix for the problem, implemented in this PR?

This PR fixes both issues by using a smarter approach similar to how we resolve prereleases:

* First resolve optimistically using only locally installed gems.
* If any conflicts are found, scan those conflicts, allow remote versions for the specific gems that run into conflicts, and re-resolve.

Fixes #6705.
Closes #7936.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)