### PR TITLE
Remove code that makes suggest_gems_from_name give worse results.

### DIFF
--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -176,18 +176,11 @@ class Gem::SpecFetcher
 
     matches = names.map do |n|
       next unless n.match_platform?
-      [n.name, 0] if n.name.downcase.tr("_-", "").include?(gem_name)
+      distance = levenshtein_distance gem_name, n.name.downcase.tr("_-", "")
+      next if distance >= max
+      return [n.name] if distance == 0
+      [n.name, distance]
     end.compact
-
-    if matches.length < num_results
-      matches += names.map do |n|
-        next unless n.match_platform?
-        distance = levenshtein_distance gem_name, n.name.downcase.tr("_-", "")
-        next if distance >= max
-        return [n.name] if distance == 0
-        [n.name, distance]
-      end.compact
-    end
 
     matches = if matches.empty? && type != :prerelease
       suggest_gems_from_name gem_name, :prerelease

--- a/test/rubygems/test_gem_commands_exec_command.rb
+++ b/test/rubygems/test_gem_commands_exec_command.rb
@@ -493,7 +493,6 @@ class TestGemCommandsExecCommand < Gem::TestCase
       assert_equal 2, e.exit_code
       assert_equal <<~ERR, @ui.error
         ERROR:  Could not find a valid gem 'a' (= 2) in any repository
-        ERROR:  Possible alternatives: a
       ERR
     end
   end
@@ -574,7 +573,6 @@ class TestGemCommandsExecCommand < Gem::TestCase
       assert_include @ui.output, "a (= 2) not available locally"
       assert_equal <<~ERROR, @ui.error
         ERROR:  Could not find a valid gem 'a' (= 2) in any repository
-        ERROR:  Possible alternatives: a
       ERROR
     end
   end
@@ -769,8 +767,7 @@ class TestGemCommandsExecCommand < Gem::TestCase
       assert_raise Gem::MockGemUi::TermError do
         invoke "a"
       end
-      assert_equal "ERROR:  Could not find a valid gem 'a' (>= 0) in any repository\n" \
-                   "ERROR:  Possible alternatives: a\n", @ui.error
+      assert_equal "ERROR:  Could not find a valid gem 'a' (>= 0) in any repository\n", @ui.error
       assert_empty @ui.output
       assert_empty @installed_specs
     end

--- a/test/rubygems/test_gem_spec_fetcher.rb
+++ b/test/rubygems/test_gem_spec_fetcher.rb
@@ -168,20 +168,20 @@ class TestGemSpecFetcher < Gem::TestCase
   def test_suggest_gems_from_name_latest
     spec_fetcher do|fetcher|
       fetcher.spec "example", 1
-      fetcher.spec "other-example", 1
+      fetcher.spec "an-example", 1
       fetcher.spec "examp", 1
     end
 
     suggestions = @sf.suggest_gems_from_name("examplw", :latest, 1)
     assert_equal ["example"], suggestions
 
-    suggestions = @sf.suggest_gems_from_name("other")
-    assert_equal ["other-example"], suggestions
+    suggestions = @sf.suggest_gems_from_name("anexample")
+    assert_equal ["an-example"], suggestions
 
-    suggestions = @sf.suggest_gems_from_name("exam")
+    suggestions = @sf.suggest_gems_from_name("xample")
     assert suggestions.any? { ["examp"] }
     assert suggestions.any? { ["example"] }
-    assert suggestions.any? { ["other-example"] }
+    assert suggestions.any? { ["an-example"] }
   end
 
   def test_suggest_gems_from_name_prerelease

--- a/test/rubygems/test_gem_spec_fetcher.rb
+++ b/test/rubygems/test_gem_spec_fetcher.rb
@@ -170,6 +170,7 @@ class TestGemSpecFetcher < Gem::TestCase
       fetcher.spec "example", 1
       fetcher.spec "an-example", 1
       fetcher.spec "examp", 1
+      fetcher.spec "other-example", 1
     end
 
     suggestions = @sf.suggest_gems_from_name("examplw", :latest, 1)
@@ -179,9 +180,10 @@ class TestGemSpecFetcher < Gem::TestCase
     assert_equal ["an-example"], suggestions
 
     suggestions = @sf.suggest_gems_from_name("xample")
-    assert suggestions.any? { ["examp"] }
-    assert suggestions.any? { ["example"] }
-    assert suggestions.any? { ["an-example"] }
+    assert_equal ["example"], suggestions
+
+    suggestions = @sf.suggest_gems_from_name("other-apple")
+    assert_equal ["other-example"], suggestions
   end
 
   def test_suggest_gems_from_name_prerelease


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The suggestions given by `gem install <gem that does not exist>` were sometimes completely irrelevant.

E.g., `gem install railss` suggesting things like `aerospike-rails-support` and `capistrano-rails-synchronizer` but not `rails`.

## What is your fix for the problem, implemented in this PR?

`suggest_gems_from_name()` had a second loop that seemed to make results significantly worse for phrases that are commonly found in gem names.

So I removed that second, unnecessary loop.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
