### PR TITLE
Fix bug report template printed when changing a path source to a git source in frozen mode

### DIFF
--- a/bundler/lib/bundler/source/path.rb
+++ b/bundler/lib/bundler/source/path.rb
@@ -53,6 +53,8 @@ module Bundler
         "source at `#{@path}`"
       end
 
+      alias_method :to_gemfile, :path
+
       def hash
         [self.class, expanded_path, version].hash
       end

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -483,6 +483,27 @@ RSpec.describe "install in deployment or frozen mode" do
       expect(err).not_to include("You have deleted from the Gemfile")
     end
 
+    it "explodes if you change a source from path to git" do
+      build_git "myrack", path: lib_path("myrack")
+
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        gem "myrack", :path => "#{lib_path("myrack")}"
+      G
+
+      gemfile <<-G
+        source "https://gem.repo1"
+        gem "myrack", :git => "https:/my-git-repo-for-myrack"
+      G
+
+      bundle "config set --local frozen true"
+      bundle :install, raise_on_error: false
+      expect(err).to include("frozen mode")
+      expect(err).to include("You have changed in the Gemfile:\n* myrack from `#{lib_path("myrack")}` to `https:/my-git-repo-for-myrack`")
+      expect(err).not_to include("You have added to the Gemfile")
+      expect(err).not_to include("You have deleted from the Gemfile")
+    end
+
     it "remembers that the bundle is frozen at runtime" do
       bundle :lock
 

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -438,7 +438,7 @@ RSpec.describe "install in deployment or frozen mode" do
       expect(err).to include("You have changed in the Gemfile:\n* myrack from `no specified source` to `git://hubz.com`")
     end
 
-    it "explodes if you change a source" do
+    it "explodes if you change a source from git to the default" do
       build_git "myrack"
 
       install_gemfile <<-G
@@ -459,7 +459,7 @@ RSpec.describe "install in deployment or frozen mode" do
       expect(err).to include("You have changed in the Gemfile:\n* myrack from `#{lib_path("myrack-1.0")}` to `no specified source`")
     end
 
-    it "explodes if you change a source" do
+    it "explodes if you change a source from git to the default, in presence of other git sources" do
       build_lib "foo", path: lib_path("myrack/foo")
       build_git "myrack", path: lib_path("myrack")
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

One edge case not covered by our tests led to the bug report being printed.

## What is your fix for the problem, implemented in this PR?

Make sure to define `Bundler::Source::Path#to_gemfile` so that a proper error gets printed when in frozen mode, you change a path source to a git source.

Fixes #8077.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
