### PR TITLE
Port ruby core changes about pretty printing hashes

### DIFF
--- a/bundler/spec/bundler/endpoint_specification_spec.rb
+++ b/bundler/spec/bundler/endpoint_specification_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Bundler::EndpointSpecification do
         expect { subject }.to raise_error(
           Bundler::GemspecError,
           a_string_including("There was an error parsing the metadata for the gem foo (1.0.0)").
-            and(a_string_including('The metadata was {"rubygems"=>">\n"}'))
+            and(a_string_including("The metadata was #{{ "rubygems" => ">\n" }.inspect}"))
         )
       end
     end

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe "compact index api" do
     bundle :install, verbose: true, artifice: "compact_index_checksum_mismatch"
     expect(out).to include("Fetching gem metadata from #{source_uri}")
     expect(out).to include("The checksum of /versions does not match the checksum provided by the server!")
-    expect(out).to include('Calculated checksums {"sha-256"=>"8KfZiM/fszVkqhP/m5s9lvE6M9xKu4I1bU4Izddp5Ms="} did not match expected {"sha-256"=>"ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0="}')
+    expect(out).to include("Calculated checksums #{{ "sha-256" => "8KfZiM/fszVkqhP/m5s9lvE6M9xKu4I1bU4Izddp5Ms=" }.inspect} did not match expected #{{ "sha-256" => "ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0=" }.inspect}")
     expect(the_bundle).to include_gems "myrack 1.0.0"
   end
 

--- a/test/rubygems/test_gem_dependency.rb
+++ b/test/rubygems/test_gem_dependency.rb
@@ -22,7 +22,7 @@ class TestGemDependency < Gem::TestCase
       Gem::Dependency.new "monkey" => "1.0"
     end
 
-    assert_equal 'dependency name must be a String, was {"monkey"=>"1.0"}',
+    assert_equal "dependency name must be a String, was #{{ "monkey" => "1.0" }.inspect}",
                  e.message
   end
 

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -721,11 +721,11 @@ class TestGemRequire < Gem::TestCase
         _, err = capture_subprocess_io do
           system(*ruby_with_rubygems_in_load_path, "-w", "--disable=gems", "-C", dir, "main.rb")
         end
-        assert_match(/{:x=>1}\n{:y=>2}\n$/, err)
+        assert_match(/#{{ x: 1 }.inspect}\n#{{ y: 2 }.inspect}\n$/, err)
         _, err = capture_subprocess_io do
           system(*ruby_with_rubygems_in_load_path, "-w", "--enable=gems", "-C", dir, "main.rb")
         end
-        assert_match(/{:x=>1}\n{:y=>2}\n$/, err)
+        assert_match(/#{{ x: 1 }.inspect}\n#{{ y: 2 }.inspect}\n$/, err)
       end
     end
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Spec started failing with ruby-head due to https://github.com/ruby/ruby/pull/10924.

## What is your fix for the problem, implemented in this PR?

~We can't just port the fixes made there, because our tests would start failing with older rubies, so I duplicated the assertions for the new and old messages.~

I'm really distracted today and the above is wrong, we can backport the commits untouched.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
