### PR TITLE
[SpecFetcher] Change < to <= like it should be.

### DIFF
--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -172,9 +172,9 @@ class Gem::SpecFetcher
   def suggest_gems_from_name(gem_name, type = :latest, num_results = 5)
     gem_name = gem_name.downcase.tr("_-", "")
 
-    # All results for 3-character (minus hyphens/underscores) gem names
-    # get rejected, so we just return an empty array immediately instead.
-    return [] if gem_name.length < 3
+    # All results for 3-character-or-shorter (minus hyphens/underscores) gem
+    # names get rejected, so we just return an empty array immediately instead.
+    return [] if gem_name.length <= 3
 
     max   = gem_name.size / 2
     names = available_specs(type).first.values.flatten(1)

--- a/test/rubygems/test_gem_commands_fetch_command.rb
+++ b/test/rubygems/test_gem_commands_fetch_command.rb
@@ -184,16 +184,16 @@ class TestGemCommandsFetchCommand < Gem::TestCase
 
   def test_execute_version_nonexistent
     spec_fetcher do |fetcher|
-      fetcher.spec "foo", 1
+      fetcher.spec "foobar", 1
     end
 
-    @cmd.options[:args] = %w[foo:2]
+    @cmd.options[:args] = %w[foobar:2]
 
     execute_with_term_error
 
     expected = <<-EXPECTED
-ERROR:  Could not find a valid gem 'foo' (2) in any repository
-ERROR:  Possible alternatives: foo
+ERROR:  Could not find a valid gem 'foobar' (2) in any repository
+ERROR:  Possible alternatives: foobar
     EXPECTED
 
     assert_equal expected, @ui.error
@@ -201,16 +201,16 @@ ERROR:  Possible alternatives: foo
 
   def test_execute_nonexistent_hint_disabled
     spec_fetcher do |fetcher|
-      fetcher.spec "foo", 1
+      fetcher.spec "foobar", 1
     end
 
-    @cmd.options[:args] = %w[foo:2]
+    @cmd.options[:args] = %w[foobar:2]
     @cmd.options[:suggest_alternate] = false
 
     execute_with_term_error
 
     expected = <<-EXPECTED
-ERROR:  Could not find a valid gem 'foo' (2) in any repository
+ERROR:  Could not find a valid gem 'foobar' (2) in any repository
     EXPECTED
 
     assert_equal expected, @ui.error


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

I accidentally used `<` instead of `<=` in #8084. :slightly_smiling_face: 

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

I switched to `<=`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

There isn't a way to test it, since it's a purely-theoretical performance improvement. (It might be less theoretical on slower computers.)