### PR TITLE
Fix bundler sometimes crashing because of trying to use a version of psych compiled for a different Ruby

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -129,3 +129,48 @@ jobs:
         shell: bash
 
     timeout-minutes: 20
+
+  shared_gem_home:
+    name: Handling issues with a shared gem home
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        rubygems:
+          - dev
+          - system
+    steps:
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      - name: Setup original ruby
+        uses: ruby/setup-ruby@f321cf5a4d1533575411f8752cf25b86478b0442 # v1.193.0
+        with:
+          ruby-version: 3.2
+          bundler: none
+      - name: Save system RubyGems version to ENV
+        run: |
+          RGV=$(ruby -e 'puts Gem::VERSION.split(".")[0..2].join(".")')
+          echo "RGV=v$RGV" >> $GITHUB_ENV
+        if: matrix.rubygems == 'system'
+      - name: Set dev RubyGems version
+        run: |
+          RGV=..
+          echo "RGV=v$RGV" >> $GITHUB_ENV
+        if: matrix.rubygems == 'dev'
+      - name: Setup app depending on psych with initial Ruby
+        run: mkdir foo && cd foo && ruby ../bundler/spec/support/bundle.rb init && ruby ../bundler/spec/support/bundle.rb add psych -v 5.1.2
+        shell: bash
+        env:
+          GEM_HOME: bar
+          GEM_PATH: bar
+      - name: Setup final ruby
+        uses: ruby/setup-ruby@f321cf5a4d1533575411f8752cf25b86478b0442 # v1.193.0
+        with:
+          ruby-version: 3.3
+          bundler: none
+      - name: Install gems with final ruby, using GEM_HOME created by the other Ruby
+        run: ruby ../bundler/spec/support/bundle.rb install
+        working-directory: foo
+        env:
+          GEM_HOME: bar
+          GEM_PATH: bar
+
+    timeout-minutes: 20

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -262,6 +262,16 @@ module Gem
       end
       out
     end
+
+    if Gem.rubygems_version < Gem::Version.new("3.5.22")
+      module FilterIgnoredSpecs
+        def matching_specs(platform_only = false)
+          super.reject(&:ignored?)
+        end
+      end
+
+      prepend FilterIgnoredSpecs
+    end
   end
 
   require "rubygems/platform"
@@ -366,6 +376,15 @@ module Gem
             Gem.default_ext_dir_for(base_dir) || File.join(base_dir, "extensions", ORIGINAL_LOCAL_PLATFORM, Gem.extension_api_version)
         end
       end
+    end
+
+    remove_method :ignored? if new.respond_to?(:ignored?)
+
+    # Same as RubyGems, but without warnings, because Bundler prints its own warnings
+    def ignored?
+      return @ignored unless @ignored.nil?
+
+      @ignored = missing_extensions?
     end
   end
 

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -57,15 +57,6 @@ module Bundler
       nil
     end
 
-    def spec_missing_extensions?(spec, default = true)
-      return spec.missing_extensions? if spec.respond_to?(:missing_extensions?)
-
-      return false if spec.default_gem?
-      return false if spec.extensions.empty?
-
-      default
-    end
-
     def stub_set_spec(stub, spec)
       stub.instance_variable_set(:@spec, spec)
     end

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -210,7 +210,7 @@ module Bundler
           checkout
         end
 
-        generate_bin_options = { disable_extensions: !Bundler.rubygems.spec_missing_extensions?(spec), build_args: options[:build_args] }
+        generate_bin_options = { disable_extensions: !spec.missing_extensions?, build_args: options[:build_args] }
         generate_bin(spec, generate_bin_options)
 
         requires_checkout? ? spec.post_install_message : nil

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -357,7 +357,7 @@ module Bundler
         @installed_specs ||= Index.build do |idx|
           Bundler.rubygems.installed_specs.reverse_each do |spec|
             spec.source = self
-            if Bundler.rubygems.spec_missing_extensions?(spec, false)
+            if spec.missing_extensions?
               Bundler.ui.debug "Source #{self} is ignoring #{spec} because it is missing extensions"
               next
             end

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -357,10 +357,7 @@ module Bundler
         @installed_specs ||= Index.build do |idx|
           Bundler.rubygems.installed_specs.reverse_each do |spec|
             spec.source = self
-            if spec.missing_extensions?
-              Bundler.ui.debug "Source #{self} is ignoring #{spec} because it is missing extensions"
-              next
-            end
+            next if spec.ignored?
             idx << spec
           end
         end

--- a/bundler/lib/bundler/stub_specification.rb
+++ b/bundler/lib/bundler/stub_specification.rb
@@ -28,6 +28,17 @@ module Bundler
 
     # @!group Stub Delegates
 
