### PR TITLE
Track the latest version of URI gem

### DIFF
--- a/bundler/spec/install/gems/dependency_api_fallback_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_fallback_spec.rb
@@ -12,9 +12,6 @@ RSpec.describe "gemcutter's dependency API" do
 
       require_relative "../../support/artifice/endpoint_timeout"
 
-      # mustermann depends on URI::RFC2396_PARSER behavior
-      URI.parser = URI::RFC2396_PARSER if URI.respond_to?(:parser=)
-
       require "rackup/server"
 
       @t = Thread.new do
@@ -36,8 +33,6 @@ RSpec.describe "gemcutter's dependency API" do
       Artifice.deactivate
       @t.kill
       @t.join
-
-      URI.parser = URI::DEFAULT_PARSER if URI.respond_to?(:parser=)
     end
 
     it "times out and falls back on the modern index" do

--- a/lib/rubygems/uri.rb
+++ b/lib/rubygems/uri.rb
@@ -30,7 +30,7 @@ class Gem::Uri
     begin
       Gem::URI.parse(uri)
     rescue Gem::URI::InvalidURIError
-      Gem::URI.parse(Gem::URI::DEFAULT_PARSER.escape(uri))
+      Gem::URI.parse(Gem::URI::RFC2396_PARSER.escape(uri))
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

https://github.com/rubygems/rubygems/pull/7878 is resolved by the latest version of `mustermann` and `URI` gem. And `URI::DEFAULT_PARSER.escape` is obsoleted with the latest version of `URI`.

## What is your fix for the problem, implemented in this PR?

Revert my workaround and suppress warning of `URI`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
