### PR TITLE
Fix spelling, it's "cannot" rather than "can not"

### DIFF
--- a/bundler/lib/bundler/cli/add.rb
+++ b/bundler/lib/bundler/cli/add.rb
@@ -34,7 +34,7 @@ module Bundler
     end
 
     def validate_options!
-      raise InvalidOption, "You can not specify `--strict` and `--optimistic` at the same time." if options[:strict] && options[:optimistic]
+      raise InvalidOption, "You cannot specify `--strict` and `--optimistic` at the same time." if options[:strict] && options[:optimistic]
 
       # raise error when no gems are specified
       raise InvalidOption, "Please specify gems to add." if gems.empty?

--- a/bundler/spec/commands/add_spec.rb
+++ b/bundler/spec/commands/add_spec.rb
@@ -304,7 +304,7 @@ RSpec.describe "bundle add" do
     it "throws error" do
       bundle "add 'foo' --strict --optimistic", raise_on_error: false
 
-      expect(err).to include("You can not specify `--strict` and `--optimistic` at the same time")
+      expect(err).to include("You cannot specify `--strict` and `--optimistic` at the same time")
     end
   end
 

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -307,7 +307,7 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
     elsif !VALID_NAME_PATTERN.match?(name)
       error "invalid value for attribute name: #{name.dump} can only include letters, numbers, dashes, and underscores"
     elsif SPECIAL_CHARACTERS.match?(name)
-      error "invalid value for attribute name: #{name.dump} can not begin with a period, dash, or underscore"
+      error "invalid value for attribute name: #{name.dump} cannot begin with a period, dash, or underscore"
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

No problem, but we want to use better English.

## What is your fix for the problem, implemented in this PR?

Use correct spelling of "cannot".

Fixes https://github.com/rubygems/rubygems/issues/5859.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