+    def ignored?
+      return @ignored unless @ignored.nil?
+
+      @ignored = missing_extensions?
+      return false unless @ignored
+
+      warn "Source #{source} is ignoring #{self} because it is missing extensions"
+
+      true
+    end
+
     def manually_installed?
       # This is for manually installed gems which are gems that were fixed in place after a
       # failed installation. Once the issue was resolved, the user then manually created

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -142,7 +142,6 @@ RSpec.shared_examples "bundle install --standalone" do
   describe "with default gems and a lockfile", :ruby_repo do
     before do
       necessary_system_gems = ["tsort --version 0.1.0"]
-      necessary_system_gems += ["etc --version 1.4.3"]
       realworld_system_gems(*necessary_system_gems)
     end
 
@@ -173,7 +172,16 @@ RSpec.shared_examples "bundle install --standalone" do
       bundle "lock", dir: cwd
 
       bundle "config set --local path #{bundled_app("bundle")}"
-      bundle :install, standalone: true, dir: cwd, env: { "BUNDLER_GEM_DEFAULT_DIR" => system_gem_path.to_s }
+
+      # Make sure rubyinstaller2 does not activate the etc gem in its
+      # `operating_system.rb` file, but completely disable that since it's not
+      # really needed here
+      if Gem.win_platform?
+        FileUtils.mkdir_p bundled_app("rubygems/defaults")
+        FileUtils.touch bundled_app("rubygems/defaults/operating_system.rb")
+      end
+
+      bundle :install, standalone: true, dir: cwd, env: { "BUNDLER_GEM_DEFAULT_DIR" => system_gem_path.to_s }, load_path: bundled_app
 
       load_path_lines = bundled_app("bundle/bundler/setup.rb").read.split("\n").select {|line| line.start_with?("$:.unshift") }
 
@@ -184,27 +192,35 @@ RSpec.shared_examples "bundle install --standalone" do
     end
 
     it "works for gems with extensions and points to the vendored copies, not to the default copies" do
-      necessary_gems_in_bundle_path = ["optparse --version 0.1.1", "psych --version 3.3.2", "logger --version 1.4.3", "etc --version 1.4.3", "stringio --version 3.1.0", "shellwords --version 0.2.0", "open3 --version 0.2.1"]
-      necessary_gems_in_bundle_path += ["yaml --version 0.1.1"] if Gem.rubygems_version < Gem::Version.new("3.4.a")
-      realworld_system_gems(*necessary_gems_in_bundle_path, path: scoped_gem_path(bundled_app("bundle")))
-
-      build_gem "baz", "1.0.0", to_system: true, default: true, &:add_c_extension
-
-      build_repo4 do
-        build_gem "baz", "1.0.0", &:add_c_extension
-      end
-
-      gemfile <<-G
-        source "https://gem.repo4"
-        gem "baz"
-      G
-
-      bundle "config set --local path #{bundled_app("bundle")}"
-
       simulate_platform "arm64-darwin-23" do
+        necessary_gems_in_bundle_path = ["optparse --version 0.1.1", "psych --version 3.3.2", "logger --version 1.4.3", "etc --version 1.4.3", "stringio --version 3.1.0", "shellwords --version 0.2.0", "open3 --version 0.2.1"]
+        necessary_gems_in_bundle_path += ["yaml --version 0.1.1"] if Gem.rubygems_version < Gem::Version.new("3.4.a")
+        realworld_system_gems(*necessary_gems_in_bundle_path, path: scoped_gem_path(bundled_app("bundle")))
+
+        build_gem "baz", "1.0.0", to_system: true, default: true, &:add_c_extension
+
+        build_repo4 do
+          build_gem "baz", "1.0.0", &:add_c_extension
+        end
+
+        gemfile <<-G
+          source "https://gem.repo4"
+          gem "baz"
+        G
+
+        bundle "config set --local path #{bundled_app("bundle")}"
+
         bundle "lock", dir: cwd
 
-        bundle :install, standalone: true, dir: cwd, env: { "BUNDLER_GEM_DEFAULT_DIR" => system_gem_path.to_s }
+        # Make sure rubyinstaller2 does not activate the etc gem in its
+        # `operating_system.rb` file, but completely disable that since it's not
+        # really needed here
+        if Gem.win_platform?
+          FileUtils.mkdir_p bundled_app("rubygems/defaults")
+          FileUtils.touch bundled_app("rubygems/defaults/operating_system.rb")
+        end
+
+        bundle :install, standalone: true, dir: cwd, env: { "BUNDLER_GEM_DEFAULT_DIR" => system_gem_path.to_s }, load_path: bundled_app
       end
 
       load_path_lines = bundled_app("bundle/bundler/setup.rb").read.split("\n").select {|line| line.start_with?("$:.unshift") }

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -865,7 +865,6 @@ end
   it "should clean $LOAD_PATH properly" do
     gem_name = "very_simple_binary"
     full_gem_name = gem_name + "-1.0"
