### PR TITLE
Remove patches for old TruffleRuby versions

### DIFF
--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -329,10 +329,6 @@ module Gem
         without_gnu_nor_abi_modifiers
       end
     end
-
-    if RUBY_ENGINE == "truffleruby" && !defined?(REUSE_AS_BINARY_ON_TRUFFLERUBY)
-      REUSE_AS_BINARY_ON_TRUFFLERUBY = %w[libv8 libv8-node sorbet-static].freeze
-    end
   end
 
   Platform.singleton_class.module_eval do

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1386,17 +1386,6 @@ begin
 rescue LoadError
 end
 
-# TruffleRuby >= 24 defines REUSE_AS_BINARY_ON_TRUFFLERUBY in defaults/truffleruby.
-# However, TruffleRuby < 24 defines REUSE_AS_BINARY_ON_TRUFFLERUBY directly in its copy
-# of lib/rubygems/platform.rb, so it is not defined if RubyGems is updated (gem update --system).
-# Instead, we define it here in that case, similar to bundler/lib/bundler/rubygems_ext.rb.
-# We must define it here and not in platform.rb because platform.rb is loaded before defaults/truffleruby.
-class Gem::Platform
-  if RUBY_ENGINE == "truffleruby" && !defined?(REUSE_AS_BINARY_ON_TRUFFLERUBY)
-    REUSE_AS_BINARY_ON_TRUFFLERUBY = %w[libv8 libv8-node sorbet-static].freeze
-  end
-end
-
 ##
 # Loads the default specs.
 Gem::Specification.load_defaults


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We only test, and thus support, the last version of TruffleRuby. At this point, we can drop code that was only meant to support old versions of TruffleRuby, and that it's out of date now anyways.
 
## What is your fix for the problem, implemented in this PR?

Remove the old code.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
