### PR TITLE
Fix `bundler/inline` resetting ENV changes

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -391,6 +391,7 @@ module Bundler
       end
 
       env.delete_if {|k, _| k[0, 7] == "BUNDLE_" }
+      env.delete("BUNDLER_SETUP)
 
       if env.key?("RUBYOPT")
         rubyopt = env["RUBYOPT"].split(" ")

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -384,29 +384,12 @@ module Bundler
 
     # @return [Hash] Environment with all bundler-related variables removed
     def unbundled_env
-      env = original_env
+      unbundle_env(original_env)
+    end
 
-      if env.key?("BUNDLER_ORIG_MANPATH")
-        env["MANPATH"] = env["BUNDLER_ORIG_MANPATH"]
-      end
-
-      env.delete_if {|k, _| k[0, 7] == "BUNDLE_" }
-      env.delete("BUNDLER_SETUP)
-
-      if env.key?("RUBYOPT")
-        rubyopt = env["RUBYOPT"].split(" ")
-        rubyopt.delete("-r#{File.expand_path("bundler/setup", __dir__)}")
-        rubyopt.delete("-rbundler/setup")
-        env["RUBYOPT"] = rubyopt.join(" ")
-      end
-
-      if env.key?("RUBYLIB")
-        rubylib = env["RUBYLIB"].split(File::PATH_SEPARATOR)
-        rubylib.delete(__dir__)
-        env["RUBYLIB"] = rubylib.join(File::PATH_SEPARATOR)
-      end
-
-      env
+    # Remove all bundler-related variables from ENV
+    def unbundle_env!
+      ENV.replace(unbundle_env(ENV))
     end
 
     # Run block with environment present before Bundler was activated
@@ -651,6 +634,30 @@ module Bundler
     end
 
     private
+
+    def unbundle_env(env)
+      if env.key?("BUNDLER_ORIG_MANPATH")
+        env["MANPATH"] = env["BUNDLER_ORIG_MANPATH"]
+      end
+
+      env.delete_if {|k, _| k[0, 7] == "BUNDLE_" }
+      env.delete("BUNDLER_SETUP")
+
+      if env.key?("RUBYOPT")
+        rubyopt = env["RUBYOPT"].split(" ")
+        rubyopt.delete("-r#{File.expand_path("bundler/setup", __dir__)}")
+        rubyopt.delete("-rbundler/setup")
+        env["RUBYOPT"] = rubyopt.join(" ")
+      end
+
+      if env.key?("RUBYLIB")
+        rubylib = env["RUBYLIB"].split(File::PATH_SEPARATOR)
+        rubylib.delete(__dir__)
+        env["RUBYLIB"] = rubylib.join(File::PATH_SEPARATOR)
+      end
+
+      env
+    end
 
     def load_marshal(data, marshal_proc: nil)
       Marshal.load(data, marshal_proc)

--- a/bundler/lib/bundler/inline.rb
+++ b/bundler/lib/bundler/inline.rb
@@ -39,7 +39,11 @@ def gemfile(install = false, options = {}, &gemfile)
   Bundler.ui = ui
   raise ArgumentError, "Unknown options: #{opts.keys.join(", ")}" unless opts.empty?
 
-  Bundler.with_unbundled_env do
+  old_gemfile = ENV["BUNDLE_GEMFILE"]
+
+  Bundler.unbundle_env!
+
+  begin
     Bundler.instance_variable_set(:@bundle_path, Pathname.new(Gem.dir))
     Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", "Gemfile"
 
@@ -80,9 +84,11 @@ def gemfile(install = false, options = {}, &gemfile)
 
       runtime.require
     end
-  end
-
-  if ENV["BUNDLE_GEMFILE"].nil?
-    ENV["BUNDLE_GEMFILE"] = ""
+  ensure
+    if old_gemfile
+      ENV["BUNDLE_GEMFILE"] = old_gemfile
+    else
+      ENV["BUNDLE_GEMFILE"] = ""
+    end
   end
 end

--- a/bundler/spec/runtime/env_helpers_spec.rb
+++ b/bundler/spec/runtime/env_helpers_spec.rb
@@ -103,6 +103,15 @@ RSpec.describe "env helpers" do
       expect(last_command.stdboth).not_to include("-rbundler/setup")
     end
 
+    it "should delete BUNDLER_SETUP even if it was present in original env" do
+      create_file("source.rb", <<-RUBY)
+        print #{modified_env}.has_key?('BUNDLER_SETUP')
+      RUBY
+      ENV["BUNDLER_ORIG_BUNDLER_SETUP"] = system_gem_path("gems/bundler-#{Bundler::VERSION}/lib/bundler/setup").to_s
+      bundle_exec_ruby bundled_app("source.rb")
+      expect(last_command.stdboth).to include "false"
+    end
+
     it "should restore RUBYLIB", :ruby_repo do
       create_file("source.rb", <<-RUBY)
         print #{modified_env}['RUBYLIB']

--- a/bundler/spec/runtime/env_helpers_spec.rb
+++ b/bundler/spec/runtime/env_helpers_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Bundler.with_env helpers" do
+RSpec.describe "env helpers" do
   def bundle_exec_ruby(args, options = {})
     build_bundler_context options.dup
     bundle "exec '#{Gem.ruby}' #{args}", options

--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -670,6 +670,22 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(out).to be_empty
   end
 
+  it "does not reset ENV" do
+    script <<-RUBY
+      require 'bundler/inline'
+
+      gemfile do
+        source "https://gem.repo1"
+
+        ENV['FOO'] = 'bar'
+      end
+
+      puts ENV['FOO']
+    RUBY
+
+    expect(out).to eq("bar")
+  end
+
   it "does not load specified version of psych and stringio", :ruby_repo do
     build_repo4 do
       build_gem "psych", "999"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since Bundler 2.4.6, `bundler/inline` will reset ENV changes.

## What is your fix for the problem, implemented in this PR?

Make sure we only strip bundler-related variables from the environment, but nothing else.

Fixes #6651.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
