### PR TITLE
Fix `bundler/inline` failing in Ruby 3.2 due to conflicting `securerandom` versions

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -616,6 +616,7 @@ lib/rubygems/vendor/uri/lib/uri/wss.rb
 lib/rubygems/vendored_molinillo.rb
 lib/rubygems/vendored_net_http.rb
 lib/rubygems/vendored_optparse.rb
+lib/rubygems/vendored_securerandom.rb
 lib/rubygems/vendored_timeout.rb
 lib/rubygems/vendored_tsort.rb
 lib/rubygems/version.rb

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -283,6 +283,10 @@ bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/version_constraint.rb
 bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/version_range.rb
 bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/version_solver.rb
 bundler/lib/bundler/vendor/pub_grub/lib/pub_grub/version_union.rb
+bundler/lib/bundler/vendor/securerandom/.document
+bundler/lib/bundler/vendor/securerandom/LICENSE.txt
+bundler/lib/bundler/vendor/securerandom/lib/random/formatter.rb
+bundler/lib/bundler/vendor/securerandom/lib/securerandom.rb
 bundler/lib/bundler/vendor/thor/.document
 bundler/lib/bundler/vendor/thor/LICENSE.md
 bundler/lib/bundler/vendor/thor/lib/thor.rb
@@ -344,6 +348,7 @@ bundler/lib/bundler/vendored_fileutils.rb
 bundler/lib/bundler/vendored_net_http.rb
 bundler/lib/bundler/vendored_persistent.rb
 bundler/lib/bundler/vendored_pub_grub.rb
+bundler/lib/bundler/vendored_securerandom.rb
 bundler/lib/bundler/vendored_thor.rb
 bundler/lib/bundler/vendored_timeout.rb
 bundler/lib/bundler/vendored_tsort.rb

--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -3,7 +3,7 @@
 require_relative "vendored_persistent"
 require_relative "vendored_timeout"
 require "cgi"
-require "securerandom"
+require_relative "vendored_securerandom"
 require "zlib"
 
 module Bundler
@@ -182,7 +182,7 @@ module Bundler
         agent << " ci/#{cis.join(",")}" if cis.any?
 
         # add a random ID so we can consolidate runs server-side
-        agent << " " << SecureRandom.hex(8)
+        agent << " " << Gem::SecureRandom.hex(8)
 
         # add any user agent strings set in the config
         extra_ua = Bundler.settings[:user_agent]

--- a/bundler/lib/bundler/vendor/securerandom/.document
+++ b/bundler/lib/bundler/vendor/securerandom/.document
@@ -1,0 +1,1 @@
+# Vendored files do not need to be documented