-    ext_dir = File.join(tmp("extensions", full_gem_name))
 
     system_gems full_gem_name
 
@@ -874,12 +873,6 @@ end
     G
 
     ruby <<-R
-      s = Gem::Specification.find_by_name '#{gem_name}'
-      s.extension_dir = '#{ext_dir}'
-
-      # Don't build extensions.
-      s.class.send(:define_method, :build_extensions) { nil }
-
       require 'bundler'
       gem '#{gem_name}'
 

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -497,7 +497,7 @@ module Spec
         write "ext/#{name}.c", <<-C
           #include "ruby.h"
 
-          void Init_#{name}_c() {
+          void Init_#{name}_c(void) {
             rb_define_module("#{Builders.constantize(name)}_IN_C");
           }
         C

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -76,9 +76,11 @@ module Spec
       requires = options.delete(:requires) || []
 
       dir = options.delete(:dir) || bundled_app
+      custom_load_path = options.delete(:load_path)
 
       load_path = []
       load_path << spec_dir
+      load_path << custom_load_path if custom_load_path
 
       build_ruby_options = { load_path: load_path, requires: requires, env: env }
       build_ruby_options.merge!(artifice: options.delete(:artifice)) if options.key?(:artifice)

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -71,18 +71,7 @@ class Gem::BasicSpecification
   # Return true if this spec can require +file+.
 
   def contains_requirable_file?(file)
-    if @ignored
-      return false
-    elsif missing_extensions?
-      @ignored = true
-
-      if platform == Gem::Platform::RUBY || Gem::Platform.local === platform
-        warn "Ignoring #{full_name} because its extensions are not built. " \
-             "Try: gem pristine #{name} --version #{version}"
-      end
-
-      return false
-    end
+    return false if ignored?
 
     is_soext = file.end_with?(".so", ".o")
 
@@ -91,6 +80,23 @@ class Gem::BasicSpecification
     else
       have_file? file, Gem.suffixes
     end
+  end
+
+  ##
+  # Return true if this spec should be ignored because it's missing extensions.
+
+  def ignored?
+    return @ignored unless @ignored.nil?
+
+    @ignored = missing_extensions?
+    return false unless @ignored
+
+    if platform == Gem::Platform::RUBY || Gem::Platform.local === platform
+      warn "Ignoring #{full_name} because its extensions are not built. " \
+           "Try: gem pristine #{name} --version #{version}"
+    end
+
+    true
   end
 
   def default_gem?

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -279,7 +279,7 @@ class Gem::Dependency
       end
     end
 
-    matches
+    matches.reject(&:ignored?)
   end
 
   ##

--- a/test/rubygems/test_gem_commands_exec_command.rb
+++ b/test/rubygems/test_gem_commands_exec_command.rb
@@ -215,7 +215,7 @@ class TestGemCommandsExecCommand < Gem::TestCase
   end
 
   def test_gem_with_platform_and_platform_dependencies
-    pend "extensions don't quite work on jruby" if Gem.java_platform?
+    pend "needs investigation" if Gem.java_platform?
     pend "terminates on mswin" if vc_windows? && ruby_repo?
 
     spec_fetcher do |fetcher|

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1567,7 +1567,7 @@ end
   end
 
   def test_find_lib_file_after_install
-    pend "extensions don't quite work on jruby" if Gem.java_platform?
+    pend "needs investigation" if Gem.java_platform?
 
     @spec = setup_base_spec
     @spec.extensions << "extconf.rb"
@@ -1655,7 +1655,7 @@ end
   end
 
   def test_install_extension_flat
-    pend "extensions don't quite work on jruby" if Gem.java_platform?
+    pend "needs investigation" if Gem.java_platform?
 
     begin
       @spec = setup_base_spec
@@ -1693,7 +1693,7 @@ end
   end
 
   def test_install_extension_clean_intermediate_files
-    pend "extensions don't quite work on jruby" if Gem.java_platform?
+    pend "needs investigation" if Gem.java_platform?
     @spec = setup_base_spec
     @spec.require_paths = ["."]
     @spec.extensions << "extconf.rb"

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1334,7 +1334,6 @@ dependencies: []
   end
 
   def test_build_args
-    pend "extensions don't quite work on jruby" if Gem.java_platform?
     ext_spec
 
     assert_empty @ext.build_args
@@ -1351,7 +1350,6 @@ dependencies: []
   end
 
   def test_build_extensions
-    pend "extensions don't quite work on jruby" if Gem.java_platform?
     ext_spec
 
     assert_path_not_exist @ext.extension_dir, "sanity check"
