### PR TITLE
Fix some errors about a previous installation folder that's unsafe to remove, when there's no need to remove it

### DIFF
--- a/bundler/lib/bundler/errors.rb
+++ b/bundler/lib/bundler/errors.rb
@@ -217,15 +217,15 @@ module Bundler
   end
 
   class InsecureInstallPathError < BundlerError
-    def initialize(path)
+    def initialize(name, path)
+      @name = name
       @path = path
     end
 
     def message
-      "The installation path is insecure. Bundler cannot continue.\n" \
-      "#{@path} is world-writable (without sticky bit).\n" \
-      "Bundler cannot safely replace gems in world-writeable directories due to potential vulnerabilities.\n" \
-      "Please change the permissions of this directory or choose a different install path."
+      "Bundler cannot reinstall #{@name} because there's a previous installation of it at #{@path} that is unsafe to remove.\n" \
+      "The parent of #{@path} is world-writable and does not have the sticky bit set, making it insecure to remove due to potential vulnerabilities.\n" \
+      "Please change the permissions of #{File.dirname(@path)} or choose a different install path."
     end
 
     status_code(38)

--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -155,7 +155,7 @@ module Bundler
       parent_st = File.stat(parent)
 
       if parent_st.world_writable? && !parent_st.sticky?
-        raise InsecureInstallPathError.new(parent)
+        raise InsecureInstallPathError.new(spec.full_name, dir)
       end
 
       begin

--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -150,6 +150,7 @@ module Bundler
 
     def strict_rm_rf(dir)
       return unless File.exist?(dir)
+      return if Dir.empty?(dir)
 
       parent = File.dirname(dir)
       parent_st = File.stat(parent)

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -1055,7 +1055,7 @@ RSpec.describe "bundle install with gem sources" do
 
       bundle "install --redownload", raise_on_error: false
 
-      expect(err).to include("The installation path is insecure. Bundler cannot continue.")
+      expect(err).to include("Bundler cannot reinstall foo-1.0.0 because there's a previous installation of it at #{gems_path}/foo-1.0.0 that is unsafe to remove")
     end
   end
 

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -1059,6 +1059,34 @@ RSpec.describe "bundle install with gem sources" do
     end
   end
 
+  describe "when gems path is world writable (no sticky bit set), but previous install is just an empty dir (like it happens with default gems)", :permissions do
+    let(:gems_path) { bundled_app("vendor/#{Bundler.ruby_scope}/gems") }
+    let(:full_path) { gems_path.join("foo-1.0.0") }
+
+    before do
+      build_repo4 do
+        build_gem "foo", "1.0.0" do |s|
+          s.write "CHANGELOG.md", "foo"
+        end
+      end
+
+      gemfile <<-G
+        source "https://gem.repo4"
+        gem 'foo'
+      G
+    end
+
+    it "does not try to remove the directory and thus don't abort with an error about unsafe directory removal" do
+      bundle "config set --local path vendor"
+
+      FileUtils.mkdir_p(gems_path)
+      FileUtils.chmod(0o777, gems_path)
+      Dir.mkdir(full_path)
+
+      bundle "install"
+    end
+  end
+
   describe "when bundle cache path does not have write access", :permissions do
     let(:cache_path) { bundled_app("vendor/#{Bundler.ruby_scope}/cache") }
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In some github actions environments, Bundler is failing with an error about the previous installation being unsafe to remove.

## What is your fix for the problem, implemented in this PR?

When this directory is actually empty because it corresponds to a default gem, there's no need to even try to remove it, so skip the removal in that case and thus circumvent the error.

Fixes https://github.com/rubygems/rubygems/issues/7983.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
