### PR TITLE
Allocate strings from Requirement match only once

### DIFF
--- a/lib/rubygems/requirement.rb
+++ b/lib/rubygems/requirement.rb
@@ -106,13 +106,15 @@ class Gem::Requirement
     unless PATTERN =~ obj.to_s
       raise BadRequirementError, "Illformed requirement [#{obj.inspect}]"
     end
+    op = -($1 || "=")
+    version = -$2
 
-    if $1 == ">=" && $2 == "0"
+    if op == ">=" && version == "0"
       DefaultRequirement
-    elsif $1 == ">=" && $2 == "0.a"
+    elsif op == ">=" && version == "0.a"
       DefaultPrereleaseRequirement
     else
-      [-($1 || "="), Gem::Version.new($2)]
+      [op, Gem::Version.new(version)]
     end
   end
 


### PR DESCRIPTION
Also lazily parse dependencies in EndpointSpecification, since not every dependency gets referenced

Signed-off-by: Samuel Giddins <segiddins@segiddins.me>

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)