### PR TITLE
Don't run hooks with nil spec

### DIFF
--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -305,6 +305,9 @@ class Gem::RequestSet
       end
     end
 
+    # Don't run hooks with nil spec since they don't expect that
+    specs.delete_if { |spec| spec.nil? }
+
     require_relative "dependency_installer"
     inst = Gem::DependencyInstaller.new options
     inst.installed_gems.replace specs


### PR DESCRIPTION

## What was the end-user or developer problem that led to this PR?

I don't really know what happened but now every time I try to install local gem with `gem install somegem.gem` it fails with

```
$ gem install somegem-0.1.0.gem
Successfully installed somegem-0.1.0
ERROR:  While executing gem ... (NoMethodError)
    undefined method `metadata' for nil

          run_yard = spec.metadata['yard.run']
                         ^^^^^^^^^
```

```
$ gem install --no-document somegem-0.1.0.gem
Successfully installed somegem-0.1.0.gem
ERROR:  While executing gem ... (NoMethodError)
    undefined method `doc_dir' for nil

      @doc_dir = spec.doc_dir
                     ^^^^^^^^
```

Note that if I install gem from RubyGems with just `gem install somegem` then that works fine.

This is backtrace that leads to issue
```
~/.rvm/rubies/ruby-3.3.4/lib/ruby/3.3.0/rdoc/rubygems_hook.rb:56:in `new'
~/.rvm/rubies/ruby-3.3.4/lib/ruby/3.3.0/rdoc/rubygems_hook.rb:56:in `block in generation_hook'
~/.rvm/rubies/ruby-3.3.4/lib/ruby/3.3.0/rdoc/rubygems_hook.rb:55:in `each'
~/.rvm/rubies/ruby-3.3.4/lib/ruby/3.3.0/rdoc/rubygems_hook.rb:55:in `generation_hook'
~/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/rubygems/request_set.rb:313:in `block in install_hooks'
~/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/rubygems/request_set.rb:312:in `each'
~/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/rubygems/request_set.rb:312:in `install_hooks'
~/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/rubygems/request_set.rb:209:in `install'
~/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/rubygems/commands/install_command.rb:207:in `install_gem'
~/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/rubygems/commands/install_command.rb:223:in `block in install_gems'
~/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/rubygems/commands/install_command.rb:216:in `each'
~/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/rubygems/commands/install_command.rb:216:in `install_gems'
~/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/rubygems/commands/install_command.rb:162:in `execute'
~/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/rubygems/command.rb:326:in `invoke_with_build_args'
~/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/rubygems/command_manager.rb:248:in `invoke_command'
~/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/rubygems/command_manager.rb:194:in `process_args'
~/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/rubygems/command_manager.rb:152:in `run'
~/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/rubygems/gem_runner.rb:56:in `run'
~/.rvm/rubies/ruby-3.3.4/bin/gem:12:in `<main>'
```

What I see is that in `install_gem()` at `install_command.rb:207` we don't pass any block.
So then at `install()` at `request_set.rb:209` we see

```ruby
      spec =
        begin
          req.spec.install options do |installer|
            res = yield req, installer if block_given?
          end
```
`req.spec.install` is `Gem::Resolver::InstalledSpecification#install` which is no-op and simply yields so because block is not given `spec` becomes `nil`
and later in `install_hooks()` we invoke them with `nil` which causes `rdoc` and `Yard` hooks to fail.

But I don't understand why this worked previously and what changed...

## What is your fix for the problem, implemented in this PR?

This PR simply ignores `nil` `spec` and that allows installation to succeed.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
