### PR TITLE
Fix `Gem::MissingSpecVersionError#to_s` not showing exception message

### DIFF
--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -230,18 +230,11 @@ class Gem::CommandManager
   def load_and_instantiate(command_name)
     command_name = command_name.to_s
     const_name = command_name.capitalize.gsub(/_(.)/) { $1.upcase } << "Command"
-    load_error = nil
 
     begin
-      begin
-        require "rubygems/commands/#{command_name}_command"
-      rescue LoadError => e
-        load_error = e
-      end
+      require "rubygems/commands/#{command_name}_command"
       Gem::Commands.const_get(const_name).new
-    rescue StandardError => e
-      e = load_error if load_error
-
+    rescue StandardError, LoadError => e
       alert_error clean_text("Loading command: #{command_name} (#{e.class})\n\t#{e}")
       ui.backtrace e
     end

--- a/lib/rubygems/errors.rb
+++ b/lib/rubygems/errors.rb
@@ -30,6 +30,7 @@ module Gem
       @name        = name
       @requirement = requirement
       @extra_message = extra_message
+      super(message)
     end
 
     def message # :nodoc:
@@ -53,8 +54,8 @@ module Gem
     attr_reader :specs
 
     def initialize(name, requirement, specs)
-      super(name, requirement)
       @specs = specs
+      super(name, requirement)
     end
 
     private

--- a/test/rubygems/rubygems/commands/ins_command.rb
+++ b/test/rubygems/rubygems/commands/ins_command.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Gem::Commands::InsCommand < Gem::Command
+  def initialize
+    super("ins", "Does something different from install", {})
+  end
+end

--- a/test/rubygems/rubygems/commands/interrupt_command.rb
+++ b/test/rubygems/rubygems/commands/interrupt_command.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Gem::Commands::InterruptCommand < Gem::Command
+  def initialize
+    super("interrupt", "Raises an Interrupt Exception", {})
+  end
+
+  def execute
+    raise Interrupt, "Interrupt exception"
+  end
+end

--- a/test/rubygems/rubygems_plugin.rb
+++ b/test/rubygems/rubygems_plugin.rb
@@ -2,23 +2,4 @@
 
 require "rubygems/command_manager"
 
-##
-# This is an example of exactly what NOT to do.
-#
-# DO NOT include code like this in your rubygems_plugin.rb
-
-module Gem::Commands
-  remove_const(:InterruptCommand) if defined?(InterruptCommand)
-end
-
-class Gem::Commands::InterruptCommand < Gem::Command
-  def initialize
-    super("interrupt", "Raises an Interrupt Exception", {})
-  end
-
-  def execute
-    raise Interrupt, "Interrupt exception"
-  end
-end
-
 Gem::CommandManager.instance.register_command :interrupt

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -21,8 +21,6 @@ class TestGem < Gem::TestCase
     common_installer_setup
 
     @additional = %w[a b].map {|d| File.join @tempdir, d }
-
-    util_remove_interrupt_command
   end
 
   def test_self_finish_resolve
@@ -1524,8 +1522,6 @@ class TestGem < Gem::TestCase
       nil
     end
 
-    util_remove_interrupt_command
-
     # Should attempt to cause a StandardError
     with_plugin("standarderror") { Gem.load_env_plugins }
     begin
@@ -1533,8 +1529,6 @@ class TestGem < Gem::TestCase
     rescue StandardError
       nil
     end
-
-    util_remove_interrupt_command
 
     # Should attempt to cause an Exception
     with_plugin("scripterror") { Gem.load_env_plugins }
@@ -1789,11 +1783,6 @@ class TestGem < Gem::TestCase
     @exec_path = File.join spec.full_gem_path, spec.bindir, "exec"
     @abin_path = File.join spec.full_gem_path, spec.bindir, "abin"
     spec
-  end
-
-  def util_remove_interrupt_command
-    Gem::Commands.send :remove_const, :InterruptCommand if
-      Gem::Commands.const_defined? :InterruptCommand
   end
 
   def util_cache_dir

--- a/test/rubygems/test_gem_command_manager.rb
+++ b/test/rubygems/test_gem_command_manager.rb
@@ -50,16 +50,17 @@ class TestGemCommandManager < Gem::TestCase
   end
 
   def test_find_command_ambiguous_exact
-    ins_command = Class.new
-    Gem::Commands.send :const_set, :InsCommand, ins_command
+    old_load_path = $:.dup
+    $: << File.expand_path("test/rubygems", PROJECT_DIR)
 
     @command_manager.register_command :ins
 
     command = @command_manager.find_command "ins"
 
-    assert_kind_of ins_command, command
+    assert_kind_of Gem::Commands::InsCommand, command
   ensure
-    Gem::Commands.send :remove_const, :InsCommand
+    $:.replace old_load_path
+    @command_manager.unregister_command :ins
   end
 
   def test_find_command_unknown

--- a/test/rubygems/test_gem_commands_help_command.rb
+++ b/test/rubygems/test_gem_commands_help_command.rb
@@ -11,8 +11,6 @@ class TestGemCommandsHelpCommand < Gem::TestCase
     super
 
     @cmd = Gem::Commands::HelpCommand.new
-
-    load File.expand_path("rubygems_plugin.rb", __dir__) unless Gem::Commands.const_defined? :InterruptCommand
   end
 
   def test_gem_help_bad


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

While working on https://github.com/rubygems/rubygems/pull/8066, I had to debug a JRuby issue where the error message looked like this:

