### PR TITLE
Remove confusing `bundle config` documentation

### DIFF
--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -199,10 +199,6 @@ The following is a list of all configuration keys and their purpose\. You can le
 .IP "\(bu" 4
 \fBwithout\fR (\fBBUNDLE_WITHOUT\fR): A \fB:\fR\-separated list of groups whose gems bundler should not install\.
 .IP "" 0
-.P
-In general, you should set these settings per\-application by using the applicable flag to the bundle install(1) \fIbundle\-install\.1\.html\fR or bundle cache(1) \fIbundle\-cache\.1\.html\fR command\.
-.P
-You can set them globally either via environment variables or \fBbundle config\fR, whichever is preferable for your setup\. If you use both, environment variables will take preference over global settings\.
 .SH "LOCAL GIT REPOS"
 Bundler also allows you to work against a git repository locally instead of using the remote version\. This can be achieved by setting up a local override:
 .IP "" 4

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -282,13 +282,6 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
 * `without` (`BUNDLE_WITHOUT`):
    A `:`-separated list of groups whose gems bundler should not install.
 
-In general, you should set these settings per-application by using the applicable
-flag to the [bundle install(1)](bundle-install.1.html) or [bundle cache(1)](bundle-cache.1.html) command.
-
-You can set them globally either via environment variables or `bundle config`,
-whichever is preferable for your setup. If you use both, environment variables
-will take preference over global settings.
-
 ## LOCAL GIT REPOS
 
 Bundler also allows you to work against a git repository locally


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The first paragraph is misleading because command line flags that set configuration are deprecated.

The second one is unnecessary because configuration precedence is explained before the different configurations.

## What is your fix for the problem, implemented in this PR?

Remove both paragraphs.

Closes https://github.com/orgs/rubygems/discussions/7533.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
