### PR TITLE
Fix `gem contents` for default gems

### DIFF
--- a/lib/rubygems/commands/contents_command.rb
+++ b/lib/rubygems/commands/contents_command.rb
@@ -103,16 +103,23 @@ prefix or only the files that are requireable.
 
   def files_in_default_gem(spec)
     spec.files.map do |file|
-      case file
-      when %r{\A#{spec.bindir}/}
-        # $' is POSTMATCH
-        [RbConfig::CONFIG["bindir"], $']
-      when /\.so\z/
-        [RbConfig::CONFIG["archdir"], file]
+      if file.start_with?("#{spec.bindir}/")
+        [RbConfig::CONFIG["bindir"], file.delete_prefix("#{spec.bindir}/")]
       else
-        [RbConfig::CONFIG["rubylibdir"], file]
+        gem spec.name, spec.version
+
+        require_path = spec.require_paths.find do |path|
+          file.start_with?("#{path}/")
+        end
+
+        requirable_part = file.delete_prefix("#{require_path}/")
+
+        resolve = $LOAD_PATH.resolve_feature_path(requirable_part)&.last
+        next unless resolve
+
+        [resolve.delete_suffix(requirable_part), requirable_part]
       end
-    end
+    end.compact
   end
 
   def gem_contents(name)

--- a/test/rubygems/test_gem_commands_contents_command.rb
+++ b/test/rubygems/test_gem_commands_contents_command.rb
@@ -227,7 +227,6 @@ lib/foo.rb
     default_gem_spec = new_default_spec("default", "2.0.0.0",
                                         nil, "default/gem.rb")
     default_gem_spec.executables = ["default_command"]
-    default_gem_spec.files += ["default_gem.so"]
     install_default_gems(default_gem_spec)
 
     @cmd.options[:args] = %w[default]
@@ -237,9 +236,8 @@ lib/foo.rb
     end
 
     expected = [
-      [RbConfig::CONFIG["bindir"], "default_command"],
-      [RbConfig::CONFIG["rubylibdir"], "default/gem.rb"],
-      [RbConfig::CONFIG["archdir"], "default_gem.so"],
+      [File.join(@gemhome, "bin"), "default_command"],
+      [File.join(@tempdir, "default_gems", "lib"), "default/gem.rb"],
     ].sort.map {|a|File.join a }.join "\n"
 
     assert_equal expected, @ui.output.chomp


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes `gem contents` with a default gem lists paths that don't exist.

## What is your fix for the problem, implemented in this PR?

A default gem does not always live in the same place. For example, Bundler may be installed to `site_dir` when RubyGems have been upgraded.

A more reliable way seems to actually activate the default gem, so that we can know for sure where it lives.

Fixes #8119.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
