### PR TITLE
Remove override of worker jobs for `bundle install --local`

### DIFF
--- a/bundler/lib/bundler/cli/pristine.rb
+++ b/bundler/lib/bundler/cli/pristine.rb
@@ -49,7 +49,7 @@ module Bundler
           true
         end.map(&:name)
 
-        jobs = installer.send(:installation_parallelization, {})
+        jobs = installer.send(:installation_parallelization)
         pristine_count = definition.specs.count - installed_specs.count
         # allow a pristining a single gem to skip the parallel worker
         jobs = [jobs, pristine_count].min

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -503,6 +503,10 @@ module Bundler
         !@locked_spec_with_invalid_deps
     end
 
+    def no_install_needed?
+      no_resolve_needed? && !missing_specs?
+    end
+
     def no_resolve_needed?
       !unlocking? && nothing_changed?
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bundle install --local` installs all gems serially currently. 
But there seems to be no reason why the install should be serial for --local. The packages are still installed in the right dependency order in the local case, so that parallel install can be used. This is most notable when installing gems with C extensions by a shorter install time.

A secondary problem is that I want to set up a test case for RubyInstaller for an [issue related to parallel gem installation by bundler](https://github.com/oneclick/rubyinstaller2/issues/397). To reproduce and test the fix I want use `bundle install --local` in order to install 2 local only test gem files for test purpose, but can't trigger the issue, due to the serialization of gem installs. The problem happens only when running without `--local`.

## What is your fix for the problem, implemented in this PR?

The PR removes the override of number of jobs to 1. It also removes the `option` argument, which is effectively not used.

I tried some rails and a test project to verify that `bundle --local` works correctly and in parallel.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
