### PR TITLE
Fix `bundle install --local` hitting the network when default gems are included

### DIFF
--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -194,7 +194,7 @@ module Bundler
     # that said, it's a rare situation (other than rake), and parallel
     # installation is SO MUCH FASTER. so we let people opt in.
     def install(options)
-      force = options["force"]
+      force = options[:force]
       jobs = installation_parallelization(options)
       install_in_parallel jobs, options[:standalone], force
     end
@@ -233,9 +233,9 @@ module Bundler
 
     # returns whether or not a re-resolve was needed
     def resolve_if_needed(options)
-      @definition.prefer_local! if options["prefer-local"]
+      @definition.prefer_local! if options[:"prefer-local"]
 
-      if options["local"] || (@definition.no_resolve_needed? && !@definition.missing_specs?)
+      if options[:local] || (@definition.no_resolve_needed? && !@definition.missing_specs?)
         @definition.resolve_with_cache!
         false
       else

--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -196,8 +196,9 @@ module Bundler
     def install(options)
       standalone = options[:standalone]
       force = options[:force]
+      local = options[:local]
       jobs = installation_parallelization(options)
-      spec_installations = ParallelInstaller.call(self, @definition.specs, jobs, standalone, force)
+      spec_installations = ParallelInstaller.call(self, @definition.specs, jobs, standalone, force, local: local)
       spec_installations.each do |installation|
         post_install_messages[installation.name] = installation.post_install_message if installation.has_post_install_message?
       end

--- a/bundler/lib/bundler/installer/gem_installer.rb
+++ b/bundler/lib/bundler/installer/gem_installer.rb
@@ -2,14 +2,15 @@
 
 module Bundler
   class GemInstaller
-    attr_reader :spec, :standalone, :worker, :force, :installer
+    attr_reader :spec, :standalone, :worker, :force, :local, :installer
 
-    def initialize(spec, installer, standalone = false, worker = 0, force = false)
+    def initialize(spec, installer, standalone = false, worker = 0, force = false, local = false)
       @spec = spec
       @installer = installer
       @standalone = standalone
       @worker = worker
       @force = force
+      @local = local
     end
 
     def install_from_spec
@@ -54,6 +55,7 @@ module Bundler
       spec.source.install(
         spec,
         force: force,
+        local: local,
         build_args: Array(spec_settings),
         previous_spec: previous_spec,
       )

--- a/bundler/lib/bundler/installer/parallel_installer.rb
+++ b/bundler/lib/bundler/installer/parallel_installer.rb
@@ -68,11 +68,12 @@ module Bundler
 
     attr_reader :size
 
-    def initialize(installer, all_specs, size, standalone, force, skip: nil)
+    def initialize(installer, all_specs, size, standalone, force, local: false, skip: nil)
       @installer = installer
       @size = size
       @standalone = standalone
       @force = force
+      @local = local
       @specs = all_specs.map {|s| SpecInstallation.new(s) }
       @specs.each do |spec_install|
         spec_install.state = :installed if skip.include?(spec_install.name)
@@ -127,7 +128,7 @@ module Bundler
     def do_install(spec_install, worker_num)
       Plugin.hook(Plugin::Events::GEM_BEFORE_INSTALL, spec_install)
       gem_installer = Bundler::GemInstaller.new(
-        spec_install.spec, @installer, @standalone, worker_num, @force
+        spec_install.spec, @installer, @standalone, worker_num, @force, @local
       )
       success, message = gem_installer.install_from_spec
       if success

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -223,11 +223,12 @@ module Bundler
       end
 
       def cached_built_in_gem(spec)
-        cached_path = cached_path(spec)
+        cached_path = cached_gem(spec)
         if cached_path.nil?
           remote_spec = remote_specs.search(spec).first
           if remote_spec
             cached_path = fetch_gem(remote_spec)
+            spec.remote = remote_spec.remote
           else
             Bundler.ui.warn "#{spec.full_name} is built in to Ruby, and can't be cached because your Gemfile doesn't have any sources that contain it."
           end
@@ -324,14 +325,6 @@ module Bundler
       end
 
       def cached_gem(spec)
-        if spec.default_gem?
-          cached_built_in_gem(spec)
-        else
-          cached_path(spec)
-        end
-      end
-
-      def cached_path(spec)
         global_cache_path = download_cache_path(spec)
         caches << global_cache_path if global_cache_path
 

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -148,7 +148,7 @@ module Bundler
       end
 
       def install(spec, options = {})
-        if (spec.default_gem? && !cached_built_in_gem(spec)) || (installed?(spec) && !options[:force])
+        if (spec.default_gem? && !cached_built_in_gem(spec, local: options[:local])) || (installed?(spec) && !options[:force])
           print_using_message "Using #{version_message(spec, options[:previous_spec])}"
           return nil # no post-install message
         end
@@ -222,9 +222,9 @@ module Bundler
         raise InstallError, e.message
       end
 