--- a/bundler/lib/bundler/vendor/securerandom/LICENSE.txt
+++ b/bundler/lib/bundler/vendor/securerandom/LICENSE.txt
@@ -1,0 +1,22 @@
+Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/bundler/lib/bundler/vendor/securerandom/lib/random/formatter.rb
+++ b/bundler/lib/bundler/vendor/securerandom/lib/random/formatter.rb
@@ -1,0 +1,373 @@
+# -*- coding: us-ascii -*-
+# frozen_string_literal: true
+
+# == \Random number formatter.
+#
+# Formats generated random numbers in many manners. When <tt>'random/formatter'</tt>
+# is required, several methods are added to empty core module <tt>Bundler::Random::Formatter</tt>,
+# making them available as Random's instance and module methods.
+#
+# Standard library Bundler::SecureRandom is also extended with the module, and the methods
+# described below are available as a module methods in it.
+#
+# === Examples
+#
+# Generate random hexadecimal strings:
+#
+#   require 'bundler/vendor/securerandom/lib/random/formatter'
+#
+#   prng = Random.new
+#   prng.hex(10) #=> "52750b30ffbc7de3b362"
+#   prng.hex(10) #=> "92b15d6c8dc4beb5f559"
+#   prng.hex(13) #=> "39b290146bea6ce975c37cfc23"
+#   # or just
+#   Random.hex #=> "1aed0c631e41be7f77365415541052ee"
+#
+# Generate random base64 strings:
+#
+#   prng.base64(10) #=> "EcmTPZwWRAozdA=="
+#   prng.base64(10) #=> "KO1nIU+p9DKxGg=="
+#   prng.base64(12) #=> "7kJSM/MzBJI+75j8"
+#   Random.base64(4) #=> "bsQ3fQ=="
+#
+# Generate random binary strings:
+#
+#   prng.random_bytes(10) #=> "\016\t{\370g\310pbr\301"
+#   prng.random_bytes(10) #=> "\323U\030TO\234\357\020\a\337"
+#   Random.random_bytes(6) #=> "\xA1\xE6Lr\xC43"
+#
+# Generate alphanumeric strings:
+#
+#   prng.alphanumeric(10) #=> "S8baxMJnPl"
+#   prng.alphanumeric(10) #=> "aOxAg8BAJe"
+#   Random.alphanumeric #=> "TmP9OsJHJLtaZYhP"
+#
+# Generate UUIDs:
+#
+#   prng.uuid #=> "2d931510-d99f-494a-8c67-87feb05e1594"
+#   prng.uuid #=> "bad85eb9-0713-4da7-8d36-07a8e4b00eab"
+#   Random.uuid #=> "f14e0271-de96-45cc-8911-8910292a42cd"
+#
+# All methods are available in the standard library Bundler::SecureRandom, too:
+#
+#   Bundler::SecureRandom.hex #=> "05b45376a30c67238eb93b16499e50cf"
+
+module Bundler::Random::Formatter
+
+  # Generate a random binary string.
+  #
+  # The argument _n_ specifies the length of the result string.
+  #
+  # If _n_ is not specified or is nil, 16 is assumed.
+  # It may be larger in future.
+  #
+  # The result may contain any byte: "\x00" - "\xff".
+  #
+  #   require 'bundler/vendor/securerandom/lib/random/formatter'
+  #
+  #   Random.random_bytes #=> "\xD8\\\xE0\xF4\r\xB2\xFC*WM\xFF\x83\x18\xF45\xB6"
+  #   # or
+  #   prng = Random.new
+  #   prng.random_bytes #=> "m\xDC\xFC/\a\x00Uf\xB2\xB2P\xBD\xFF6S\x97"
+  def random_bytes(n=nil)
+    n = n ? n.to_int : 16
+    gen_random(n)
+  end
+
+  # Generate a random hexadecimal string.
+  #
+  # The argument _n_ specifies the length, in bytes, of the random number to be generated.
+  # The length of the resulting hexadecimal string is twice of _n_.
+  #
+  # If _n_ is not specified or is nil, 16 is assumed.
+  # It may be larger in the future.
+  #
+  # The result may contain 0-9 and a-f.
+  #
+  #   require 'bundler/vendor/securerandom/lib/random/formatter'
+  #
+  #   Random.hex #=> "eb693ec8252cd630102fd0d0fb7c3485"
+  #   # or
+  #   prng = Random.new
+  #   prng.hex #=> "91dc3bfb4de5b11d029d376634589b61"
+  def hex(n=nil)
+    random_bytes(n).unpack1("H*")
+  end
+
+  # Generate a random base64 string.
+  #
+  # The argument _n_ specifies the length, in bytes, of the random number
+  # to be generated. The length of the result string is about 4/3 of _n_.
+  #
+  # If _n_ is not specified or is nil, 16 is assumed.
+  # It may be larger in the future.
+  #
+  # The result may contain A-Z, a-z, 0-9, "+", "/" and "=".
+  #
+  #   require 'bundler/vendor/securerandom/lib/random/formatter'
+  #
+  #   Random.base64 #=> "/2BuBuLf3+WfSKyQbRcc/A=="
+  #   # or
+  #   prng = Random.new
+  #   prng.base64 #=> "6BbW0pxO0YENxn38HMUbcQ=="
+  #
+  # See RFC 3548 for the definition of base64.
+  def base64(n=nil)
+    [random_bytes(n)].pack("m0")
+  end
+
+  # Generate a random URL-safe base64 string.
+  #
+  # The argument _n_ specifies the length, in bytes, of the random number
+  # to be generated. The length of the result string is about 4/3 of _n_.
+  #
+  # If _n_ is not specified or is nil, 16 is assumed.
+  # It may be larger in the future.
+  #
+  # The boolean argument _padding_ specifies the padding.
+  # If it is false or nil, padding is not generated.
+  # Otherwise padding is generated.
+  # By default, padding is not generated because "=" may be used as a URL delimiter.
+  #
+  # The result may contain A-Z, a-z, 0-9, "-" and "_".
+  # "=" is also used if _padding_ is true.
+  #
+  #   require 'bundler/vendor/securerandom/lib/random/formatter'
+  #
+  #   Random.urlsafe_base64 #=> "b4GOKm4pOYU_-BOXcrUGDg"
+  #   # or
+  #   prng = Random.new
+  #   prng.urlsafe_base64 #=> "UZLdOkzop70Ddx-IJR0ABg"
+  #
+  #   prng.urlsafe_base64(nil, true) #=> "i0XQ-7gglIsHGV2_BNPrdQ=="
+  #   prng.urlsafe_base64(nil, true) #=> "-M8rLhr7JEpJlqFGUMmOxg=="
+  #
+  # See RFC 3548 for the definition of URL-safe base64.
+  def urlsafe_base64(n=nil, padding=false)
+    s = [random_bytes(n)].pack("m0")
+    s.tr!("+/", "-_")
+    s.delete!("=") unless padding
+    s
+  end
+
+  # Generate a random v4 UUID (Universally Unique IDentifier).
+  #
+  #   require 'bundler/vendor/securerandom/lib/random/formatter'
+  #
+  #   Random.uuid #=> "2d931510-d99f-494a-8c67-87feb05e1594"
+  #   Random.uuid #=> "bad85eb9-0713-4da7-8d36-07a8e4b00eab"
+  #   # or
+  #   prng = Random.new
+  #   prng.uuid #=> "62936e70-1815-439b-bf89-8492855a7e6b"
+  #
+  # The version 4 UUID is purely random (except the version).
+  # It doesn't contain meaningful information such as MAC addresses, timestamps, etc.
+  #
+  # The result contains 122 random bits (15.25 random bytes).
+  #
+  # See RFC4122[https://datatracker.ietf.org/doc/html/rfc4122] for details of UUID.
+  #
+  def uuid
+    ary = random_bytes(16).unpack("NnnnnN")
+    ary[2] = (ary[2] & 0x0fff) | 0x4000
+    ary[3] = (ary[3] & 0x3fff) | 0x8000
+    "%08x-%04x-%04x-%04x-%04x%08x" % ary
+  end
+
+  alias uuid_v4 uuid
+
+  # Generate a random v7 UUID (Universally Unique IDentifier).
+  #
+  #   require 'bundler/vendor/securerandom/lib/random/formatter'
+  #
+  #   Random.uuid_v7 # => "0188d4c3-1311-7f96-85c7-242a7aa58f1e"
+  #   Random.uuid_v7 # => "0188d4c3-16fe-744f-86af-38fa04c62bb5"
+  #   Random.uuid_v7 # => "0188d4c3-1af8-764f-b049-c204ce0afa23"
+  #   Random.uuid_v7 # => "0188d4c3-1e74-7085-b14f-ef6415dc6f31"
+  #   #                    |<--sorted-->| |<----- random ---->|
+  #
+  #   # or
+  #   prng = Random.new
+  #   prng.uuid_v7 # => "0188ca51-5e72-7950-a11d-def7ff977c98"
+  #
+  # The version 7 UUID starts with the least significant 48 bits of a 64 bit
+  # Unix timestamp (milliseconds since the epoch) and fills the remaining bits
+  # with random data, excluding the version and variant bits.
+  #
+  # This allows version 7 UUIDs to be sorted by creation time.  Time ordered
+  # UUIDs can be used for better database index locality of newly inserted
+  # records, which may have a significant performance benefit compared to random
+  # data inserts.
+  #
+  # The result contains 74 random bits (9.25 random bytes).
+  #
+  # Note that this method cannot be made reproducable because its output
+  # includes not only random bits but also timestamp.
+  #
+  # See draft-ietf-uuidrev-rfc4122bis[https://datatracker.ietf.org/doc/draft-ietf-uuidrev-rfc4122bis/]
+  # for details of UUIDv7.
+  #
+  # ==== Monotonicity
+  #
+  # UUIDv7 has millisecond precision by default, so multiple UUIDs created
+  # within the same millisecond are not issued in monotonically increasing
+  # order.  To create UUIDs that are time-ordered with sub-millisecond
+  # precision, up to 12 bits of additional timestamp may added with
+  # +extra_timestamp_bits+.  The extra timestamp precision comes at the expense
+  # of random bits.  Setting <tt>extra_timestamp_bits: 12</tt> provides ~244ns
+  # of precision, but only 62 random bits (7.75 random bytes).
+  #
+  #   prng = Random.new
+  #   Array.new(4) { prng.uuid_v7(extra_timestamp_bits: 12) }
+  #   # =>
+  #   ["0188d4c7-13da-74f9-8b53-22a786ffdd5a",
+  #    "0188d4c7-13da-753b-83a5-7fb9b2afaeea",
+  #    "0188d4c7-13da-754a-88ea-ac0baeedd8db",
+  #    "0188d4c7-13da-7557-83e1-7cad9cda0d8d"]
+  #   # |<--- sorted --->| |<-- random --->|
+  #
+  #   Array.new(4) { prng.uuid_v7(extra_timestamp_bits: 8) }
+  #   # =>
+  #   ["0188d4c7-3333-7a95-850a-de6edb858f7e",
+  #    "0188d4c7-3333-7ae8-842e-bc3a8b7d0cf9",  # <- out of order
+  #    "0188d4c7-3333-7ae2-995a-9f135dc44ead",  # <- out of order
+  #    "0188d4c7-3333-7af9-87c3-8f612edac82e"]
+  #   # |<--- sorted -->||<---- random --->|
+  #
+  # Any rollbacks of the system clock will break monotonicity.  UUIDv7 is based
+  # on UTC, which excludes leap seconds and can rollback the clock.  To avoid
+  # this, the system clock can synchronize with an NTP server configured to use
+  # a "leap smear" approach.  NTP or PTP will also be needed to synchronize
+  # across distributed nodes.
+  #
+  # Counters and other mechanisms for stronger guarantees of monotonicity are
+  # not implemented.  Applications with stricter requirements should follow
+  # {Section 6.2}[https://www.ietf.org/archive/id/draft-ietf-uuidrev-rfc4122bis-07.html#monotonicity_counters]
+  # of the specification.
+  #
+  def uuid_v7(extra_timestamp_bits: 0)
+    case (extra_timestamp_bits = Integer(extra_timestamp_bits))
+    when 0 # min timestamp precision
+      ms = Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond)
+      rand = random_bytes(10)
+      rand.setbyte(0, rand.getbyte(0) & 0x0f | 0x70) # version
+      rand.setbyte(2, rand.getbyte(2) & 0x3f | 0x80) # variant
+      "%08x-%04x-%s" % [
+        (ms & 0x0000_ffff_ffff_0000) >> 16,
+        (ms & 0x0000_0000_0000_ffff),
+        rand.unpack("H4H4H12").join("-")
+      ]
+
+    when 12 # max timestamp precision
+      ms, ns = Process.clock_gettime(Process::CLOCK_REALTIME, :nanosecond)
+        .divmod(1_000_000)
+      extra_bits = ns * 4096 / 1_000_000
+      rand = random_bytes(8)
+      rand.setbyte(0, rand.getbyte(0) & 0x3f | 0x80) # variant
+      "%08x-%04x-7%03x-%s" % [
+        (ms & 0x0000_ffff_ffff_0000) >> 16,
+        (ms & 0x0000_0000_0000_ffff),
+        extra_bits,
+        rand.unpack("H4H12").join("-")
+      ]
+
+    when (0..12) # the generic version is slower than the special cases above
+      rand_a, rand_b1, rand_b2, rand_b3 = random_bytes(10).unpack("nnnN")
+      rand_mask_bits = 12 - extra_timestamp_bits
+      ms, ns = Process.clock_gettime(Process::CLOCK_REALTIME, :nanosecond)
+        .divmod(1_000_000)
+      "%08x-%04x-%04x-%04x-%04x%08x" % [
+        (ms & 0x0000_ffff_ffff_0000) >> 16,
+        (ms & 0x0000_0000_0000_ffff),
+        0x7000 |
+          ((ns * (1 << extra_timestamp_bits) / 1_000_000) << rand_mask_bits) |
+          rand_a & ((1 << rand_mask_bits) - 1),
+        0x8000 | (rand_b1 & 0x3fff),
+        rand_b2,
+        rand_b3
+      ]
+
+    else
+      raise ArgumentError, "extra_timestamp_bits must be in 0..12"
+    end
+  end
+
+  # Internal interface to Random; Generate random data _n_ bytes.
+  private def gen_random(n)
+    self.bytes(n)
+  end
+
+  # Generate a string that randomly draws from a
+  # source array of characters.
+  #
+  # The argument _source_ specifies the array of characters from which
+  # to generate the string.
+  # The argument _n_ specifies the length, in characters, of the string to be
+  # generated.
+  #
+  # The result may contain whatever characters are in the source array.
+  #
+  #   require 'bundler/vendor/securerandom/lib/random/formatter'
+  #
+  #   prng.choose([*'l'..'r'], 16) #=> "lmrqpoonmmlqlron"
+  #   prng.choose([*'0'..'9'], 5)  #=> "27309"
+  private def choose(source, n)
+    size = source.size
+    m = 1
+    limit = size
+    while limit * size <= 0x100000000
+      limit *= size
+      m += 1
+    end
+    result = ''.dup
+    while m <= n
+      rs = random_number(limit)
+      is = rs.digits(size)
+      (m-is.length).times { is << 0 }
+      result << source.values_at(*is).join('')
+      n -= m
+    end
+    if 0 < n
+      rs = random_number(limit)
+      is = rs.digits(size)
+      if is.length < n
+        (n-is.length).times { is << 0 }
+      else
+        is.pop while n < is.length
+      end
+      result.concat source.values_at(*is).join('')
+    end
+    result
+  end
+
+  # The default character list for #alphanumeric.
+  ALPHANUMERIC = [*'A'..'Z', *'a'..'z', *'0'..'9']
+
+  # Generate a random alphanumeric string.
+  #
+  # The argument _n_ specifies the length, in characters, of the alphanumeric
+  # string to be generated.
+  # The argument _chars_ specifies the character list which the result is
+  # consist of.
+  #
+  # If _n_ is not specified or is nil, 16 is assumed.
+  # It may be larger in the future.
+  #
+  # The result may contain A-Z, a-z and 0-9, unless _chars_ is specified.
+  #
+  #   require 'bundler/vendor/securerandom/lib/random/formatter'
+  #
+  #   Random.alphanumeric     #=> "2BuBuLf3WfSKyQbR"
+  #   # or
+  #   prng = Random.new
+  #   prng.alphanumeric(10) #=> "i6K93NdqiH"
+  #
+  #   Random.alphanumeric(4, chars: [*"0".."9"]) #=> "2952"
+  #   # or
+  #   prng = Random.new
+  #   prng.alphanumeric(10, chars: [*"!".."/"]) #=> ",.,++%/''."
+  def alphanumeric(n = nil, chars: ALPHANUMERIC)
+    n = 16 if n.nil?
+    choose(chars, n)
+  end
+end

