### PR TITLE
Fix test failure with not git environment

### DIFF
--- a/bundler/spec/cache/git_spec.rb
+++ b/bundler/spec/cache/git_spec.rb
@@ -294,6 +294,8 @@ RSpec.describe "bundle cache with git" do
     FileUtils.mkdir_p bundled_app("vendor/cache")
     FileUtils.cp_r git_path, bundled_app("vendor/cache/foo-1.0-#{path_revision}")
     FileUtils.rm_rf bundled_app("vendor/cache/foo-1.0-#{path_revision}/.git")
+    # bundle install with git repo needs to be run under the git environment.
+    Dir.chdir(bundled_app) { system(*%W[git init --quiet]) }
 
     bundle :install, env: { "BUNDLE_DEPLOYMENT" => "true", "BUNDLE_CACHE_ALL" => "true" }
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bundler/spec/cache/git_spec.rb:261` is failing with not git environment like ruby tar package. 

## What is your fix for the problem, implemented in this PR?

Backport from https://github.com/ruby/ruby/pull/11458. I invoked `git init` under the dummy app.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
