### PR TITLE
Improve several permission errors

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -493,7 +493,7 @@ module Bundler
     end
 
     def mkdir_p(path)
-      SharedHelpers.filesystem_access(path, :write) do |p|
+      SharedHelpers.filesystem_access(path, :create) do |p|
         FileUtils.mkdir_p(p)
       end
     end

--- a/bundler/lib/bundler/process_lock.rb
+++ b/bundler/lib/bundler/process_lock.rb
@@ -2,23 +2,19 @@
 
 module Bundler
   class ProcessLock
-    def self.lock(bundle_path = Bundler.bundle_path)
+    def self.lock(bundle_path = Bundler.bundle_path, &block)
       lock_file_path = File.join(bundle_path, "bundler.lock")
-      has_lock = false
+      base_lock_file_path = lock_file_path.delete_suffix(".lock")
 
-      File.open(lock_file_path, "w") do |f|
-        f.flock(File::LOCK_EX)
-        has_lock = true
-        yield
-        f.flock(File::LOCK_UN)
+      require "fileutils" if Bundler.rubygems.provides?("< 3.5.23")
+
+      begin
+        SharedHelpers.filesystem_access(lock_file_path, :write) do
+          Gem.open_file_with_lock(base_lock_file_path, &block)
+        end
+      rescue PermissionError
+        block.call
       end
-    rescue Errno::EACCES, Errno::ENOLCK, Errno::ENOTSUP, Errno::EPERM, Errno::EROFS
-      # In the case the user does not have access to
-      # create the lock file or is using NFS where
-      # locks are not available we skip locking.
-      yield
-    ensure
-      FileUtils.rm_f(lock_file_path) if has_lock
     end
   end
 end

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -425,8 +425,12 @@ module Bundler
       Validator.validate!(raw_key, converted_value(value, raw_key), hash)
 
       return unless file
+
+      SharedHelpers.filesystem_access(file.dirname, :create) do |p|
+        FileUtils.mkdir_p(p)
+      end
+
       SharedHelpers.filesystem_access(file) do |p|
-        FileUtils.mkdir_p(p.dirname)
         p.open("w") {|f| f.write(serializer_class.dump(hash)) }
       end
     end

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -96,7 +96,7 @@ module Bundler
     #   given block
     #
     # @example
-    #   filesystem_access("vendor/cache", :write) do
+    #   filesystem_access("vendor/cache", :create) do
     #     FileUtils.mkdir_p("vendor/cache")
     #   end
     #

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -103,7 +103,9 @@ module Bundler
     # @see {Bundler::PermissionError}
     def filesystem_access(path, action = :write, &block)
       yield(path.dup)
-    rescue Errno::EACCES
+    rescue Errno::EACCES => e
+      raise unless e.message.include?(path.to_s) || action == :create
+
       raise PermissionError.new(path, action)
     rescue Errno::EAGAIN
       raise TemporaryResourceError.new(path, action)

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -116,7 +116,7 @@ module Bundler
     rescue Errno::EEXIST, Errno::ENOENT
       raise
     rescue SystemCallError => e
-      raise GenericSystemCallError.new(e, "There was an error accessing `#{path}`.")
+      raise GenericSystemCallError.new(e, "There was an error #{[:create, :write].include?(action) ? "creating" : "accessing"} `#{path}`.")
     end
 
     def major_deprecation(major_version, message, removed_message: nil, print_caller_location: false)

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Bundler::Definition do
       it "raises an PermissionError with explanation" do
         allow(File).to receive(:open).and_call_original
         expect(File).to receive(:open).with(bundled_app_lock, "wb").
-          and_raise(Errno::EACCES)
+          and_raise(Errno::EACCES.new(bundled_app_lock.to_s))
         expect { subject.lock }.
           to raise_error(Bundler::PermissionError, /Gemfile\.lock/)
       end

--- a/bundler/spec/bundler/settings_spec.rb
+++ b/bundler/spec/bundler/settings_spec.rb
@@ -121,12 +121,13 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
       end
     end
 
-    context "when it's not possible to write to the file" do
+    context "when it's not possible to create the settings directory" do
       it "raises an PermissionError with explanation" do
-        expect(::Bundler::FileUtils).to receive(:mkdir_p).with(settings.send(:local_config_file).dirname).
-          and_raise(Errno::EACCES)
+        settings_dir = settings.send(:local_config_file).dirname
+        expect(::Bundler::FileUtils).to receive(:mkdir_p).with(settings_dir).
+          and_raise(Errno::EACCES.new(settings_dir.to_s))
         expect { settings.set_local :frozen, "1" }.
