### PR TITLE
Make an exe file executable when generating new gems

### DIFF
--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -191,7 +191,10 @@ module Bundler
         templates.merge!("standard.yml.tt" => ".standard.yml")
       end
 
-      templates.merge!("exe/newgem.tt" => "exe/#{name}") if config[:exe]
+      if config[:exe]
+        templates.merge!("exe/newgem.tt" => "exe/#{name}")
+        executables.push("exe/#{name}")
+      end
 
       if extension == "c"
         templates.merge!(

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -681,6 +681,9 @@ RSpec.describe "bundle gem" do
 
       it "builds exe skeleton" do
         expect(bundled_app("#{gem_name}/exe/#{gem_name}")).to exist
+        unless Gem.win_platform?
+          expect(bundled_app("#{gem_name}/exe/#{gem_name}")).to be_executable
+        end
       end
 
       it "requires the main file" do


### PR DESCRIPTION
## What is your fix for the problem, implemented in this PR?

Currently, an exe file isn't executable when generating new gems because it doesn't have the correct permission.
This PR sets the correct permission same as files under the `bin`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
