### PR TITLE
Fix `Gem::Specification#gem_dir` losing custom source for some reason

### DIFF
--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -123,6 +123,13 @@ module Gem
       end
     end
 
+    # Can be removed once RubyGems 3.5.21 support is dropped
+    remove_method :gem_dir if method_defined?(:gem_dir, false)
+
+    def gem_dir
+      full_gem_path
+    end
+
     unless const_defined?(:LATEST_RUBY_WITHOUT_PATCH_VERSIONS)
       LATEST_RUBY_WITHOUT_PATCH_VERSIONS = Gem::Version.new("2.1")
 

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -706,6 +706,21 @@ RSpec.describe "Bundler.setup" do
     expect(out).to be_empty
   end
 
+  it "has gem_dir pointing to local repo" do
+    build_lib "foo", "1.0", path: bundled_app
+
+    install_gemfile <<-G
+      source "https://gem.repo1"
+      gemspec
+    G
+
+    run <<-R
+      puts Gem.loaded_specs['foo'].gem_dir
+    R
+
+    expect(out).to eq(bundled_app.to_s)
+  end
+
   it "does not load all gemspecs" do
     install_gemfile <<-G
       source "https://gem.repo1"

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1912,14 +1912,6 @@ class Gem::Specification < Gem::BasicSpecification
     @full_name ||= super
   end
 
-  ##
-  # Work around old bundler versions removing my methods
-  # Can be removed once RubyGems can no longer install Bundler 2.5
-
-  def gem_dir # :nodoc:
-    super
-  end
-
   def gems_dir
     @gems_dir ||= File.join(base_dir, "gems")
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`Gem::Specification#gem_dir` no longer returns the right directory for a local `gemspec` after https://github.com/rubygems/rubygems/issues/8030.

## What is your fix for the problem, implemented in this PR?

Honestly I don't fully understand why the previous approach didn't work. But this works too and I think it's better because it allows us to remove more code earlier.

Fixes #8108.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
