### PR TITLE
Make benchmark and rdoc as optional

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -336,6 +336,8 @@ By default, this RubyGems will install gem as:
 
       require_relative "../rdoc"
 
+      return false unless defined?(Gem::RDoc)
+
       fake_spec = Gem::Specification.new "rubygems", Gem::VERSION
       def fake_spec.full_gem_path
         File.expand_path "../../..", __dir__

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -19,7 +19,6 @@ require "shellwords"
 require "tmpdir"
 require "rubygems/vendor/uri/lib/uri"
 require "zlib"
-require "benchmark" # stdlib
 require_relative "mock_gem_ui"
 
 module Gem

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -667,7 +667,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
 
     assert_path_exist File.join(a2.doc_dir, "ri")
     assert_path_exist File.join(a2.doc_dir, "rdoc")
-  end
+  end if defined?(Gem::RDoc)
 
   def test_execute_rdoc_with_path
     specs = spec_fetcher do |fetcher|
@@ -703,7 +703,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
     wait_for_child_process_to_exit
 
     assert_path_exist "whatever/doc/a-2", "documentation not installed"
-  end
+  end if defined?(Gem::RDoc)
 
   def test_execute_saves_build_args
     specs = spec_fetcher do |fetcher|

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -506,7 +506,7 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
     a2 = @specs["a-2"]
 
     assert_path_exist File.join(a2.doc_dir, "rdoc")
-  end
+  end if defined?(Gem::RDoc)
 
   def test_execute_named
     spec_fetcher do |fetcher|

--- a/test/rubygems/test_gem_rdoc.rb
+++ b/test/rubygems/test_gem_rdoc.rb
@@ -134,4 +134,4 @@ class TestGemRDoc < Gem::TestCase
       FileUtils.rm_r @a.doc_dir
     end
   end
-end
+end if defined?(Gem::RDoc)

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "benchmark"
 require_relative "helper"
 require "date"
 require "pathname"
@@ -146,6 +145,12 @@ end
   end
 
   def test_find_in_unresolved_tree_is_not_exponentiental
+    begin
+      require "benchmark"
+    rescue LoadError
+      pend "Benchmark is not available in this environment. Please install it with `gem install benchmark`."
+    end
+
     pend "currently slower in CI on TruffleRuby" if RUBY_ENGINE == "truffleruby"
     num_of_pkg = 7
     num_of_version_per_pkg = 3

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -223,7 +223,7 @@ class TestGemRequire < Gem::TestCase
 
   def test_activate_via_require_respects_loaded_files
     pend "Not sure what's going on. If another spec creates a 'a' gem before
-      this test, somehow require will load the benchmark in b, and ignore that the
+      this test, somehow require will load the erb in b, and ignore that the
       stdlib one is already in $LOADED_FEATURES?. Reproducible by running the
       spaceship_specific_file test before this one" if Gem.java_platform?
 
@@ -240,11 +240,11 @@ class TestGemRequire < Gem::TestCase
       load_path_changed = true
     end
 
-    require "benchmark" # the stdlib
+    require "erb" # the stdlib
 
     a1 = util_spec "a", "1", { "b" => ">= 1" }, "lib/test_gem_require_a.rb"
-    b1 = util_spec "b", "1", nil, "lib/benchmark.rb"
-    b2 = util_spec "b", "2", nil, "lib/benchmark.rb"
+    b1 = util_spec "b", "1", nil, "lib/erb.rb"
+    b2 = util_spec "b", "2", nil, "lib/erb.rb"
 
     install_specs b1, b2, a1
 
@@ -257,12 +257,12 @@ class TestGemRequire < Gem::TestCase
 
     assert_equal unresolved_names, ["b (>= 1)"]
 
-    # The require('benchmark') below will activate b-2. However, its
-    # lib/benchmark.rb won't ever be loaded. The reason is MRI sees that even
-    # though b-2 is earlier in $LOAD_PATH it already loaded a benchmark.rb file
+    # The require('erb') below will activate b-2. However, its
+    # lib/erb.rb won't ever be loaded. The reason is MRI sees that even
+    # though b-2 is earlier in $LOAD_PATH it already loaded a erb.rb file
     # and that still exists in $LOAD_PATH (further down),
     # and as a result #gem_original_require returns false.
-    refute require("benchmark"), "the benchmark stdlib should be recognized as already loaded"
+    refute require("erb"), "the erb stdlib should be recognized as already loaded"
 
     assert_includes $LOAD_PATH, b2.full_require_paths[0]
     assert_includes $LOAD_PATH, rubylibdir
@@ -273,7 +273,7 @@ class TestGemRequire < Gem::TestCase
     assert_operator $LOAD_PATH.index(b2.full_require_paths[0]), :<, $LOAD_PATH.index(rubylibdir), message
 
     # We detected that we should activate b-2, so we did so, but
-    # then #gem_original_require decided "I've already got some benchmark.rb" loaded.
+    # then #gem_original_require decided "I've already got some erb.rb" loaded.
     # This case is fine because our lazy loading provided exactly
     # the same behavior as eager loading would have.
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I have a plan to make `benchmark` and `rdoc` bundled gems(`benchmark` is TBD status). After that, the test suite of rubygems is failing because they are not located in `LOAD_PATH`.

## What is your fix for the problem, implemented in this PR?

If `benchmark` and `rdoc` is not available, skip related tests for that. And use `erb` for example library of bundler, not `benchmark`.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
