### PR TITLE
Use new platform in `Gem::Specification` `to_ruby` and `to_yaml`

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1813,15 +1813,9 @@ class Gem::Specification < Gem::BasicSpecification
   def encode_with(coder) # :nodoc:
     coder.add "name", @name
     coder.add "version", @version
-    platform = case @original_platform
-               when nil, "" then
-                 "ruby"
-               when String then
-                 @original_platform
-               else
-                 @original_platform.to_s
+    if @platform && @platform != Gem::Platform::RUBY
+      coder.add "platform", @platform
     end
-    coder.add "platform", platform
 
     attributes = @@attributes.map(&:to_s) - %w[name version platform]
     attributes.each do |name|

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2433,8 +2433,8 @@ class Gem::Specification < Gem::BasicSpecification
 
     result << "  s.name = #{ruby_code name}"
     result << "  s.version = #{ruby_code version}"
-    unless platform.nil? || platform == Gem::Platform::RUBY
-      result << "  s.platform = #{ruby_code original_platform}"
+    if platform && platform != Gem::Platform::RUBY
+      result << "  s.platform = #{ruby_code platform}"
     end
     result << ""
     result << "  s.required_rubygems_version = #{ruby_code required_rubygems_version} if s.respond_to? :required_rubygems_version="

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -934,7 +934,7 @@ class Gem::TestCase < Test::Unit::TestCase
   #              don't collide with a.
   # +@b2+:: gem b version 2
   # +@c1_2+:: gem c version 1.2
-  # +@pl1+:: gem pl version 1, this gem has a legacy platform of i386-linux.
+  # +@pl1+:: gem pl version 1, this gem has a legacy platform of x86-linux.
   #
   # Additional +prerelease+ gems may also be created:
   #
@@ -978,8 +978,8 @@ Also, a list:
     @pl1 = quick_gem "pl", "1" do |s| # l for legacy
       s.files = %w[lib/code.rb]
       s.require_paths = %w[lib]
-      s.platform = Gem::Platform.new "i386-linux"
-      s.instance_variable_set :@original_platform, "i386-linux"
+      s.platform = Gem::Platform.new "x86-linux"
+      s.instance_variable_set :@original_platform, "x86-linux"
     end
 
     if prerelease

--- a/test/rubygems/test_gem_commands_query_command.rb
+++ b/test/rubygems/test_gem_commands_query_command.rb
@@ -36,7 +36,7 @@ class TestGemCommandsQueryCommandWithInstalledGems < Gem::TestCase
 *** REMOTE GEMS ***
 
 a (2)
-pl (1 i386-linux)
+pl (1 x86-linux)
     EOF
 
     assert_equal expected, @stub_ui.output
@@ -57,7 +57,7 @@ pl (1 i386-linux)
 *** REMOTE GEMS ***
 
 a (2, 1)
-pl (1 i386-linux)
+pl (1 x86-linux)
     EOF
 
     assert_equal expected, @stub_ui.output
@@ -78,7 +78,7 @@ pl (1 i386-linux)
 *** REMOTE GEMS ***
 
 a (3.a, 2, 1)
-pl (1 i386-linux)
+pl (1 x86-linux)
     EOF
 
     assert_equal expected, @stub_ui.output
@@ -114,7 +114,7 @@ a (2)
     This is a lot of text.
 
 pl (1)
-    Platform: i386-linux
+    Platform: x86-linux
     Author: A User
     Homepage: http://example.com
 
@@ -154,7 +154,7 @@ a (2)
     This is a lot of text.
 
 pl (1)
-    Platform: i386-linux
+    Platform: x86-linux
     Author: A User
     Homepage: http://example.com
 
@@ -194,7 +194,7 @@ a (2)
 #{"    This is a lot of text. This is a lot of text. This is a lot of text.\n" * 1449}    This is a lot of te
 
 pl (1)
-    Platform: i386-linux
+    Platform: x86-linux
     Author: A User
     Homepage: http://example.com
 
