### PR TITLE
Fix `gem update --system` leaving old default bundler executables around

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -361,9 +361,15 @@ By default, this RubyGems will install gem as:
   def install_default_bundler_gem(bin_dir)
     current_default_spec = Gem::Specification.default_stubs.find {|s| s.name == "bundler" }
     specs_dir = if current_default_spec && default_dir == Gem.default_dir
+      all_specs_current_version = Gem::Specification.stubs.select {|s| s.full_name == current_default_spec.full_name }
+
       Gem::Specification.remove_spec current_default_spec
       loaded_from = current_default_spec.loaded_from
       File.delete(loaded_from)
+
+      # Remove previous default gem executables if they were not shadowed by a regular gem
+      FileUtils.rm_rf current_default_spec.full_gem_path if all_specs_current_version.size == 1
+
       File.dirname(loaded_from)
     else
       target_specs_dir = File.join(default_dir, "specifications", "default")

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -224,8 +224,10 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     # expect to remove normal gem that was same version. because it's promoted default gems.
     assert_path_not_exist File.join(Gem.dir, "specifications", "bundler-#{bundler_version}.gemspec")
 
+    # expect to remove the previous default version
+    assert_path_not_exist "#{Gem.dir}/gems/bundler-1.15.4"
+
     assert_path_exist "#{Gem.dir}/gems/bundler-#{bundler_version}"
-    assert_path_exist "#{Gem.dir}/gems/bundler-1.15.4"
     assert_path_exist "#{Gem.dir}/gems/bundler-audit-1.0.0"
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I noticed that after `gem update --system`, an installation folder with executables of the previous Bundler version is left around:

```
$ gem -v
3.5.21
$ ls /Users/deivid/.asdf/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/bundler-2.5.21/exe 
bundle  bundler
$ gem update --system 3.5.22
Installing RubyGems 3.5.22
(...)
RubyGems system software updated
$ ls /Users/deivid/.asdf/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/bundler-2.5.21/exe 
bundle  bundler
```

Also, if the version we are upgrading to is already installed as a regular gem, `gem update --system` will remove it. I think it's unexpected that `gem update --system` removes a gem, and a regular gem of the same version shadowing a default gem works just fine and it's generally better, so I believe it's better to leave it around.

## What is your fix for the problem, implemented in this PR?

For the first issue, I made sure the installation folder of the previous default version is removed when upgrading, since there's no installation associated to it.

For the second issue, I stopped removing any Bundler installations when upgrading, except for the previous default version.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
