### PR TITLE
Fix a `gem install` crash during "done installing" hooks

### DIFF
--- a/lib/rubygems/specification_record.rb
+++ b/lib/rubygems/specification_record.rb
@@ -30,7 +30,7 @@ module Gem
     # Returns the list of all specifications in the record
 
     def all
-      @all ||= Gem.loaded_specs.values | stubs.map(&:to_spec)
+      @all ||= Gem.loaded_specs.values + stubs.map(&:to_spec)
     end
 
     ##

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -819,6 +819,49 @@ class TestGemDependencyInstaller < Gem::TestCase
     assert_equal %w[a-1], inst.installed_gems.map(&:full_name)
   end
 
+  def test_install_dual_repository_and_done_installing_hooks
+    util_setup_gems
+
+    FileUtils.mv @a1_gem, @tempdir
+    FileUtils.mv @b1_gem, @tempdir
+    inst = nil
+
+    # Make sure gem is installed to standard GEM_HOME
+
+    Dir.chdir @tempdir do
+      inst = Gem::DependencyInstaller.new install_dir: @gemhome
+      inst.install "b"
+    end
+
+    # and also to an additional GEM_PATH
+
+    gemhome2 = "#{@gemhome}2"
+
+    Dir.chdir @tempdir do
+      inst = Gem::DependencyInstaller.new install_dir: gemhome2
+      inst.install "b"
+    end
+
+    # Now install the local gem with the additional GEM_PATH
+
+    ENV["GEM_HOME"] = @gemhome
+    ENV["GEM_PATH"] = [@gemhome, gemhome2].join File::PATH_SEPARATOR
+    Gem.clear_paths
+
+    Gem.done_installing do |installer, specs|
+      done_installing_ran = true
+      refute_nil installer
+      assert_equal [@b1], specs
+    end
+
+    Dir.chdir @tempdir do
+      inst = Gem::DependencyInstaller.new
+      inst.install "b-1.gem"
+    end
+
+    assert_equal %w[b-1], inst.installed_gems.map(&:full_name)
+  end
+
   def test_install_remote
     util_setup_gems
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

It would happen when the gem is already installed to multiple GEM_PATHS. RubyGems was removing duplicate specs without considering the potentially different `base_dir`. That was causing the gem to be misidentified as not already installed, and a nil specification getting returned from the installer as a result, causing the crash.

## What is your fix for the problem, implemented in this PR?

Solve it by making sure `Gem::Specification.all` really iterates through all the different specifications in all GEM_PATHs.

Closes #8107.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