@@ -318,7 +318,7 @@ pl (1)
 *** LOCAL GEMS ***
 
 a (3.a, 2, 1)
-pl (1 i386-linux)
+pl (1 x86-linux)
     EOF
 
     assert_equal expected, @stub_ui.output
@@ -338,7 +338,7 @@ pl (1 i386-linux)
 
     expected = <<-EOF
 a (3.a, 2, 1)
-pl (1 i386-linux)
+pl (1 x86-linux)
     EOF
 
     assert_equal expected, @stub_ui.output
@@ -357,7 +357,7 @@ pl (1 i386-linux)
 
     expected = <<-EOF
 a (3.a, 2, 1)
-pl (1 i386-linux)
+pl (1 x86-linux)
     EOF
 
     assert_equal expected, @stub_ui.output
@@ -398,7 +398,7 @@ pl
 
     expected = <<-EOF
 a (2)
-pl (1 i386-linux)
+pl (1 x86-linux)
     EOF
 
     assert_equal expected, @stub_ui.output
@@ -437,7 +437,7 @@ a (3.a)
 *** LOCAL GEMS ***
 
 a (3.a, 2, 1)
-pl (1 i386-linux)
+pl (1 x86-linux)
     EOF
 
     assert_equal expected, @stub_ui.output
@@ -457,7 +457,7 @@ pl (1 i386-linux)
 *** LOCAL GEMS ***
 
 a (2, 1)
-pl (1 i386-linux)
+pl (1 x86-linux)
     EOF
 
     assert_equal expected, @stub_ui.output
@@ -477,7 +477,7 @@ pl (1 i386-linux)
 *** REMOTE GEMS ***
 
 a (2)
-pl (1 i386-linux)
+pl (1 x86-linux)
     EOF
 
     assert_equal expected, @stub_ui.output
@@ -497,7 +497,7 @@ pl (1 i386-linux)
 
     expected = <<-EOF
 a (3.a, 2, 1)
-pl (1 i386-linux)
+pl (1 x86-linux)
     EOF
 
     assert_equal expected, @stub_ui.output
@@ -516,7 +516,7 @@ pl (1 i386-linux)
 
     expected = <<-EOF
 a (2)
-pl (1 i386-linux)
+pl (1 x86-linux)
     EOF
 
     assert_equal expected, @stub_ui.output
@@ -726,7 +726,7 @@ a (2, 1)
     This is a lot of text.
 
 pl (1)
-    Platform: i386-linux
+    Platform: x86-linux
     Author: A User
     Homepage: http://example.com
     Installed at: -

--- a/test/rubygems/test_gem_source.rb
+++ b/test/rubygems/test_gem_source.rb
@@ -108,7 +108,7 @@ class TestGemSource < Gem::TestCase
   def test_fetch_spec_platform
     specs = spec_fetcher(&:legacy_platform)
 
-    spec = @source.fetch_spec tuple("pl", Gem::Version.new(1), "i386-linux")
+    spec = @source.fetch_spec tuple("pl", Gem::Version.new(1), "x86-linux")
 
     assert_equal specs["pl-1-x86-linux"].full_name, spec.full_name
   end

--- a/test/rubygems/test_gem_spec_fetcher.rb
+++ b/test/rubygems/test_gem_spec_fetcher.rb
@@ -107,7 +107,7 @@ class TestGemSpecFetcher < Gem::TestCase
   end
 
   def test_spec_for_dependency_platform
-    util_set_arch "i386-linux"
+    util_set_arch "x86-linux"
 
     spec_fetcher(&:legacy_platform)
 
@@ -134,8 +134,8 @@ class TestGemSpecFetcher < Gem::TestCase
     assert_equal 1, errors.size
     pmm = errors.first
 
