### PR TITLE
Cancel deprecation of Gemfiles without a global source

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -594,10 +594,20 @@ module Bundler
         missing_specs.each do |s|
           locked_gem = @locked_specs[s.name].last
           next if locked_gem.nil? || locked_gem.version != s.version || sources.local_mode?
-          raise GemNotFound, "Your bundle is locked to #{locked_gem} from #{locked_gem.source}, but that version can " \
-                             "no longer be found in that source. That means the author of #{locked_gem} has removed it. " \
-                             "You'll need to update your bundle to a version other than #{locked_gem} that hasn't been " \
-                             "removed in order to install."
+
+          message = if sources.implicit_global_source?
+            "Because your Gemfile specifies no global remote source, your bundle is locked to " \
+            "#{locked_gem} from #{locked_gem.source}. However, #{locked_gem} is not installed. You'll " \
+            "need to either add a global remote source to your Gemfile or make sure #{locked_gem} is " \
+            "available locally before rerunning Bundler."
+          else
+            "Your bundle is locked to #{locked_gem} from #{locked_gem.source}, but that version can " \
+            "no longer be found in that source. That means the author of #{locked_gem} has removed it. " \
+            "You'll need to update your bundle to a version other than #{locked_gem} that hasn't been " \
+            "removed in order to install."
+          end
+
+          raise GemNotFound, message
         end
 
         missing_specs_list = missing_specs.group_by(&:source).map do |source, missing_specs_for_source|

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -503,18 +503,7 @@ module Bundler
     end
 
     def check_rubygems_source_safety
-      if @sources.implicit_global_source?
-        implicit_global_source_warning
-      elsif @sources.aggregate_global_source?
-        multiple_global_source_warning
-      end
-    end
-
-    def implicit_global_source_warning
-      Bundler::SharedHelpers.major_deprecation 2, "This Gemfile does not include an explicit global source. " \
-        "Not using an explicit global source may result in a different lockfile being generated depending on " \
-        "the gems you have installed locally before bundler is run. " \
-        "Instead, define a global source in your Gemfile like this: source \"https://rubygems.org\"."
+      multiple_global_source_warning if @sources.aggregate_global_source?
     end
 
     def multiple_global_source_warning

--- a/bundler/spec/bundler/dsl_spec.rb
+++ b/bundler/spec/bundler/dsl_spec.rb
@@ -350,21 +350,4 @@ RSpec.describe Bundler::Dsl do
       end
     end
   end
-
-  describe "#check_primary_source_safety" do
-    context "when a global source is not defined implicitly" do
-      it "will raise a major deprecation warning" do
-        not_a_global_source = double("not-a-global-source", no_remotes?: true)
-        allow(Bundler::Source::Rubygems).to receive(:new).and_return(not_a_global_source)
-
-        warning = "This Gemfile does not include an explicit global source. " \
-          "Not using an explicit global source may result in a different lockfile being generated depending on " \
-          "the gems you have installed locally before bundler is run. " \
-          "Instead, define a global source in your Gemfile like this: source \"https://rubygems.org\"."
-        expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(2, warning)
-
-        subject.check_primary_source_safety
-      end
-    end
-  end
 end


### PR DESCRIPTION



## What was the end-user or developer problem that led to this PR?

After having a second look at this deprecation, the explanation that we're giving does not make a lot of sense. When working only with local gems, Bundler will indeed generate a different lockfile depending on what the latest installed version of each gem is at `bundle install` time.
    
That's the same situation that happens with remote sources: Bundler will generate a different lockfile depending on the latest version of each gem available remotely.
    
So, I don't think "a consistent lockfile not getting generated" is a good motivation for deprecating this.
    
Also, this deprecation brings additional challenges, since for example, it should arguably not get printed when using `bundle install --local`?
    
The original problem when this deprecation was introduced was an incorrect message about a missing gem having been yanked. See https://github.com/rubygems/rubygems/issues/4757.

## What is your fix for the problem, implemented in this PR?

As long as we give proper error messages when things go wrong, let users do what's best for them and move on.

Fixes #8212.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
