### PR TITLE
Don't print bug report template when psych is incorrectly linked

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -130,3 +130,46 @@ jobs:
         shell: bash
 
     timeout-minutes: 20
+
+  mess_up_installation:
+    name: Handling issues with messed up psych (${{ matrix.os.name }})
+    runs-on: ${{ matrix.os.value }}
+    strategy:
+      matrix:
+        include:
+          - os: { name: macOS, value: macos-14, ext: bundle }
+          - os: { name: linux, value: ubuntu-24.04, ext: so }
+          - os: { name: Windows, value: windows-2022, ext: so }
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Setup original ruby
+        uses: ruby/setup-ruby@f321cf5a4d1533575411f8752cf25b86478b0442 # v1.193.0
+        with:
+          ruby-version: 3.2
+          bundler: none
+      - name: Install rubygems in original ruby
+        run: ruby setup.rb
+        shell: bash
+      - name: Setup app depending on psych with local bundle path
+        run: mkdir foo && cd foo && bundle init && bundle config path vendor/bundle && bundle add psych -v 5.1.2
+        shell: bash
+      - name: Setup final ruby
+        uses: ruby/setup-ruby@f321cf5a4d1533575411f8752cf25b86478b0442 # v1.193.0
+        with:
+          ruby-version: 3.3
+          bundler: none
+      - name: Install rubygems in final ruby
+        run: ruby setup.rb
+        shell: bash
+      - name: Install gems with final ruby
+        run: bundle install
+        working-directory: foo
+      - name: Break compiled psych
+        run: mv vendor/bundle/ruby/3.2.0/gems/psych-5.1.2/lib/psych.${{ matrix.os.ext }} vendor/bundle/ruby/3.3.0/gems/psych-5.1.2/lib/psych.${{ matrix.os.ext }}
+        shell: bash
+        working-directory: foo
+      - name: Reinstall gems with final ruby
+        run: bundle install --redownload | grep -v "ERROR REPORT TEMPLATE"
+        working-directory: foo
+
+    timeout-minutes: 20

--- a/bundler/lib/bundler/errors.rb
+++ b/bundler/lib/bundler/errors.rb
@@ -246,4 +246,17 @@ module Bundler
   end
 
   class InvalidArgumentError < BundlerError; status_code(40); end
+
+  class PsychLinkedToIncompatibleOrMissingRubyError < BundlerError
+    def initialize(orig_exception)
+      full_message = "The psych library used by RubyGems to load its configuration is linked to an incompatible or missing Ruby.\n" \
+                     "The underlying error was #{orig_exception.class}: #{orig_exception.message}, with backtrace:\n" \
+                     "  #{orig_exception.backtrace.join("\n  ")}\n\n" \
+                     "You may try reinstalling `psych` or completely reinstalling Ruby"
+
+      super(full_message)
+    end
+
+    status_code(41)
+  end
 end

--- a/bundler/lib/bundler/installer/gem_installer.rb
+++ b/bundler/lib/bundler/installer/gem_installer.rb
@@ -18,7 +18,7 @@ module Bundler
       Bundler.ui.debug "#{worker}:  #{spec.name} (#{spec.version}) from #{spec.loaded_from}"
       generate_executable_stubs
       [true, post_install_message]
-    rescue Bundler::InstallHookError, Bundler::SecurityError, Bundler::APIResponseMismatchError, Bundler::InsecureInstallPathError
+    rescue Bundler::InstallHookError, Bundler::SecurityError, Bundler::APIResponseMismatchError, Bundler::InsecureInstallPathError, Bundler::PsychLinkedToIncompatibleOrMissingRubyError
       raise
     rescue Errno::ENOSPC
       [false, out_of_space_message]


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This comes up every once in a while when users have somehow messed up their Ruby installation and have dynamic libraries linked to a different Ruby. We print the bug report template, so users report a bug to us.

## What is your fix for the problem, implemented in this PR?

This is an attempt to avoid printing the bug report template and instead print a more useful error that helps users and frees us from receiving bug reports.

Fixes #8053.
Fixes #8063.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
