### PR TITLE
Use `Set` for large array calling `includes?`

### DIFF
--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -6,43 +6,43 @@ module Bundler
     autoload :Mirrors, File.expand_path("mirror", __dir__)
     autoload :Validator, File.expand_path("settings/validator", __dir__)
 
-    BOOL_KEYS = %w[
-      allow_offline_install
-      auto_clean_without_path
-      auto_install
-      cache_all
-      cache_all_platforms
-      clean
-      default_install_uses_path
-      deployment
-      disable_checksum_validation
-      disable_exec_load
-      disable_local_branch_check
-      disable_local_revision_check
-      disable_shared_gems
-      disable_version_check
-      force_ruby_platform
-      forget_cli_options
-      frozen
-      gem.changelog
-      gem.coc
-      gem.mit
-      git.allow_insecure
-      global_gem_cache
-      ignore_messages
-      init_gems_rb
-      inline
-      no_install
-      no_prune
-      path_relative_to_cwd
-      path.system
-      plugins
-      prefer_patch
-      print_only_version_number
-      setup_makes_kernel_gem_public
-      silence_deprecations
-      silence_root_warning
-      update_requires_all_flag
+    BOOL_KEYS = Set[
+      'allow_offline_install',
+      'auto_clean_without_path',
+      'auto_install',
+      'cache_all',
+      'cache_all_platforms',
+      'clean',
+      'default_install_uses_path',
+      'deployment',
+      'disable_checksum_validation',
+      'disable_exec_load',
+      'disable_local_branch_check',
+      'disable_local_revision_check',
+      'disable_shared_gems',
+      'disable_version_check',
+      'force_ruby_platform',
+      'forget_cli_options',
+      'frozen',
+      'gem.changelog',
+      'gem.coc',
+      'gem.mit',
+      'git.allow_insecure',
+      'global_gem_cache',
+      'ignore_messages',
+      'init_gems_rb',
+      'inline',
+      'no_install',
+      'no_prune',
+      'path_relative_to_cwd',
+      'path.system',
+      'plugins',
+      'prefer_patch',
+      'print_only_version_number',
+      'setup_makes_kernel_gem_public',
+      'silence_deprecations',
+      'silence_root_warning',
+      'update_requires_all_flag'
     ].freeze
 
     REMEMBERED_KEYS = %w[


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?
Array#includes? is much slower than Set#includes?

<!-- Write a clear and complete description of the problem -->

We instantiate a Set for a large example Array. 

This was pointed out on Ruby Core discussion group:
https://bugs.ruby-lang.org/issues/16989

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Perhaps we need to wait until March to release this sort of change, unless we want to explicitly `require 'set'`
https://endoflife.date/ruby

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
