### PR TITLE
Fix welcome bot link to the contributing guide

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -5,4 +5,4 @@ newPRWelcomeComment: |
 
   If you have any questions or concerns that you wish to ask, feel free to leave a comment in this PR or join our #rubygems or #bundler channel on [Slack](http://slack.bundler.io/).
 
-  For more information about contributing to the RubyGems project feel free to review our [CONTRIBUTING](https://github.com/rubygems/rubygems/blob/master/CONTRIBUTING.md) guide
+  For more information about contributing to the RubyGems project feel free to review our [CONTRIBUTING](https://github.com/rubygems/rubygems/blob/master/doc/rubygems/CONTRIBUTING.md) guide


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`CONTRIBUTING.md` was moved in PR https://github.com/rubygems/rubygems/pull/8159, but the welcome bot is [linking](https://github.com/rubygems/rubygems/pull/8198#issuecomment-2451616113) to the old path.

## What is your fix for the problem, implemented in this PR?

Change `.github/config.yml` to use the new `doc/rubygems/CONTRIBUTING.md` path.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
