### PR TITLE
Handle two `gemspec` usages in same Gemfile with same dep and compatible requirements

### DIFF
--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -485,6 +485,63 @@ RSpec.describe "bundle install with gem sources" do
       expect(the_bundle).to include_gems("rubocop 1.36.0")
     end
 
+    it "includes the gem without warning if two gemspecs add it with compatible requirements" do
+      gem1 = tmp("my-gem-1")
+      gem2 = tmp("my-gem-2")
+
+      build_lib "my-gem", path: gem1 do |s|
+        s.add_development_dependency "rubocop", "~> 1.0"
+      end
+
+      build_lib "my-gem-2", path: gem2 do |s|
+        s.add_development_dependency "rubocop", "~> 1.36.0"
+      end
+
+      build_repo4 do
+        build_gem "rubocop", "1.36.0"
+      end
+
+      gemfile <<~G
+        source "https://gem.repo4"
+
+        gemspec path: "#{gem1}"
+        gemspec path: "#{gem2}"
+      G
+
+      bundle :install
+
+      expect(err).to be_empty
+      expect(the_bundle).to include_gems("rubocop 1.36.0")
+    end
+
+    it "errors out if two gemspecs add it with incompatible requirements" do
+      gem1 = tmp("my-gem-1")
+      gem2 = tmp("my-gem-2")
+
+      build_lib "my-gem", path: gem1 do |s|
+        s.add_development_dependency "rubocop", "~> 2.0"
+      end
+
+      build_lib "my-gem-2", path: gem2 do |s|
+        s.add_development_dependency "rubocop", "~> 1.36.0"
+      end
+
+      build_repo4 do
+        build_gem "rubocop", "1.36.0"
+      end
+
+      gemfile <<~G
+        source "https://gem.repo4"
+
+        gemspec path: "#{gem1}"
+        gemspec path: "#{gem2}"
+      G
+
+      bundle :install, raise_on_error: false
+
+      expect(err).to include("Two gemspecs have conflicting requirements on the same gem: rubocop (~> 1.36.0, development) and rubocop (~> 2.0, development). Bundler cannot continue.")
+    end
+
     it "warns when a Gemfile dependency is overriding a gemspec development dependency, with different requirements" do
       build_lib "my-gem", path: bundled_app do |s|
         s.add_development_dependency "rails", ">= 5"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Our code was not handling the case of having two `gemspec` usages in the same Gemfile, with the same dependency and compatible requirements. Also, this bug in Bundler was being hidden by `rescue` code.
  
## What is your fix for the problem, implemented in this PR?

* Less swallowing of errors happening during Gemfile evaluation.
* Handle two `gemspecs` in the same Gemfile with the same dependency. If requirements are compatible, merge the requirements. Otherwise, print an error.

Fixes #7995.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
