### PR TITLE
Fix `gem cleanup` warning when two versions of psych installed

### DIFF
--- a/lib/rubygems/commands/cleanup_command.rb
+++ b/lib/rubygems/commands/cleanup_command.rb
@@ -38,8 +38,6 @@ class Gem::Commands::CleanupCommand < Gem::Command
     @default_gems    = []
     @full            = nil
     @gems_to_cleanup = nil
-    @original_home   = nil
-    @original_path   = nil
     @primary_gems    = nil
   end
 
@@ -95,9 +93,6 @@ If no gems are named all gems in GEM_HOME are cleaned.
   end
 
   def clean_gems
-    @original_home = Gem.dir
-    @original_path = Gem.path
-
     get_primary_gems
     get_candidate_gems
     get_gems_to_cleanup
@@ -112,8 +107,6 @@ If no gems are named all gems in GEM_HOME are cleaned.
     deps.reverse_each do |spec|
       uninstall_dep spec
     end
-
-    Gem::Specification.reset
   end
 
   def get_candidate_gems
@@ -133,7 +126,7 @@ If no gems are named all gems in GEM_HOME are cleaned.
 
     default_gems, gems_to_cleanup = gems_to_cleanup.partition(&:default_gem?)
 
-    uninstall_from = options[:user_install] ? Gem.user_dir : @original_home
+    uninstall_from = options[:user_install] ? Gem.user_dir : Gem.dir
 
     gems_to_cleanup = gems_to_cleanup.select do |spec|
       spec.base_dir == uninstall_from
@@ -181,8 +174,5 @@ If no gems are named all gems in GEM_HOME are cleaned.
       say "Unable to uninstall #{spec.full_name}:"
       say "\t#{e.class}: #{e.message}"
     end
-  ensure
-    # Restore path Gem::Uninstaller may have changed
-    Gem.use_paths @original_home, *@original_path
   end
 end

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1412,7 +1412,7 @@ class Gem::Specification < Gem::BasicSpecification
       end
 
       begin
-        specs = spec_dep.to_specs
+        specs = spec_dep.to_specs.uniq(&:full_name)
       rescue Gem::MissingSpecError => e
         raise Gem::MissingSpecError.new(e.name, e.requirement, "at: #{spec_file}")
       end

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1208,7 +1208,7 @@ class Gem::Specification < Gem::BasicSpecification
       unresolved.values.each do |dep|
         warn "      #{dep}"
 
-        versions = find_all_by_name(dep.name)
+        versions = find_all_by_name(dep.name).uniq(&:full_name)
         unless versions.empty?
           warn "      Available/installed versions of this gem:"
           versions.each {|s| warn "      - #{s.version}" }

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -182,6 +182,22 @@ class TestGemRequire < Gem::TestCase
     assert_equal %w[a-1 b-1], loaded_spec_names
   end
 
+  def test_require_is_not_lazy_with_shadowed_default_gem
+    b1_default = new_default_spec("b", "1", nil, "foo.rb")
+    install_default_gems b1_default
+
+    a1 = util_spec "a", "1", { "b" => ">= 1" }, "lib/test_gem_require_a.rb"
+    b1 = util_spec("b", "1", nil, "lib/foo.rb")
+    install_specs b1, a1
+
+    # Load default ruby gems fresh as if we've just started a ruby script.
+    Gem::Specification.reset
+
+    assert_require "test_gem_require_a"
+    assert_equal %w[a-1 b-1], loaded_spec_names
+    assert_equal unresolved_names, []
+  end
+
   def test_require_is_lazy_with_inexact_req
     a1 = util_spec "a", "1", { "b" => ">= 1" }, "lib/test_gem_require_a.rb"
     b1 = util_spec "b", "1", nil, "lib/b/c.rb"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Running `gem cleanup` prints `Gem::Specification.reset` warnings when more than one version of psych is installed.

## What is your fix for the problem, implemented in this PR?

Avoid using `Gem::Specification.reset` during `gem cleanup`. This is similar to https://github.com/rubygems/rubygems/pull/7667, except that was for `gem uninstall`.

I also fixed some small issues with the warning when regular gems with the same version as the default version are installed.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
