### PR TITLE
fix `@license` typo preventing licenses from being correctly unmarshalled

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1318,7 +1318,7 @@ class Gem::Specification < Gem::BasicSpecification
     spec.instance_variable_set :@has_rdoc,                  array[15]
     spec.instance_variable_set :@new_platform,              array[16]
     spec.instance_variable_set :@platform,                  array[16].to_s
-    spec.instance_variable_set :@license,                   array[17]
+    spec.instance_variable_set :@licenses,                  [array[17]]
     spec.instance_variable_set :@metadata,                  array[18]
     spec.instance_variable_set :@loaded,                    false
     spec.instance_variable_set :@activated,                 false

--- a/test/rubygems/test_gem_safe_marshal.rb
+++ b/test/rubygems/test_gem_safe_marshal.rb
@@ -305,6 +305,18 @@ class TestGemSafeMarshal < Gem::TestCase
     end
   end
 
+  def test_gem_spec_unmarshall_license
+    spec = Gem::Specification.new do |s|
+      s.name = "hi"
+      s.version = "1.2.3"
+      s.license = "MIT"
+    end
+
+    unmarshalled_spec = Gem::SafeMarshal.safe_load(Marshal.dump(spec))
+
+    assert_equal ["MIT"], unmarshalled_spec.license
+  end
+
   def test_gem_spec_disallowed_symbol
     e = assert_raise(Gem::SafeMarshal::Visitors::ToRuby::UnpermittedSymbolError) do
       spec = Gem::Specification.new do |s|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Unmarshalling of the license field is not working right due to a typo.

This script should work, but does not:

```
require 'rubygems'

fetcher = Gem::SpecFetcher.fetcher

specs = fetcher.detect(:latest) do |tuple|

                                  ARGV.detect { |arg| tuple.name.start_with? arg}

                                end.map do |tuple| 
                                  name_tuple, source = *tuple
                                  source.fetch_spec(name_tuple)
                                end

specs.each do |_|
  puts "#{_.name} released under #{_.license}"
end
```

This script, on the other hand, does work:

```
require 'rubygems'
require 'rubygems/query_utils'

fetcher = Gem::SpecFetcher.fetcher

specs = fetcher.detect(:latest) do |tuple|

                                  ARGV.detect { |arg| tuple.name.start_with? arg}

                                end.map do |tuple| 
                                  name_tuple, source = *tuple
                                  source.fetch_spec(name_tuple)
                                end

specs.each do |_|
  puts "#{_.name} released under #{_.instance_variable_get('@license')}"
end
```

The current Gem::Specification#_load method does correctly grab the license from the unmarshalled - but it stores it in @license, which is not (currently) used in the code.
 
## What is your fix for the problem, implemented in this PR?

Replace the single remaining reference to @license with @licenses.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
