### PR TITLE
Load gemspecs in the context of its parent also when using local overrides

### DIFF
--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -392,9 +392,12 @@ module Bundler
       def validate_spec(_spec); end
 
       def load_gemspec(file)
-        stub = Gem::StubSpecification.gemspec_stub(file, install_path.parent, install_path.parent)
-        stub.full_gem_path = Pathname.new(file).dirname.expand_path(root).to_s
-        StubSpecification.from_stub(stub)
+        dirname = Pathname.new(file).dirname
+        SharedHelpers.chdir(dirname.to_s) do
+          stub = Gem::StubSpecification.gemspec_stub(file, install_path.parent, install_path.parent)
+          stub.full_gem_path = dirname.expand_path(root).to_s
+          StubSpecification.from_stub(stub)
+        end
       end
 
       def git_scope


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler normally loads gemspecs in the context of its parent directory, so no explicit `chdir` is necessary when building the list of files in the gemspec. However, when using local overrides, this does not happen.

## What is your fix for the problem, implemented in this PR?

Make sure to also explicitly `chdir` in this case.

Fixes #4528.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
