### PR TITLE
Fix error in one source when fetching dependency APIs clearing results from all sources

### DIFF
--- a/lib/rubygems/resolver/api_set.rb
+++ b/lib/rubygems/resolver/api_set.rb
@@ -104,16 +104,21 @@ class Gem::Resolver::APISet < Gem::Resolver::Set
     end
 
     uri = @dep_uri + name
-    str = Gem::RemoteFetcher.fetcher.fetch_path uri
 
-    lines(str).each do |ver|
-      number, platform, dependencies, requirements = parse_gem(ver)
+    begin
+      str = Gem::RemoteFetcher.fetcher.fetch_path uri
+    rescue Gem::RemoteFetcher::FetchError
+      @data[name] = []
+    else
+      lines(str).each do |ver|
+        number, platform, dependencies, requirements = parse_gem(ver)
 
-      platform ||= "ruby"
-      dependencies = dependencies.map {|dep_name, reqs| [dep_name, reqs.join(", ")] }
-      requirements = requirements.map {|req_name, reqs| [req_name.to_sym, reqs] }.to_h
+        platform ||= "ruby"
+        dependencies = dependencies.map {|dep_name, reqs| [dep_name, reqs.join(", ")] }
+        requirements = requirements.map {|req_name, reqs| [req_name.to_sym, reqs] }.to_h
 
-      @data[name] << { name: name, number: number, platform: platform, dependencies: dependencies, requirements: requirements }
+        @data[name] << { name: name, number: number, platform: platform, dependencies: dependencies, requirements: requirements }
+      end
     end
 
     @data[name]

--- a/lib/rubygems/resolver/best_set.rb
+++ b/lib/rubygems/resolver/best_set.rb
@@ -29,8 +29,6 @@ class Gem::Resolver::BestSet < Gem::Resolver::ComposedSet
     pick_sets if @remote && @sets.empty?
 
     super
-  rescue Gem::RemoteFetcher::FetchError
-    []
   end
 
   def prefetch(reqs) # :nodoc:

--- a/test/rubygems/test_gem_resolver_api_set.rb
+++ b/test/rubygems/test_gem_resolver_api_set.rb
@@ -136,6 +136,25 @@ class TestGemResolverAPISet < Gem::TestCase
     assert_empty set.find_all(a_dep)
   end
 
+  def test_find_all_not_found
+    spec_fetcher
+
+    @fetcher.data["#{@dep_uri}/a"] =
+      proc do
+        raise Gem::RemoteFetcher::FetchError
+      end
+
+    set = Gem::Resolver::APISet.new @dep_uri
+
+    a_dep = Gem::Resolver::DependencyRequest.new dep("a"), nil
+
+    assert_empty set.find_all(a_dep)
+
+    @fetcher.data.delete "#{@dep_uri}a"
+
+    assert_empty set.find_all(a_dep)
+  end
+
   def test_prefetch
     spec_fetcher
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since https://github.com/rubygems/rubygems/issues/8006, if one source fails to fetch dependency API results, the resuls from all sources will be cleared, causing `gem install` to fail instead of falling back to the source that has the target gem.

## What is your fix for the problem, implemented in this PR?

Make sure ignoring fetch errors happens at the right level (`Gem::Resolver::APISet`) instead of at the level the aggregates the different sources (`Gem::Resolver::BestSet`).

As a nice side effect, 404 info requests are now cached too, resulting in less network requests, and less output in verbose mode.
 
Fixes #8042.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
