### PR TITLE
Changelogs for RubyGems 3.5.23 and Bundler 2.5.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,37 @@
+# 3.5.23 / 2024-11-05
+
+## Enhancements:
+
+* Validate user input encoding of `gem` CLI arguments. Pull request
+  [#6471](https://github.com/rubygems/rubygems/pull/6471) by
+  deivid-rodriguez
+* Fix `gem update --system` leaving old default bundler executables
+  around. Pull request
+  [#8172](https://github.com/rubygems/rubygems/pull/8172) by
+  deivid-rodriguez
+* Installs bundler 2.5.23 as a default gem.
+
+## Bug fixes:
+
+* Fix commands with 2 MFA requests when webauthn is enabled. Pull request
+  [#8174](https://github.com/rubygems/rubygems/pull/8174) by
+  deivid-rodriguez
+* Make `--enable-load-relative` binstubs prolog work when Ruby is not
+  installed in the same directory as the binstub. Pull request
+  [#7872](https://github.com/rubygems/rubygems/pull/7872) by
+  deivid-rodriguez
+
+## Performance:
+
+* Speed up `gem install <nonexistent-gem>` by finding alternative name
+  suggestions faster. Pull request
+  [#8084](https://github.com/rubygems/rubygems/pull/8084) by duckinator
+
+## Documentation:
+
+* Add missing comma in documentation. Pull request
+  [#8152](https://github.com/rubygems/rubygems/pull/8152) by leoarnold
+
 # 3.5.22 / 2024-10-16
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,27 @@
+# 2.5.23 (November 5, 2024)
+
+## Enhancements:
+
+  - Add useful error message for plugin load [#7639](https://github.com/rubygems/rubygems/pull/7639)
+  - Indent github workflow steps for generated gems [#8193](https://github.com/rubygems/rubygems/pull/8193)
+  - Improve several permission errors [#8168](https://github.com/rubygems/rubygems/pull/8168)
+  - Add `bundle add` `--quiet` option [#8157](https://github.com/rubygems/rubygems/pull/8157)
+
+## Bug fixes:
+
+  - Fix incompatible encodings error when paths with UTF-8 characters are involved [#8196](https://github.com/rubygems/rubygems/pull/8196)
+  - Update `--ext=rust` to support compiling the native extension from source [#7610](https://github.com/rubygems/rubygems/pull/7610)
+  - Print a proper error when there's a previous empty installation path with bad permissions [#8169](https://github.com/rubygems/rubygems/pull/8169)
+  - Fix running `bundler` (with a final `r`) in a `bundle exec` context [#8165](https://github.com/rubygems/rubygems/pull/8165)
+  - Handle two `gemspec` usages in same Gemfile with same dep and compatible requirements [#7999](https://github.com/rubygems/rubygems/pull/7999)
+  - Fix `bundle check` sometimes locking gems under the wrong source [#8148](https://github.com/rubygems/rubygems/pull/8148)
+
+## Documentation:
+
+  - Remove confusing `bundle config` documentation [#8177](https://github.com/rubygems/rubygems/pull/8177)
+  - Rename bundler inline's `install` parameter and clarify docs [#8170](https://github.com/rubygems/rubygems/pull/8170)
+  - Clarify `bundle install --quiet` documentation [#8163](https://github.com/rubygems/rubygems/pull/8163)
+
 # 2.5.22 (October 16, 2024)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.5.23 and Bundler 2.5.23 into master.