### PR TITLE
One more attempt at grouping cargo dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,7 @@ updates:
       - '/test/rubygems/test_gem_ext_cargo_builder/rust_ruby_example'
     schedule:
       interval: 'weekly'
+    groups:
+      rb-sys:
+        patterns:
+          - 'rb-sys'


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We get one separate dependabot PR for updating `rb-sys` for each of the test directories where we have cargo dependencies.

## What is your fix for the problem, implemented in this PR?

Figure out how to tell Dependabot to group the PRs. According to [Dependabot documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directory)

> Multidirectory support is different than update grouping in pull requests.
>
> * The `directories` option in the dependabot.yml file allows you to apply Dependabot updates to multiple directories at the same time.
> * The `groups` option in the dependabot.yml file creates sets of dependencies (per package manager) for Dependabot to put in the same single pull request.

So let's try to set both.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