-    assert_equal "i386-linux", pmm.platforms.first
-    assert_equal "Found pl (1), but was for platform i386-linux", pmm.wordy
+    assert_equal "x86-linux", pmm.platforms.first
+    assert_equal "Found pl (1), but was for platform x86-linux", pmm.wordy
   end
 
   def test_spec_for_dependency_bad_fetch_spec
@@ -213,7 +213,7 @@ class TestGemSpecFetcher < Gem::TestCase
 
     expected = Gem::NameTuple.from_list \
       [["a",      v(2),     Gem::Platform::RUBY],
-       ["pl",     v(1),     "i386-linux"]]
+       ["pl",     v(1),     "x86-linux"]]
 
     assert_equal expected, specs[@source]
   end
@@ -230,7 +230,7 @@ class TestGemSpecFetcher < Gem::TestCase
 
     expected = Gem::NameTuple.from_list \
       [["a",      v(1),     Gem::Platform::RUBY],
-       ["pl",     v(1),     "i386-linux"]]
+       ["pl",     v(1),     "x86-linux"]]
 
     assert_equal expected, specs[@source]
   end
@@ -251,7 +251,7 @@ class TestGemSpecFetcher < Gem::TestCase
       [["a",      v(1),     Gem::Platform::RUBY],
        ["a",      v("2.a"), Gem::Platform::RUBY],
        ["b",      v(2),     Gem::Platform::RUBY],
-       ["pl",     v(1),     "i386-linux"]]
+       ["pl",     v(1),     "x86-linux"]]
 
     assert_equal expected, specs[@source]
   end
@@ -274,7 +274,7 @@ class TestGemSpecFetcher < Gem::TestCase
     expected = Gem::NameTuple.from_list \
       [["a",      v(1), Gem::Platform::RUBY],
        ["b",      v(2), Gem::Platform::RUBY],
-       ["pl",     v(1), "i386-linux"]]
+       ["pl",     v(1), "x86-linux"]]
 
     assert_equal expected, specs[@source]
   end

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2462,7 +2462,7 @@ end
 
   def test_to_ruby_platform
     @a2.platform = Gem::Platform.local
-    @a2.instance_variable_set :@original_platform, "some_old_platform"
+    @a2.instance_variable_set :@original_platform, "old_platform"
 
     ruby_code = @a2.to_ruby
 
@@ -2496,25 +2496,25 @@ end
   def test_to_yaml_platform_empty_string
     @a1.instance_variable_set :@original_platform, ""
 
-    assert_match(/^platform: ruby$/, @a1.to_yaml)
+    refute_match(/^platform: /, @a1.to_yaml)
   end
 
   def test_to_yaml_platform_legacy
     @a1.platform = "powerpc-darwin7.9.0"
-    @a1.instance_variable_set :@original_platform, "powerpc-darwin7.9.0"
+    @a1.instance_variable_set :@original_platform, "old_platform"
 
     yaml_str = @a1.to_yaml
 
     same_spec = load_yaml yaml_str
 
     assert_equal Gem::Platform.new("powerpc-darwin7"), same_spec.platform
-    assert_equal "powerpc-darwin7.9.0", same_spec.original_platform
+    assert_equal "powerpc-darwin-7", same_spec.original_platform
   end
 
   def test_to_yaml_platform_nil
     @a1.instance_variable_set :@original_platform, nil
 
-    assert_match(/^platform: ruby$/, @a1.to_yaml)
+    refute_match(/^platform: /, @a1.to_yaml)
   end
 
   def test_to_yaml_no_autorequire

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2462,13 +2462,14 @@ end
 
   def test_to_ruby_platform
     @a2.platform = Gem::Platform.local
-    @a2.instance_variable_set :@original_platform, "old_platform"
+    @a2.instance_variable_set :@original_platform, "some_old_platform"
 
     ruby_code = @a2.to_ruby
 
     same_spec = eval ruby_code
 
-    assert_equal "old_platform", same_spec.original_platform
+    assert_equal Gem::Platform.local, same_spec.platform
+    assert_equal Gem::Platform.local, same_spec.original_platform
   end
 
   def test_to_yaml

