### PR TITLE
Remove temporary `.lock` files unintentionally left around by gem installer

### DIFF
--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -33,20 +33,17 @@ module Gem
   # Can be removed once RubyGems 3.5.14 support is dropped
   unless Gem.respond_to?(:open_file_with_flock)
     def self.open_file_with_flock(path, &block)
-      flags = File.exist?(path) ? "r+" : "a+"
+      mode = IO::RDONLY | IO::APPEND | IO::CREAT | IO::BINARY
+      mode |= IO::SHARE_DELETE if IO.const_defined?(:SHARE_DELETE)
 
-      File.open(path, flags) do |io|
+      File.open(path, mode) do |io|
         begin
           io.flock(File::LOCK_EX)
         rescue Errno::ENOSYS, Errno::ENOTSUP
+        rescue Errno::ENOLCK # NFS
+          raise unless Thread.main == Thread.current
         end
         yield io
-      rescue Errno::ENOLCK # NFS
-        if Thread.main != Thread.current
-          raise
-        else
-          File.open(path, flags, &block)
-        end
       end
     end
   end

--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -81,11 +81,11 @@ module Bundler
       end
     end
 
-    if Bundler.rubygems.provides?("< 3.5.15")
+    if Bundler.rubygems.provides?("< 3.5.19")
       def generate_bin_script(filename, bindir)
         bin_script_path = File.join bindir, formatted_program_filename(filename)
 
-        Gem.open_file_with_flock("#{bin_script_path}.lock") do
+        Gem.open_file_with_lock(bin_script_path) do
           require "fileutils"
           FileUtils.rm_f bin_script_path # prior install may have been --no-wrappers
 

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -1591,4 +1591,17 @@ RSpec.describe "bundle install with gem sources" do
       expect(err).to include("The running version of Bundler (9.99.9) does not match the version of the specification installed for it (9.99.8)")
     end
   end
+
+  it "only installs executable files in bin" do
+    bundle "config set --local path vendor/bundle"
+
+    install_gemfile <<~G
+      source "https://gem.repo1"
+      gem "myrack"
+    G
+
+    expected_executables = [vendored_gems("bin/myrackup").to_s]
+    expected_executables << vendored_gems("bin/myrackup.bat").to_s if Gem.win_platform?
+    expect(Dir.glob(vendored_gems("bin/*"))).to eq(expected_executables)
+  end
 end

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -795,6 +795,16 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   end
 
   ##
+  # Open a file with given flags, and protect access with a file lock
+
+  def self.open_file_with_lock(path, &block)
+    file_lock = "#{path}.lock"
+    open_file_with_flock(file_lock, &block)
+  ensure
+    FileUtils.rm_f file_lock
+  end
+
+  ##
   # Open a file with given flags, and protect access with flock
 
   def self.open_file_with_flock(path, &block)

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -794,15 +794,14 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     File.open(path, flags, &block)
   end
 
-  mode = IO::RDONLY | IO::APPEND | IO::CREAT | IO::BINARY
-  mode |= IO::SHARE_DELETE if IO.const_defined?(:SHARE_DELETE)
-  MODE_TO_FLOCK = mode # :nodoc:
-
   ##
   # Open a file with given flags, and protect access with flock
 
   def self.open_file_with_flock(path, &block)
-    File.open(path, MODE_TO_FLOCK) do |io|
+    mode = IO::RDONLY | IO::APPEND | IO::CREAT | IO::BINARY
+    mode |= IO::SHARE_DELETE if IO.const_defined?(:SHARE_DELETE)
+
+    File.open(path, mode) do |io|
       begin
         io.flock(File::LOCK_EX)
       rescue Errno::ENOSYS, Errno::ENOTSUP

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -538,7 +538,7 @@ class Gem::Installer
   def generate_bin_script(filename, bindir)
     bin_script_path = File.join bindir, formatted_program_filename(filename)
 
-    Gem.open_file_with_flock("#{bin_script_path}.lock") do |lock|
+    Gem.open_file_with_lock(bin_script_path) do
       require "fileutils"
       FileUtils.rm_f bin_script_path # prior install may have been --no-wrappers
 
@@ -546,8 +546,6 @@ class Gem::Installer
         file.write app_script_text(filename)
         file.chmod(options[:prog_mode] || 0o755)
       end
-    ensure
-      FileUtils.rm_f lock.path
     end
 
     verbose bin_script_path


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This fixes the same issue as #7939, but when Bundler is used with RubyGems versions that don't include the "cleanup fix".

## What is your fix for the problem, implemented in this PR?

I backported the changes to Bundler, but also made implementation in both sides the same, and extracted a new method so that `.lock` files are removed automatically.

The idea is to use this new method to fix issues like #7959 or #7786.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
