### PR TITLE
[SpecFetcher] If candidates include {name}-ruby or ruby-{name}, recommend those.

### DIFF
--- a/test/rubygems/test_gem_spec_fetcher.rb
+++ b/test/rubygems/test_gem_spec_fetcher.rb
@@ -199,6 +199,33 @@ class TestGemSpecFetcher < Gem::TestCase
     assert_equal ["example"], suggestions
   end
 
+  def test_suggest_gems_from_name_prefix_or_suffix
+    spec_fetcher do|fetcher|
+      fetcher.spec "example-one-ruby", 1
+      fetcher.spec "example-one-rrrr", 1
+      fetcher.spec "ruby-example-two", 1
+      fetcher.spec "rrrr-example-two", 1
+    end
+
+    suggestions = @sf.suggest_gems_from_name("example-one")
+    assert_equal ["example-one-ruby"], suggestions
+
+    suggestions = @sf.suggest_gems_from_name("example-two")
+    assert_equal ["ruby-example-two"], suggestions
+
+    suggestions = @sf.suggest_gems_from_name("exampleone")
+    assert_equal ["example-one-ruby"], suggestions
+
+    suggestions = @sf.suggest_gems_from_name("exampletwo")
+    assert_equal ["ruby-example-two"], suggestions
+
+    suggestions = @sf.suggest_gems_from_name("example---one")
+    assert_equal ["example-one-ruby"], suggestions
+
+    suggestions = @sf.suggest_gems_from_name("example---two")
+    assert_equal ["ruby-example-two"], suggestions
+  end
+
   def test_available_specs_latest
     spec_fetcher do |fetcher|
       fetcher.spec "a", 1


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

The recent work in #8083 made most results better, but lost recommendations like recommending "taglib-ruby" as an option for "taglib".

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

I made `suggest_gems_from_name` check if a name matches `#{gem_name}-ruby` or `ruby-#{gem_name}` and, if it does, offers it as a suggestion.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
