### PR TITLE
Add `Gem::Specification#gem_dir` back

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1912,6 +1912,14 @@ class Gem::Specification < Gem::BasicSpecification
     @full_name ||= super
   end
 
+  ##
+  # Work around old bundler versions removing my methods
+  # Can be removed once RubyGems can no longer install Bundler 2.5
+
+  def gem_dir # :nodoc:
+    super
+  end
+
   def gems_dir
     @gems_dir ||= File.join(base_dir, "gems")
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If old Bundler versions that unconditionally try to remove this method are run with RubyGems versions _without_ this method, Bundler crashes because it tries to remove a method that does not exist.

We need to wait until RubyGems cannot install any Bundler versions that unconditionally remove this method.

## What is your fix for the problem, implemented in this PR?

Add back the method for now.

This is a follow up to #8111.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
