### PR TITLE
Fix `bundle.bat` re-execution

### DIFF
--- a/bundler/lib/bundler/self_manager.rb
+++ b/bundler/lib/bundler/self_manager.rb
@@ -85,7 +85,7 @@ module Bundler
         cmd = [*Shellwords.shellsplit(bundler_spec_original_cmd), *ARGV]
       else
         cmd = [$PROGRAM_NAME, *ARGV]
-        cmd.unshift(Gem.ruby) unless File.executable?($PROGRAM_NAME)
+        cmd.unshift(Gem.ruby) unless File.executable?($PROGRAM_NAME) || $PROGRAM_NAME.end_with?(".bat")
       end
 
       Bundler.with_original_env do


### PR DESCRIPTION



## What was the end-user or developer problem that led to this PR?

Failing CI in https://github.com/rubygems/compact_index/ under mswin, because Bundler was trying to run a `.bat` script using `ruby`:

```
$ C:\Windows\system32\cmd.exe /D /S /C "D:\ruby-mswin\bin\bundle.bat install --jobs 4"
Bundler 2.6.0.dev is running, but your lockfile was generated with 2.4.12. Installing Bundler 2.4.12 and restarting using that version.
Fetching gem metadata from https://rubygems.org/.
Fetching bundler 2.4.12
Installing bundler 2.4.12
D:/ruby-mswin/bin/bundle: --> D:/ruby-mswin/bin/bundle
'$(' is not allowed as a global variable nameunexpected '(', expecting end-of-input
  2  {
> 3    bindir=$(dirname "$0")
> 4    exec "$bindir/ruby" "-x" "$0" "$@"
  5  }
D:/ruby-mswin/bin/bundle:3: syntax errors found (SyntaxError)
  1 | #!
  2 | {
> 3 |   bindir=$(dirname "$0")
    |          ^~ '$(' is not allowed as a global variable name
    |           ^ expected a `=>` between the hash key and value
> 4 |   exec "$bindir/ruby" "-x" "$0" "$@" ...
    | ^ expected a `}` to close the hash literal
    |   ^~~~ unexpected local variable or method, expecting end-of-input
> 5 | }
    | ^ unexpected '}', ignoring it
  6 | #!/usr/bin/env ruby
  7 | #
```


## What is your fix for the problem, implemented in this PR?

`.bat` scripts don't have ruby code, so we should not prepend `ruby` to the command the re-execute it.

This fixes https://github.com/rubygems/compact_index CI as proved by https://github.com/rubygems/compact_index/pull/67.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
