### PR TITLE
Fix duplicated specs when they have been previously activated

### DIFF
--- a/lib/rubygems/specification_record.rb
+++ b/lib/rubygems/specification_record.rb
@@ -30,7 +30,7 @@ module Gem
     # Returns the list of all specifications in the record
 
     def all
-      @all ||= Gem.loaded_specs.values + stubs.map(&:to_spec)
+      @all ||= stubs.map(&:to_spec)
     end
 
     ##

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -1026,6 +1026,20 @@ class TestGem < Gem::TestCase
     Gem.refresh
   end
 
+  def test_activated_specs_does_not_cause_duplicates_when_looping_through_specs
+    util_make_gems
+
+    s = Gem::Specification.first
+    s.activate
+
+    Gem.refresh
+
+    assert_equal 1, Gem::Specification.count {|spec| spec.full_name == s.full_name }
+
+    Gem.loaded_specs.delete(s)
+    Gem.refresh
+  end
+
   def test_self_ruby_escaping_spaces_in_path
     with_clean_path_to_ruby do
       with_rb_config_ruby("C:/Ruby 1.8/bin/ruby.exe") do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

https://github.com/rubygems/rubygems/pull/8113 (still unreleased) caused a regression where looping through specifications would have duplicates if specs have been previously activated.

## What is your fix for the problem, implemented in this PR?

This commit fixes the issue by not considering loaded specs here. This was introduced to make sure that the activation state of specs is preserved across resets, but it's already preserved when stub specifications are materialized into actual specifications.

Fixes https://github.com/MSP-Greg/ruby-loco/pull/15#issuecomment-2405622556.
Fixes #8134.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