--- a/bundler/lib/bundler/vendor/securerandom/lib/securerandom.rb
+++ b/bundler/lib/bundler/vendor/securerandom/lib/securerandom.rb
@@ -1,0 +1,96 @@
+# -*- coding: us-ascii -*-
+# frozen_string_literal: true
+
+require_relative 'random/formatter'
+
+# == Secure random number generator interface.
+#
+# This library is an interface to secure random number generators which are
+# suitable for generating session keys in HTTP cookies, etc.
+#
+# You can use this library in your application by requiring it:
+#
+#   require 'bundler/vendor/securerandom/lib/securerandom'
+#
+# It supports the following secure random number generators:
+#
+# * openssl
+# * /dev/urandom
+# * Win32
+#
+# Bundler::SecureRandom is extended by the Bundler::Random::Formatter module which
+# defines the following methods:
+#
+# * alphanumeric
+# * base64
+# * choose
+# * gen_random
+# * hex
+# * rand
+# * random_bytes
+# * random_number
+# * urlsafe_base64
+# * uuid
+#
+# These methods are usable as class methods of Bundler::SecureRandom such as
+# +Bundler::SecureRandom.hex+.
+#
+# If a secure random number generator is not available,
+# +NotImplementedError+ is raised.
+
+module Bundler::SecureRandom
+
+  # The version
+  VERSION = "0.3.1"
+
+  class << self
+    # Returns a random binary string containing +size+ bytes.
+    #
+    # See Random.bytes
+    def bytes(n)
+      return gen_random(n)
+    end
+
+    private
+
+    # :stopdoc:
+
+    # Implementation using OpenSSL
+    def gen_random_openssl(n)
+      return OpenSSL::Random.random_bytes(n)
+    end
+
+    # Implementation using system random device
+    def gen_random_urandom(n)
+      ret = Random.urandom(n)
+      unless ret
+        raise NotImplementedError, "No random device"
+      end
+      unless ret.length == n
+        raise NotImplementedError, "Unexpected partial read from random device: only #{ret.length} for #{n} bytes"
+      end
+      ret
+    end
+
+    begin
+      # Check if Random.urandom is available
+      Random.urandom(1)
+      alias gen_random gen_random_urandom
+    rescue RuntimeError
+      begin
+        require 'openssl'
+      rescue NoMethodError
+        raise NotImplementedError, "No random device"
+      else
+        alias gen_random gen_random_openssl
+      end
+    end
+
+    # :startdoc:
+
+    # Generate random data bytes for Bundler::Random::Formatter
+    public :gen_random
+  end
+end
+
+Bundler::SecureRandom.extend(Bundler::Random::Formatter)

