### PR TITLE
Fix daily Bundler CI

### DIFF
--- a/bundler/spec/commands/viz_spec.rb
+++ b/bundler/spec/commands/viz_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "bundle viz", bundler: "< 3", if: Bundler.which("dot"), realworld: true do
+RSpec.describe "bundle viz", bundler: "< 3", if: Bundler.which("dot") do
   before do
     realworld_system_gems "ruby-graphviz --version 1.2.5"
   end

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -87,8 +87,6 @@ RSpec.configure do |config|
     # Don't wrap output in tests
     ENV["THOR_COLUMNS"] = "10000"
 
-    Spec::Helpers.install_dev_bundler unless ENV["CI"]
-
     extend(Spec::Builders)
 
     check_test_gems!

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -235,10 +235,6 @@ module Spec
         FileUtils.rm_rf(base_system_gems)
         Spec::Rubygems.install_test_deps
       end
-
-      if rake_path.nil?
-        abort "Your test gems are missing! Run `rm -rf #{tmp}` and try again."
-      end
     end
 
     def update_repo(path, build_compact_index: true)

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -235,6 +235,8 @@ module Spec
         FileUtils.rm_rf(base_system_gems)
         Spec::Rubygems.install_test_deps
       end
+
+      Helpers.install_dev_bundler unless pristine_system_gem_path.exist?
     end
 
     def update_repo(path, build_compact_index: true)

--- a/tool/bundler/test_gems.rb.lock
+++ b/tool/bundler/test_gems.rb.lock
@@ -6,7 +6,7 @@ GEM
     compact_index (0.15.0)
     mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
-    rack (3.1.7)
+    rack (3.1.8)
     rack-protection (4.0.0)
       base64 (>= 0.1.0)
       rack (>= 3.0.0, < 4)
@@ -57,7 +57,7 @@ CHECKSUMS
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   compact_index (0.15.0) sha256=5c6c404afca8928a7d9f4dde9524f6e1610db17e675330803055db282da84a8b
   mustermann (3.0.3) sha256=d1f8e9ba2ddaed47150ddf81f6a7ea046826b64c672fbc92d83bce6b70657e88
-  rack (3.1.7) sha256=0e9982db4ea9013326788ca2a7f48e32a4e746765e7c3512d424ef0dd22ae58b
+  rack (3.1.8) sha256=d3fbcbca43dc2b43c9c6d7dfbac01667ae58643c42cea10013d0da970218a1b1
   rack-protection (4.0.0) sha256=d0db6185caa46a8c0d134c2c6b4803f4f392a67b2984da311409cb505f67bbf6
   rack-session (2.0.0) sha256=db04b2063e180369192a9046b4559af311990af38c6a93d4c600cee4eb6d4e81
   rack-test (2.1.0) sha256=0c61fc61904049d691922ea4bb99e28004ed3f43aa5cfd495024cc345f125dfb


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Our daily CI has been broken for a while.

## What is your fix for the problem, implemented in this PR?

Turns out I broke `bin/rake spec:all`, most likely in c194a1d753ebb65634a292660e80940e33767631.

Only daily CI runs this task, that's why it was not detected back then.

I left one last commit to enable the daily CI to proof that it's fixed, but I'll remove it before merge.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
