### PR TITLE
Fix `gem install` on NFS shares

### DIFF
--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -36,15 +36,14 @@ module Gem
       remove_method :open_file_with_flock if Gem.respond_to?(:open_file_with_flock)
 
       def open_file_with_flock(path, &block)
-        mode = IO::RDONLY | IO::APPEND | IO::CREAT | IO::BINARY
+        # read-write mode is used rather than read-only in order to support NFS
+        mode = IO::RDWR | IO::APPEND | IO::CREAT | IO::BINARY
         mode |= IO::SHARE_DELETE if IO.const_defined?(:SHARE_DELETE)
 
         File.open(path, mode) do |io|
           begin
             io.flock(File::LOCK_EX)
           rescue Errno::ENOSYS, Errno::ENOTSUP
-          rescue Errno::ENOLCK # NFS
-            raise unless Thread.main == Thread.current
           end
           yield io
         end

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -808,15 +808,14 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   # Open a file with given flags, and protect access with flock
 
   def self.open_file_with_flock(path, &block)
-    mode = IO::RDONLY | IO::APPEND | IO::CREAT | IO::BINARY
+    # read-write mode is used rather than read-only in order to support NFS
+    mode = IO::RDWR | IO::APPEND | IO::CREAT | IO::BINARY
     mode |= IO::SHARE_DELETE if IO.const_defined?(:SHARE_DELETE)
 
     File.open(path, mode) do |io|
       begin
         io.flock(File::LOCK_EX)
       rescue Errno::ENOSYS, Errno::ENOTSUP
-      rescue Errno::ENOLCK # NFS
-        raise unless Thread.main == Thread.current
       end
       yield io
     end


### PR DESCRIPTION



## What was the end-user or developer problem that led to this PR?

https://github.com/rubygems/rubygems/pull/7931 changed open file mode from read-write to read-only and that broke NFS shares.

It seems unintentional since the [original comment](https://github.com/rubygems/rubygems/pull/7806#discussion_r1698091858) that motivated the patch actually kept the same mode.

## What is your fix for the problem, implemented in this PR?

Restore the previous mode. Also remove some NFS specific fallback code that seems no longer needed, since NFS shares seem to support flock these days, but they need read-write permissions.

Fixes #8105.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