--- a/bundler/lib/bundler/vendored_securerandom.rb
+++ b/bundler/lib/bundler/vendored_securerandom.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Use RubyGems vendored copy when available. Otherwise fallback to Bundler
+# vendored copy. The vendored copy in Bundler can be removed once support for
+# RubyGems 3.5.18 is dropped.
+
+begin
+  require "rubygems/vendored_securerandom"
+rescue LoadError
+  module Bundler::Random; end
+  require_relative "vendor/securerandom/lib/securerandom"
+  Gem::SecureRandom = Bundler::SecureRandom
+  Gem::Random = Bundler::Random
+end

--- a/lib/rubygems/vendor/resolv/lib/resolv.rb
+++ b/lib/rubygems/vendor/resolv/lib/resolv.rb
@@ -5,7 +5,7 @@ require_relative '../../timeout/lib/timeout'
 require 'io/wait'
 
 begin
-  require_relative '../../securerandom/lib/securerandom'
+  require_relative '../../../vendored_securerandom'
 rescue LoadError
 end
 

--- a/lib/rubygems/vendor/securerandom/lib/random/formatter.rb
+++ b/lib/rubygems/vendor/securerandom/lib/random/formatter.rb
@@ -4,7 +4,7 @@
 # == \Random number formatter.
 #
 # Formats generated random numbers in many manners. When <tt>'random/formatter'</tt>