-          to raise_error(Bundler::PermissionError, /config/)
+          to raise_error(Bundler::PermissionError, /#{settings_dir}/)
       end
     end
   end
@@ -164,12 +165,13 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
   end
 
   describe "#set_global" do
-    context "when it's not possible to write to the file" do
+    context "when it's not possible to write to create the settings directory" do
       it "raises an PermissionError with explanation" do
-        expect(::Bundler::FileUtils).to receive(:mkdir_p).with(settings.send(:global_config_file).dirname).
-          and_raise(Errno::EACCES)
+        settings_dir = settings.send(:global_config_file).dirname
+        expect(::Bundler::FileUtils).to receive(:mkdir_p).with(settings_dir).
+          and_raise(Errno::EACCES.new(settings_dir.to_s))
         expect { settings.set_global(:frozen, "1") }.
-          to raise_error(Bundler::PermissionError, %r{\.bundle/config})
+          to raise_error(Bundler::PermissionError, /#{settings_dir}/)
       end
     end
   end

--- a/bundler/spec/bundler/shared_helpers_spec.rb
+++ b/bundler/spec/bundler/shared_helpers_spec.rb
@@ -513,7 +513,7 @@ RSpec.describe Bundler::SharedHelpers do
 
       it "raises a GenericSystemCallError" do
         expect { subject.filesystem_access("/path", &file_op_block) }.to raise_error(
-          Bundler::GenericSystemCallError, /error accessing.+underlying.+Shields down/m
+          Bundler::GenericSystemCallError, /error creating.+underlying.+Shields down/m
         )
       end
     end

--- a/bundler/spec/bundler/shared_helpers_spec.rb
+++ b/bundler/spec/bundler/shared_helpers_spec.rb
@@ -458,7 +458,7 @@ RSpec.describe Bundler::SharedHelpers do
     end
 
     context "system throws Errno::EACESS" do
-      let(:file_op_block) { proc {|_path| raise Errno::EACCES } }
+      let(:file_op_block) { proc {|_path| raise Errno::EACCES.new("/path") } }
 
       it "raises a PermissionError" do
         expect { subject.filesystem_access("/path", &file_op_block) }.to raise_error(

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -1067,7 +1067,7 @@ RSpec.describe "bundle install with gem sources" do
       G
     end
 
-    it "should display a proper message to explain the problem" do
+    it "should still work" do
       bundle "config set --local path vendor"
       bundle :install
       expect(out).to include("Bundle complete!")

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -890,7 +890,7 @@ RSpec.describe "bundle install with gem sources" do
       bundle "config set --local path vendor"
       bundle :install, raise_on_error: false
       expect(err).to include(bundle_path.to_s)
-      expect(err).to include("grant write permissions")
+      expect(err).to include("grant executable permissions")
     end
   end
 

--- a/bundler/spec/install/process_lock_spec.rb
+++ b/bundler/spec/install/process_lock_spec.rb
@@ -21,36 +21,19 @@ RSpec.describe "process lock spec" do
       expect(the_bundle).to include_gems "myrack 1.0"
     end
 
-    context "when creating a lock raises Errno::ENOTSUP" do
-      before { allow(File).to receive(:open).and_raise(Errno::ENOTSUP) }
-
-      it "skips creating the lock file and yields" do
-        processed = false
-        Bundler::ProcessLock.lock(default_bundle_path) { processed = true }
-
-        expect(processed).to eq true
-      end
-    end
-
     context "when creating a lock raises Errno::EPERM" do
       before { allow(File).to receive(:open).and_raise(Errno::EPERM) }
 
-      it "skips creating the lock file and yields" do
-        processed = false
-        Bundler::ProcessLock.lock(default_bundle_path) { processed = true }
-
-        expect(processed).to eq true
+      it "raises a friendly error" do
+        expect { Bundler::ProcessLock.lock(default_bundle_path) }.to raise_error(Bundler::GenericSystemCallError)
       end
     end
 
     context "when creating a lock raises Errno::EROFS" do
       before { allow(File).to receive(:open).and_raise(Errno::EROFS) }
 
-      it "skips creating the lock file and yields" do
-        processed = false
-        Bundler::ProcessLock.lock(default_bundle_path) { processed = true }
-
-        expect(processed).to eq true
+      it "raises a friendly error" do
+        expect { Bundler::ProcessLock.lock(default_bundle_path) }.to raise_error(Bundler::GenericSystemCallError)
       end
     end
   end

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -801,6 +801,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     file_lock = "#{path}.lock"
     open_file_with_flock(file_lock, &block)
   ensure
+    require "fileutils"
     FileUtils.rm_f file_lock
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

While working on #8166, I noticed some other potential permission improvements that I'm proposing separately.

## What is your fix for the problem, implemented in this PR?

Improve some small tweaks in error messages and improve the error you get when you try to install to a protected location in macOS.

### Before

```
$ GEM_HOME=/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/gems/2.6.0/ bundle
Fetching gem metadata from https://rubygems.org/.
Source rubygems repository https://rubygems.org/ or installed locally is ignoring #<Bundler::StubSpecification name=sqlite3 version=1.3.13 platform=ruby> because it is missing extensions
Source rubygems repository https://rubygems.org/ or installed locally is ignoring #<Bundler::StubSpecification name=nokogiri version=1.13.8 platform=ruby> because it is missing extensions
Source rubygems repository https://rubygems.org/ or installed locally is ignoring #<Bundler::StubSpecification name=libxml-ruby version=3.2.1 platform=ruby> because it is missing extensions
Resolving dependencies...
Fetching ruby2_keywords 0.0.5

Retrying download gem from https://rubygems.org/ due to error (2/4): Bundler::GenericSystemCallError There was an error accessing `/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/gems/2.6.0/cache/ruby2_keywords-0.0.5.gem`.
The underlying system error is Errno::EPERM: Operation not permitted @ rb_sysopen - /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/gems/2.6.0/cache/ruby2_keywords-0.0.5.gem

Retrying download gem from https://rubygems.org/ due to error (3/4): Bundler::GenericSystemCallError There was an error accessing `/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/gems/2.6.0/cache/ruby2_keywords-0.0.5.gem`.
The underlying system error is Errno::EPERM: Operation not permitted @ rb_sysopen - /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/gems/2.6.0/cache/ruby2_keywords-0.0.5.gem

Retrying download gem from https://rubygems.org/ due to error (4/4): Bundler::GenericSystemCallError There was an error accessing `/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/gems/2.6.0/cache/ruby2_keywords-0.0.5.gem`.
The underlying system error is Errno::EPERM: Operation not permitted @ rb_sysopen - /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/gems/2.6.0/cache/ruby2_keywords-0.0.5.gem

Bundler::GenericSystemCallError: There was an error accessing `/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/gems/2.6.0/cache/ruby2_keywords-0.0.5.gem`.
The underlying system error is Errno::EPERM: Operation not permitted @ rb_sysopen - /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/gems/2.6.0/cache/ruby2_keywords-0.0.5.gem
  /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/shared_helpers.rb:119:in `rescue in filesystem_access'
  /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/shared_helpers.rb:104:in `filesystem_access'
  /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/rubygems_integration.rb:431:in `block in download_gem'
  /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/retry.rb:40:in `run'
  /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/retry.rb:30:in `attempt'
  /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/rubygems_integration.rb:423:in `download_gem'
  /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/source/rubygems.rb:479:in `download_gem'
  /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/source/rubygems.rb:436:in `fetch_gem'
  /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/source/rubygems.rb:420:in `fetch_gem_if_possible'
  /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/source/rubygems.rb:162:in `install'
  /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/installer/gem_installer.rb:55:in `install'
  /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/installer/gem_installer.rb:17:in `install_from_spec'
  /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/installer/parallel_installer.rb:133:in `do_install'
  /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/installer/parallel_installer.rb:124:in `block in worker_pool'
  /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/worker.rb:62:in `apply_func'
  /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/worker.rb:57:in `block in process_queue'
  <internal:kernel>:187:in `loop'
  /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/worker.rb:54:in `process_queue'
  /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/worker.rb:90:in `block (2 levels) in create_threads'

An error occurred while installing ruby2_keywords (0.0.5), and Bundler cannot continue.

In Gemfile:
  ruby2_keywords
```

### After

```
$ GEM_HOME=/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/gems/2.6.0/ bundle
There was an error creating `/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/gems/2.6.0/bundler.lock`.
The underlying system error is Errno::EPERM: Operation not permitted @ rb_sysopen - /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/gems/2.6.0/bundler.lock
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
