### PR TITLE
Fix commands with 2 MFA requests when webauthn is enabled

### DIFF
--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -136,7 +136,6 @@ module Gem::GemcutterUtilities
     response = rubygems_api_request(:put, "api/v1/api_key",
                                     sign_in_host, scope: scope) do |request|
       request.basic_auth identifier, password
-      request["OTP"] = otp if otp
       request.body = Gem::URI.encode_www_form({ api_key: api_key }.merge(update_scope_params))
     end
 
@@ -176,7 +175,6 @@ module Gem::GemcutterUtilities
     response = rubygems_api_request(:post, "api/v1/api_key",
                                     sign_in_host, credentials: credentials, scope: scope) do |request|
       request.basic_auth identifier, password
-      request["OTP"] = otp if otp
       request.body = Gem::URI.encode_www_form({ name: key_name }.merge(all_params))
     end
 

--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -62,6 +62,10 @@ module Gem::GemcutterUtilities
     options[:otp] || ENV["GEM_HOST_OTP_CODE"]
   end
 
+  def webauthn_enabled?
+    options[:webauthn]
+  end
+
   ##
   # The host to connect to either from the RUBYGEMS_HOST environment variable
   # or from the user's configuration
@@ -249,6 +253,8 @@ module Gem::GemcutterUtilities
       req["OTP"] = otp if otp
       block.call(req)
     end
+  ensure
+    options[:otp] = nil if webauthn_enabled?
   end
 
   def fetch_otp(credentials)
@@ -268,6 +274,8 @@ module Gem::GemcutterUtilities
         alert_error error.message
         terminate_interaction(1)
       end
+
+      options[:webauthn] = true
 
       say "You are verified with a security device. You may close the browser window."
       otp_thread[:otp]

--- a/test/rubygems/mock_gem_ui.rb
+++ b/test/rubygems/mock_gem_ui.rb
@@ -16,7 +16,7 @@ class Gem::MockGemUi < Gem::StreamUI
     end
   end
 
-  class TermError < RuntimeError
+  class TermError < SystemExit
     attr_reader :exit_code
 
     def initialize(exit_code)

--- a/test/rubygems/test_gem_commands_owner_command.rb
+++ b/test/rubygems/test_gem_commands_owner_command.rb
@@ -176,8 +176,10 @@ EOF
     response = "You don't have permission to push to this gem"
     @stub_fetcher.data["#{Gem.host}/api/v1/gems/freewill/owners"] = HTTPResponseFactory.create(body: response, code: 403, msg: "Forbidden")
 
-    use_ui @stub_ui do
-      @cmd.add_owners("freewill", ["user-new1@example.com"])
+    assert_raise Gem::MockGemUi::TermError do
+      use_ui @stub_ui do
+        @cmd.add_owners("freewill", ["user-new1@example.com"])
+      end
     end
 
     assert_match response, @stub_ui.output
@@ -196,8 +198,10 @@ EOF
       headers: { "location" => redirected_uri }
     )
 
-    use_ui @stub_ui do
-      @cmd.add_owners("freewill", ["user-new1@example.com"])
+    assert_raise Gem::MockGemUi::TermError do
+      use_ui @stub_ui do
+        @cmd.add_owners("freewill", ["user-new1@example.com"])
+      end
     end
 
     response = "The request has redirected permanently to #{redirected_uri}. Please check your defined push host URL."
@@ -255,8 +259,10 @@ EOF
     response = "You don't have permission to push to this gem"
     @stub_fetcher.data["#{Gem.host}/api/v1/gems/freewill/owners"] = HTTPResponseFactory.create(body: response, code: 403, msg: "Forbidden")
 
-    use_ui @stub_ui do
-      @cmd.remove_owners("freewill", ["user-remove1@example.com"])
+    assert_raise Gem::MockGemUi::TermError do
+      use_ui @stub_ui do
+        @cmd.remove_owners("freewill", ["user-remove1@example.com"])
+      end
     end
 
     assert_match response, @stub_ui.output
@@ -274,8 +280,10 @@ EOF
       headers: { "location" => redirected_uri }
     )
 
-    use_ui @stub_ui do
-      @cmd.remove_owners("freewill", ["user-remove1@example.com"])
+    assert_raise Gem::MockGemUi::TermError do
+      use_ui @stub_ui do
+        @cmd.remove_owners("freewill", ["user-remove1@example.com"])
+      end
     end
 
     response = "The request has redirected permanently to #{redirected_uri}. Please check your defined push host URL."
