### PR TITLE
Fix private registry credentials being written to logs

### DIFF
--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -393,7 +393,9 @@ module Bundler
     def download_gem(spec, uri, cache_dir, fetcher)
       require "rubygems/remote_fetcher"
       uri = Bundler.settings.mirror_for(uri)
-      Bundler::Retry.new("download gem from #{uri}").attempts do
+      redacted_uri = Gem::Uri.redact(uri)
+
+      Bundler::Retry.new("download gem from #{redacted_uri}").attempts do
         gem_file_name = spec.file_name
         local_gem_path = File.join cache_dir, gem_file_name
         return if File.exist? local_gem_path
@@ -415,7 +417,7 @@ module Bundler
         end
       end
     rescue Gem::RemoteFetcher::FetchError => e
-      raise Bundler::HTTPError, "Could not download gem from #{uri} due to underlying error <#{e.message}>"
+      raise Bundler::HTTPError, "Could not download gem from #{redacted_uri} due to underlying error <#{e.message}>"
     end
 
     def build(spec, skip_validation = false)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Private registry credentials are written to logs when Bundler runs into errors.

## What is your fix for the problem, implemented in this PR?

Redact credentials before printing it to logs.

Fixes #5281.
Supersedes #5292.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
