### PR TITLE
docs: Fix missing link in `.github/pull_request_template.md`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,4 +21,4 @@ alternatives, explain why you end up choosing the current implementation -->
 - [ ] Describe the problem / feature
 - [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
 - [ ] Write code to solve the problem
-- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
+- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Follow up on #8159

https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md is referenced in [`.github/pull_request_template.md`](https://github.com/rubygems/rubygems/blob/73d8efb1524a032dabfa1b5fec99a840d83a9ef4/.github/pull_request_template.md).

But `bundler/doc/development/PULL_REQUESTS.md` has been moved to `doc/bundler/development/PULL_REQUESTS.md` at 2f760aa

## What is your fix for the problem, implemented in this PR?
Fix link in `.github/pull_request_template.md`

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
