### PR TITLE
Restore `Gem::BasicSpecification#gem_dir` as an attribute accessor

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -136,12 +136,12 @@ class Gem::BasicSpecification
 
   ##
   # The full path to the gem (install path + full name).
+  #
+  # TODO: This is duplicated with #gem_dir. Eventually either of them should be deprecated.
 
   def full_gem_path
     @full_gem_path ||= find_full_gem_path
   end
-
-  alias_method :gem_dir, :full_gem_path
 
   ##
   # Returns the full name (name-version) of this Gem.  Platform information
@@ -210,6 +210,16 @@ class Gem::BasicSpecification
       end
       @paths_map[path]
     end
+  end
+
+  ##
+  # Returns the full path to this spec's gem directory.
+  # eg: /usr/local/lib/ruby/1.8/gems/mygem-1.0
+  #
+  # TODO: This is duplicated with #full_gem_path. Eventually either of them should be deprecated.
+
+  def gem_dir
+    @gem_dir ||= find_full_gem_path
   end
 
   ##

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -129,7 +129,6 @@ class Gem::BasicSpecification
   end
 
   def find_full_gem_path # :nodoc:
-    # TODO: also, shouldn't it default to full_name if it hasn't been written?
     File.expand_path File.join(gems_dir, full_name)
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I suspect someone could be setting this instance variable, and the previous changes made that no longer effective.
    
Also I implemented a previous TODO in `full_gem_path` the other way around:

```  
# TODO: This is a heavily used method by gems, so we'll need
# to aleast just alias it to #gem_dir rather than remove it.
``` 
I made `gem_dir` an alias of `full_gem_path` rather than the opposite.

## What is your fix for the problem, implemented in this PR?

This alternative change keeps both methods symmetric without deprecating either of them for now.

This is just a small follow up to #8030 to try make it a bit safer.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
