### PR TITLE
Change one `bundle check` spec to not touch the network

### DIFF
--- a/bundler/spec/commands/check_spec.rb
+++ b/bundler/spec/commands/check_spec.rb
@@ -86,11 +86,16 @@ RSpec.describe "bundle check" do
   end
 
   it "prints a generic error if gem git source is not checked out" do
-    gemfile <<-G
+    build_git "foo", path: lib_path("foo")
+
+    bundle "config path vendor/bundle"
+
+    install_gemfile <<-G
       source "https://gem.repo1"
-      gem "rails", git: "git@github.com:rails/rails.git"
+      gem "foo", git: "#{lib_path("foo")}"
     G
 
+    FileUtils.rm_rf bundled_app("vendor/bundle")
     bundle :check, raise_on_error: false
     expect(exitstatus).to eq 1
     expect(err).to include("Bundler can't satisfy your Gemfile's dependencies.")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In general, it's best if specs don't touch the network.

## What is your fix for the problem, implemented in this PR?

Migrate this particular spec to not hit it.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
