### PR TITLE
Revert previous change about `bundle.bat` re-execution

### DIFF
--- a/bundler/lib/bundler/self_manager.rb
+++ b/bundler/lib/bundler/self_manager.rb
@@ -85,7 +85,7 @@ module Bundler
         cmd = [*Shellwords.shellsplit(bundler_spec_original_cmd), *ARGV]
       else
         cmd = [$PROGRAM_NAME, *ARGV]
-        cmd.unshift(Gem.ruby) unless File.executable?($PROGRAM_NAME) || $PROGRAM_NAME.end_with?(".bat")
+        cmd.unshift(Gem.ruby) unless File.executable?($PROGRAM_NAME)
       end
 
       Bundler.with_original_env do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

https://github.com/rubygems/rubygems/pull/8101 fixed nothing. `bundle.bat` is not a Ruby script so it's never the `$PROGRAM_NAME` of a Ruby process.

## What is your fix for the problem, implemented in this PR?

Revert #8101.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
