### PR TITLE
Fix `bundle outdated` with `--group` option

### DIFF
--- a/bundler/lib/bundler/cli/outdated.rb
+++ b/bundler/lib/bundler/cli/outdated.rb
@@ -97,28 +97,26 @@ module Bundler
         }
       end
 
-      if outdated_gems.empty?
+      relevant_outdated_gems = if options_include_groups
+        outdated_gems.group_by {|g| g[:groups] }.sort.flat_map do |groups, gems|
+          contains_group = groups.split(", ").include?(options[:group])
+          next unless options[:groups] || contains_group
+
+          gems
+        end.compact
+      else
+        outdated_gems
+      end
+
+      if relevant_outdated_gems.empty?
         unless options[:parseable]
           Bundler.ui.info(nothing_outdated_message)
         end
       else
-        if options_include_groups
-          relevant_outdated_gems = outdated_gems.group_by {|g| g[:groups] }.sort.flat_map do |groups, gems|
-            contains_group = groups.split(", ").include?(options[:group])
-            next unless options[:groups] || contains_group
-
-            gems
-          end.compact
-
-          if options[:parseable]
-            print_gems(relevant_outdated_gems)
-          else
-            print_gems_table(relevant_outdated_gems)
-          end
-        elsif options[:parseable]
-          print_gems(outdated_gems)
+        if options[:parseable]
+          print_gems(relevant_outdated_gems)
         else
-          print_gems_table(outdated_gems)
+          print_gems_table(relevant_outdated_gems)
         end
 
         exit 1

--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -251,6 +251,14 @@ RSpec.describe "bundle outdated" do
       expect(out).to end_with("Bundle up to date!")
     end
 
+    it "works when only out of date gems are not in given group" do
+      update_repo2 do
+        build_gem "terranova", "9"
+      end
+      bundle "outdated --group development"
+      expect(out).to end_with("Bundle up to date!")
+    end
+
     it "returns a sorted list of outdated gems from one group => 'default'" do
       test_group_option("default")
 


### PR DESCRIPTION



## What was the end-user or developer problem that led to this PR?

It was printing incorrect output and returning incorrect status.

## What is your fix for the problem, implemented in this PR?

Make sure to filter gems by group before hand, so that logic to print empty header and return 1 exit code otherwise applies to it as well.

Fixes #7425.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
