### PR TITLE
Print a proper error when there's a previous empty installation path with bad permissions

### DIFF
--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -23,7 +23,9 @@ module Bundler
         FileUtils.mkdir_p gem_dir, mode: 0o755
       end
 
-      extract_files
+      SharedHelpers.filesystem_access(gem_dir, :write) do
+        extract_files
+      end
 
       build_extensions if spec.extensions.any?
       write_build_info_file


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Default gems come with empty installation folders (or with installation folders including their executables by default). If a default gem is included in the Gemfile, and this empty install folder has incorrect permissions, Bundler will crash printing the bug report template.

## What is your fix for the problem, implemented in this PR?

Wrap the block that tries to write to this empty folder with the proper helper so that Bundler prints nice errors instead of the bug report template.

Fixes #8166.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
