### PR TITLE
Removed psych and stringio from gemfile at bundler/inline

### DIFF
--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -655,4 +655,27 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(out).to include("before: [\"Test_Variable\"]")
     expect(out).to include("after: [\"Test_Variable\"]")
   end
+
+  it "does not load specified version of psych and stringio" do
+    build_repo4 do
+      build_gem "psych", "999"
+      build_gem "stringio", "999"
+    end
+
+    script <<-RUBY, env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+      require "bundler/inline"
+
+      gemfile(true) do
+        source "https://gem.repo4"
+
+        gem "psych"
+        gem "stringio"
+      end
+    RUBY
+
+    expect(out).to include("Installing psych 999")
+    expect(out).to include("Installing stringio 999")
+    expect(err).to include("bundler/inline can't activate psych-999")
+    expect(err).to include("bundler/inline can't activate stringio-999")
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Workaround for https://github.com/rubygems/rubygems/issues/7996

Bundler can't activate `psych` and `stringio` when user declared different version of `psych` and `stringio` from default gems with `bundler/inline` and run `gemfile(true)`

`gemfile(true)` called `Gem.load_yaml` for gemspec verification after gem installation. We can't activate declared gem version because they are not installed yet. So, Bundler always activate default gems with `bundler/inline` and `gemfile(true)`.

## What is your fix for the problem, implemented in this PR?

It's difficult to resolve without Namespace feature of Ruby runtime. I removed `psych` and `stringio` from `Bundler.definition` and warn it.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
