### PR TITLE
Removed unused stringio

### DIFF
--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -75,7 +75,6 @@ class Gem::RemoteFetcher
   def initialize(proxy=nil, dns=nil, headers={})
     require_relative "core_ext/tcpsocket_init" if Gem.configuration.ipv4_fallback_enabled
     require_relative "vendored_net_http"
-    require "stringio"
     require_relative "vendor/uri/lib/uri"
 
     Socket.do_not_reverse_lookup = true


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Fixed #7996

## What is your fix for the problem, implemented in this PR?

The following script raises activated conflict error:

```
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rdoc"
end
```

```
$ ruby test.rb
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
/Users/hsbt/.local/share/gem/gems/bundler-2.5.18/lib/bundler/runtime.rb:299:in 'Bundler::Runtime#check_for_activated_spec!': You have already activated stringio 3.1.2.dev, but your Gemfile requires stringio 3.1.1. Since stringio is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports stringio as a default gem. (Gem::LoadError)
```

`gemfile(true)` call `Bundler::Installer.install` and load `stringio` of `Gem::RemoteFetcher`. Fortunately, loading `stringio`of `Gem::RemoteFetcher` is not necessary today. I removed that.

After that:

```
$ ruby test.rb
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
