### PR TITLE
Fix incompatible encodings error when paths with UTF-8 characters are involved

### DIFF
--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -433,4 +433,18 @@ module Gem
       end
     end
   end
+
+  unless Gem.rubygems_version >= Gem::Version.new("3.5.23")
+    class Package; end
+    require "rubygems/package/tar_reader"
+    require "rubygems/package/tar_reader/entry"
+
+    module FixFullNameEncoding
+      def full_name
+        super.force_encoding(Encoding::UTF_8)
+      end
+    end
+
+    Package::TarReader::Entry.prepend(FixFullNameEncoding)
+  end
 end

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -1218,6 +1218,35 @@ RSpec.describe "bundle install with gem sources" do
     end
   end
 
+  describe "when configured path is UTF-8 and a file inside a gem package too" do
+    let(:app_path) do
+      path = tmp("♥")
+      FileUtils.mkdir_p(path)
+      path
+    end
+
+    let(:path) do
+      root.join("vendor/bundle")
+    end
+
+    before do
+      build_repo4 do
+        build_gem "mygem" do |s|
+          s.write "spec/fixtures/_posts/2016-04-01-错误.html"
+        end
+      end
+    end
+
+    it "works" do
+      bundle "config path #{app_path}/vendor/bundle", dir: app_path
+
+      install_gemfile app_path.join("Gemfile"),<<~G, dir: app_path
+        source "https://gem.repo4"
+        gem "mygem", "1.0"
+      G
+    end
+  end
+
   context "after installing with --standalone" do
     before do
       install_gemfile <<-G

--- a/lib/rubygems/package/tar_header.rb
+++ b/lib/rubygems/package/tar_header.rb
@@ -228,6 +228,17 @@ class Gem::Package::TarHeader
     @checksum = oct calculate_checksum(header), 6
   end
 
+  ##
+  # Header's full name, including prefix
+
+  def full_name
+    if prefix != ""
+      File.join prefix, name
+    else
+      name
+    end
+  end
+
   private
 
   def calculate_checksum(header)

--- a/lib/rubygems/package/tar_reader/entry.rb
+++ b/lib/rubygems/package/tar_reader/entry.rb
@@ -87,11 +87,7 @@ class Gem::Package::TarReader::Entry
   # Full name of the tar entry
 
   def full_name
-    if @header.prefix != ""
-      File.join @header.prefix, @header.name
-    else
-      @header.name
-    end
+    @header.full_name.force_encoding(Encoding::UTF_8)
   rescue ArgumentError => e
     raise unless e.message == "string contains null byte"
     raise Gem::Package::TarInvalidError,


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If Bundler is configured to install gems to a folder with a name including UTF-8 characters, and the gem package being installed includes files with UTF-8 characters in the name, Bundler will end up crashing with a "incompatible encodings error".

## What is your fix for the problem, implemented in this PR?

The problem is that file names in `.gem` packages have ASCII encoding, which cause this error when joining the file name with the UTF-8 installation folder.

Casting the file names in the package to UTF-8 seems to fix the problem.

Fixes #6538.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
