### PR TITLE
Exit successfully for a successful bundle oudated run

### DIFF
--- a/bundler/lib/bundler/cli/outdated.rb
+++ b/bundler/lib/bundler/cli/outdated.rb
@@ -118,8 +118,6 @@ module Bundler
         else
           print_gems_table(relevant_outdated_gems)
         end
-
-        exit 1
       end
     end
 

--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "bundle outdated" do
       expect(out).to include(expected_output.strip)
     end
 
-    it "returns non zero exit status if outdated gems present" do
+    it "returns success exit status if outdated gems present" do
       update_repo2 do
         build_gem "activesupport", "3.0"
         update_git "foo", path: lib_path("foo")
@@ -68,11 +68,13 @@ RSpec.describe "bundle outdated" do
 
       bundle "outdated", raise_on_error: false
 
-      expect(exitstatus).to_not be_zero
+      expect(exitstatus).to be_zero
     end
 
     it "returns success exit status if no outdated gems present" do
       bundle "outdated"
+
+      expect(exitstatus).to be_zero
     end
 
     it "adds gem group to dependency output when repo is updated" do


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

After [this change](https://github.com/rubygems/rubygems/pull/7966), we're finding programmatically impossible to determine if running `bundle outdated --parseable` was successful or not. This command `exit 1` when there are dependencies that are out of date:

https://github.com/rubygems/rubygems/blob/c63c4b0305de7a5712436d37decca648b14b0091/bundler/lib/bundler/cli/outdated.rb#L122

Before #7966, we were scanning `stderr` to a non-empty string to determine if the command ran successful. I'm not sure what's the best way to do that now.

I think `bundle outdated` should exit 0 (cleanly) on a successful run, **whether there are outdated dependencies or not**. I'd be very surprised if there are projects out there that use this command programmatically with 0 out of date dependencies. Even then, folks could parse `stdout` for empty string (if using `--parseable`). Looking at the specs, `bundle oudated` is expected to `exit 1` when there's actual errors (eg invalid gem, or parsing errors, etc) so I think this is overloading `exit 1`.

## What is your fix for the problem, implemented in this PR?

Remove the `exit 1`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
