### PR TITLE
Only pristine executables for default gems

### DIFF
--- a/lib/rubygems/commands/pristine_command.rb
+++ b/lib/rubygems/commands/pristine_command.rb
@@ -137,6 +137,13 @@ extensions will be restored.
     specs.group_by(&:full_name_with_location).values.each do |grouped_specs|
       spec = grouped_specs.find {|s| !s.default_gem? } || grouped_specs.first
 
+      unless only_executables_or_plugins?
+        # Default gemspecs include changes provided by ruby-core installer that
+        # can't currently be pristined (inclusion of compiled extension targets in
+        # the file list). So stick to resetting executables if it's a default gem.
+        options[:only_executables] = true if spec.default_gem?
+      end
+
       if options.key? :skip
         if options[:skip].include? spec.name
           say "Skipped #{spec.full_name}, it was given through options"
@@ -144,14 +151,14 @@ extensions will be restored.
         end
       end
 
-      unless spec.extensions.empty? || options[:extensions] || options[:only_executables] || options[:only_plugins]
+      unless spec.extensions.empty? || options[:extensions] || only_executables_or_plugins?
         say "Skipped #{spec.full_name_with_location}, it needs to compile an extension"
         next
       end
 
       gem = spec.cache_file
 
-      unless File.exist?(gem) || options[:only_executables] || options[:only_plugins]
+      unless File.exist?(gem) || only_executables_or_plugins?
         require_relative "../remote_fetcher"
 
         say "Cached gem for #{spec.full_name_with_location} not found, attempting to fetch..."
@@ -185,7 +192,6 @@ extensions will be restored.
         env_shebang: env_shebang,
         build_args: spec.build_args,
         bin_dir: bin_dir,
-        install_as_default: spec.default_gem?,
       }
 
       if options[:only_executables]
@@ -201,5 +207,11 @@ extensions will be restored.
 
       say "Restored #{spec.full_name_with_location}"
     end
+  end
+
+  private
+
+  def only_executables_or_plugins?
+    options[:only_executables] || options[:only_plugins]
   end
 end

--- a/test/rubygems/test_gem_commands_pristine_command.rb
+++ b/test/rubygems/test_gem_commands_pristine_command.rb
@@ -630,8 +630,16 @@ class TestGemCommandsPristineCommand < Gem::TestCase
 
   def test_execute_default_gem
     default_gem_spec = new_default_spec("default", "2.0.0.0",
-                                        nil, "default/gem.rb")
-    install_default_gems(default_gem_spec)
+                                        nil, "exe/executable")
+    default_gem_spec.executables = "executable"
+    install_default_gems default_gem_spec
+
+    exe = File.join @gemhome, "bin", "executable"
+
+    assert_path_exist exe, "default gem's executable not installed"
+
+    content_with_replaced_shebang = File.read(exe).gsub(/^#![^\n]+ruby/, "#!/usr/bin/env ruby_executable_hooks")
+    File.write(exe, content_with_replaced_shebang)
 
     @cmd.options[:args] = %w[default]
 
@@ -642,8 +650,7 @@ class TestGemCommandsPristineCommand < Gem::TestCase
     assert_equal(
       [
         "Restoring gems to pristine condition...",
-        "Cached gem for default-2.0.0.0 not found, attempting to fetch...",
-        "Skipped default-2.0.0.0, it was not found from cache and remote sources",
+        "Restored default-2.0.0.0",
       ],
       @ui.output.split("\n")
     )


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In #8118, we allowed `gem pristine` to reset default gems. That essentially means resetting their installed `.gemspec` files, and their binstubs, because their actual code "belongs to Ruby installation".

However, we can't really reset `.gemspec` files either, because they include some [tweaks](https://github.com/ruby/ruby/pull/9673) from ruby-core for default gem activation to work that cannot be reset from a remote `.gem` file.

## What is your fix for the problem, implemented in this PR?

Limit `gem pristine` to executables when running for a default gem.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
