### PR TITLE
Prevent `._*` files in packages generated from macOS

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -252,7 +252,8 @@ file "pkg/rubygems-#{v}.tgz" => "pkg/rubygems-#{v}" do
     tar_version = `tar --version`
     if tar_version.include?("bsdtar")
       # bsdtar, as used by at least FreeBSD and macOS, uses `--uname` and `--gname`.
-      sh "tar -czf rubygems-#{v}.tgz --uname=rubygems:0 --gname=rubygems:0 rubygems-#{v}"
+      # COPYFILE_DISABLE prevents storing macOS extended attribute data in `._*` files inside the archive
+      sh({ "COPYFILE_DISABLE" => "1" }, "tar -czf rubygems-#{v}.tgz --uname=rubygems:0 --gname=rubygems:0 rubygems-#{v}")
     else # If a third variant is added, change this line to: elsif tar_version =~ /GNU tar/
       # GNU Tar, as used by many Linux distros, uses `--owner` and `--group`.
       sh "tar -czf rubygems-#{v}.tgz --owner=rubygems:0 --group=rubygems:0 rubygems-#{v}"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Somehow some files in my working copy of rubygems got extended attributes, which are saved as `._*` in generated archives.

## What is your fix for the problem, implemented in this PR?

My fix was to cleanup these extended attributes from my working copy, but I'm also making sure they are ignored from generated packages so that `._*` files never leak into the release package.

Fixes #8139.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
