### PR TITLE
Emit progress to stderr when `--print` is passed to `bundle lock`

### DIFF
--- a/bundler/lib/bundler/cli/lock.rb
+++ b/bundler/lib/bundler/cli/lock.rb
@@ -15,8 +15,8 @@ module Bundler
       end
 
       print = options[:print]
-      previous_ui_level = Bundler.ui.level
-      Bundler.ui.level = "silent" if print
+      previous_output_stream = Bundler.ui.output_stream
+      Bundler.ui.output_stream = :stderr if print
 
       Bundler::Fetcher.disable_endpoint = options["full-index"]
 
@@ -68,7 +68,7 @@ module Bundler
         end
       end
 
-      Bundler.ui.level = previous_ui_level
+      Bundler.ui.output_stream = previous_output_stream
     end
   end
 end

--- a/bundler/lib/bundler/retry.rb
+++ b/bundler/lib/bundler/retry.rb
@@ -50,7 +50,7 @@ module Bundler
       end
       return true unless name
       Bundler.ui.info "" unless Bundler.ui.debug? # Add new line in case dots preceded this
-      Bundler.ui.warn "Retrying #{name} due to error (#{current_run.next}/#{total_runs}): #{e.class} #{e.message}", Bundler.ui.debug?
+      Bundler.ui.warn "Retrying #{name} due to error (#{current_run.next}/#{total_runs}): #{e.class} #{e.message}", true
     end
 
     def keep_trying?

--- a/bundler/lib/bundler/ui/shell.rb
+++ b/bundler/lib/bundler/ui/shell.rb
@@ -84,7 +84,7 @@ module Bundler
         @shell.yes?(msg)
       end
 
-      def no?
+      def no?(msg)
         @shell.no?(msg)
       end
 

--- a/bundler/lib/bundler/ui/shell.rb
+++ b/bundler/lib/bundler/ui/shell.rb
@@ -130,7 +130,7 @@ module Bundler
       def tell_err(message, color = nil, newline = nil)
         return if @shell.send(:stderr).closed?
 
-        newline ||= !message.to_s.match?(/( |\t)\Z/)
+        newline = !message.to_s.match?(/( |\t)\Z/) if newline.nil?
         message = word_wrap(message) if newline.is_a?(Hash) && newline[:wrap]
 
         color = nil if color && !$stderr.tty?

--- a/bundler/lib/bundler/ui/silent.rb
+++ b/bundler/lib/bundler/ui/silent.rb
@@ -53,6 +53,13 @@ module Bundler
         false
       end
 
+      def output_stream=(_symbol)
+      end
+
+      def output_stream
+        nil
+      end
+
       def ask(message)
       end
 

--- a/bundler/lib/bundler/ui/silent.rb
+++ b/bundler/lib/bundler/ui/silent.rb
@@ -60,7 +60,7 @@ module Bundler
         raise "Cannot ask yes? with a silent shell"
       end
 
-      def no?
+      def no?(msg)
         raise "Cannot ask no? with a silent shell"
       end
 

--- a/bundler/spec/bundler/retry_spec.rb
+++ b/bundler/spec/bundler/retry_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Bundler::Retry do
       it "print error message with newlines" do
         allow(Bundler.ui).to  receive(:debug?).and_return(false)
         expect(Bundler.ui).to receive(:info).with("").twice
-        expect(Bundler.ui).to receive(:warn).with(failure_message, false)
+        expect(Bundler.ui).to receive(:warn).with(failure_message, true)
 
         expect do
           Bundler::Retry.new("test", [], 1).attempt do

--- a/bundler/spec/bundler/ui/shell_spec.rb
+++ b/bundler/spec/bundler/ui/shell_spec.rb
@@ -10,12 +10,26 @@ RSpec.describe Bundler::UI::Shell do
     it "prints to stdout" do
       expect { subject.info("info") }.to output("info\n").to_stdout
     end
+
+    context "when output_stream is :stderr" do
+      before { subject.output_stream = :stderr }
+      it "prints to stderr" do
+        expect { subject.info("info") }.to output("info\n").to_stderr
+      end
+    end
   end
 
   describe "#confirm" do
     before { subject.level = "confirm" }
     it "prints to stdout" do
       expect { subject.confirm("confirm") }.to output("confirm\n").to_stdout
+    end
+
+    context "when output_stream is :stderr" do
+      before { subject.output_stream = :stderr }
+      it "prints to stderr" do
+        expect { subject.confirm("confirm") }.to output("confirm\n").to_stderr
+      end
     end
   end
 
@@ -32,6 +46,13 @@ RSpec.describe Bundler::UI::Shell do
   describe "#debug" do
     it "prints to stdout" do
       expect { subject.debug("debug") }.to output("debug\n").to_stdout
+    end
+
+    context "when output_stream is :stderr" do
+      before { subject.output_stream = :stderr }
+      it "prints to stderr" do
+        expect { subject.debug("debug") }.to output("debug\n").to_stderr
+      end
     end
   end
 

--- a/bundler/spec/bundler/ui/shell_spec.rb
+++ b/bundler/spec/bundler/ui/shell_spec.rb
@@ -21,8 +21,11 @@ RSpec.describe Bundler::UI::Shell do
 
   describe "#warn" do
     before { subject.level = "warn" }
-    it "prints to stderr" do
+    it "prints to stderr, implicitly adding a newline" do
       expect { subject.warn("warning") }.to output("warning\n").to_stderr
+    end
+    it "can be told not to emit a newline" do
+      expect { subject.warn("warning", false) }.to output("warning").to_stderr
     end
   end
 

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -202,6 +202,25 @@ RSpec.describe "bundle lock" do
     expect(read_lockfile).to eq(expected_lockfile)
   end
 
+  it "prints an updated lockfile when there is an outdated lockfile using --print --update" do
+    lockfile outdated_lockfile
+
+    bundle "lock --print --update"
+
+    expect(out).to eq(expected_lockfile.rstrip)
+  end
+
+  it "emits info messages to stderr when updating an outdated lockfile using --print --update" do
+    lockfile outdated_lockfile
+
+    bundle "lock --print --update"
+
+    expect(err).to eq(<<~STDERR.rstrip)
+      Fetching gem metadata from https://gem.repo4/...
+      Resolving dependencies...
+    STDERR
+  end
+
   it "writes a lockfile when there is an outdated lockfile and bundle is frozen" do
     lockfile outdated_lockfile
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bundle lock --print --update` can take a long time to fetch sources and resolve the lock file.

Before, `--print` caused output to be completely silenced, so nothing was printed at all until the resolved lock file is finally emitted to stdout.

See #7938

## What is your fix for the problem, implemented in this PR?

With this change, `--print` now prints progress to stderr. E.g.:

```
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
```

This provides a better user experience, especially when `lock --print --update` takes several seconds or more.

The lock file is still printed to stdout, so tools consuming the lock file on stdout will not be affected.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
