### PR TITLE
Raise original errors when unexpected errors happen during Gemfile evaluation

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -670,7 +670,7 @@ module Bundler
     rescue ScriptError, StandardError => e
       msg = "There was an error while loading `#{path.basename}`: #{e.message}"
 
-      raise GemspecError, Dsl::DSLError.new(msg, path, e.backtrace, contents)
+      raise GemspecError, Dsl::DSLError.new(msg, path.to_s, e.backtrace, contents)
     end
 
     def configure_gem_path

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -53,7 +53,7 @@ module Bundler
         "#{e.is_a?(GemfileEvalError) ? "evaluating" : "parsing"} " \
         "`#{File.basename gemfile.to_s}`: #{e.message}"
 
-      raise DSLError.new(message, gemfile, e.backtrace, contents)
+      raise DSLError.new(message, gemfile.to_s, e.backtrace, contents)
     ensure
       @gemfile = original_gemfile
     end
@@ -577,7 +577,7 @@ module Bundler
 
           return m unless backtrace && dsl_path && contents
 
-          trace_line = backtrace.find {|l| l.include?(dsl_path.to_s) } || trace_line
+          trace_line = backtrace.find {|l| l.include?(dsl_path) } || trace_line
           return m unless trace_line
           line_numer = trace_line.split(":")[1].to_i - 1
           return m unless line_numer
@@ -603,7 +603,7 @@ module Bundler
 
       def parse_line_number_from_description
         description = self.description
-        if dsl_path && description =~ /((#{Regexp.quote File.expand_path(dsl_path)}|#{Regexp.quote dsl_path.to_s}):\d+)/
+        if dsl_path && description =~ /((#{Regexp.quote File.expand_path(dsl_path)}|#{Regexp.quote dsl_path}):\d+)/
           trace_line = Regexp.last_match[1]
           description = description.sub(/\n.*\n(\.\.\.)? *\^~+$/, "").sub(/#{Regexp.quote trace_line}:\s*/, "").sub("\n", " - ")
         end

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -45,7 +45,7 @@ module Bundler
       with_gemfile(gemfile) do |current_gemfile|
         contents ||= Bundler.read_file(current_gemfile)
         instance_eval(contents, current_gemfile, 1)
-      rescue Exception => e # rubocop:disable Lint/RescueException
+      rescue StandardError, ScriptError => e
         message = "There was an error " \
           "#{e.is_a?(GemfileEvalError) ? "evaluating" : "parsing"} " \
           "`#{File.basename current_gemfile}`: #{e.message}"

--- a/bundler/lib/bundler/errors.rb
+++ b/bundler/lib/bundler/errors.rb
@@ -244,4 +244,6 @@ module Bundler
 
     status_code(39)
   end
+
+  class InvalidArgumentError < BundlerError; status_code(40); end
 end

--- a/bundler/lib/bundler/ruby_version.rb
+++ b/bundler/lib/bundler/ruby_version.rb
@@ -23,7 +23,13 @@ module Bundler
       #   specified must match the version.
 
       @versions = Array(versions).map do |v|
-        op, v = Gem::Requirement.parse(normalize_version(v))
+        normalized_v = normalize_version(v)
+
+        unless Gem::Requirement::PATTERN.match?(normalized_v)
+          raise InvalidArgumentError, "#{v} is not a valid requirement on the Ruby version"
+        end
+
+        op, v = Gem::Requirement.parse(normalized_v)
         op == "=" ? v.to_s : "#{op} #{v}"
       end
 

--- a/bundler/spec/bundler/ruby_dsl_spec.rb
+++ b/bundler/spec/bundler/ruby_dsl_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Bundler::RubyDsl do
     context "with two requirements in the same string" do
       let(:ruby_version) { ">= 2.0.0, < 3.0" }
       it "raises an error" do
-        expect { subject }.to raise_error(ArgumentError)
+        expect { subject }.to raise_error(Bundler::InvalidArgumentError)
       end
     end
 
@@ -168,7 +168,7 @@ RSpec.describe Bundler::RubyDsl do
         let(:file_content) { "ruby-#{version}@gemset\n" }
 
         it "raises an error" do
-          expect { subject }.to raise_error(Gem::Requirement::BadRequirementError, "Illformed requirement [\"#{version}@gemset\"]")
+          expect { subject }.to raise_error(Bundler::InvalidArgumentError, "2.0.0@gemset is not a valid requirement on the Ruby version")
         end
       end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When unexpected errors happen during Gemfile evaluation, Bundler shows an unhelpful error.

## What is your fix for the problem, implemented in this PR?

It's better to let the original error be raised in this case, so that the actual culprit code line can be identified.

Fixes the first of the problems reported at #7995.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