--- a/test/rubygems/utilities.rb
+++ b/test/rubygems/utilities.rb
@@ -348,8 +348,8 @@ class Gem::TestCase::SpecFetcherSetup
 
   def legacy_platform
     spec "pl", 1 do |s|
-      s.platform = Gem::Platform.new "i386-linux"
-      s.instance_variable_set :@original_platform, "i386-linux"
+      s.platform = Gem::Platform.new "x86-linux"
+      s.instance_variable_set :@original_platform, "x86-linux"
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/rubygems/rubygems/issues/6056.

## What was the end-user or developer problem that led to this PR?

When packaging a gem via `PackageTask`, it outputs the original_platform as `platform: `, instead of the current platform.

For example if the platform is changed by a script such as this one:

```ruby
require 'rubygems/package_task'
require 'bundler'
task :doit do
  spec = Gem::Specification::load("examplegem.gemspec").dup
  spec.platform = Gem::Platform.new("java") # <-- platform changed here
  #p spec.to_ruby
  task = Gem::PackageTask.new(spec)
  task.define
  task(:gem).invoke()
end
```

The resulting manifest output shows the original platform instead of the new platform. See https://github.com/rubygems/rubygems/issues/6056 for details and steps to repro.

Edit: it seems that the culprit is `#to_yaml`, which outputs the incorrect original platform.

~According to the discussion on https://github.com/rubygems/rubygems/issues/6056, the culprit seems to be the following code in `Gem::Specification#to_ruby`:~

~`https://github.com/rubygems/rubygems/blob/3425d3d35db5cad46891bd7328765b1c93effcb2/lib/rubygems/specification.rb#L2436-L2438`~

~The suggested solution in the discussion is to change it to use `platform` instead of `original_platform`.~

~Other reasons to support that solution:~

~- it seems inconsistent that the condition is checking `platform`, while `original_platform` is added to the string.~
~- `original_platform` is [considered cruft](https://github.com/rubygems/rubygems/blob/3425d3d35db5cad46891bd7328765b1c93effcb2/lib/rubygems/specification.rb#L2178-L2183) and `platform` should be used instead.~

## What is your fix for the problem, implemented in this PR?

#### Immediate fix for the issue:

- Fix `#to_yaml` by changing `encode_with` (used by [Psych](https://ruby-doc.org/3.3.5/exts/psych/Psych/Coder.html)) to set the platform to the current platform.

#### Additional fixes:

Arguably these fixes are not needed but I think they are useful for consistency.

1. Change `Gem::Specification#to_ruby` to also use `platform` instead of `original_platform`, so there is logic parity between `#to_ruby` and `#to_yaml`
2. Some tests related to `#to_ruby` were expecting a `i386-linux` platform because they relied on test helpers like this: https://github.com/rubygems/rubygems/blob/3425d3d35db5cad46891bd7328765b1c93effcb2/test/rubygems/utilities.rb#L349-L354

    That test helper sets `original_platform` as a string, so tests worked. But now that I have done the change in 1, `Gem::Specification#to_ruby` uses `platform`, which in the test helper is set up as a `Gem::Platform.new "i386-linux"` object. However there is special [initialize logic](https://github.com/rubygems/rubygems/blob/3425d3d35db5cad46891bd7328765b1c93effcb2/lib/rubygems/platform.rb#L100-L102) in `Gem::Platform` so that `Gem::Platform.new("i386-linux").to_s` actually returns `"x86-linux"`, not `"i386-linux"`. So I had to change test expectations to `"x86-linux"` instead.

    To summarize, those tests should probably have set the correct `"x86-linux"` string from the beginning, and my PR shed light on those issues, so I fixed them.

3. While I was at it, I also changed the test helpers to directly set up the platforms and original platforms to `"x86-linux"` to better match test expectations, otherwise when trying to understand tests people might be wondering where the `"x86-linux"` expectation is coming from.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
