### PR TITLE
Fix manifest in gem package using incorrect platform sometimes

### DIFF
--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -438,6 +438,33 @@ class TestGemPackage < Gem::Package::TarTestCase
     assert_equal %w[lib/code.rb], reader.contents
   end
 
+  def test_build_modified_platform
+    spec = quick_gem "a", "1" do |s|
+      s.files = %w[lib/code.rb]
+      s.platform = Gem::Platform.new "x86_64-linux"
+    end
+
+    spec.platform = Gem::Platform.new "java"
+
+    FileUtils.mkdir "lib"
+
+    File.open "lib/code.rb", "w" do |io|
+      io.write "# lib/code.rb"
+    end
+
+    package = Gem::Package.new spec.file_name
+    package.spec = spec
+
+    package.build
+
+    assert_path_exist spec.file_name
+
+    reader = Gem::Package.new spec.file_name
+    assert reader.verify
+
+    assert_equal spec, reader.spec
+  end
+
   def test_raw_spec
     data_tgz = util_tar_gz {}
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If a gem package is built from a specification whose platform has been modified, it will include metadata using the old platform.

## What is your fix for the problem, implemented in this PR?

This change should fix the problem by making sure `original_platform` is always properly set.

Fixes #6056.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
