### PR TITLE
Automatically fix lockfile when it's missing dependencies

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -587,10 +587,18 @@ module Bundler
     end
 
     def materialize(dependencies)
+      # Tracks potential endless loops trying to re-resolve.
+      # TODO: Remove as dead code if not reports are received in a while
+      incorrect_spec = nil
+
       specs = begin
         resolve.materialize(dependencies)
       rescue IncorrectLockfileDependencies => e
-        reresolve_without([e.spec])
+        spec = e.spec
+        raise "Infinite loop while fixing lockfile dependencies" if incorrect_spec == spec
+
+        incorrect_spec = spec
+        reresolve_without([spec])
         retry
       end
 

--- a/bundler/lib/bundler/errors.rb
+++ b/bundler/lib/bundler/errors.rb
@@ -246,4 +246,14 @@ module Bundler
   end
 
   class InvalidArgumentError < BundlerError; status_code(40); end
+
+  class IncorrectLockfileDependencies < BundlerError
+    attr_reader :spec
+
+    def initialize(spec)
+      @spec = spec
+    end
+
+    status_code(41)
+  end
 end

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -136,7 +136,7 @@ module Bundler
       end
       if search.nil? && fallback_to_non_installable
         search = candidates.last
-      elsif search && search.full_name == full_name && (search.is_a?(RemoteSpecification) || search.is_a?(EndpointSpecification))
+      elsif search && search.full_name == full_name && (search.is_a?(RemoteSpecification) || search.instance_of?(EndpointSpecification))
         search.dependencies = dependencies
       end
       search

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -136,8 +136,12 @@ module Bundler
       end
       if search.nil? && fallback_to_non_installable
         search = candidates.last
-      elsif search && search.full_name == full_name && (search.is_a?(RemoteSpecification) || search.instance_of?(EndpointSpecification))
-        search.dependencies = dependencies
+      elsif search && search.full_name == full_name
+        if search.is_a?(StubSpecification)
+          search.dependencies = dependencies
+        elsif !source.is_a?(Source::Path) && search.runtime_dependencies.sort != dependencies.sort
+          raise IncorrectLockfileDependencies.new(self)
+        end
       end
       search
     end

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -136,8 +136,8 @@ module Bundler
       end
       if search.nil? && fallback_to_non_installable
         search = candidates.last
-      else
-        search.dependencies = dependencies if search && search.full_name == full_name && (search.is_a?(RemoteSpecification) || search.is_a?(EndpointSpecification))
+      elsif search && search.full_name == full_name && (search.is_a?(RemoteSpecification) || search.is_a?(EndpointSpecification))
+        search.dependencies = dependencies
       end
       search
     end

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -137,6 +137,10 @@ module Bundler
       if search.nil? && fallback_to_non_installable
         search = candidates.last
       elsif search && search.full_name == full_name
+        # We don't validate locally installed dependencies but accept what's in
+        # the lockfile instead for performance, since loading locally installed
+        # dependencies would mean evaluating all gemspecs, which would affect
+        # `bundler/setup` performance
         if search.is_a?(StubSpecification)
           search.dependencies = dependencies
         elsif !source.is_a?(Source::Path) && search.runtime_dependencies.sort != dependencies.sort

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -162,10 +162,10 @@ module Bundler
       extra_deps = new_deps - old_deps
       return if extra_deps.empty?
 
-      Bundler.ui.debug "#{spec.full_name} from #{spec.remote} has either corrupted API or lockfile dependencies" \
+      Bundler.ui.debug "#{spec.full_name} from #{spec.remote} has corrupted API dependencies" \
         " (was expecting #{old_deps.map(&:to_s)}, but the real spec has #{new_deps.map(&:to_s)})"
       raise APIResponseMismatchError,
-        "Downloading #{spec.full_name} revealed dependencies not in the API or the lockfile (#{extra_deps.join(", ")})." \
+        "Downloading #{spec.full_name} revealed dependencies not in the API (#{extra_deps.join(", ")})." \
         "\nRunning `bundle update #{spec.name}` should fix the problem."
     end
 

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -1074,9 +1074,9 @@ RSpec.describe "compact index api" do
             Gem::Dependency.new("activerecord", "= 2.3.2"),
             Gem::Dependency.new("actionmailer", "= 2.3.2"),
             Gem::Dependency.new("activeresource", "= 2.3.2")]
-    expect(out).to include("rails-2.3.2 from rubygems remote at #{source_uri}/ has either corrupted API or lockfile dependencies")
+    expect(out).to include("rails-2.3.2 from rubygems remote at #{source_uri}/ has corrupted API dependencies")
     expect(err).to include(<<-E.strip)
-Bundler::APIResponseMismatchError: Downloading rails-2.3.2 revealed dependencies not in the API or the lockfile (#{deps.map(&:to_s).join(", ")}).
+Bundler::APIResponseMismatchError: Downloading rails-2.3.2 revealed dependencies not in the API (#{deps.map(&:to_s).join(", ")}).
 Running `bundle update rails` should fix the problem.
     E
   end

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe "bundle install with install-time dependencies" do
       gem "actionpack", "2.3.2"
     G
 
-    expect(err).to include("Downloading actionpack-2.3.2 revealed dependencies not in the API or the lockfile (activesupport (= 2.3.2)).")
+    expect(err).to include("Downloading actionpack-2.3.2 revealed dependencies not in the API (activesupport (= 2.3.2)).")
 
     expect(the_bundle).not_to include_gems "actionpack 2.3.2", "activesupport 2.3.2"
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We already try to automatically fix lockfiles when possible instead of just erroring out, but we were not doing it in this situation. My main goal was to make the code simpler, but I think it also improves the user experience.

## What is your fix for the problem, implemented in this PR?

Don't overwrite remote specification dependencies with lockfile dependencies (except for `StubSpecification`'s where we do it to avoid loading the installed `.gemspec` for performance). That way, the lockfile is corrected automatically with the proper dependencies from the API.

NOTE: I extracted these changes from #8029 because that PR is ready now but got a bit too big and had some unrelated changes like the ones in here.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