-# is required, several methods are added to empty core module <tt>Random::Formatter</tt>,
+# is required, several methods are added to empty core module <tt>Gem::Random::Formatter</tt>,
 # making them available as Random's instance and module methods.
 #
 # Standard library Gem::SecureRandom is also extended with the module, and the methods
@@ -14,7 +14,7 @@
 #
 # Generate random hexadecimal strings:
 #
-#   require 'random/formatter'
+#   require 'rubygems/vendor/securerandom/lib/random/formatter'
 #
 #   prng = Random.new
 #   prng.hex(10) #=> "52750b30ffbc7de3b362"
@@ -52,7 +52,7 @@
 #
 #   Gem::SecureRandom.hex #=> "05b45376a30c67238eb93b16499e50cf"
 
-module Random::Formatter
+module Gem::Random::Formatter
 
   # Generate a random binary string.
   #
@@ -63,7 +63,7 @@ module Random::Formatter
   #
   # The result may contain any byte: "\x00" - "\xff".
   #
-  #   require 'random/formatter'
+  #   require 'rubygems/vendor/securerandom/lib/random/formatter'
   #
   #   Random.random_bytes #=> "\xD8\\\xE0\xF4\r\xB2\xFC*WM\xFF\x83\x18\xF45\xB6"
   #   # or
@@ -84,7 +84,7 @@ module Random::Formatter
   #
   # The result may contain 0-9 and a-f.
   #
