### PR TITLE
Don't blow up when explicit version is removed from some git sources

### DIFF
--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -70,13 +70,13 @@ module Bundler
       end
 
       def hash
-        [self.class, uri, ref, branch, name, version, glob, submodules].hash
+        [self.class, uri, ref, branch, name, glob, submodules].hash
       end
 
       def eql?(other)
         other.is_a?(Git) && uri == other.uri && ref == other.ref &&
           branch == other.branch && name == other.name &&
-          version == other.version && glob == other.glob &&
+          glob == other.glob &&
           submodules == other.submodules
       end
 

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -1107,6 +1107,25 @@ RSpec.describe "bundle install with git sources" do
       run "require 'new_file'"
       expect(out).to eq("USING GIT")
     end
+
+    it "doesn't explode when removing an explicit exact version from a git gem with dependencies" do
+      build_lib "activesupport", "7.1.4", path: lib_path("rails/activesupport")
+      build_git "rails", "7.1.4", path: lib_path("rails") do |s|
+        s.add_dependency "activesupport", "= 7.1.4"
+      end
+
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        gem "rails", "7.1.4", :git => "#{lib_path("rails")}"
+      G
+
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        gem "rails", :git => "#{lib_path("rails")}"
+      G
+
+      expect(the_bundle).to include_gem "rails 7.1.4", "activesupport 7.1.4"
+    end
   end
 
   describe "bundle install after the remote has been updated" do

--- a/bundler/spec/install/git_spec.rb
+++ b/bundler/spec/install/git_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "bundle install" do
       expect(the_bundle).to include_gems "foo 2.0", source: "git@#{lib_path("foo")}"
     end
 
-    it "should allows git repos that are missing but not being installed" do
+    it "allows git repos that are missing but not being installed" do
       revision = build_git("foo").ref_for("HEAD")
 
       gemfile <<-G


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If the Gemfile specifies a git source with a explicit version, and then the explicit version is removed, then `bundle install` will start failing for no reason, provided the git source has a gemspec with dependencies in the same source (like Rails).

## What is your fix for the problem, implemented in this PR?

The `version` attribute is actually the `requirement` attribute of the Gemfile dependency, it's not really an attribute of the git source. Under certain situations (if it's an exact version), it's also passed to the git source so that a gemspec can be faked if the source does not have gemspecs, but it should not be used for source comparison.

Fixes https://github.com/rubygems/rubygems/issues/7718#issuecomment-2310738318.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
