### PR TITLE
Fix error message when Bundler refuses to install due to frozen being set without a lockfile

### DIFF
--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -29,9 +29,10 @@ module Bundler
 
       if options[:deployment] || options[:frozen] || Bundler.frozen_bundle?
         unless Bundler.default_lockfile.exist?
-          flag   = "--deployment flag" if options[:deployment]
-          flag ||= "--frozen flag"     if options[:frozen]
-          flag ||= "deployment setting"
+          flag = "--deployment flag" if options[:deployment]
+          flag ||= "--frozen flag" if options[:frozen]
+          flag ||= "deployment setting" if Bundler.settings[:deployment]
+          flag ||= "frozen setting" if Bundler.settings[:frozen]
           raise ProductionError, "The #{flag} requires a lockfile. Please make " \
                                  "sure you have checked your #{SharedHelpers.relative_lockfile_path} into version control " \
                                  "before deploying."

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -74,6 +74,18 @@ RSpec.describe "install in deployment or frozen mode" do
     end
   end
 
+  it "fails without a lockfile and says that deployment requires a lock" do
+    bundle "config deployment true"
+    bundle "install", raise_on_error: false
+    expect(err).to include("The deployment setting requires a lockfile")
+  end
+
+  it "fails without a lockfile and says that frozen requires a lock" do
+    bundle "config frozen true"
+    bundle "install", raise_on_error: false
+    expect(err).to include("The frozen setting requires a lockfile")
+  end
+
   it "still works if you are not in the app directory and specify --gemfile" do
     bundle "install"
     simulate_new_machine


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If you have the `frozen` setting set, and try to run `bundle install` without a lockfile, Bundler currently prints the following error.

>  The deployment setting requires a lockfile.

That's confusing because the `deployment` setting is not set.

## What is your fix for the problem, implemented in this PR?

The PR corrects the error message by mentioning the `frozen` setting instead when it makes sense.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
