### PR TITLE
Don't include hook templates in cached git source

### DIFF
--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -226,6 +226,7 @@ module Bundler
         git_proxy.checkout if requires_checkout?
         FileUtils.cp_r("#{cache_path}/.", app_cache_path)
         FileUtils.touch(app_cache_path.join(".bundlecache"))
+        FileUtils.rm_rf(Dir.glob(app_cache_path.join("hooks/*.sample")))
       end
 
       def load_spec_files

--- a/bundler/spec/cache/git_spec.rb
+++ b/bundler/spec/cache/git_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe "bundle cache with git" do
     expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist
     expect(bundled_app("vendor/cache/foo-1.0-#{ref}/.git")).not_to exist
     expect(bundled_app("vendor/cache/foo-1.0-#{ref}/.bundlecache")).to be_file
+    expect(Dir.glob(bundled_app("vendor/cache/foo-1.0-#{ref}/hooks/*.sample"))).to be_empty
 
     FileUtils.rm_rf lib_path("foo-1.0")
     expect(the_bundle).to include_gems "foo 1.0"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We're starting to look at https://github.com/rubygems/rubygems/pull/4469 at GitHub, and we noticed some git files in the cache that don't seem strictly necessary. These are mostly files coming from the standard git template dir.

The sample hooks ending in `.sample` in particular seem unnecessary, since these are disabled by default anyway. Removing them would save roughly 60K per cached git repo. We can easily add these files to our application's .gitignore, but I thought it might be generally nice to make the cache a bit smaller.

## What is your fix for the problem, implemented in this PR?

This PR removes the `.sample` git hooks from the cached repos.

It might be possible to remove more, but I'm not sure. Doing the initial clone with an empty `--template` dir, for example, might be possible but I'm not sure if folks expect their custom git template files to apply here.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
