### PR TITLE
Make `gem exec` use the standard GEM_HOME

### DIFF
--- a/lib/rubygems/commands/exec_command.rb
+++ b/lib/rubygems/commands/exec_command.rb
@@ -143,7 +143,7 @@ to the same gem path as user-installed gems.
   end
 
   def set_gem_exec_install_paths
-    home = File.join(Gem.dir, "gem_exec")
+    home = Gem.dir
 
     ENV["GEM_PATH"] = ([home] + Gem.path).join(File::PATH_SEPARATOR)
     ENV["GEM_HOME"] = home

--- a/lib/rubygems/commands/exec_command.rb
+++ b/lib/rubygems/commands/exec_command.rb
@@ -57,8 +57,6 @@ to the same gem path as user-installed gems.
   end
 
   def execute
-    gem_paths = { "GEM_HOME" => Gem.paths.home, "GEM_PATH" => Gem.paths.path.join(File::PATH_SEPARATOR), "GEM_SPEC_CACHE" => Gem.paths.spec_cache_dir }.compact
-
     check_executable
 
     print_command
@@ -74,9 +72,6 @@ to the same gem path as user-installed gems.
     end
 
     load!
-  ensure
-    ENV.update(gem_paths) if gem_paths
-    Gem.clear_paths
   end
 
   private

--- a/test/rubygems/test_gem_commands_exec_command.rb
+++ b/test/rubygems/test_gem_commands_exec_command.rb
@@ -749,7 +749,7 @@ class TestGemCommandsExecCommand < Gem::TestCase
       assert_match(/\A\s*\** LOCAL GEMS \**\s*\z/m, @ui.output)
 
       invoke "gem", "env", "GEM_HOME"
-      assert_equal "#{@gem_home}/gem_exec\n", @ui.output
+      assert_equal "#{@gem_home}\n", @ui.output
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The `gem exec` command is documented as

>    The exec command handles installing (if necessary) and running an executable
>    from a gem, regardless of whether that gem is currently installed.
>    
>    The exec command can be thought of as a shortcut to running `gem install`
>    and then the executable from the installed gem.

However, it's not exactly that because it actually installs to a different home from `gem install`.

I think that's surprising and it also causes issues like https://github.com/rubygems/rubygems/issues/7671.

## What is your fix for the problem, implemented in this PR?

I see two alternatives to make `gem exec` work in a "principle of least surprise way":

* Leave as it is now, but make it have no side effects whatsoever in the RubyGems installation by completely wiping out the `gem_exec` folder after it's done. I think this would make `gem exec` something to "magically" generate a Rails app without actually having to install Rails globally.
* Let it install to the standard GEM_HOME. This would make it match more closely what we document.

I went with the latter because I don't see many downsides of actually installing the `exec`'d gem.

Fixes #6914.
Fixes #7671.
Supersedes #7956.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
