### PR TITLE
Fix `bundler/inline` overwriting lockfiles

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -317,7 +317,7 @@ module Bundler
 
     def lock(file_or_preserve_unknown_sections = false, preserve_unknown_sections_or_unused = false)
       if [true, false, nil].include?(file_or_preserve_unknown_sections)
-        target_lockfile = lockfile || Bundler.default_lockfile
+        target_lockfile = lockfile
         preserve_unknown_sections = file_or_preserve_unknown_sections
       else
         target_lockfile = file_or_preserve_unknown_sections


### PR DESCRIPTION




## What was the end-user or developer problem that led to this PR?

After 0b7be7bb770538fc26238dbaf055be9b06062ef8, `bundler/inline` will overwrite existing lockfiles. The regression happened I think because it was an old PR that had not been rebased in a while, and that commit needed to be adapted to some changes in `Definition` class.

## What is your fix for the problem, implemented in this PR?

Make sure to pass `nil` to `write_lock` when there's no lockfile (like in `bundler/inline` situation), so that the early return introduced by 0b7be7bb770538fc26238dbaf055be9b06062ef8 is effective.

Fixes https://github.com/rubygems/rubygems/pull/8022#issuecomment-2363893826.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
