### PR TITLE
Fix `gem fetch` always exiting with zero status code

### DIFF
--- a/lib/rubygems/commands/fetch_command.rb
+++ b/lib/rubygems/commands/fetch_command.rb
@@ -63,6 +63,17 @@ then repackaging it.
 
   def execute
     check_version
+
+    exit_code = fetch_gems
+
+    terminate_interaction exit_code
+  end
+
+  private
+
+  def fetch_gems
+    exit_code = 0
+
     version = options[:version]
 
     platform  = Gem.platforms.last
@@ -86,10 +97,13 @@ then repackaging it.
 
       if spec.nil?
         show_lookup_failure gem_name, gem_version, errors, suppress_suggestions, options[:domain]
+        exit_code |= 2
         next
       end
       source.download spec
       say "Downloaded #{spec.full_name}"
     end
+
+    exit_code
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`gem fetch` is printing user friendly errors when it fails, but it's not exiting with a proper error code.

## What is your fix for the problem, implemented in this PR?

Do what `gem install` does.

Fixes #8004.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
