### PR TITLE
Don't try to install locked bundler when `--local` is passed

### DIFF
--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -12,7 +12,11 @@ module Bundler
 
       warn_if_root
 
-      Bundler.self_manager.install_locked_bundler_and_restart_with_it_if_needed
+      if options[:local]
+        Bundler.self_manager.restart_with_locked_bundler_if_needed
+      else
+        Bundler.self_manager.install_locked_bundler_and_restart_with_it_if_needed
+      end
 
       Bundler::SharedHelpers.set_env "RB_USER_INSTALL", "1" if Gem.freebsd_platform?
 

--- a/bundler/spec/runtime/self_management_spec.rb
+++ b/bundler/spec/runtime/self_management_spec.rb
@@ -131,6 +131,17 @@ RSpec.describe "Self management", rubygems: ">= 3.3.0.dev" do
       expect(out).to eq(Bundler::VERSION[0] == "2" ? "Bundler version #{Bundler::VERSION}" : Bundler::VERSION)
     end
 
+    it "does not try to install when --local is passed" do
+      lockfile_bundled_with(previous_minor)
+      system_gems "myrack-1.0.0", path: default_bundle_path
+
+      bundle "install --local"
+      expect(out).not_to match(/Installing Bundler/)
+
+      bundle "-v"
+      expect(out).to eq(Bundler::VERSION[0] == "2" ? "Bundler version #{Bundler::VERSION}" : Bundler::VERSION)
+    end
+
     it "shows a discrete message if locked bundler does not exist" do
       missing_minor = "#{Bundler::VERSION[0]}.999.999"
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler will try to download & install the version of Bundler in the lockfile, even if `--local` was given.

## What is your fix for the problem, implemented in this PR?

Skip doing this when `--local` was given.

Fixes https://github.com/rubygems/rubygems/issues/5227.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
