### PR TITLE
 Warning about PATH in `--user-install` mode is only necessary for gems with executables

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -66,8 +66,6 @@ class Gem::Installer
 
   attr_reader :package
 
-  @path_warning = false
-
   class << self
     #
     # Changes in rubygems to lazily loading `rubygems/command` (in order to
@@ -85,11 +83,6 @@ class Gem::Installer
 
       super(klass)
     end
-
-    ##
-    # True if we've warned about PATH not including Gem.bindir
-
-    attr_accessor :path_warning
 
     ##
     # Overrides the executable format.
@@ -188,15 +181,6 @@ class Gem::Installer
     @package.dir_mode = options[:dir_mode]
     @package.prog_mode = options[:prog_mode]
     @package.data_mode = options[:data_mode]
-
-    if @gem_home == Gem.user_dir
-      # If we get here, then one of the following likely happened:
-      # - `--user-install` was specified
-      # - `Gem::PathSupport#home` fell back to `Gem.user_dir`
-      # - GEM_HOME was manually set to `Gem.user_dir`
-
-      check_that_user_bin_dir_is_in_path
-    end
   end
 
   ##
@@ -488,11 +472,21 @@ class Gem::Installer
   end
 
   def generate_bin # :nodoc:
-    return if spec.executables.nil? || spec.executables.empty?
+    executables = spec.executables
+    return if executables.nil? || executables.empty?
+
+    if @gem_home == Gem.user_dir
+      # If we get here, then one of the following likely happened:
+      # - `--user-install` was specified
+      # - `Gem::PathSupport#home` fell back to `Gem.user_dir`
+      # - GEM_HOME was manually set to `Gem.user_dir`
+
+      check_that_user_bin_dir_is_in_path(executables)
+    end
 
     ensure_writable_dir @bin_dir
 
-    spec.executables.each do |filename|
+    executables.each do |filename|
       bin_path = File.join gem_dir, spec.bindir, filename
       next unless File.exist? bin_path
 
@@ -694,9 +688,7 @@ class Gem::Installer
     end
   end
 
-  def check_that_user_bin_dir_is_in_path # :nodoc:
-    return if self.class.path_warning
-
+  def check_that_user_bin_dir_is_in_path(executables) # :nodoc:
     user_bin_dir = @bin_dir || Gem.bindir(gem_home)
     user_bin_dir = user_bin_dir.tr(File::ALT_SEPARATOR, File::SEPARATOR) if File::ALT_SEPARATOR
 
@@ -712,8 +704,7 @@ class Gem::Installer
 
     unless path.include? user_bin_dir
       unless !Gem.win_platform? && (path.include? user_bin_dir.sub(ENV["HOME"], "~"))
-        alert_warning "You don't have #{user_bin_dir} in your PATH,\n\t  gem executables will not run."
-        self.class.path_warning = true
+        alert_warning "You don't have #{user_bin_dir} in your PATH,\n\t  gem executables (#{executables.join(", ")}) will not run."
       end
     end
   end

--- a/test/rubygems/installer_test_case.rb
+++ b/test/rubygems/installer_test_case.rb
@@ -64,12 +64,6 @@ end
 # A test case for Gem::Installer.
 
 class Gem::InstallerTestCase < Gem::TestCase
-  def setup
-    super
-
-    Gem::Installer.path_warning = false
-  end
-
   ##
   # The path where installed executables live
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -208,7 +208,7 @@ gem 'other', version
     ENV["PATH"] = [ENV["PATH"], bin_dir].join(File::PATH_SEPARATOR)
 
     use_ui @ui do
-      installer.check_that_user_bin_dir_is_in_path
+      installer.check_that_user_bin_dir_is_in_path(["executable"])
     end
 
     assert_empty @ui.error
@@ -218,7 +218,7 @@ gem 'other', version
     ENV["PATH"] = [orig_path, bin_dir.tr(File::SEPARATOR, File::ALT_SEPARATOR)].join(File::PATH_SEPARATOR)
 
     use_ui @ui do
-      installer.check_that_user_bin_dir_is_in_path
+      installer.check_that_user_bin_dir_is_in_path(["executable"])
     end
 
     assert_empty @ui.error
@@ -236,7 +236,7 @@ gem 'other', version
     installer.bin_dir.replace File.join @userhome, "bin"
 
     use_ui @ui do
-      installer.check_that_user_bin_dir_is_in_path
+      installer.check_that_user_bin_dir_is_in_path(["executable"])
     end
 
     assert_empty @ui.error
@@ -248,7 +248,7 @@ gem 'other', version
     installer = setup_base_installer
 
     use_ui @ui do
-      installer.check_that_user_bin_dir_is_in_path
+      installer.check_that_user_bin_dir_is_in_path(["executable"])
     end
 
     expected = installer.bin_dir
@@ -258,6 +258,7 @@ gem 'other', version
     end
 
     assert_match expected, @ui.error
+    assert_match "(executable)", @ui.error
   end
 
   def test_ensure_dependency
@@ -358,10 +359,8 @@ gem 'other', version
 
     inst = Gem::Installer.at "", options
 
-    Gem::Installer.path_warning = false
-
     use_ui @ui do
-      inst.check_that_user_bin_dir_is_in_path
+      inst.check_that_user_bin_dir_is_in_path(["executable"])
     end
 
     assert_equal "", @ui.error


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Yesterday I saw some transient tests failures about RubyGems warnings because some `gem install` commands where falling back to `--user-install` mode due to permission issues, and printing a warning about user directory not being in PATH, and executables installed potentially not working.

## What is your fix for the problem, implemented in this PR?

I had the idea that this warning is only necessary if the gem actually has executables, and that it could be useful to list the executables that may fail to run due to this.

I explored this idea.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