-  #   require 'random/formatter'
+  #   require 'rubygems/vendor/securerandom/lib/random/formatter'
   #
   #   Random.hex #=> "eb693ec8252cd630102fd0d0fb7c3485"
   #   # or
@@ -104,7 +104,7 @@ module Random::Formatter
   #
   # The result may contain A-Z, a-z, 0-9, "+", "/" and "=".
   #
-  #   require 'random/formatter'
+  #   require 'rubygems/vendor/securerandom/lib/random/formatter'
   #
   #   Random.base64 #=> "/2BuBuLf3+WfSKyQbRcc/A=="
   #   # or
@@ -132,7 +132,7 @@ module Random::Formatter
   # The result may contain A-Z, a-z, 0-9, "-" and "_".
   # "=" is also used if _padding_ is true.
   #
-  #   require 'random/formatter'
+  #   require 'rubygems/vendor/securerandom/lib/random/formatter'
   #
   #   Random.urlsafe_base64 #=> "b4GOKm4pOYU_-BOXcrUGDg"
   #   # or
@@ -152,7 +152,7 @@ module Random::Formatter
 
   # Generate a random v4 UUID (Universally Unique IDentifier).
   #
-  #   require 'random/formatter'
+  #   require 'rubygems/vendor/securerandom/lib/random/formatter'
   #
   #   Random.uuid #=> "2d931510-d99f-494a-8c67-87feb05e1594"
   #   Random.uuid #=> "bad85eb9-0713-4da7-8d36-07a8e4b00eab"
@@ -178,7 +178,7 @@ module Random::Formatter
 
   # Generate a random v7 UUID (Universally Unique IDentifier).
   #
-  #   require 'random/formatter'
+  #   require 'rubygems/vendor/securerandom/lib/random/formatter'
   #
   #   Random.uuid_v7 # => "0188d4c3-1311-7f96-85c7-242a7aa58f1e"
   #   Random.uuid_v7 # => "0188d4c3-16fe-744f-86af-38fa04c62bb5"
@@ -307,7 +307,7 @@ module Random::Formatter
   #
   # The result may contain whatever characters are in the source array.
   #
-  #   require 'random/formatter'
+  #   require 'rubygems/vendor/securerandom/lib/random/formatter'
   #
   #   prng.choose([*'l'..'r'], 16) #=> "lmrqpoonmmlqlron"
   #   prng.choose([*'0'..'9'], 5)  #=> "27309"
@@ -355,7 +355,7 @@ module Random::Formatter
   #
   # The result may contain A-Z, a-z and 0-9, unless _chars_ is specified.
   #
-  #   require 'random/formatter'
+  #   require 'rubygems/vendor/securerandom/lib/random/formatter'
   #
   #   Random.alphanumeric     #=> "2BuBuLf3WfSKyQbR"
   #   # or

--- a/lib/rubygems/vendor/securerandom/lib/securerandom.rb
+++ b/lib/rubygems/vendor/securerandom/lib/securerandom.rb
@@ -1,7 +1,7 @@
 # -*- coding: us-ascii -*-
 # frozen_string_literal: true
 
-require 'random/formatter'
+require_relative 'random/formatter'
 
 # == Secure random number generator interface.
 #
@@ -18,7 +18,7 @@ require 'random/formatter'
 # * /dev/urandom
 # * Win32
 #
-# Gem::SecureRandom is extended by the Random::Formatter module which
+# Gem::SecureRandom is extended by the Gem::Random::Formatter module which
 # defines the following methods:
 #
 # * alphanumeric
@@ -88,9 +88,9 @@ module Gem::SecureRandom
 
     # :startdoc:
 
-    # Generate random data bytes for Random::Formatter
+    # Generate random data bytes for Gem::Random::Formatter
     public :gen_random
   end
 end
 
-Gem::SecureRandom.extend(Random::Formatter)
+Gem::SecureRandom.extend(Gem::Random::Formatter)

--- a/lib/rubygems/vendored_securerandom.rb
+++ b/lib/rubygems/vendored_securerandom.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module Gem::Random; end
+require_relative "vendor/securerandom/lib/securerandom"

--- a/tool/automatiek/resolv-v0.4.0.patch
+++ b/tool/automatiek/resolv-v0.4.0.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/rubygems/vendor/resolv/lib/resolv.rb b/lib/rubygems/vendor/resolv/lib/resolv.rb
+index 0301f4f161..0f5ded3b76 100644
+--- a/lib/rubygems/vendor/resolv/lib/resolv.rb
++++ b/lib/rubygems/vendor/resolv/lib/resolv.rb
+@@ -5,7 +5,7 @@
+ require 'io/wait'
+ 
+ begin
+-  require_relative '../../securerandom/lib/securerandom'
++  require_relative '../../../vendored_securerandom'
+ rescue LoadError
+ end
+ 

