### PR TITLE
Add a `lockfile_checksums` configuration to include checksums in fresh lockfiles

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -117,7 +117,7 @@ module Bundler
         @originally_locked_specs = @locked_specs
         @locked_sources = []
         @locked_platforms = []
-        @locked_checksums = Bundler.feature_flag.bundler_3_mode?
+        @locked_checksums = Bundler.feature_flag.lockfile_checksums?
       end
 
       locked_gem_sources = @locked_sources.select {|s| s.is_a?(Source::Rubygems) }

--- a/bundler/lib/bundler/feature_flag.rb
+++ b/bundler/lib/bundler/feature_flag.rb
@@ -33,6 +33,7 @@ module Bundler
     settings_flag(:default_install_uses_path) { bundler_3_mode? }
     settings_flag(:forget_cli_options) { bundler_3_mode? }
     settings_flag(:global_gem_cache) { bundler_3_mode? }
+    settings_flag(:lockfile_checksums) { bundler_3_mode? }
     settings_flag(:path_relative_to_cwd) { bundler_3_mode? }
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }
     settings_flag(:print_only_version_number) { bundler_3_mode? }

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -149,6 +149,8 @@ The following is a list of all configuration keys and their purpose\. You can le
 .IP "\(bu" 4
 \fBjobs\fR (\fBBUNDLE_JOBS\fR): The number of gems Bundler can install in parallel\. Defaults to the number of available processors\.
 .IP "\(bu" 4
+\fBlockfile_checksums\fR (\fBBUNDLE_LOCKFILE_CHECKSUMS\fR): Whether Bundler should include a checksums section in new lockfiles, to protect from compromised gem sources\.
+.IP "\(bu" 4
 \fBno_install\fR (\fBBUNDLE_NO_INSTALL\fR): Whether \fBbundle package\fR should skip installing gems\.
 .IP "\(bu" 4
 \fBno_prune\fR (\fBBUNDLE_NO_PRUNE\fR): Whether Bundler should leave outdated gems unpruned when caching\.

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -217,6 +217,8 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
 * `jobs` (`BUNDLE_JOBS`):
    The number of gems Bundler can install in parallel. Defaults to the number of
    available processors.
+* `lockfile_checksums` (`BUNDLE_LOCKFILE_CHECKSUMS`):
+   Whether Bundler should include a checksums section in new lockfiles, to protect from compromised gem sources.
 * `no_install` (`BUNDLE_NO_INSTALL`):
    Whether `bundle package` should skip installing gems.
 * `no_prune` (`BUNDLE_NO_PRUNE`):

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -32,6 +32,7 @@ module Bundler
       ignore_messages
       init_gems_rb
       inline
+      lockfile_checksums
       no_install
       no_prune
       path_relative_to_cwd


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

There's no easy way to enable the lockfile checksums feature.

## What is your fix for the problem, implemented in this PR?

I plan to add two ways to opt in to the feature:

* A setting `lockfile_checksums` that controls whether new lockfiles include checksums or not.
* An `--add-checksums` flag to bundle lock to add checksums to an existing lockfile.

This PR implements the former. The latter is implemented by https://github.com/rubygems/rubygems/pull/8214.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
