### PR TITLE
Fix old cache format detection when application is not source controlled

### DIFF
--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -191,7 +191,7 @@ module Bundler
         set_up_app_cache!(app_cache_path) if use_app_cache?
 
         if requires_checkout? && !@copied
-          FileUtils.rm_rf(app_cache_path) if use_app_cache? && git_proxy.not_a_bare_repository?
+          FileUtils.rm_rf(app_cache_path) if use_app_cache? && git_proxy.not_a_repository?
 
           fetch
           checkout

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -84,8 +84,10 @@ module Bundler
           end
         end
 
-        def not_a_bare_repository?
-          git_local("rev-parse", "--is-bare-repository", dir: path).strip == "false"
+        def not_a_repository?
+          _, status = git_null("rev-parse", "--resolve-git-dir", path.to_s, dir: path)
+
+          !status.success?
         end
 
         def contains?(commit)

--- a/bundler/spec/cache/git_spec.rb
+++ b/bundler/spec/cache/git_spec.rb
@@ -323,8 +323,6 @@ RSpec.describe "bundle cache with git" do
     FileUtils.mkdir_p bundled_app("vendor/cache")
     FileUtils.cp_r git_path, bundled_app("vendor/cache/foo-1.0-#{path_revision}")
     FileUtils.rm_rf bundled_app("vendor/cache/foo-1.0-#{path_revision}/.git")
-    # bundle install with git repo needs to be run under the git environment.
-    Dir.chdir(bundled_app) { system(*%W[git init --quiet]) }
 
     bundle :install, env: { "BUNDLE_DEPLOYMENT" => "true", "BUNDLE_CACHE_ALL" => "true" }
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If an application is not source controlled, and generated the cache for a git gem using the old format (prior to #4469), then our code to detect whether the cache is using new or old format will fail.

## What is your fix for the problem, implemented in this PR?

Change the cache detection to use a helper that does not fail, and check the command status. Also, I changed the command to be `git rev-parse --resolve-git-dir <cache-path>`, because the old cache was not a git dir anyways, so we don't need to detect a bare repo specifically and this way I don't need to check both command success and output being `false`, but just command success.

Fixes #8069.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
