### PR TITLE
Disallow RubyGems warnings during Bundler test suite

### DIFF
--- a/bundler/spec/commands/binstubs_spec.rb
+++ b/bundler/spec/commands/binstubs_spec.rb
@@ -115,7 +115,8 @@ RSpec.describe "bundle binstubs <gem>" do
           build_gem "prints_loaded_gems", "1.0" do |s|
             s.executables = "print_loaded_gems"
             s.bindir = "exe"
-            s.write "exe/print_loaded_gems", <<-R
+            s.write "exe/print_loaded_gems", <<~R
+              #!/usr/bin/env ruby
               specs = Gem.loaded_specs.values.reject {|s| s.default_gem? }
               puts specs.map(&:full_name).sort.inspect
             R

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -1202,10 +1202,10 @@ RSpec.describe "bundle update when a gem depends on a newer version of bundler" 
   before do
     build_repo2 do
       build_gem "rails", "3.0.1" do |s|
-        s.add_dependency "bundler", Bundler::VERSION.succ
+        s.add_dependency "bundler", "9.9.9"
       end
 
-      build_gem "bundler", Bundler::VERSION.succ
+      build_gem "bundler", "9.9.9"
     end
 
     gemfile <<-G
@@ -1218,7 +1218,7 @@ RSpec.describe "bundle update when a gem depends on a newer version of bundler" 
     bundle "update", all: true, raise_on_error: false
     expect(last_command.stdboth).not_to match(/in snapshot/i)
     expect(err).to match(/current Bundler version/i).
-      and match(/Install the necessary version with `gem install bundler:#{Bundler::VERSION.succ}`/i)
+      and match(/Install the necessary version with `gem install bundler:9\.9\.9`/i)
   end
 end
 

--- a/bundler/spec/install/bundler_spec.rb
+++ b/bundler/spec/install/bundler_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "bundle install" do
     before(:each) do
       build_repo2 do
         build_gem "rails", "3.0" do |s|
-          s.add_dependency "bundler", ">= 0.9.0.pre"
+          s.add_dependency "bundler", ">= 0.9.0"
         end
         build_gem "bundler", "0.9.1"
         build_gem "bundler", Bundler::VERSION
@@ -59,8 +59,8 @@ RSpec.describe "bundle install" do
       nice_error = <<~E.strip
         Could not find compatible versions
 
-        Because rails >= 3.0 depends on bundler >= 0.9.0.pre
-          and the current Bundler version (#{Bundler::VERSION}) does not satisfy bundler >= 0.9.0.pre, < 1.A,
+        Because rails >= 3.0 depends on bundler >= 0.9.0
+          and the current Bundler version (#{Bundler::VERSION}) does not satisfy bundler >= 0.9.0, < 1.A,
           rails >= 3.0 requires bundler >= 1.A.
         So, because Gemfile depends on rails = 3.0
           and Gemfile depends on bundler ~> 0.8,

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -456,6 +456,7 @@ module Spec
           s.email       = "foo@bar.baz"
           s.homepage    = "http://example.com"
           s.license     = "MIT"
+          s.required_ruby_version = ">= 3.0"
         end
         @files = {}
       end

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -473,11 +473,7 @@ module Spec
         @spec.executables = Array(val)
         @spec.executables.each do |file|
           executable = "#{@spec.bindir}/#{file}"
-          shebang = if Bundler.current_ruby.jruby?
-            "#!/usr/bin/env jruby\n"
-          else
-            "#!/usr/bin/env ruby\n"
-          end
+          shebang = "#!/usr/bin/env ruby\n"
           @spec.files << executable
           write executable, "#{shebang}require_relative '../lib/#{@name}' ; puts #{Builders.constantize(@name)}"
         end

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -153,7 +153,7 @@ module Spec
 
         build_gem "bundler", "0.9" do |s|
           s.executables = "bundle"
-          s.write "bin/bundle", "puts 'FAIL'"
+          s.write "bin/bundle", "#!/usr/bin/env ruby\nputs 'FAIL'"
         end
 
         # The bundler 0.8 gem has a rubygems plugin that always loads :(

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -538,10 +538,10 @@ module Spec
         end
 
         @files.each do |file, source|
-          file = Pathname.new(path).join(file)
-          FileUtils.mkdir_p(file.dirname)
-          File.open(file, "w") {|f| f.puts source }
-          File.chmod("+x", file) if @spec.executables.map {|exe| "#{@spec.bindir}/#{exe}" }.include?(file)
+          full_path = Pathname.new(path).join(file)
+          FileUtils.mkdir_p(full_path.dirname)
+          File.open(full_path, "w") {|f| f.puts source }
+          FileUtils.chmod("+x", full_path) if @spec.executables.map {|exe| "#{@spec.bindir}/#{exe}" }.include?(file)
         end
         path
       end

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -186,7 +186,10 @@ module Spec
       env = options[:env] || {}
       env["RUBYOPT"] = opt_add(opt_add("-r#{spec_dir}/support/hax.rb", env["RUBYOPT"]), ENV["RUBYOPT"])
       options[:env] = env
-      sys_exec("#{Path.gem_bin} #{command}", options)
+      output = sys_exec("#{Path.gem_bin} #{command}", options)
+      stderr = last_command.stderr
+      raise stderr if stderr.include?("WARNING") && !allowed_rubygems_warning?(stderr)
+      output
     end
 
     def rake
@@ -541,6 +544,10 @@ module Spec
     end
 
     private
+
+    def allowed_rubygems_warning?(text)
+      text.include?("open-ended") || text.include?("is a symlink") || text.include?("rake based") || text.include?("expected RubyGems version")
+    end
 
     def match_source(contents)
       match = /source ["']?(?<source>http[^"']+)["']?/.match(contents)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Our test suite runs a lot of RubyGems commands that results in warnings. We should stick to our own best practices, and don't run RubyGems commands that result into warnings. Also, when a test fails, the output of all commands is displayed, and warnings make that less readable.

## What is your fix for the problem, implemented in this PR?

I fixed most of the warnings and allowed some of them for now, and made sure that at least the warnings fixed are not reintroduced.
 
## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
