### PR TITLE
Fix plugin command loading

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -89,6 +89,10 @@ jobs:
         if: matrix.ruby.name != 'truffleruby' && matrix.ruby.name != 'jruby'
       - name: Check rails can be installed
         run: gem install rails --verbose --backtrace
+      - name: Install and load a gem that defines a command as a plugin
+        run: |
+          gem install nexus:1.5.2
+          gem nexus --help
     timeout-minutes: 10
 
   install_rubygems_windows:

--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -232,9 +232,14 @@ class Gem::CommandManager
     const_name = command_name.capitalize.gsub(/_(.)/) { $1.upcase } << "Command"
 
     begin
-      require "rubygems/commands/#{command_name}_command"
+      begin
+        require "rubygems/commands/#{command_name}_command"
+      rescue LoadError
+        # it may have been defined from a rubygems_plugin.rb file
+      end
+
       Gem::Commands.const_get(const_name).new
-    rescue StandardError, LoadError => e
+    rescue StandardError => e
       alert_error clean_text("Loading command: #{command_name} (#{e.class})\n\t#{e}")
       ui.backtrace e
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In 95f60f0e60614ac2397cd0debdafa07c0b72c1ef, I misunderstood how gems load plugins and thought they needed to define a `rubygems/command/<command_name>_command.rb` file that rubygems will load.

This is completely wrong, and I should've realized when I saw the interrupt command that our tests defined before 0a75590ac98757211b72552afe39ed671f2c39ae. Plugins can (and should) define custom commands in a `rubygems_plugin.rb` file, and they should take care of registering it themselves.

## What is your fix for the problem, implemented in this PR?

Restore ignored the `LoadError` from trying to load `rubygems/command/<command_name>_command.rb`. It will happen if the command registered itself in a `rubygems_plugin.rb` file.

Fixes #8120.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