@@ -1387,7 +1385,6 @@ dependencies: []
   end
 
   def test_build_extensions_built
-    pend "extensions don't quite work on jruby" if Gem.java_platform?
     ext_spec
 
     refute_empty @ext.extensions, "sanity check"
@@ -1426,7 +1423,6 @@ dependencies: []
   end
 
   def test_build_extensions_error
-    pend "extensions don't quite work on jruby" if Gem.java_platform?
     ext_spec
 
     refute_empty @ext.extensions, "sanity check"
@@ -1440,7 +1436,7 @@ dependencies: []
     pend "chmod not supported" if Gem.win_platform?
     pend "skipped in root privilege" if Process.uid.zero?
 
-    pend "extensions don't quite work on jruby" if Gem.java_platform?
+    pend "needs investigation" if Gem.java_platform?
     ext_spec
 
     refute_empty @ext.extensions, "sanity check"
@@ -1473,7 +1469,6 @@ dependencies: []
 
   def test_build_extensions_no_extensions_dir_unwritable
     pend "chmod not supported" if Gem.win_platform?
-    pend "extensions don't quite work on jruby" if Gem.java_platform?
     ext_spec
 
     refute_empty @ext.extensions, "sanity check"
@@ -1512,7 +1507,6 @@ dependencies: []
   end
 
   def test_build_extensions_preview
-    pend "extensions don't quite work on jruby" if Gem.java_platform?
     ext_spec
 
     extconf_rb = File.join @ext.gem_dir, @ext.extensions.first
@@ -1547,7 +1541,6 @@ dependencies: []
   end
 
   def test_contains_requirable_file_eh_extension
-    pend "extensions don't quite work on jruby" if Gem.java_platform?
     ext_spec
 
     _, err = capture_output do
@@ -3843,7 +3836,6 @@ end
   end
 
   def test_missing_extensions_eh
-    pend "extensions don't quite work on jruby" if Gem.java_platform?
     ext_spec
 
     assert @ext.missing_extensions?

--- a/test/rubygems/test_gem_stub_specification.rb
+++ b/test/rubygems/test_gem_stub_specification.rb
@@ -66,7 +66,6 @@ class TestStubSpecification < Gem::TestCase
   end
 
   def test_contains_requirable_file_eh_extension
-    pend "I guess making the stub match the running platform should work" if Gem.java_platform?
     stub_with_extension do |stub|
       _, err = capture_output do
         refute stub.contains_requirable_file? "nonexistent"
@@ -123,7 +122,6 @@ class TestStubSpecification < Gem::TestCase
   end
 
   def test_missing_extensions_eh
-    pend "I guess making the stub match the running platform should work" if Gem.java_platform?
     stub = stub_with_extension do |s|
       extconf_rb = File.join s.gem_dir, s.extensions.first
       FileUtils.mkdir_p File.dirname extconf_rb

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -130,7 +130,7 @@ class TestGemRequire < Gem::TestCase
   end
 
   def test_dash_i_respects_default_library_extension_priority
-    pend "extensions don't quite work on jruby" if Gem.java_platform?
+    pend "needs investigation" if Gem.java_platform?
     pend "not installed yet" unless RbConfig::TOPDIR
 
     dash_i_ext_arg = util_install_extension_file("a")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Some users run into issues when upgrading Ruby, where Bundler will try to use a version of psych compiled for the previous Ruby and will of course crash.

I think there are a number of situations where this can happen but I think a very common one is when users have `GEM_HOME` set to a folder that's not scoped to the Ruby ABI version, and that `GEM_HOME` includes an installation of `psych`.

We've got a lot of issues opened with this problem. A few recent examples:

* https://github.com/rubygems/rubygems/issues/8099.
* https://github.com/rubygems/rubygems/issues/8098.
* https://github.com/rubygems/rubygems/issues/8063.
* https://github.com/rubygems/rubygems/issues/8053.
* https://github.com/rubygems/rubygems/issues/8044.
* https://github.com/rubygems/rubygems/issues/8005.
* https://github.com/orgs/rubygems/discussions/8097.

## What is your fix for the problem, implemented in this PR?

My first approach was to rescue this particular error and try give users a better error message. See https://github.com/rubygems/rubygems/pull/8054. I think that approach may still have some merit, since under some circumstances the error may still happen, but it's brittle and I found a better approach after understanding the error better. I have the feeling that after this fix, this will become a non issue, so we can probably optimistically close the initial approach.

Anyways, I realized that we should never try to activate a gem installation if it has missing extensions, and I recalled that we already have code to detect that. However, when the gem is a default gem, the code path to detect missing extensions was not getting run.

This PR fixes that issue.

Now, the "bad" psych installation is ignored, and Bundler will use instead the default `psych` installation of the running Ruby, which should always be properly compiled.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