--- a/tool/automatiek/vendor.rb
+++ b/tool/automatiek/vendor.rb
@@ -26,20 +26,23 @@ VendoredGem = Struct.new(:name, :extra_dependencies, :namespace, :prefix, :vendo
 
     files.each do |file|
       contents = File.read(file)
-
-      contents.gsub!(/module Kernel/, "module #{prefix}")
-      contents.gsub!(/#{prefix}::#{namespace}::/, "#{namespace}::")
-      contents.gsub!(/#{namespace}::/, "#{prefix}::#{namespace}::")
-      contents.gsub!(/(\s)::#{namespace}/, '\1' + "::#{prefix}::#{namespace}")
-      contents.gsub!(/(?<!\w|def |:)#{namespace}\b/, "#{prefix}::#{namespace}")
-
-      contents.gsub!(/^(\s*)require (["'])#{Regexp.escape require_entrypoint}/, "\\1require_relative \\2#{relative_require_target_from(file)}")
-      contents.gsub!(/require (["'])#{Regexp.escape require_entrypoint}/, "require \\1#{require_target}/#{require_entrypoint}")
-
-      contents.gsub!(%r{(autoload\s+[:\w]+,\s+["'])(#{Regexp.escape require_entrypoint}[\w\/]+["'])}, "\\1#{require_target}/\\2")
-
-      File.open(file, "w") {|f| f << contents }
+      contents = namespace_file(file, contents, namespace)
+      File.write(file, contents)
     end
+  end
+
+  def namespace_file(file, contents, namespace)
+    contents.gsub!(/module Kernel/, "module #{prefix}")
+    contents.gsub!(/#{prefix}::#{namespace}::/, "#{namespace}::")
+    contents.gsub!(/#{namespace}::/, "#{prefix}::#{namespace}::")
+    contents.gsub!(/(\s)::#{namespace}/, '\1' + "::#{prefix}::#{namespace}")
+    contents.gsub!(/(?<!\w|def |:)#{namespace}\b/, "#{prefix}::#{namespace}")
+
+    contents.gsub!(/^(\s*)require (["'])#{Regexp.escape require_entrypoint}/, "\\1require_relative \\2#{relative_require_target_from(file)}")
+    contents.gsub!(/require (["'])#{Regexp.escape require_entrypoint}/, "require \\1#{require_target}/#{require_entrypoint}")
+
+    contents.gsub!(%r{(autoload\s+[:\w]+,\s+["'])(#{Regexp.escape require_entrypoint}[\w\/]+["'])}, "\\1#{require_target}/\\2")
+    contents
   end
 
   def clean
@@ -66,12 +69,25 @@ VendoredGem = Struct.new(:name, :extra_dependencies, :namespace, :prefix, :vendo
 
   alias_method :gem_name, :name
 
-  def relative_require_target_from(file)
-    Pathname.new("#{vendor_lib}/lib/#{require_entrypoint}").relative_path_from(File.dirname(file))
+  def relative_require_target_from(file, entrypoint = require_entrypoint)
+    Pathname.new("#{vendor_lib}/lib/#{entrypoint}").relative_path_from(File.dirname(file))
   end
 
   def require_target
     @require_target ||= vendor_lib.sub(%r{^(.+?/)?lib/}, "") << "/lib"
+  end
+end
+
+class VendoredSecureRandom < VendoredGem
+  def namespace_file(file, contents, namespace)
+    contents = super(file, contents, namespace)
+
+    contents.gsub!(/Random::/, "#{prefix}::Random::")
+
+    entrypoint = "random"
+    contents.gsub!(/^require (["'])#{Regexp.escape entrypoint}/, "require_relative \\1#{relative_require_target_from(file, "random")}")
+    contents.gsub!(/require (["'])#{Regexp.escape entrypoint}/, "require \\1#{require_target}/#{entrypoint}")
+    contents
   end
 end
 
@@ -84,8 +100,8 @@ vendored_gems = [
   VendoredGem.new(name: "net-http-persistent", namespace: "Net::HTTP::Persistent", prefix: "Gem", vendor_lib: "bundler/lib/bundler/vendor/net-http-persistent", license_path: "README.rdoc", extra_dependencies: %w[net-http uri/lib/rubygems/vendor/uri], patch_name: "net-http-persistent-v4.0.2.patch"),
   VendoredGem.new(name: "net-protocol", namespace: "Net", prefix: "Gem", vendor_lib: "lib/rubygems/vendor/net-protocol", license_path: "LICENSE.txt"),
   VendoredGem.new(name: "optparse", namespace: "OptionParser", prefix: "Gem", vendor_lib: "lib/rubygems/vendor/optparse", license_path: "COPYING", extra_dependencies: %w[uri/lib/rubygems/vendor/uri], patch_name: "optparse-v0.4.0.patch"),
-  VendoredGem.new(name: "resolv", namespace: "Resolv", prefix: "Gem", vendor_lib: "lib/rubygems/vendor/resolv", license_path: "LICENSE.txt", extra_dependencies: %w[securerandom timeout]),
-  VendoredGem.new(name: "securerandom", namespace: "SecureRandom", prefix: "Gem", vendor_lib: "lib/rubygems/vendor/securerandom", license_path: "LICENSE.txt"),
+  VendoredGem.new(name: "resolv", namespace: "Resolv", prefix: "Gem", vendor_lib: "lib/rubygems/vendor/resolv", license_path: "LICENSE.txt", extra_dependencies: %w[securerandom timeout], patch_name: "resolv-v0.4.0.patch"),
+  VendoredSecureRandom.new(name: "securerandom", namespace: "SecureRandom", prefix: "Gem", vendor_lib: "lib/rubygems/vendor/securerandom", license_path: "LICENSE.txt"),
   VendoredGem.new(name: "timeout", namespace: "Timeout", prefix: "Gem", vendor_lib: "lib/rubygems/vendor/timeout", license_path: "LICENSE.txt", patch_name: "timeout-v0.4.1.patch"),
   VendoredGem.new(name: "tsort", namespace: "TSort", prefix: "Gem", vendor_lib: "lib/rubygems/vendor/tsort", license_path: "LICENSE.txt"),
   VendoredGem.new(name: "uri", namespace: "URI", prefix: "Gem", vendor_lib: "lib/rubygems/vendor/uri", license_path: "LICENSE.txt"),

--- a/tool/automatiek/vendor.rb
+++ b/tool/automatiek/vendor.rb
@@ -100,7 +100,7 @@ vendored_gems = [
   VendoredGem.new(name: "net-http-persistent", namespace: "Net::HTTP::Persistent", prefix: "Gem", vendor_lib: "bundler/lib/bundler/vendor/net-http-persistent", license_path: "README.rdoc", extra_dependencies: %w[net-http uri/lib/rubygems/vendor/uri], patch_name: "net-http-persistent-v4.0.2.patch"),
   VendoredGem.new(name: "net-protocol", namespace: "Net", prefix: "Gem", vendor_lib: "lib/rubygems/vendor/net-protocol", license_path: "LICENSE.txt"),
   VendoredGem.new(name: "optparse", namespace: "OptionParser", prefix: "Gem", vendor_lib: "lib/rubygems/vendor/optparse", license_path: "COPYING", extra_dependencies: %w[uri/lib/rubygems/vendor/uri], patch_name: "optparse-v0.4.0.patch"),
-  VendoredGem.new(name: "resolv", namespace: "Resolv", prefix: "Gem", vendor_lib: "lib/rubygems/vendor/resolv", license_path: "LICENSE.txt", extra_dependencies: %w[securerandom timeout], patch_name: "resolv-v0.4.0.patch"),
+  VendoredGem.new(name: "resolv", namespace: "Resolv", prefix: "Gem", vendor_lib: "lib/rubygems/vendor/resolv", license_path: "LICENSE.txt", extra_dependencies: %w[securerandom/lib/rubygems/vendor/securerandom timeout], patch_name: "resolv-v0.4.0.patch"),
   VendoredSecureRandom.new(name: "securerandom", namespace: "SecureRandom", prefix: "Gem", vendor_lib: "lib/rubygems/vendor/securerandom", license_path: "LICENSE.txt"),
   VendoredGem.new(name: "timeout", namespace: "Timeout", prefix: "Gem", vendor_lib: "lib/rubygems/vendor/timeout", license_path: "LICENSE.txt", patch_name: "timeout-v0.4.1.patch"),
   VendoredGem.new(name: "tsort", namespace: "TSort", prefix: "Gem", vendor_lib: "lib/rubygems/vendor/tsort", license_path: "LICENSE.txt"),
@@ -112,6 +112,7 @@ vendored_gems = [
   VendoredGem.new(name: "thor", namespace: "Thor", prefix: "Bundler", vendor_lib: "bundler/lib/bundler/vendor/thor", license_path: "LICENSE.md", patch_name: "thor-v1.3.0.patch"),
   VendoredGem.new(name: "tsort", namespace: "TSort", prefix: "Bundler", vendor_lib: "bundler/lib/bundler/vendor/tsort", license_path: "LICENSE.txt"),
   VendoredGem.new(name: "uri", namespace: "URI", prefix: "Bundler", vendor_lib: "bundler/lib/bundler/vendor/uri", license_path: "LICENSE.txt"),
+  VendoredSecureRandom.new(name: "securerandom", namespace: "SecureRandom", prefix: "Bundler", vendor_lib: "bundler/lib/bundler/vendor/securerandom", license_path: "LICENSE.txt"),
 ].group_by(&:name)
 
 Bundler.definition.resolve.materialized_for_all_platforms.reject {|s| ignore.include?(s.name) }.each do |s|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In Ruby 3.2, when using `bundler/inline`, Bundler `Fetcher` will internally activate the default version of `securerandom` (0.2.2). If the inline gemfile is using a different version of `securerandom`, and activation conflict will be raised.

See https://github.com/rubygems/rubygems/pull/7930.

## What is your fix for the problem, implemented in this PR?

In the future we believe the ideal solution is to have `bundler/inline` reexec the original process once the install is done. However, re-exec'ing with original Ruby arguments is tricky, so for now we're vendoring `securerandom` in Bundler to skip this particular problem.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
