### PR TITLE
Allow `gem pristine` to reset default gems too

### DIFF
--- a/lib/rubygems/commands/pristine_command.rb
+++ b/lib/rubygems/commands/pristine_command.rb
@@ -134,11 +134,8 @@ extensions will be restored.
 
     say "Restoring gems to pristine condition..."
 
-    specs.each do |spec|
-      if spec.default_gem?
-        say "Skipped #{spec.full_name}, it is a default gem"
-        next
-      end
+    specs.group_by(&:full_name_with_location).values.each do |grouped_specs|
+      spec = grouped_specs.find {|s| !s.default_gem? } || grouped_specs.first
 
       if options.key? :skip
         if options[:skip].include? spec.name
@@ -188,6 +185,7 @@ extensions will be restored.
         env_shebang: env_shebang,
         build_args: spec.build_args,
         bin_dir: bin_dir,
+        install_as_default: spec.default_gem?,
       }
 
       if options[:only_executables]

--- a/test/rubygems/test_gem_commands_pristine_command.rb
+++ b/test/rubygems/test_gem_commands_pristine_command.rb
@@ -642,7 +642,8 @@ class TestGemCommandsPristineCommand < Gem::TestCase
     assert_equal(
       [
         "Restoring gems to pristine condition...",
-        "Skipped default-2.0.0.0, it is a default gem",
+        "Cached gem for default-2.0.0.0 not found, attempting to fetch...",
+        "Skipped default-2.0.0.0, it was not found from cache and remote sources",
       ],
       @ui.output.split("\n")
     )


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Recently, I installed `rubygems-bundler`, `executable-hooks` and the other RVM gems to try reproduce a user problem. Then I eventually removed them, but my executables remained unusable, because they had a shebang like this:  `#!/usr/bin/env ruby_executable_hooks` and the `ruby_executable_hooks` thingy was no longer there.

`gem pristine` fixed most of my binstubs, expect for the ones belonging to default gems.

## What is your fix for the problem, implemented in this PR?

This change allows `gem pristine` to restore default gems too, so that I can fix all my executables.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
