### PR TITLE
Remove `x64-mingw32` from our lockfiles

### DIFF
--- a/tool/bundler/dev_gems.rb.lock
+++ b/tool/bundler/dev_gems.rb.lock
@@ -66,7 +66,6 @@ PLATFORMS
   universal-java-18
   universal-java-19
   x64-mingw-ucrt
-  x64-mingw32
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-darwin-22

--- a/tool/bundler/lint_gems.rb.lock
+++ b/tool/bundler/lint_gems.rb.lock
@@ -38,7 +38,6 @@ PLATFORMS
   ruby
   universal-java-11
   x64-mingw-ucrt
-  x64-mingw32
   x86_64-darwin-20
   x86_64-linux
 

--- a/tool/bundler/test_gems.rb.lock
+++ b/tool/bundler/test_gems.rb.lock
@@ -38,7 +38,6 @@ PLATFORMS
   universal-java-18
   universal-java-19
   x64-mingw-ucrt
-  x64-mingw32
   x86_64-darwin-20
   x86_64-linux
 

--- a/tool/bundler/vendor_gems.rb.lock
+++ b/tool/bundler/vendor_gems.rb.lock
@@ -36,7 +36,6 @@ PLATFORMS
   universal-java-18
   universal-java-19
   x64-mingw-ucrt
-  x64-mingw32
   x86_64-darwin-20
   x86_64-linux
 


### PR DESCRIPTION

## What was the end-user or developer problem that led to this PR?

Sometimes when changing dependencies, I noticed we lose all platform specific versions of nokogiri. I tracked the problem down to keeping both this platform and x64-mingw-ucrt in the lockfiles, which sometimes forces the generic variant of nokogiri to be resolved, as explained in https://github.com/rubygems/rubygems/issues/6690.
  
## What is your fix for the problem, implemented in this PR?

x64-mingw32 is no longer a thing since Ruby 3.1, and we only support Ruby >= 3.1 now, so remove it.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
