### PR TITLE
Fix `bundle check` sometimes locking gems under the wrong source

### DIFF
--- a/bundler/lib/bundler/cli/check.rb
+++ b/bundler/lib/bundler/cli/check.rb
@@ -32,7 +32,7 @@ module Bundler
         Bundler.ui.error "This bundle has been frozen, but there is no #{SharedHelpers.relative_lockfile_path} present"
         exit 1
       else
-        Bundler.load.lock(preserve_unknown_sections: true) unless options[:"dry-run"]
+        definition.lock(true) unless options[:"dry-run"]
         Bundler.ui.info "The Gemfile's dependencies are satisfied"
       end
     end

--- a/bundler/lib/bundler/cli/check.rb
+++ b/bundler/lib/bundler/cli/check.rb
@@ -15,7 +15,7 @@ module Bundler
       definition.validate_runtime!
 
       begin
-        definition.resolve_only_locally!
+        definition.check!
         not_installed = definition.missing_specs
       rescue GemNotFound, GitError, SolveFailure
         Bundler.ui.error "Bundler can't satisfy your Gemfile's dependencies."

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -19,7 +19,8 @@ module Bundler
       :ruby_version,
       :lockfile,
       :gemfiles,
-      :locked_checksums
+      :locked_checksums,
+      :sources
     )
 
     # Given a gemfile and lockfile creates a Bundler definition
@@ -499,8 +500,6 @@ module Bundler
     attr_writer :source_requirements
 
     private
-
-    attr_reader :sources
 
     def should_add_extra_platforms?
       !lockfile_exists? && generic_local_platform_is_ruby? && !Bundler.settings[:force_ruby_platform]

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -887,8 +887,6 @@ module Bundler
       converged = []
       deps = []
 
-      @specs_that_changed_sources = []
-
       specs.each do |s|
         name = s.name
         dep = @dependencies.find {|d| s.satisfies?(d) }
@@ -897,7 +895,6 @@ module Bundler
         if dep
           gemfile_source = dep.source || default_source
 
-          @specs_that_changed_sources << s if gemfile_source != lockfile_source
           deps << dep if !dep.source || lockfile_source.include?(dep.source)
           @gems_to_unlock << name if lockfile_source.include?(dep.source) && lockfile_source != gemfile_source
 
@@ -979,20 +976,11 @@ module Bundler
         source_requirements["bundler"] = sources.metadata_source # needs to come last to override
       end
 
-      verify_changed_sources!
       source_requirements
     end
 
     def default_source
       sources.default_source
-    end
-
-    def verify_changed_sources!
-      @specs_that_changed_sources.each do |s|
-        if s.source.specs.search(s.name).empty?
-          raise GemNotFound, "Could not find gem '#{s.name}' in #{s.source}"
-        end
-      end
     end
 
     def requested_groups

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -163,7 +163,14 @@ module Bundler
       @gem_version_promoter ||= GemVersionPromoter.new
     end
 
-    def resolve_only_locally!
+    def check!
+      # If dependencies have changed, we need to resolve remotely. Otherwise,
+      # since we'll be resolving with a single local source, we may end up
+      # locking gems under the wrong source in the lockfile, and missing lockfile
+      # checksums
+      resolve_remotely! if @dependency_changes
+
+      # Now do a local only resolve, to verify if any gems are missing locally
       sources.local_only!
       resolve
     end

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -27,9 +27,16 @@ module Bundler
       @dependencies  = []
       @required_ruby_version = Gem::Requirement.default
       @required_rubygems_version = Gem::Requirement.default
-      @platform      = platform || Gem::Platform::RUBY
-      @source        = source
+      @platform = platform || Gem::Platform::RUBY
+
+      @original_source = source
+      @source = source
+
       @force_ruby_platform = default_force_ruby_platform
+    end
+
+    def source_changed?
+      @original_source != source
     end
 
     def full_name

--- a/bundler/lib/bundler/lockfile_generator.rb
+++ b/bundler/lib/bundler/lockfile_generator.rb
@@ -29,7 +29,7 @@ module Bundler
     private
 
     def add_sources
-      definition.send(:sources).lock_sources.each_with_index do |source, idx|
+      definition.sources.lock_sources.each_with_index do |source, idx|
         out << "\n" unless idx.zero?
 
         # Add the source header

--- a/bundler/lib/bundler/resolver/base.rb
+++ b/bundler/lib/bundler/resolver/base.rb
@@ -107,6 +107,10 @@ module Bundler
       def build_base_requirements
         base_requirements = {}
         @base.each do |ls|
+          if ls.source_changed? && ls.source.specs.search(ls.name).empty?
+            raise GemNotFound, "Could not find gem '#{ls.name}' in #{ls.source}"
+          end
+
           req = Gem::Requirement.new(ls.version)
           base_requirements[ls.name] = req
         end

--- a/bundler/spec/resolver/basic_spec.rb
+++ b/bundler/spec/resolver/basic_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe "Resolving" do
     it "resolves foo only to latest patch - changing dependency declared case" do
       # bar is locked AND a declared dependency in the Gemfile, so it will not move, and therefore
       # foo can only move up to 1.4.4.
-      @base << build_spec("bar", "2.0.3").first
+      @base << Bundler::LazySpecification.new("bar", Gem::Version.new("2.0.3"), nil)
       should_conservative_resolve_and_include :patch, ["foo"], %w[foo-1.4.4 bar-2.0.3]
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bundle check` runs a special resolution where all sources use only local gems, so that we can verify that the resolution is resolvable with only local gems.

This has the problem that information about which gems should be locked under which source is lost. If the lockfile source information is also discarded because the lockfile has been expired by Gemfile changes, then we may end up locking gems under the wrong source.

## What is your fix for the problem, implemented in this PR?

My fix is to apply some refactors to `Bundler::Definition` so that we can resolve sources remotely when necessary before running the local resolution that `bundle check` performs.

Closes #8146.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