-      def cached_built_in_gem(spec)
+      def cached_built_in_gem(spec, local: false)
         cached_path = cached_gem(spec)
-        if cached_path.nil?
+        if cached_path.nil? && !local
           remote_spec = remote_specs.search(spec).first
           if remote_spec
             cached_path = fetch_gem(remote_spec)

--- a/bundler/spec/bundler/installer/gem_installer_spec.rb
+++ b/bundler/spec/bundler/installer/gem_installer_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Bundler::GemInstaller do
   let(:installer) { instance_double("Installer", definition: definition) }
   let(:spec_source) { instance_double("SpecSource") }
   let(:spec) { instance_double("Specification", name: "dummy", version: "0.0.1", loaded_from: "dummy", source: spec_source) }
+  let(:base_options) { { force: false, local: false, previous_spec: nil } }
 
   subject { described_class.new(spec, installer) }
 
@@ -14,7 +15,7 @@ RSpec.describe Bundler::GemInstaller do
     it "invokes install method with empty build_args" do
       allow(spec_source).to receive(:install).with(
         spec,
-        { force: false, build_args: [], previous_spec: nil }
+        base_options.merge(build_args: [])
       )
       subject.install_from_spec
     end
@@ -28,7 +29,7 @@ RSpec.describe Bundler::GemInstaller do
       allow(Bundler.settings).to receive(:[]).with("build.dummy").and_return("--with-dummy-config=dummy")
       expect(spec_source).to receive(:install).with(
         spec,
-        { force: false, build_args: ["--with-dummy-config=dummy"], previous_spec: nil }
+        base_options.merge(build_args: ["--with-dummy-config=dummy"])
       )
       subject.install_from_spec
     end
@@ -42,7 +43,7 @@ RSpec.describe Bundler::GemInstaller do
       allow(Bundler.settings).to receive(:[]).with("build.dummy").and_return("--with-dummy-config=dummy --with-another-dummy-config")
       expect(spec_source).to receive(:install).with(
         spec,
-        { force: false, build_args: ["--with-dummy-config=dummy", "--with-another-dummy-config"], previous_spec: nil }
+        base_options.merge(build_args: ["--with-dummy-config=dummy", "--with-another-dummy-config"])
       )
       subject.install_from_spec
     end

--- a/bundler/spec/cache/gems_spec.rb
+++ b/bundler/spec/cache/gems_spec.rb
@@ -149,9 +149,10 @@ RSpec.describe "bundle cache" do
     end
 
     context "when a remote gem is not available for caching" do
-      it "uses builtin gems when installing to system gems" do
+      it "warns, but uses builtin gems when installing to system gems" do
         bundle "config set path.system true"
         install_gemfile %(source "https://gem.repo1"; gem 'json', '#{default_json_version}'), verbose: true
+        expect(err).to include("json-#{default_json_version} is built in to Ruby, and can't be cached")
         expect(out).to include("Using json #{default_json_version}")
       end
 

--- a/bundler/spec/cache/gems_spec.rb
+++ b/bundler/spec/cache/gems_spec.rb
@@ -134,9 +134,7 @@ RSpec.describe "bundle cache" do
       end
 
       it "doesn't make remote request after caching the gem" do
-        build_gem "builtin_gem_2", "1.0.2", path: bundled_app("vendor/cache") do |s|
-          s.summary = "This builtin_gem is bundled with Ruby"
-        end
+        build_gem "builtin_gem_2", "1.0.2", path: bundled_app("vendor/cache"), default: true
 
         install_gemfile <<-G
           source "https://gem.repo2"

--- a/bundler/spec/cache/gems_spec.rb
+++ b/bundler/spec/cache/gems_spec.rb
@@ -103,8 +103,7 @@ RSpec.describe "bundle cache" do
         end
       end
 
-      it "uses remote gems when installing to system gems" do
-        bundle "config set path.system true"
+      it "uses remote gems when installing" do
         install_gemfile %(source "https://gem.repo2"; gem 'json', '#{default_json_version}'), verbose: true
         expect(out).to include("Installing json #{default_json_version}")
       end

--- a/bundler/spec/cache/gems_spec.rb
+++ b/bundler/spec/cache/gems_spec.rb
@@ -108,6 +108,11 @@ RSpec.describe "bundle cache" do
         expect(out).to include("Installing json #{default_json_version}")
       end
 
+      it "does not use remote gems when installing with --local flag" do
+        install_gemfile %(source "https://gem.repo2"; gem 'json', '#{default_json_version}'), verbose: true, local: true
+        expect(out).to include("Using json #{default_json_version}")
+      end
+
       it "caches remote and builtin gems" do
         install_gemfile <<-G
           source "https://gem.repo2"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This is a regression from #7673, where Bundler will no longer respect the `--local` install flag if default gems are included in the Gemfile.

## What is your fix for the problem, implemented in this PR?

My fix is to make sure the installer respects the `--local` flag and avoids fetching `.gem` packages for default gems if `--local` was given.

Fixes #8025.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
