### PR TITLE
Fix to work with UTF-8 Gem $HOME

### DIFF
--- a/bundler/lib/bundler/cli/exec.rb
+++ b/bundler/lib/bundler/cli/exec.rb
@@ -69,11 +69,13 @@ module Bundler
     end
 
     def ruby_shebang?(file)
+      gem_ruby = Gem.ruby.dup
+      gem_ruby.force_encoding('ASCII-8BIT')
       possibilities = [
         "#!/usr/bin/env ruby\n",
         "#!/usr/bin/env jruby\n",
         "#!/usr/bin/env truffleruby\n",
-        "#!#{Gem.ruby}\n",
+        "#!#{gem_ruby}\n",
       ]
 
       if File.zero?(file)


### PR DESCRIPTION

## What was the end-user or developer problem that led to this PR?

I'm using RVM and my $HOME is `/home/Dāvis` so `Gem.ruby` returns `/home/Dāvis/.rvm/rubies/ruby-3.3.4/bin/ruby` which is with `UTF-8` encoding and that causes failure

```
Encoding::CompatibilityError: incompatible character encodings: ASCII-8BIT and UTF-8
  /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/bundler/cli/exec.rb:85:in `start_with?'
          /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/bundler/cli/exec.rb:85:in `block in ruby_shebang?'
          /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/bundler/cli/exec.rb:85:in `any?'
          /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/bundler/cli/exec.rb:85:in `ruby_shebang?'
          /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/bundler/cli/exec.rb:22:in `run'
          /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/bundler/cli.rb:455:in `exec'
          /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/bundler/vendor/thor/lib/thor/command.rb:28:in `run'
          /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
          /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/bundler/vendor/thor/lib/thor.rb:527:in `dispatch'
          /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/bundler/cli.rb:35:in `dispatch'
          /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/bundler/vendor/thor/lib/thor/base.rb:584:in `start'
          /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/bundler/cli.rb:29:in `start'
          /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.22/exe/bundle:28:in `block in <top (required)>'
          /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/site_ruby/3.3.0/bundler/friendly_errors.rb:117:in `with_friendly_errors'
          /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/gems/3.3.0/gems/bundler-2.5.22/exe/bundle:20:in `<top (required)>'
          /home/Dāvis/.rvm/rubies/ruby-3.3.4/bin/bundle:25:in `load'
          /home/Dāvis/.rvm/rubies/ruby-3.3.4/bin/bundle:25:in `<main>'
```

## What is your fix for the problem, implemented in this PR?

This PR fixes this issue by setting `ASCII-8BIT` and using that for comparison instead.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
