### PR TITLE
Check that the binstub was actually reset

### DIFF
--- a/test/rubygems/test_gem_commands_pristine_command.rb
+++ b/test/rubygems/test_gem_commands_pristine_command.rb
@@ -655,6 +655,8 @@ class TestGemCommandsPristineCommand < Gem::TestCase
       @ui.output.split("\n")
     )
     assert_empty(@ui.error)
+
+    refute_includes "ruby_executable_hooks", File.read(exe)
   end
 
   def test_execute_multi_platform


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I forgot to finish writing this test in #8130, I wanted to actually check that the binstub has been reset after `gem pristine` is run.

## What is your fix for the problem, implemented in this PR?

Complete the test.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