@@ -291,8 +299,10 @@ EOF
       headers: { "location" => redirected_uri }
     )
 
-    use_ui @stub_ui do
-      @cmd.add_owners("freewill", ["user-new1@example.com"])
+    assert_raise Gem::MockGemUi::TermError do
+      use_ui @stub_ui do
+        @cmd.add_owners("freewill", ["user-new1@example.com"])
+      end
     end
 
     response = "The request has redirected permanently to #{redirected_uri}. Please check your defined push host URL."
@@ -317,8 +327,10 @@ EOF
     response = "Owner could not be found."
     @stub_fetcher.data["#{Gem.host}/api/v1/gems/freewill/owners"] = HTTPResponseFactory.create(body: response, code: 404, msg: "Not Found")
 
-    use_ui @stub_ui do
-      @cmd.remove_owners("freewill", ["missing@example"])
+    assert_raise Gem::MockGemUi::TermError do
+      use_ui @stub_ui do
+        @cmd.remove_owners("freewill", ["missing@example"])
+      end
     end
 
     assert_equal "Removing missing@example: #{response}\n", @stub_ui.output
@@ -346,8 +358,11 @@ EOF
       HTTPResponseFactory.create(body: "You don't have any security devices", code: 422, msg: "Unprocessable Entity")
 
     @otp_ui = Gem::MockGemUi.new "111111\n"
-    use_ui @otp_ui do
-      @cmd.add_owners("freewill", ["user-new1@example.com"])
+
+    assert_raise Gem::MockGemUi::TermError do
+      use_ui @otp_ui do
+        @cmd.add_owners("freewill", ["user-new1@example.com"])
+      end
     end
 
     assert_match response, @otp_ui.output
@@ -389,8 +404,10 @@ EOF
 
     TCPServer.stub(:new, server) do
       Gem::GemcutterUtilities::WebauthnListener.stub(:listener_thread, Thread.new { Thread.current[:error] = error }) do
-        use_ui @stub_ui do
-          @cmd.add_owners("freewill", ["user-new1@example.com"])
+        assert_raise Gem::MockGemUi::TermError do
+          use_ui @stub_ui do
+            @cmd.add_owners("freewill", ["user-new1@example.com"])
+          end
         end
       end
     end
@@ -438,8 +455,10 @@ EOF
     @stub_fetcher.respond_with_webauthn_polling_failure
 
     TCPServer.stub(:new, server) do
-      use_ui @stub_ui do
-        @cmd.add_owners("freewill", ["user-new1@example.com"])
+      assert_raise Gem::MockGemUi::TermError do
+        use_ui @stub_ui do
+          @cmd.add_owners("freewill", ["user-new1@example.com"])
+        end
       end
     end
 

--- a/test/rubygems/utilities.rb
+++ b/test/rubygems/utilities.rb
@@ -30,13 +30,13 @@ require "rubygems/remote_fetcher"
 # See RubyGems' tests for more examples of FakeFetcher.
 
 class Gem::FakeFetcher
-  attr_reader :data
-  attr_reader :last_request
+  attr_reader :data, :requests
   attr_accessor :paths
 
   def initialize
     @data = {}
     @paths = []
+    @requests = []
   end
 
   def find_data(path)
@@ -99,9 +99,13 @@ class Gem::FakeFetcher
     create_response(uri)
   end
 
+  def last_request
+    @requests.last
+  end
+
   def request(uri, request_class, last_modified = nil)
-    @last_request = request_class.new uri.request_uri
-    yield @last_request if block_given?
+    @requests << request_class.new(uri.request_uri)
+    yield last_request if block_given?
 
     create_response(uri)
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If a command requires two MFA authenticated requests, and webauthn is enabled, then first one will succeed but the second one will fail because it tries to reuse the OTP code from the first request and that does not work.

This happens when you have not yet logged in to rubygems.org, or when you have an API key with invalid scopes for the current operation. In that case, we need:

* An API request to get a token or change scopes for the one that you have.
* Another API request to perform the actual operation.

## What is your fix for the problem, implemented in this PR?

Instead of trying to reuse the token, make sure it's cleared so we are asked to authenticate again.

TODO:

* [x] Fix it for `gem push` (and maybe others?).
* [x] Add tests.

Fixes #7643.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
