### PR TITLE
Add missing comma in documentation

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -391,7 +391,7 @@ class Gem::Specification < Gem::BasicSpecification
   #     "homepage_uri"      => "https://bestgemever.example.io",
   #     "mailing_list_uri"  => "https://groups.example.com/bestgemever",
   #     "source_code_uri"   => "https://example.com/user/bestgemever",
-  #     "wiki_uri"          => "https://example.com/user/bestgemever/wiki"
+  #     "wiki_uri"          => "https://example.com/user/bestgemever/wiki",
   #     "funding_uri"       => "https://example.com/donate"
   #   }
   #


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I copied and pasted from the documentation and the Ruby code did not compile.

## What is your fix for the problem, implemented in this PR?

I added the missing comma.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
