### PR TITLE
Don't try to auto-install dev versions of Bundler not available remotely

### DIFF
--- a/bundler/lib/bundler/self_manager.rb
+++ b/bundler/lib/bundler/self_manager.rb
@@ -98,10 +98,10 @@ module Bundler
 
     def needs_switching?
       autoswitching_applies? &&
-        released?(lockfile_version) &&
-        !running?(lockfile_version) &&
-        !updating? &&
-        Bundler.settings[:version] != "system"
+        Bundler.settings[:version] != "system" &&
+        released?(restart_version) &&
+        !running?(restart_version) &&
+        !updating?
     end
 
     def autoswitching_applies?

--- a/bundler/spec/runtime/self_management_spec.rb
+++ b/bundler/spec/runtime/self_management_spec.rb
@@ -165,6 +165,17 @@ RSpec.describe "Self management", rubygems: ">= 3.3.0.dev" do
       expect(out).to eq(Bundler::VERSION[0] == "2" ? "Bundler version #{Bundler::VERSION}" : Bundler::VERSION)
     end
 
+    it "does not try to install when using bundle config version <dev-version>" do
+      lockfile_bundled_with(previous_minor)
+
+      bundle "config set version #{previous_minor}.dev"
+      bundle "install"
+      expect(out).not_to match(/restarting using that version/)
+
+      bundle "-v"
+      expect(out).to eq(Bundler::VERSION[0] == "2" ? "Bundler version #{Bundler::VERSION}" : Bundler::VERSION)
+    end
+
     it "ignores malformed lockfile version" do
       lockfile_bundled_with("2.3.")
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Running `BUNDLE_VERSION=2.6.0.dev bundle` tries to install 2.6.0.dev from `rubygems.org`.

## What is your fix for the problem, implemented in this PR?

Make sure the `version` setting is also included in the list of exceptions to skip installing the configured version from `rubygems.org`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