```
ERROR:  Loading command: install (Gem::MissingSpecVersionError)
	Gem::MissingSpecVersionError
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/dependency.rb:303:in `to_specs'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/dependency.rb:313:in `to_spec'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/core_ext/kernel_gem.rb:56:in `gem'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/core_ext/kernel_require.rb:68:in `block in require'
	org/jruby/ext/monitor/Monitor.java:82:in `synchronize'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/core_ext/kernel_require.rb:39:in `require'
	/Users/deivid/.asdf/installs/ruby/jruby-9.4.8.0/lib/ruby/stdlib/socket.rb:6:in `<main>'
	org/jruby/RubyKernel.java:1184:in `require'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/core_ext/kernel_require.rb:136:in `require'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/vendor/net-protocol/lib/net/protocol.rb:22:in `<main>'
	org/jruby/RubyKernel.java:1184:in `require'
	org/jruby/RubyKernel.java:1213:in `require_relative'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/vendor/net-http/lib/net/http.rb:23:in `<main>'
	org/jruby/RubyKernel.java:1184:in `require'
	org/jruby/RubyKernel.java:1213:in `require_relative'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/vendored_net_http.rb:5:in `<main>'
	org/jruby/RubyKernel.java:1184:in `require'
	org/jruby/RubyKernel.java:1213:in `require_relative'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/request.rb:3:in `<main>'
	org/jruby/RubyKernel.java:1184:in `require'
	org/jruby/RubyKernel.java:1213:in `require_relative'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/remote_fetcher.rb:4:in `<main>'
	org/jruby/RubyKernel.java:1184:in `require'
	org/jruby/RubyKernel.java:1213:in `require_relative'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/spec_fetcher.rb:3:in `<main>'
	org/jruby/RubyKernel.java:1184:in `require'
	org/jruby/RubyKernel.java:1213:in `require_relative'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/dependency_installer.rb:7:in `<main>'
	org/jruby/RubyKernel.java:1184:in `require'
	org/jruby/RubyKernel.java:1213:in `require_relative'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/commands/install_command.rb:5:in `<main>'
	org/jruby/RubyKernel.java:1184:in `require'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/core_ext/kernel_require.rb:136:in `require'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/command_manager.rb:235:in `load_and_instantiate'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/command_manager.rb:138:in `[]'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/command_manager.rb:210:in `find_command'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/command_manager.rb:245:in `invoke_command'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/command_manager.rb:194:in `process_args'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/command_manager.rb:152:in `run'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/gem_runner.rb:56:in `run'
	/Users/deivid/.asdf/installs/ruby/jruby-9.4.8.0/bin/gem:12:in `<main>'
```

Not being able to see that actual Exception message made it hard to debug. This PR changes that error to instead look like this:

```
ERROR:  Loading command: install (Gem::MissingSpecVersionError)
	Could not find 'io-wait' (>= 0.a) - did find: [io-wait-0.3.0-java]
Checked in 'GEM_PATH=/Users/deivid/Code/rubygems/rubygems/bundler/tmp/1.1/gems/system' , execute `gem env` for more information
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/dependency.rb:303:in `to_specs'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/dependency.rb:313:in `to_spec'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/core_ext/kernel_gem.rb:56:in `gem'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/core_ext/kernel_require.rb:68:in `block in require'
	org/jruby/ext/monitor/Monitor.java:82:in `synchronize'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/core_ext/kernel_require.rb:39:in `require'
	/Users/deivid/.asdf/installs/ruby/jruby-9.4.8.0/lib/ruby/stdlib/socket.rb:6:in `<main>'
	org/jruby/RubyKernel.java:1184:in `require'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/core_ext/kernel_require.rb:136:in `require'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/vendor/net-protocol/lib/net/protocol.rb:22:in `<main>'
	org/jruby/RubyKernel.java:1184:in `require'
	org/jruby/RubyKernel.java:1213:in `require_relative'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/vendor/net-http/lib/net/http.rb:23:in `<main>'
	org/jruby/RubyKernel.java:1184:in `require'
	org/jruby/RubyKernel.java:1213:in `require_relative'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/vendored_net_http.rb:5:in `<main>'
	org/jruby/RubyKernel.java:1184:in `require'
	org/jruby/RubyKernel.java:1213:in `require_relative'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/request.rb:3:in `<main>'
	org/jruby/RubyKernel.java:1184:in `require'
	org/jruby/RubyKernel.java:1213:in `require_relative'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/remote_fetcher.rb:4:in `<main>'
	org/jruby/RubyKernel.java:1184:in `require'
	org/jruby/RubyKernel.java:1213:in `require_relative'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/spec_fetcher.rb:3:in `<main>'
	org/jruby/RubyKernel.java:1184:in `require'
	org/jruby/RubyKernel.java:1213:in `require_relative'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/dependency_installer.rb:7:in `<main>'
	org/jruby/RubyKernel.java:1184:in `require'
	org/jruby/RubyKernel.java:1213:in `require_relative'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/commands/install_command.rb:5:in `<main>'
	org/jruby/RubyKernel.java:1184:in `require'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/core_ext/kernel_require.rb:136:in `require'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/command_manager.rb:235:in `load_and_instantiate'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/command_manager.rb:138:in `[]'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/command_manager.rb:210:in `find_command'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/command_manager.rb:245:in `invoke_command'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/command_manager.rb:194:in `process_args'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/command_manager.rb:152:in `run'
	/Users/deivid/Code/rubygems/rubygems/lib/rubygems/gem_runner.rb:56:in `run'
	/Users/deivid/.asdf/installs/ruby/jruby-9.4.8.0/bin/gem:12:in `<main>'
```

## What is your fix for the problem, implemented in this PR?

I made sure the exception message is properly set, so that `#to_s` works as expected. I also simplified several things in tests, and also the way commands are loaded while working on this.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
