### PR TITLE
Update test_project_sanity.rb

### DIFF
--- a/test/rubygems/test_project_sanity.rb
+++ b/test/rubygems/test_project_sanity.rb
@@ -12,25 +12,26 @@ class TestGemProjectSanity < Gem::TestCase
 
   def test_manifest_is_up_to_date
     pend unless File.exist?("#{root}/Rakefile")
+    rake = "#{root}/bin/rake"
 
-    _, status = Open3.capture2e("rake check_manifest")
+    _, status = Open3.capture2e(rake, "check_manifest")
 
     unless status.success?
       original_contents = File.read("#{root}/Manifest.txt")
 
       # Update the manifest to see if it fixes the problem
-      Open3.capture2e("rake update_manifest")
+      Open3.capture2e(rake, "update_manifest")
 
-      out, status = Open3.capture2e("rake check_manifest")
+      out, status = Open3.capture2e(rake, "check_manifest")
 
       # If `rake update_manifest` fixed the problem, that was the original
       # issue, otherwise it was an unknown error, so print the error output
       if status.success?
         File.write("#{root}/Manifest.txt", original_contents)
 
-        raise "Expected Manifest.txt to be up to date, but it's not. Run `rake update_manifest` to sync it."
+        raise "Expected Manifest.txt to be up to date, but it's not. Run `bin/rake update_manifest` to sync it."
       else
-        raise "There was an error running `rake check_manifest`: #{out}"
+        raise "There was an error running `bin/rake check_manifest`: #{out}"
       end
     end
   end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?
We were getting this error when running `bin/rake test`

```bash
rubygems/test/rubygems/test_project_sanity.rb:33:in `test_manifest_is_up_to_date'
     30:
     31:         raise "Expected Manifest.txt to be up to date, but it's not. Run `rake update_manifest` to sync it."
     32:       else
  => 33:         raise "There was an error running `rake check_manifest`: #{out}"
     34:       end
     35:     end
     36:   end
```

## What is your fix for the problem, implemented in this PR?
This is a patch for the new developer local dev experience developed by @segiddins 

We update both the runner and the instructions to the user to use `bin/rake` for `check_manifest`

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
