### PR TITLE
Fix running `bundler` (with a final `r`) in a `bundle exec` context

### DIFF
--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -232,9 +232,7 @@ module Bundler
       end
     end
 
-    # Used to make bin stubs that are not created by bundler work
-    # under bundler. The new Gem.bin_path only considers gems in
-    # +specs+
+    # Used to give better error messages when activating specs outside of the current bundle
     def replace_bin_path(specs_by_name)
       gem_class = (class << Gem; self; end)
 
@@ -273,31 +271,6 @@ module Bundler
 
         spec
       end
-
-      redefine_method(gem_class, :activate_bin_path) do |name, *args|
-        exec_name = args.first
-        return ENV["BUNDLE_BIN_PATH"] if exec_name == "bundle"
-
-        # Copy of Rubygems activate_bin_path impl
-        requirement = args.last
-        spec = find_spec_for_exe name, exec_name, [requirement]
-
-        gem_bin = File.join(spec.full_gem_path, spec.bindir, exec_name)
-        gem_from_path_bin = File.join(File.dirname(spec.loaded_from), spec.bindir, exec_name)
-        File.exist?(gem_bin) ? gem_bin : gem_from_path_bin
-      end
-
-      redefine_method(gem_class, :bin_path) do |name, *args|
-        exec_name = args.first
-        return ENV["BUNDLE_BIN_PATH"] if exec_name == "bundle"
-
-        spec = find_spec_for_exe(name, *args)
-        exec_name ||= spec.default_executable
-
-        gem_bin = File.join(spec.full_gem_path, spec.bindir, exec_name)
-        gem_from_path_bin = File.join(File.dirname(spec.loaded_from), spec.bindir, exec_name)
-        File.exist?(gem_bin) ? gem_bin : gem_from_path_bin
-      end
     end
 
     # Replace or hook into RubyGems to provide a bundlerized view
@@ -314,7 +287,7 @@ module Bundler
         Gem::BUNDLED_GEMS.replace_require(specs) if Gem::BUNDLED_GEMS.respond_to?(:replace_require)
       end
       replace_gem(specs, specs_by_name)
-      stub_rubygems(specs)
+      stub_rubygems(specs_by_name.values)
       replace_bin_path(specs_by_name)
 
       Gem.clear_paths

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -274,15 +274,7 @@ module Bundler
       until !File.directory?(current) || current == previous
         if ENV["BUNDLER_SPEC_RUN"]
           # avoid stepping above the tmp directory when testing
-          gemspec = if ENV["GEM_COMMAND"]
-            # for Ruby Core
-            "lib/bundler/bundler.gemspec"
-          else
-            "bundler.gemspec"
-          end
-
-          # avoid stepping above the tmp directory when testing
-          return nil if File.file?(File.join(current, gemspec))
+          return nil if File.directory?(File.join(current, "tmp"))
         end
 
         names.each do |name|

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -314,17 +314,35 @@ module Bundler
 
     def bundle_bin_path
       # bundler exe & lib folders have same root folder, typical gem installation
-      exe_file = File.expand_path("../../exe/bundle", __dir__)
+      exe_file = File.join(source_root, "exe/bundle")
 
       # for Ruby core repository testing
-      exe_file = File.expand_path("../../libexec/bundle", __dir__) unless File.exist?(exe_file)
+      exe_file = File.join(source_root, "libexec/bundle") unless File.exist?(exe_file)
 
       # bundler is a default gem, exe path is separate
-      exe_file = Bundler.rubygems.bin_path("bundler", "bundle", VERSION) unless File.exist?(exe_file)
+      exe_file = Gem.bin_path("bundler", "bundle", VERSION) unless File.exist?(exe_file)
 
       exe_file
     end
     public :bundle_bin_path
+
+    def gemspec_path
+      # inside a gem repository, typical gem installation
+      gemspec_file = File.join(source_root, "../../specifications/bundler-#{VERSION}.gemspec")
+
+      # for Ruby core repository testing
+      gemspec_file = File.expand_path("bundler.gemspec", __dir__) unless File.exist?(gemspec_file)
+
+      # bundler is a default gem
+      gemspec_file = File.join(Gem.default_specifications_dir, "bundler-#{VERSION}.gemspec") unless File.exist?(gemspec_file)
+
+      gemspec_file
+    end
+    public :gemspec_path
+
+    def source_root
+      File.expand_path("../..", __dir__)
+    end
 
     def set_path
       validate_bundle_path

--- a/bundler/lib/bundler/source/metadata.rb
+++ b/bundler/lib/bundler/source/metadata.rb
@@ -25,8 +25,7 @@ module Bundler
               s.homepage = "https://bundler.io"
               s.summary  = "The best way to manage your application's dependencies"
               s.executables = %w[bundle]
-              # can't point to the actual gemspec or else the require paths will be wrong
-              s.loaded_from = __dir__
+              s.loaded_from = SharedHelpers.gemspec_path
             end
           end
 

--- a/bundler/lib/bundler/source/metadata.rb
+++ b/bundler/lib/bundler/source/metadata.rb
@@ -24,7 +24,7 @@ module Bundler
               s.bindir   = "exe"
               s.homepage = "https://bundler.io"
               s.summary  = "The best way to manage your application's dependencies"
-              s.executables = %w[bundle]
+              s.executables = %w[bundle bundler]
               s.loaded_from = SharedHelpers.gemspec_path
             end
           end

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -1200,6 +1200,23 @@ __FILE__: #{path.to_s.inspect}
         expect(err).to be_empty
         expect(out).to eq("6.1.0")
       end
+
+      it "can still find gems after a nested subprocess when using bundler (with a final r) executable" do
+        script = bundled_app("bin/myscript")
+
+        create_file(script, <<~RUBY)
+          #!#{Gem.ruby}
+
+          puts `bundler exec rails`
+        RUBY
+
+        script.chmod(0o777)
+
+        bundle "exec #{script}"
+
+        expect(err).to be_empty
+        expect(out).to eq("6.1.0")
+      end
     end
 
     context "with a system gem that shadows a default gem" do

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -366,7 +366,8 @@ RSpec.describe "Bundler.setup" do
 
       it "removes system gems from Gem.source_index" do
         run "require 'yard'"
-        expect(out).to eq("bundler-#{Bundler::VERSION}\nyard-1.0")
+        expect(out).to include("bundler-#{Bundler::VERSION}").and include("yard-1.0")
+        expect(out).not_to include("activesupport-2.3.5")
       end
 
       context "when the ruby stdlib is a substring of Gem.path" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Running `bundler` (with a final `r`) in a `bundle exec` context does not work.

## What is your fix for the problem, implemented in this PR?

An alternative fix was proposed at #8116, but I believe we should be able to actually get rid of the code that PR is modifying, providing better integration between Bundler & RubyGems in addition to fixing the problem.

Fixes #8115.
Closes #8116.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
