### PR TITLE
fix: add special case for bundler executable

### DIFF
--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -285,7 +285,7 @@ module Bundler
 
       redefine_method(gem_class, :activate_bin_path) do |name, *args|
         exec_name = args.first
-        return ENV["BUNDLE_BIN_PATH"] if exec_name == "bundle"
+        return ENV["BUNDLE_BIN_PATH"] if exec_name == "bundle" or exec_name == "bundler"
 
         # Copy of Rubygems activate_bin_path impl
         requirement = args.last
@@ -298,7 +298,7 @@ module Bundler
 
       redefine_method(gem_class, :bin_path) do |name, *args|
         exec_name = args.first
-        return ENV["BUNDLE_BIN_PATH"] if exec_name == "bundle"
+        return ENV["BUNDLE_BIN_PATH"] if exec_name == "bundle" or exec_name == "bundler"
 
         spec = find_spec_for_exe(name, *args)
         exec_name ||= spec.default_executable


### PR DESCRIPTION
Resolves #8115.

Bundler explicitly provides both `bundle` and `bundler` executables. Therefore, it should be possible to resolve both via `Gem.bin_path`. Special handling is required because bundler lives outside of the current bundle, but previous handling only accounted for the `bundle` executable. Here we add support for `bundler`.

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

See #8115: the `bundler` executable cannot be found without special handling.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Add the same special handling as used for the `bundle` executable.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
