### PR TITLE
Prevent some test suite warnings about missing extensions

### DIFF
--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -384,13 +384,13 @@ module Gem
       end
     end
 
-    remove_method :ignored? if new.respond_to?(:ignored?)
+    # Can be removed once RubyGems 3.5.22 support is dropped
+    unless new.respond_to?(:ignored?)
+      def ignored?
+        return @ignored unless @ignored.nil?
 
-    # Same as RubyGems, but without warnings, because Bundler prints its own warnings
-    def ignored?
-      return @ignored unless @ignored.nil?
-
-      @ignored = missing_extensions?
+        @ignored = missing_extensions?
+      end
     end
   end
 

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -71,7 +71,14 @@ class Gem::BasicSpecification
   # Return true if this spec can require +file+.
 
   def contains_requirable_file?(file)
-    return false if ignored?
+    if ignored?
+      if platform == Gem::Platform::RUBY || Gem::Platform.local === platform
+        warn "Ignoring #{full_name} because its extensions are not built. " \
+             "Try: gem pristine #{name} --version #{version}"
+      end
+
+      return false
+    end
 
     is_soext = file.end_with?(".so", ".o")
 
@@ -89,14 +96,6 @@ class Gem::BasicSpecification
     return @ignored unless @ignored.nil?
 
     @ignored = missing_extensions?
-    return false unless @ignored
-
-    if platform == Gem::Platform::RUBY || Gem::Platform.local === platform
-      warn "Ignoring #{full_name} because its extensions are not built. " \
-           "Try: gem pristine #{name} --version #{version}"
-    end
-
-    true
   end
 
   def default_gem?


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We fixed some issues recently where Bundler would try to activate a pysch spec with missing extensions and crash. However, as a side effect, we started printing warnings about missing extensions in situations where we did not warn before.

## What is your fix for the problem, implemented in this PR?

It may be interesting to warn on these new situations too, but in order to minimize changes for now, I'm reverting to printing warnings in the same situations as before.

Fixes #8141.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
