### PR TITLE
Changelogs for RubyGems 3.5.19 and Bundler 2.5.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,43 @@
+# 3.5.19 / 2024-09-18
+
+## Enhancements:
+
+* Standardize pretty-print output for `Gem::Source` and subclasses. Pull
+  request [#7994](https://github.com/rubygems/rubygems/pull/7994) by
+  djberube
+* Update vendored `molinillo` to master and vendored `resolv` to 0.4.0.
+  Pull request [#7521](https://github.com/rubygems/rubygems/pull/7521) by
+  hsbt
+* Installs bundler 2.5.19 as a default gem.
+
+## Bug fixes:
+
+* Fix `bundle exec rake install` failing when local gem has extensions.
+  Pull request [#7977](https://github.com/rubygems/rubygems/pull/7977) by
+  deivid-rodriguez
+* Make `gem exec` use the standard GEM_HOME. Pull request
+  [#7982](https://github.com/rubygems/rubygems/pull/7982) by
+  deivid-rodriguez
+* Fix `gem fetch` always exiting with zero status code. Pull request
+  [#8007](https://github.com/rubygems/rubygems/pull/8007) by
+  deivid-rodriguez
+* Remove temporary `.lock` files unintentionally left around by gem
+  installer. Pull request
+  [#7939](https://github.com/rubygems/rubygems/pull/7939) by nobu
+* Removed unused stringio. Pull request
+  [#8001](https://github.com/rubygems/rubygems/pull/8001) by hsbt
+* Avoid another race condition of open mode. Pull request
+  [#7931](https://github.com/rubygems/rubygems/pull/7931) by nobu
+* Fix `@license` typo preventing licenses from being correctly
+  unmarshalled. Pull request
+  [#7975](https://github.com/rubygems/rubygems/pull/7975) by djberube
+
+## Performance:
+
+* Fix `gem install does-not-exist` being super slow. Pull request
+  [#8006](https://github.com/rubygems/rubygems/pull/8006) by
+  deivid-rodriguez
+
 # 3.5.18 / 2024-08-26
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,31 @@
+# 2.5.19 (September 18, 2024)
+
+## Enhancements:
+
+  - Raise original errors when unexpected errors happen during Gemfile evaluation [#8003](https://github.com/rubygems/rubygems/pull/8003)
+  - Make an exe file executable when generating new gems [#8020](https://github.com/rubygems/rubygems/pull/8020)
+  - Gracefully handle gem activation conflicts in inline mode [#5535](https://github.com/rubygems/rubygems/pull/5535)
+  - Don't include hook templates in cached git source [#8013](https://github.com/rubygems/rubygems/pull/8013)
+  - Fix some errors about a previous installation folder that's unsafe to remove, when there's no need to remove it [#7985](https://github.com/rubygems/rubygems/pull/7985)
+  - Emit progress to stderr during `bundle outdated --parseable` [#7966](https://github.com/rubygems/rubygems/pull/7966)
+  - Reject unknown platforms when running `bundle lock --add-platform` [#7967](https://github.com/rubygems/rubygems/pull/7967)
+  - Emit progress to stderr when `--print` is passed to `bundle lock` [#7957](https://github.com/rubygems/rubygems/pull/7957)
+
+## Bug fixes:
+
+  - Fix `bundle install --local` hitting the network when default gems are included [#8027](https://github.com/rubygems/rubygems/pull/8027)
+  - Remove temporary `.lock` files unintentionally left around by gem installer [#8022](https://github.com/rubygems/rubygems/pull/8022)
+  - Fix `bundle exec rake install` failing when local gem has extensions [#7977](https://github.com/rubygems/rubygems/pull/7977)
+  - Load gemspecs in the context of its parent also when using local overrides [#7993](https://github.com/rubygems/rubygems/pull/7993)
+  - Fix `bundler/inline` failing in Ruby 3.2 due to conflicting `securerandom` versions [#7984](https://github.com/rubygems/rubygems/pull/7984)
+  - Don't blow up when explicit version is removed from some git sources [#7973](https://github.com/rubygems/rubygems/pull/7973)
+  - Fix `gem exec rails new project` failing on Ruby 3.2 [#7960](https://github.com/rubygems/rubygems/pull/7960)
+
+## Documentation:
+
+  - Improve `bundle add` man page [#5903](https://github.com/rubygems/rubygems/pull/5903)
+  - Add some documentation about backwards compatibility [#7964](https://github.com/rubygems/rubygems/pull/7964)
+
 # 2.5.18 (August 26, 2024)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.5.19 and Bundler 2.5.19 into master.