### PR TITLE
Consistently use `bin/rake` over `rake`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,11 +11,11 @@ contributors to follow to reduce the time it takes to get changes merged in.
 2.  Ensure that your code blends well with ours:
     *   No trailing whitespace
     *   Match indentation (two spaces)
-    *   Match coding style (run `rake rubocop`)
+    *   Match coding style (run `bin/rake rubocop`)
 
 3.  If any new files are added or existing files removed in a commit or PR,
     please update the `Manifest.txt` accordingly. This can be done by running
-    `rake update_manifest`
+    `bin/rake update_manifest`
 
 4.  Don't modify the history file or version number.
 
@@ -74,7 +74,7 @@ Everything needs to be run from the `bundler/` subfolder.
 
 To setup bundler tests:
 
-    rake spec:parallel_deps
+    bin/rake spec:parallel_deps
 
 To run the entire bundler test suite in parallel (it takes a while):
 
@@ -92,11 +92,11 @@ To run an individual test file location for example in `spec/install/gems/standa
 
 You can check compliance with our code style with
 
-    rake rubocop
+    bin/rake rubocop
 
 Optionally you can configure git hooks with to check this before every commit with
 
-    rake git_hooks
+    bin/rake git_hooks
 
 ## Issues
 

--- a/POLICIES.md
+++ b/POLICIES.md
@@ -84,7 +84,7 @@ changes to `master` by default _won't_ make their way into the current stable
 branch, and development on `master` will be targeting the next minor
 or major release.
 
-There is a `rake prepare_release[<target_rubygems_version>]` rake task
+There is a `bin/rake prepare_release[<target_rubygems_version>]` rake task
 that helps with creating a release. It takes a single argument, the _exact
 rubygems release_ being made (e.g.  `3.2.3` when releasing bundler `2.2.3`).
 This task checks out the appropriate stable branch (`3.2`, for example), grabs
@@ -158,21 +158,21 @@ affect only very few users in rare cases.
 
 *   Confirm all PRs that you want backported are properly tagged with `rubygems:
     <type>` or `bundler: <type>` labels at GitHub.
-*   Run `rake prepare_release[<target_rubygems_version>]`. This will create a PR
-    to the stable branch with the backports included in the release, and proper
-    changelogs and version bumps. It will also create a PR to merge release
-    changelogs into master.
+*   Run `bin/rake prepare_release[<target_rubygems_version>]`. This will create
+    a PR to the stable branch with the backports included in the release, and
+    proper changelogs and version bumps. It will also create a PR to merge
+    release changelogs into master.
 *   Once CI passes, merge the release PR, switch to the stable branch and pull
     the PR just merged.
-*   Release `bundler` with `rake bundler:release`.
-*   Release `rubygems` with `rake release`.
+*   Release `bundler` with `bin/rake bundler:release`.
+*   Release `rubygems` with `bin/rake release`.
 
 ### Steps for minor and major releases
 
 *   Confirm all PRs that you want listed in changelogs are properly tagged with
     `rubygems: <type>` or `bundler: <type>` labels at GitHub.
-*   Run `rake prepare_release[<target_rubygems_version>]`. This will create a
-    new stable branch off the master branch, and create a PR to it with the
+*   Run `bin/rake prepare_release[<target_rubygems_version>]`. This will create
+    a new stable branch off the master branch, and create a PR to it with the
     proper version bumps and changelogs. It will also create a PR to merge
     release changelogs into master.
 *   Replace the stable branch in the workflows with the new stable branch, and
@@ -181,8 +181,8 @@ affect only very few users in rare cases.
     to the master PR.
 *   Once CI passes, merge the release PR, switch to  the stable branch and pull
     the PR just merged.
-*   Release `bundler` with `rake bundler:release`.
-*   Release `rubygems` with `rake release`.
+*   Release `bundler` with `bin/rake bundler:release`.
+*   Release `rubygems` with `bin/rake release`.
 
 ## Committer Access
 

--- a/bundler/doc/development/PULL_REQUESTS.md
+++ b/bundler/doc/development/PULL_REQUESTS.md
@@ -10,7 +10,7 @@ Before you submit a pull request, please remember to do the following:
 
 Make sure the code formatting and styling adheres to the guidelines. We use RuboCop for this. Lack of formatting adherence will result in automatic GitHub Actions build failures.
 
-      $ rake rubocop
+      $ bin/rake rubocop
 
 ## Tests
 

--- a/bundler/doc/documentation/WRITING.md
+++ b/bundler/doc/documentation/WRITING.md
@@ -39,12 +39,12 @@ If you're not sure if the formatting looks right, that's ok! Make a pull request
 To preview your changes as they will print out for Bundler users, you'll need to run a series of commands:
 
 ```
-$ rake spec:deps
-$ rake man:build
+$ bin/rake spec:deps
+$ bin/rake man:build
 $ man ./lib/bundler/man/bundle-cookies.1
 ```
 
-If you make more changes to `bundle-cookies.1.ronn`, you'll need to run the `rake man:build` again before previewing.
+If you make more changes to `bundle-cookies.1.ronn`, you'll need to run the `bin/rake man:build` again before previewing.
 
 ## Testing
 
@@ -59,7 +59,7 @@ $ bin/rspec ./spec/quality_spec.rb
 
 If you'd like to submit a pull request for any of the primary commands or utilities on [the Bundler documentation site](https://bundler.io), please follow the instructions above for writing documentation for man pages from the `rubygems/rubygems` repository. They are the same in each case.
 
-Note: Editing `.ronn` files from the `rubygems/rubygems` repository for the primary commands and utilities documentation is all you need 🎉. There is no need to manually change anything in the `rubygems/bundler-site` repository, because the man pages and the docs for primary commands and utilities on [the Bundler documentation site](https://bundler.io) are one in the same. They are generated automatically from the `rubygems/rubygems` repository's `.ronn` files from the `rake man:build` command.
+Note: Editing `.ronn` files from the `rubygems/rubygems` repository for the primary commands and utilities documentation is all you need 🎉. There is no need to manually change anything in the `rubygems/bundler-site` repository, because the man pages and the docs for primary commands and utilities on [the Bundler documentation site](https://bundler.io) are one in the same. They are generated automatically from the `rubygems/rubygems` repository's `.ronn` files from the `bin/rake man:build` command.
 
 Additionally, if you'd like to add a guide or tutorial: in the `rubygems/bundler-site` repository, go to `/bundler-site/source/current_version_of_bundler/guides` and add [a new Markdown file](https://guides.github.com/features/mastering-markdown/) (with an extension ending in `.md`). Be sure to correctly format the title of your new guide, like so:
 ```

--- a/tool/release.rb
+++ b/tool/release.rb
@@ -250,7 +250,7 @@ class Release
     bundler_changelog = `git show --no-patch --pretty=format:%h`
 
     @bundler.bump_versions!
-    system("rake", "version:update_locked_bundler", exception: true)
+    system("bin/rake", "version:update_locked_bundler", exception: true)
     system("git", "commit", "-am", "Bump Bundler version to #{@bundler.version}", exception: true)
 
     @rubygems.cut_changelog!


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

None, just unifying things.

## What is your fix for the problem, implemented in this PR?

Use `bin/rake` consistently.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
