### PR TITLE
Standardize pretty-print output for `Gem::Source` and subclasses

### DIFF
--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -213,14 +213,16 @@ class Gem::Source
   end
 
   def pretty_print(q) # :nodoc:
-    q.group 2, "[Remote:", "]" do
-      q.breakable
-      q.text @uri.to_s
-
-      if api = uri
+    q.object_group(self) do
+      q.group 2, "[Remote:", "]" do
         q.breakable
-        q.text "API URI: "
-        q.text api.to_s
+        q.text @uri.to_s
+
+        if api = uri
+          q.breakable
+          q.text "API URI: "
+          q.text api.to_s
+        end
       end
     end
   end

--- a/lib/rubygems/source/git.rb
+++ b/lib/rubygems/source/git.rb
@@ -157,12 +157,14 @@ class Gem::Source::Git < Gem::Source
   end
 
   def pretty_print(q) # :nodoc:
-    q.group 2, "[Git: ", "]" do
-      q.breakable
-      q.text @repository
+    q.object_group(self) do
+      q.group 2, "[Git: ", "]" do
+        q.breakable
+        q.text @repository
 
-      q.breakable
-      q.text @reference
+        q.breakable
+        q.text @reference
+      end
     end
   end
 

--- a/lib/rubygems/source/installed.rb
+++ b/lib/rubygems/source/installed.rb
@@ -32,6 +32,8 @@ class Gem::Source::Installed < Gem::Source
   end
 
   def pretty_print(q) # :nodoc:
-    q.text "[Installed]"
+    q.object_group(self) do
+      q.text "[Installed]"
+    end
   end
 end

--- a/lib/rubygems/source/local.rb
+++ b/lib/rubygems/source/local.rb
@@ -117,10 +117,14 @@ class Gem::Source::Local < Gem::Source
   end
 
   def pretty_print(q) # :nodoc:
-    q.group 2, "[Local gems:", "]" do
-      q.breakable
-      q.seplist @specs.keys do |v|
-        q.text v.full_name
+    q.object_group(self) do
+      q.group 2, "[Local gems:", "]" do
+        q.breakable
+        if @specs
+          q.seplist @specs.keys do |v|
+            q.text v.full_name
+          end
+        end
       end
     end
   end

--- a/lib/rubygems/source/specific_file.rb
+++ b/lib/rubygems/source/specific_file.rb
@@ -42,9 +42,11 @@ class Gem::Source::SpecificFile < Gem::Source
   end
 
   def pretty_print(q) # :nodoc:
-    q.group 2, "[SpecificFile:", "]" do
-      q.breakable
-      q.text @path
+    q.object_group(self) do
+      q.group 2, "[SpecificFile:", "]" do
+        q.breakable
+        q.text @path
+      end
     end
   end
 

--- a/test/rubygems/test_gem_source_git.rb
+++ b/test/rubygems/test_gem_source_git.rb
@@ -292,6 +292,12 @@ class TestGemSourceGit < Gem::TestCase
     assert_equal Gem::URI(@repository), @source.uri
   end
 
+  def test_pretty_print
+    assert_equal "#<Gem::Source::Git[Git: \n" \
+                 "   #{@repository}\n" \
+                 "   HEAD]>\n", @source.pretty_inspect
+  end
+
   def test_uri_hash
     assert_equal @hash, @source.uri_hash
 

--- a/test/rubygems/test_gem_source_installed.rb
+++ b/test/rubygems/test_gem_source_installed.rb
@@ -32,4 +32,9 @@ class TestGemSourceInstalled < Gem::TestCase
     assert_equal(1, vendor.<=>(installed), "vendor <=> installed")
     assert_equal(-1, installed.<=>(vendor), "installed <=> vendor")
   end
+
+  def test_pretty_print
+    local = Gem::Source::Installed.new
+    assert_equal "#<Gem::Source::Installed[Installed]>\n", local.pretty_inspect
+  end
 end

--- a/test/rubygems/test_gem_source_local.rb
+++ b/test/rubygems/test_gem_source_local.rb
@@ -104,4 +104,9 @@ class TestGemSourceLocal < Gem::TestCase
     assert_equal(-1, specific.<=>(local), "specific <=> local")
     assert_equal(1, local.<=>(specific), "local <=> specific")
   end
+
+  def test_pretty_print
+    local = Gem::Source::Local.new
+    assert_equal "#<Gem::Source::Local[Local gems: ]>\n", local.pretty_inspect
+  end
 end

--- a/test/rubygems/test_gem_source_specific_file.rb
+++ b/test/rubygems/test_gem_source_specific_file.rb
@@ -73,4 +73,8 @@ class TestGemSourceSpecificFile < Gem::TestCase
     assert_equal(0, a1_source.<=>(a1_source), "a1_source <=> a1_source") # rubocop:disable Lint/BinaryOperatorWithIdenticalOperands
     assert_equal(1, a2_source.<=>(a1_source), "a2_source <=> a1_source")
   end
+
+  def test_pretty_print
+    assert_equal "#<Gem::Source::SpecificFile[SpecificFile:\n   #{@sf.path}]>\n", @sf.pretty_inspect
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The pretty print output from Gem::Source and subclasses is informative, but unclear if you're not familiar with it. For example, take this:

```
$ irb 
>> Gem::SpecFetcher.fetcher.sources
=>
#<Gem::SourceList:0x00007f3fe89bedd8
 @sources=[[Remote: https://rubygems.org/ API URI: https://rubygems.org/]]>
```

One could conclude that Gem::SourceList is full of Remote or Gem::Remote objects - but it actually has Gem::Source objects in it.

This PR slightly tweaks the output so it is as follows:

```
$ irb 
>> Gem::SpecFetcher.fetcher.sources
=>
#<Gem::SourceList:0x00007f8c3de88340
 @sources=[#<Gem::Source[Remote: https://rubygems.org/ API URI: https://rubygems.org/]>]>
```


## What is your fix for the problem, implemented in this PR?

The current output of the various `#pretty_print` methods were wrapped in a call to `q.object_group(self)`, which will include the name of the relevant class.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
