### PR TITLE
Stop fighting with ourselves

### DIFF
--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -123,11 +123,6 @@ module Gem
       end
     end
 
-    remove_method :gem_dir
-    def gem_dir
-      full_gem_path
-    end
-
     unless const_defined?(:LATEST_RUBY_WITHOUT_PATCH_VERSIONS)
       LATEST_RUBY_WITHOUT_PATCH_VERSIONS = Gem::Version.new("2.1")
 

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -139,10 +139,10 @@ class Gem::BasicSpecification
   # The full path to the gem (install path + full name).
 
   def full_gem_path
-    # TODO: This is a heavily used method by gems, so we'll need
-    # to aleast just alias it to #gem_dir rather than remove it.
     @full_gem_path ||= find_full_gem_path
   end
+
+  alias_method :gem_dir, :full_gem_path
 
   ##
   # Returns the full name (name-version) of this Gem.  Platform information
@@ -211,14 +211,6 @@ class Gem::BasicSpecification
       end
       @paths_map[path]
     end
-  end
-
-  ##
-  # Returns the full path to this spec's gem directory.
-  # eg: /usr/local/lib/ruby/1.8/gems/mygem-1.0
-
-  def gem_dir
-    @gem_dir ||= File.expand_path File.join(gems_dir, full_name)
   end
 
   ##

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1914,6 +1914,7 @@ class Gem::Specification < Gem::BasicSpecification
 
   ##
   # Work around old bundler versions removing my methods
+  # Can be removed once RubyGems can no longer install Bundler 2.5
 
   def gem_dir # :nodoc:
     super

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1913,7 +1913,7 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   ##
-  # Work around bundler removing my methods
+  # Work around old bundler versions removing my methods
 
   def gem_dir # :nodoc:
     super


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Comment in RubyGems code complains that it needs to define a method because Bundler is removing it. This should not be necessary these days since both tools are maintained by the same team.
  
## What is your fix for the problem, implemented in this PR?

Try to fix the mess by defining only what needs to be defined.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
