### PR TITLE
Add `bundle add` `--quiet` option

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -353,6 +353,7 @@ module Bundler
     method_option "branch", type: :string
     method_option "ref", type: :string
     method_option "glob", type: :string, banner: "The location of a dependency's .gemspec, expanded within Ruby (single quotes recommended)"
+    method_option "quiet", type: :boolean, banner: "Only output warnings and errors."
     method_option "skip-install", type: :boolean, banner: "Adds gem to the Gemfile but does not install it"
     method_option "optimistic", type: :boolean, banner: "Adds optimistic declaration of version to gem"
     method_option "strict", type: :boolean, banner: "Adds strict declaration of version to gem"

--- a/bundler/lib/bundler/cli/add.rb
+++ b/bundler/lib/bundler/cli/add.rb
@@ -12,6 +12,8 @@ module Bundler
     end
 
     def run
+      Bundler.ui.level = "warn" if options[:quiet]
+
       validate_options!
       inject_dependencies
       perform_bundle_install unless options["skip-install"]

--- a/bundler/lib/bundler/man/bundle-add.1
+++ b/bundler/lib/bundler/man/bundle-add.1
@@ -4,7 +4,7 @@
 .SH "NAME"
 \fBbundle\-add\fR \- Add gem to the Gemfile and run bundle install
 .SH "SYNOPSIS"
-\fBbundle add\fR \fIGEM_NAME\fR [\-\-group=GROUP] [\-\-version=VERSION] [\-\-source=SOURCE] [\-\-path=PATH] [\-\-git=GIT|\-\-github=GITHUB] [\-\-branch=BRANCH] [\-\-ref=REF] [\-\-skip\-install] [\-\-strict|\-\-optimistic]
+\fBbundle add\fR \fIGEM_NAME\fR [\-\-group=GROUP] [\-\-version=VERSION] [\-\-source=SOURCE] [\-\-path=PATH] [\-\-git=GIT|\-\-github=GITHUB] [\-\-branch=BRANCH] [\-\-ref=REF] [\-\-quiet] [\-\-skip\-install] [\-\-strict|\-\-optimistic]
 .SH "DESCRIPTION"
 Adds the named gem to the [\fBGemfile(5)\fR][Gemfile(5)] and run \fBbundle install\fR\. \fBbundle install\fR can be avoided by using the flag \fB\-\-skip\-install\fR\.
 .SH "OPTIONS"
@@ -35,6 +35,9 @@ Specify the git branch for the added gem\.
 .TP
 \fB\-\-ref\fR
 Specify the git ref for the added gem\.
+.TP
+\fB\-\-quiet\fR
+Do not print progress information to the standard output\.
 .TP
 \fB\-\-skip\-install\fR
 Adds the gem to the Gemfile but does not install it\.

--- a/bundler/lib/bundler/man/bundle-add.1.ronn
+++ b/bundler/lib/bundler/man/bundle-add.1.ronn
@@ -5,7 +5,7 @@ bundle-add(1) -- Add gem to the Gemfile and run bundle install
 
 `bundle add` <GEM_NAME> [--group=GROUP] [--version=VERSION] [--source=SOURCE]
            [--path=PATH] [--git=GIT|--github=GITHUB] [--branch=BRANCH] [--ref=REF]
-           [--skip-install] [--strict|--optimistic]
+           [--quiet] [--skip-install] [--strict|--optimistic]
 
 ## DESCRIPTION
 
@@ -40,6 +40,9 @@ Adds the named gem to the [`Gemfile(5)`][Gemfile(5)] and run `bundle install`.
 
 * `--ref`:
   Specify the git ref for the added gem.
+
+* `--quiet`:
+  Do not print progress information to the standard output.
 
 * `--skip-install`:
   Adds the gem to the Gemfile but does not install it.


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bundle install` has a `--quiet` option to not print progress information to stdout.
There is some support for adding a similar `--quiet` option to `bundle add` (see [discussion](https://github.com/orgs/rubygems/discussions/8154)).

## What is your fix for the problem, implemented in this PR?

Add a `--quiet` option to `bundle add`. It is implemented the same way as how `bundle install` does it. Stdout is hidden, but errors and warnings are still displayed.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
