### PR TITLE
Remove compatibility code with old RubyGems

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -577,7 +577,7 @@ module Bundler
 
       requested_path_gems = definition.requested_specs.select {|s| s.source.is_a?(Source::Path) }
       path_plugin_files = requested_path_gems.map do |spec|
-        Bundler.rubygems.spec_matches_for_glob(spec, "rubygems_plugin#{Bundler.rubygems.suffix_pattern}")
+        spec.matches_for_glob("rubygems_plugin#{Bundler.rubygems.suffix_pattern}")
       rescue TypeError
         error_message = "#{spec.name} #{spec.version} has an invalid gemspec"
         raise Gem::InvalidSpecificationException, error_message

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -70,14 +70,6 @@ module Bundler
       default
     end
 
-    def spec_matches_for_glob(spec, glob)
-      return spec.matches_for_glob(glob) if spec.respond_to?(:matches_for_glob)
-
-      spec.load_paths.flat_map do |lp|
-        Dir["#{lp}/#{glob}#{suffix_pattern}"]
-      end
-    end
-
     def stub_set_spec(stub, spec)
       stub.instance_variable_set(:@spec, spec)
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We have dead code in `bundler/lib/bundler/rubygems_integration.rb`.

## What is your fix for the problem, implemented in this PR?

According to 1b923ece4a5e421f89eba723ded7e6ae44e90854, this was introduced to support RubyGems < 1.8, so seems fine to remove at this point.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
