### PR TITLE
Fix `gem pristine etc` resetting gem twice sometimes

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -94,7 +94,7 @@ class Gem::BasicSpecification
   end
 
   def default_gem?
-    loaded_from &&
+    !loaded_from.nil? &&
       File.dirname(loaded_from) == Gem.default_specifications_dir
   end
 

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -83,11 +83,7 @@ class Gem::StubSpecification < Gem::BasicSpecification
   # True when this gem has been activated
 
   def activated?
-    @activated ||=
-      begin
-        loaded = Gem.loaded_specs[name]
-        loaded && loaded.version == version
-      end
+    @activated ||= !loaded_spec.nil?
   end
 
   def default_gem?
@@ -187,11 +183,7 @@ class Gem::StubSpecification < Gem::BasicSpecification
   # The full Gem::Specification for this gem, loaded from evalling its gemspec
 
   def spec
-    @spec ||= if @data
-      loaded = Gem.loaded_specs[name]
-      loaded if loaded && loaded.version == version
-    end
-
+    @spec ||= loaded_spec if @data
     @spec ||= Gem::Specification.load(loaded_from)
   end
   alias_method :to_spec, :spec
@@ -230,5 +222,14 @@ class Gem::StubSpecification < Gem::BasicSpecification
 
   def sort_obj # :nodoc:
     [name, version, Gem::Platform.sort_priority(platform)]
+  end
+
+  private
+
+  def loaded_spec
+    spec = Gem.loaded_specs[name]
+    return unless spec && spec.version == version && spec.default_gem? == default_gem?
+
+    spec
   end
 end

--- a/test/rubygems/test_gem_stub_specification.rb
+++ b/test/rubygems/test_gem_stub_specification.rb
@@ -184,14 +184,14 @@ class TestStubSpecification < Gem::TestCase
   def stub_with_version
     spec = File.join @gemhome, "specifications", "stub_e-2.gemspec"
     File.open spec, "w" do |io|
-      io.write <<-STUB
-# -*- encoding: utf-8 -*-
-# stub: stub_v 2 ruby lib
+      io.write <<~STUB
+        # -*- encoding: utf-8 -*-
+        # stub: stub_v 2 ruby lib
 
-Gem::Specification.new do |s|
-  s.name = 'stub_v'
-  s.version = Gem::Version.new '2'
-end
+        Gem::Specification.new do |s|
+          s.name = 'stub_v'
+          s.version = Gem::Version.new '2'
+        end
       STUB
 
       io.flush
@@ -207,14 +207,14 @@ end
   def stub_without_version
     spec = File.join @gemhome, "specifications", "stub-2.gemspec"
     File.open spec, "w" do |io|
-      io.write <<-STUB
-# -*- encoding: utf-8 -*-
-# stub: stub_v ruby lib
+      io.write <<~STUB
+        # -*- encoding: utf-8 -*-
+        # stub: stub_v ruby lib
 
-Gem::Specification.new do |s|
-  s.name = 'stub_v'
-  s.version = ""
-end
+        Gem::Specification.new do |s|
+          s.name = 'stub_v'
+          s.version = ""
+        end
       STUB
 
       io.flush
@@ -230,17 +230,17 @@ end
   def stub_with_extension
     spec = File.join @gemhome, "specifications", "stub_e-2.gemspec"
     File.open spec, "w" do |io|
-      io.write <<-STUB
-# -*- encoding: utf-8 -*-
-# stub: stub_e 2 ruby lib
-# stub: ext/stub_e/extconf.rb
+      io.write <<~STUB
+        # -*- encoding: utf-8 -*-
+        # stub: stub_e 2 ruby lib
+        # stub: ext/stub_e/extconf.rb
 
-Gem::Specification.new do |s|
-  s.name = 'stub_e'
-  s.version = Gem::Version.new '2'
-  s.extensions = ['ext/stub_e/extconf.rb']
-  s.installed_by_version = '2.2'
-end
+        Gem::Specification.new do |s|
+          s.name = 'stub_e'
+          s.version = Gem::Version.new '2'
+          s.extensions = ['ext/stub_e/extconf.rb']
+          s.installed_by_version = '2.2'
+        end
       STUB
 
       io.flush
@@ -256,14 +256,14 @@ end
   def stub_without_extension
     spec = File.join @gemhome, "specifications", "stub-2.gemspec"
     File.open spec, "w" do |io|
-      io.write <<-STUB
-# -*- encoding: utf-8 -*-
-# stub: stub 2 ruby lib
+      io.write <<~STUB
+        # -*- encoding: utf-8 -*-
+        # stub: stub 2 ruby lib
 
-Gem::Specification.new do |s|
-  s.name = 'stub'
-  s.version = Gem::Version.new '2'
-end
+        Gem::Specification.new do |s|
+          s.name = 'stub'
+          s.version = Gem::Version.new '2'
+        end
       STUB
 
       io.flush

--- a/test/rubygems/test_gem_stub_specification.rb
+++ b/test/rubygems/test_gem_stub_specification.rb
@@ -173,6 +173,35 @@ class TestStubSpecification < Gem::TestCase
     assert_same real_foo, @foo.to_spec
   end
 
+  def test_to_spec_default
+    bar_default_spec = File.join(@gemhome, "specifications", "default", "bar-0.0.2.gemspec")
+    File.open bar_default_spec, "w" do |io|
+      io.write <<~STUB
+        # -*- encoding: utf-8 -*-
+        # stub: bar 0.0.2 ruby lib
+
+        Gem::Specification.new do |s|
+          s.name          = "bar"
+          s.version       = "0.0.2"
+          s.platform      = "ruby"
+          s.require_paths = ["lib"]
+          s.summary       = "A very bar gem"
+        end
+      STUB
+    end
+
+    bar = Gem::StubSpecification.gemspec_stub BAR, @base_dir, @gems_dir
+    bar_default = Gem::StubSpecification.default_gemspec_stub bar_default_spec, @base_dir, @gems_dir
+
+    real_bar = util_spec bar_default.name, bar_default.version
+    real_bar.activate
+
+    assert_equal bar.version, Gem.loaded_specs[bar.name].version,
+                 "sanity check"
+
+    refute_same real_bar, bar_default.to_spec
+  end
+
   def test_to_spec_with_other_specs_loaded_does_not_warn
     real_foo = util_spec @foo.name, @foo.version
     real_foo.activate


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If a default version and a regular version of etc are present at the same time, RubyGems will end up duplicating work and running pristine twice.

The `etc` gem is special because it's loaded by RubyGems by default. When doing this, RubyGems will activate the regularly installed version. The when `gem pristine` runs, it will find two installed specifications but materialize both to the already activated specification.

## What is your fix for the problem, implemented in this PR?

Make sure we only reuse an already loaded spec instead of loading the installed specification when the `default_gem` attribute matches it.


Before:

```
$ gem pristine etc --version 1.4.3
Restoring gems to pristine condition...
Building native extensions. This could take a while...
Restored etc-1.4.3
Building native extensions. This could take a while...
Restored etc-1.4.3
```

After:

```
$ gem pristine etc --version 1.4.3
Restoring gems to pristine condition...
Skipped etc-1.4.3, it is a default gem
Building native extensions. This could take a while...
Restored etc-1.4.3
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
