### PR TITLE
Include original error when openssl fails to load

### DIFF
--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -738,14 +738,14 @@ RSpec.describe "compact index api" do
       end
     end
 
-    it "explains what to do to get it" do
+    it "explains what to do to get it, and includes original error" do
       gemfile <<-G
         source "#{source_uri.gsub(/http/, "https")}"
         gem "myrack"
       G
 
       bundle :install, env: { "RUBYOPT" => opt_add("-I#{bundled_app("broken_ssl")}", ENV["RUBYOPT"]) }, raise_on_error: false, artifice: nil
-      expect(err).to include("OpenSSL")
+      expect(err).to include("recompile Ruby").and include("cannot load such file")
     end
   end
 

--- a/bundler/spec/install/gems/dependency_api_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_spec.rb
@@ -707,14 +707,14 @@ RSpec.describe "gemcutter's dependency API" do
       end
     end
 
-    it "explains what to do to get it" do
+    it "explains what to do to get it, and includes original error" do
       gemfile <<-G
         source "#{source_uri.gsub(/http/, "https")}"
         gem "myrack"
       G
 
       bundle :install, artifice: "fail", env: { "RUBYOPT" => opt_add("-I#{bundled_app("broken_ssl")}", ENV["RUBYOPT"]) }, raise_on_error: false
-      expect(err).to include("OpenSSL")
+      expect(err).to include("recompile Ruby").and include("cannot load such file")
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Current error does not help debugging situations where openssl fails to load.

## What is your fix for the problem, implemented in this PR?

Include original error in the message.

Fixes #8229.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
