### PR TITLE
Improve working with different rubies using the same lockfile

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -155,6 +155,7 @@ bundler/lib/bundler/man/index.txt
 bundler/lib/bundler/match_metadata.rb
 bundler/lib/bundler/match_platform.rb
 bundler/lib/bundler/match_remote_metadata.rb
+bundler/lib/bundler/materialization.rb
 bundler/lib/bundler/mirror.rb
 bundler/lib/bundler/plugin.rb
 bundler/lib/bundler/plugin/api.rb

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -62,6 +62,7 @@ module Bundler
   autoload :LazySpecification,      File.expand_path("bundler/lazy_specification", __dir__)
   autoload :LockfileParser,         File.expand_path("bundler/lockfile_parser", __dir__)
   autoload :MatchRemoteMetadata,    File.expand_path("bundler/match_remote_metadata", __dir__)
+  autoload :Materialization,        File.expand_path("bundler/materialization", __dir__)
   autoload :NULL,                   File.expand_path("bundler/constants", __dir__)
   autoload :ProcessLock,            File.expand_path("bundler/process_lock", __dir__)
   autoload :RemoteSpecification,    File.expand_path("bundler/remote_specification", __dir__)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -152,7 +152,7 @@ module Bundler
         @gems_to_unlock = @explicit_unlocks.any? ? @explicit_unlocks : @dependencies.map(&:name)
       else
         eager_unlock = @explicit_unlocks.map {|name| Dependency.new(name, ">= 0") }
-        @gems_to_unlock = @locked_specs.for(eager_unlock, false, platforms).map(&:name).uniq
+        @gems_to_unlock = @locked_specs.for(eager_unlock, platforms).map(&:name).uniq
       end
 
       @dependency_changes = converge_dependencies
@@ -495,7 +495,7 @@ module Bundler
     def normalize_platforms
       @platforms = resolve.normalize_platforms!(current_dependencies, platforms)
 
-      @resolve = SpecSet.new(resolve.for(current_dependencies, false, @platforms))
+      @resolve = SpecSet.new(resolve.for(current_dependencies, @platforms))
     end
 
     def add_platform(platform)
@@ -620,7 +620,7 @@ module Bundler
     end
 
     def filter_specs(specs, deps)
-      SpecSet.new(specs).for(deps, false, platforms)
+      SpecSet.new(specs).for(deps, platforms)
     end
 
     def materialize(dependencies)
@@ -726,7 +726,7 @@ module Bundler
 
       @platforms = result.add_extra_platforms!(platforms) if should_add_extra_platforms?
 
-      SpecSet.new(result.for(dependencies, false, @platforms))
+      SpecSet.new(result.for(dependencies, @platforms))
     end
 
     def precompute_source_requirements_for_indirect_dependencies?

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -998,7 +998,7 @@ module Bundler
         if source.instance_of?(Source::Path) || source.instance_of?(Source::Gemspec) || (source.instance_of?(Source::Git) && !@gems_to_unlock.include?(name) && deps.include?(dep))
           new_spec = source.specs[s].first
           if new_spec
-            s.dependencies.replace(new_spec.dependencies)
+            s.runtime_dependencies.replace(new_spec.runtime_dependencies)
           else
             # If the spec is no longer in the path source, unlock it. This
             # commonly happens if the version changed in the gemspec

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -241,7 +241,7 @@ module Bundler
     end
 
     def missing_specs
-      resolve.materialize(requested_dependencies).missing_specs
+      resolve.missing_specs_for(requested_dependencies)
     end
 
     def missing_specs?
@@ -639,7 +639,7 @@ module Bundler
         retry
       end
 
-      missing_specs = specs.missing_specs
+      missing_specs = resolve.missing_specs
 
       if missing_specs.any?
         missing_specs.each do |s|
@@ -668,7 +668,7 @@ module Bundler
         raise GemNotFound, "Could not find #{missing_specs_list.join(" nor ")}"
       end
 
-      incomplete_specs = specs.incomplete_specs
+      incomplete_specs = resolve.incomplete_specs
       loop do
         break if incomplete_specs.empty?
 
@@ -677,7 +677,7 @@ module Bundler
         reresolve_without(incomplete_specs)
         specs = resolve.materialize(dependencies)
 
-        still_incomplete_specs = specs.incomplete_specs
+        still_incomplete_specs = resolve.incomplete_specs
 
         if still_incomplete_specs == incomplete_specs
           package = resolution_packages.get_package(incomplete_specs.first.name)
@@ -687,7 +687,7 @@ module Bundler
         incomplete_specs = still_incomplete_specs
       end
 
-      insecurely_materialized_specs = specs.insecurely_materialized_specs
+      insecurely_materialized_specs = resolve.insecurely_materialized_specs
 
       if insecurely_materialized_specs.any?
         Bundler.ui.warn "The following platform specific gems are getting installed, yet the lockfile includes only their generic ruby version:\n" \

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -511,7 +511,7 @@ module Bundler
     end
 
     def most_specific_locked_platform
-      @platforms.min_by do |bundle_platform|
+      @locked_platforms.min_by do |bundle_platform|
         platform_specificity_match(bundle_platform, local_platform)
       end
     end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -668,6 +668,14 @@ module Bundler
         raise GemNotFound, "Could not find #{missing_specs_list.join(" nor ")}"
       end
 
+      partially_missing_specs = resolve.partially_missing_specs
+
+      if partially_missing_specs.any? && !sources.local_mode?
+        Bundler.ui.warn "Some locked specs have possibly been yanked (#{partially_missing_specs.map(&:full_name).join(", ")}). Ignoring them..."
+
+        resolve.delete(partially_missing_specs)
+      end
+
       incomplete_specs = resolve.incomplete_specs
       loop do
         break if incomplete_specs.empty?

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -108,14 +108,14 @@ module Bundler
         end
       else
         @unlock         = {}
-        @platforms      = []
         @locked_gems    = nil
+        @locked_platforms = []
+        @platforms      = []
         @locked_deps    = {}
         @locked_specs   = SpecSet.new([])
         @originally_locked_deps = {}
         @originally_locked_specs = @locked_specs
         @locked_sources = []
-        @locked_platforms = []
         @locked_checksums = Bundler.feature_flag.lockfile_checksums?
       end
 

--- a/bundler/lib/bundler/gem_helpers.rb
+++ b/bundler/lib/bundler/gem_helpers.rb
@@ -68,6 +68,8 @@ module Bundler
     module_function :select_best_local_platform_match
 
     def sort_best_platform_match(matching, platform)
+      return matching if matching.one?
+
       exact = matching.select {|spec| spec.platform == platform }
       return exact if exact.any?
 

--- a/bundler/lib/bundler/gem_helpers.rb
+++ b/bundler/lib/bundler/gem_helpers.rb
@@ -63,7 +63,7 @@ module Bundler
     module_function :select_best_platform_match
 
     def select_best_local_platform_match(specs, force_ruby: false)
-      select_best_platform_match(specs, local_platform, force_ruby: force_ruby).filter_map(&:materialize_for_installation)
+      select_best_platform_match(specs, local_platform, force_ruby: force_ruby).filter_map(&:materialized_for_installation)
     end
     module_function :select_best_local_platform_match
 

--- a/bundler/lib/bundler/gem_helpers.rb
+++ b/bundler/lib/bundler/gem_helpers.rb
@@ -62,8 +62,8 @@ module Bundler
     end
     module_function :select_best_platform_match
 
-    def select_best_local_platform_match(specs, force_ruby: false, most_specific_locked_platform: nil)
-      select_best_platform_match(specs, local_platform, force_ruby: force_ruby).filter_map {|spec| spec.materialize_for_installation(most_specific_locked_platform) }
+    def select_best_local_platform_match(specs, force_ruby: false)
+      select_best_platform_match(specs, local_platform, force_ruby: force_ruby).filter_map(&:materialize_for_installation)
     end
     module_function :select_best_local_platform_match
 

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -27,7 +27,7 @@ module Bundler
 
     def self.from_spec(s)
       lazy_spec = new(s.name, s.version, s.platform, s.source)
-      lazy_spec.dependencies = s.dependencies
+      lazy_spec.dependencies = s.runtime_dependencies
       lazy_spec.required_ruby_version = s.required_ruby_version
       lazy_spec.required_rubygems_version = s.required_rubygems_version
       lazy_spec

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -11,6 +11,18 @@ module Bundler
     attr_reader :name, :version, :platform
     attr_accessor :source, :remote, :force_ruby_platform, :dependencies, :required_ruby_version, :required_rubygems_version
 
+    #
+    # For backwards compatibility with existing lockfiles, if the most specific
+    # locked platform is not a specific platform like x86_64-linux or
+    # universal-java-11, then we keep the previous behaviour of resolving the
+    # best platform variant at materiliazation time. For previous bundler
+    # versions (before 2.2.0) this was always the case (except when the lockfile
+    # only included non-ruby platforms), but we're also keeping this behaviour
+    # on newer bundlers unless users generate the lockfile from scratch or
+    # explicitly add a more specific platform.
+    #
+    attr_accessor :most_specific_locked_platform
+
     alias_method :runtime_dependencies, :dependencies
 
     def self.from_spec(s)
@@ -33,6 +45,7 @@ module Bundler
       @source = source
 
       @force_ruby_platform = default_force_ruby_platform
+      @most_specific_locked_platform = nil
     end
 
     def source_changed?
@@ -108,10 +121,10 @@ module Bundler
       __materialize__(matching_specs)
     end
 
-    def materialize_for_installation(most_specific_locked_platform = nil)
+    def materialize_for_installation
       source.local!
 
-      if use_exact_resolved_specifications?(most_specific_locked_platform)
+      if use_exact_resolved_specifications?
         materialize_strictly
       else
         matching_specs = source.specs.search([name, version])
@@ -180,21 +193,11 @@ module Bundler
 
     private
 
-    def use_exact_resolved_specifications?(most_specific_locked_platform)
-      !source.is_a?(Source::Path) && ruby_platform_materializes_to_ruby_platform?(most_specific_locked_platform)
+    def use_exact_resolved_specifications?
+      !source.is_a?(Source::Path) && ruby_platform_materializes_to_ruby_platform?
     end
 
-    #
-    # For backwards compatibility with existing lockfiles, if the most specific
-    # locked platform is not a specific platform like x86_64-linux or
-    # universal-java-11, then we keep the previous behaviour of resolving the
-    # best platform variant at materiliazation time. For previous bundler
-    # versions (before 2.2.0) this was always the case (except when the lockfile
-    # only included non-ruby platforms), but we're also keeping this behaviour
-    # on newer bundlers unless users generate the lockfile from scratch or
-    # explicitly add a more specific platform.
-    #
-    def ruby_platform_materializes_to_ruby_platform?(most_specific_locked_platform)
+    def ruby_platform_materializes_to_ruby_platform?
       generic_platform = generic_local_platform == Gem::Platform::JAVA ? Gem::Platform::JAVA : Gem::Platform::RUBY
 
       (most_specific_locked_platform != generic_platform) || force_ruby_platform || Bundler.settings[:force_ruby_platform]

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -8,7 +8,7 @@ module Bundler
     include MatchPlatform
     include ForcePlatform
 
-    attr_reader :name, :version, :platform
+    attr_reader :name, :version, :platform, :materialization
     attr_accessor :source, :remote, :force_ruby_platform, :dependencies, :required_ruby_version, :required_rubygems_version
 
     #
@@ -46,6 +46,15 @@ module Bundler
 
       @force_ruby_platform = default_force_ruby_platform
       @most_specific_locked_platform = nil
+      @materialization = nil
+    end
+
+    def missing?
+      @materialization == self
+    end
+
+    def incomplete?
+      @materialization.nil?
     end
 
     def source_changed?
@@ -119,6 +128,12 @@ module Bundler
       return self if matching_specs.empty?
 
       __materialize__(matching_specs)
+    end
+
+    def materialized_for_installation
+      @materialization = materialize_for_installation
+
+      self unless incomplete?
     end
 
     def materialize_for_installation

--- a/bundler/lib/bundler/materialization.rb
+++ b/bundler/lib/bundler/materialization.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Bundler
+  #
+  # This class materializes a set of resolved specifications (`LazySpecification`)
+  # for a given gem into the most appropriate real specifications
+  # (`StubSepecification`, `EndpointSpecification`, etc), given a dependency and a
+  # target platform.
+  #
+  class Materialization
+    def initialize(dep, platform, candidates:)
+      @dep = dep
+      @platform = platform
+      @candidates = candidates
+    end
+
+    def complete?
+      specs.any?
+    end
+
+    def specs
+      @specs ||= if @candidates.nil?
+        []
+      elsif platform
+        GemHelpers.select_best_platform_match(@candidates, platform, force_ruby: dep.force_ruby_platform)
+      else
+        GemHelpers.select_best_local_platform_match(@candidates, force_ruby: dep.force_ruby_platform || dep.default_force_ruby_platform)
+      end
+    end
+
+    def dependencies
+      specs.first.runtime_dependencies.map {|d| [d, platform] }
+    end
+
+    def materialized_spec
+      specs.first&.materialization
+    end
+
+    def missing_specs
+      specs.select(&:missing?)
+    end
+
+    def incomplete_specs
+      return [] if complete?
+
+      @candidates || LazySpecification.new(dep.name, nil, nil)
+    end
+
+    private
+
+    attr_reader :dep, :platform
+  end
+end

--- a/bundler/lib/bundler/materialization.rb
+++ b/bundler/lib/bundler/materialization.rb
@@ -33,10 +33,16 @@ module Bundler
     end
 
     def materialized_spec
-      specs.first&.materialization
+      specs.reject(&:missing?).first&.materialization
     end
 
-    def missing_specs
+    def completely_missing_specs
+      return [] unless specs.all?(&:missing?)
+
+      specs
+    end
+
+    def partially_missing_specs
       specs.select(&:missing?)
     end
 

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -80,8 +80,7 @@ module Bundler
     def solve_versions(root:, logger:)
       solver = PubGrub::VersionSolver.new(source: self, root: root, logger: logger)
       result = solver.solve
-      resolved_specs = result.flat_map {|package, version| version.to_specs(package, @most_specific_locked_platform) }
-      resolved_specs |= @base.specs_compatible_with(SpecSet.new(resolved_specs))
+      result.flat_map {|package, version| version.to_specs(package, @most_specific_locked_platform) }
     rescue PubGrub::SolveFailure => e
       incompatibility = e.incompatibility
 

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -15,10 +15,11 @@ module Bundler
 
     include GemHelpers
 
-    def initialize(base, gem_version_promoter)
+    def initialize(base, gem_version_promoter, most_specific_locked_platform = nil)
       @source_requirements = base.source_requirements
       @base = base
       @gem_version_promoter = gem_version_promoter
+      @most_specific_locked_platform = most_specific_locked_platform
     end
 
     def start
@@ -79,7 +80,7 @@ module Bundler
     def solve_versions(root:, logger:)
       solver = PubGrub::VersionSolver.new(source: self, root: root, logger: logger)
       result = solver.solve
-      resolved_specs = result.flat_map {|package, version| version.to_specs(package) }
+      resolved_specs = result.flat_map {|package, version| version.to_specs(package, @most_specific_locked_platform) }
       resolved_specs |= @base.specs_compatible_with(SpecSet.new(resolved_specs))
     rescue PubGrub::SolveFailure => e
       incompatibility = e.incompatibility

--- a/bundler/lib/bundler/resolver/base.rb
+++ b/bundler/lib/bundler/resolver/base.rb
@@ -30,10 +30,6 @@ module Bundler
         end
       end
 
-      def specs_compatible_with(result)
-        @base.specs_compatible_with(result)
-      end
-
       def [](name)
         @base[name]
       end

--- a/bundler/lib/bundler/resolver/candidate.rb
+++ b/bundler/lib/bundler/resolver/candidate.rb
@@ -34,10 +34,10 @@ module Bundler
         @spec_group.dependencies
       end
 
-      def to_specs(package)
+      def to_specs(package, most_specific_locked_platform)
         return [] if package.meta?
 
-        @spec_group.to_specs(package.force_ruby_platform?)
+        @spec_group.to_specs(package.force_ruby_platform?, most_specific_locked_platform)
       end
 
       def prerelease?

--- a/bundler/lib/bundler/resolver/spec_group.rb
+++ b/bundler/lib/bundler/resolver/spec_group.rb
@@ -25,10 +25,11 @@ module Bundler
         @source ||= exemplary_spec.source
       end
 
-      def to_specs(force_ruby_platform)
+      def to_specs(force_ruby_platform, most_specific_locked_platform)
         @specs.map do |s|
           lazy_spec = LazySpecification.from_spec(s)
           lazy_spec.force_ruby_platform = force_ruby_platform
+          lazy_spec.most_specific_locked_platform = most_specific_locked_platform
           lazy_spec
         end
       end

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -173,12 +173,6 @@ module Bundler
       @specs.detect {|spec| spec.name == name && spec.match_platform(platform) }
     end
 
-    def specs_compatible_with(other)
-      select do |spec|
-        other.valid?(spec)
-      end
-    end
-
     def delete_by_name(name)
       @specs.reject! {|spec| spec.name == name }
 

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -37,7 +37,6 @@ module Bundler
 
           specs_for_dep.first.dependencies.each do |d|
             next if d.type == :development
-            incomplete = true if d.name != "bundler" && lookup[d.name].nil?
             deps << [d, platform]
           end
         else

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -38,7 +38,7 @@ module Bundler
           specs_for_dep.first.dependencies.each do |d|
             next if d.type == :development
             incomplete = true if d.name != "bundler" && lookup[d.name].nil?
-            deps << [d, dep[1]]
+            deps << [d, platform]
           end
         else
           incomplete = true

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -34,11 +34,7 @@ module Bundler
         specs_for_dep = specs_for_dependency(*dep)
         if specs_for_dep.any?
           specs.concat(specs_for_dep)
-
-          specs_for_dep.first.dependencies.each do |d|
-            next if d.type == :development
-            deps << [d, platform]
-          end
+          deps.concat(specs_for_dep.first.runtime_dependencies.map {|d| [d, platform] })
         else
           incomplete = true
         end

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -11,7 +11,18 @@ module Bundler
       @specs = specs
     end
 
-    def for(dependencies, check = false, platforms = [nil])
+    def for(dependencies, platforms_or_legacy_check = [nil], legacy_platforms = [nil])
+      platforms = if [true, false].include?(platforms_or_legacy_check)
+        Bundler::SharedHelpers.major_deprecation 2,
+          "SpecSet#for received a `check` parameter, but that's no longer used and deprecated. " \
+          "SpecSet#for always implicitly performs validation. Please remove this parameter",
+          print_caller_location: true
+
+        legacy_platforms
+      else
+        platforms_or_legacy_check
+      end
+
       materialize_dependencies(dependencies, platforms)
 
       @materializations.flat_map(&:specs).uniq
@@ -117,7 +128,7 @@ module Bundler
       return false if @specs.empty?
 
       validation_set = self.class.new(@specs)
-      validation_set.for(deps, true, [platform])
+      validation_set.for(deps, [platform])
 
       validation_set.incomplete_specs.any?
     end

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -140,7 +140,11 @@ module Bundler
     end
 
     def missing_specs
-      @materializations.flat_map(&:missing_specs)
+      @materializations.flat_map(&:completely_missing_specs)
+    end
+
+    def partially_missing_specs
+      @materializations.flat_map(&:partially_missing_specs)
     end
 
     def incomplete_specs

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -14,7 +14,7 @@ module Bundler
       @incomplete_specs = incomplete_specs
     end
 
-    def for(dependencies, check = false, platforms = [nil], most_specific_locked_platform = nil)
+    def for(dependencies, check = false, platforms = [nil])
       handled = ["bundler"].product(platforms).map {|k| [k, true] }.to_h
       deps = dependencies.product(platforms)
       specs = []
@@ -31,7 +31,7 @@ module Bundler
 
         handled[key] = true
 
-        specs_for_dep = specs_for_dependency(*dep, most_specific_locked_platform)
+        specs_for_dep = specs_for_dependency(*dep)
         if specs_for_dep.any?
           specs.concat(specs_for_dep)
 
@@ -130,8 +130,8 @@ module Bundler
       lookup.dup
     end
 
-    def materialize(deps, most_specific_locked_platform = nil)
-      materialized = self.for(deps, true, [nil], most_specific_locked_platform)
+    def materialize(deps)
+      materialized = self.for(deps, true)
 
       SpecSet.new(materialized, incomplete_specs)
     end
@@ -295,14 +295,14 @@ module Bundler
       @specs.sort_by(&:name).each {|s| yield s }
     end
 
-    def specs_for_dependency(dep, platform, most_specific_locked_platform)
+    def specs_for_dependency(dep, platform)
       specs_for_name = lookup[dep.name]
       return [] unless specs_for_name
 
       if platform
         GemHelpers.select_best_platform_match(specs_for_name, platform, force_ruby: dep.force_ruby_platform)
       else
-        GemHelpers.select_best_local_platform_match(specs_for_name, force_ruby: dep.force_ruby_platform || dep.default_force_ruby_platform, most_specific_locked_platform: most_specific_locked_platform)
+        GemHelpers.select_best_local_platform_match(specs_for_name, force_ruby: dep.force_ruby_platform || dep.default_force_ruby_platform)
       end
     end
 

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -7,44 +7,14 @@ module Bundler
     include Enumerable
     include TSort
 
-    attr_reader :incomplete_specs
-
-    def initialize(specs, incomplete_specs = [])
+    def initialize(specs)
       @specs = specs
-      @incomplete_specs = incomplete_specs
     end
 
     def for(dependencies, check = false, platforms = [nil])
-      handled = ["bundler"].product(platforms).map {|k| [k, true] }.to_h
-      deps = dependencies.product(platforms)
-      specs = []
+      materialize_dependencies(dependencies, platforms)
 
-      loop do
-        break unless dep = deps.shift
-
-        name = dep[0].name
-        platform = dep[1]
-        incomplete = false
-
-        key = [name, platform]
-        next if handled.key?(key)
-
-        handled[key] = true
-
-        specs_for_dep = specs_for_dependency(*dep)
-        if specs_for_dep.any?
-          specs.concat(specs_for_dep)
-          deps.concat(specs_for_dep.first.runtime_dependencies.map {|d| [d, platform] })
-        else
-          incomplete = true
-        end
-
-        if incomplete && check
-          @incomplete_specs += lookup[name] || [LazySpecification.new(name, nil, nil)]
-        end
-      end
-
-      specs.uniq
+      @materializations.flat_map(&:specs).uniq
     end
 
     def normalize_platforms!(deps, platforms)
@@ -126,13 +96,12 @@ module Bundler
     end
 
     def materialize(deps)
-      materialized = self.for(deps, true)
+      materialize_dependencies(deps)
 
-      SpecSet.new(materialized, incomplete_specs)
+      SpecSet.new(materialized_specs)
     end
 
     # Materialize for all the specs in the spec set, regardless of what platform they're for
-    # This is in contrast to how for does platform filtering (and specifically different from how `materialize` calls `for` only for the current platform)
     # @return [Array<Gem::Specification>]
     def materialized_for_all_platforms
       @specs.map do |s|
@@ -153,12 +122,22 @@ module Bundler
       validation_set.incomplete_specs.any?
     end
 
+    def missing_specs_for(dependencies)
+      materialize_dependencies(dependencies)
+
+      missing_specs
+    end
+
     def missing_specs
-      @specs.select {|s| s.is_a?(LazySpecification) }
+      @materializations.flat_map(&:missing_specs)
+    end
+
+    def incomplete_specs
+      @materializations.flat_map(&:incomplete_specs)
     end
 
     def insecurely_materialized_specs
-      @specs.select(&:insecurely_materialized?)
+      materialized_specs.select(&:insecurely_materialized?)
     end
 
     def -(other)
@@ -211,6 +190,37 @@ module Bundler
     end
 
     private
+
+    def materialize_dependencies(dependencies, platforms = [nil])
+      handled = ["bundler"].product(platforms).map {|k| [k, true] }.to_h
+      deps = dependencies.product(platforms)
+      @materializations = []
+
+      loop do
+        break unless dep = deps.shift
+
+        dependency = dep[0]
+        platform = dep[1]
+        name = dependency.name
+
+        key = [name, platform]
+        next if handled.key?(key)
+
+        handled[key] = true
+
+        materialization = Materialization.new(dependency, platform, candidates: lookup[name])
+
+        deps.concat(materialization.dependencies) if materialization.complete?
+
+        @materializations << materialization
+      end
+
+      @materializations
+    end
+
+    def materialized_specs
+      @materializations.filter_map(&:materialized_spec)
+    end
 
     def reset!
       @sorted = nil
@@ -282,17 +292,6 @@ module Bundler
     def tsort_each_node
       # MUST sort by name for backwards compatibility
       @specs.sort_by(&:name).each {|s| yield s }
-    end
-
-    def specs_for_dependency(dep, platform)
-      specs_for_name = lookup[dep.name]
-      return [] unless specs_for_name
-
-      if platform
-        GemHelpers.select_best_platform_match(specs_for_name, platform, force_ruby: dep.force_ruby_platform)
-      else
-        GemHelpers.select_best_local_platform_match(specs_for_name, force_ruby: dep.force_ruby_platform || dep.default_force_ruby_platform)
-      end
     end
 
     def tsort_each_child(s)

--- a/bundler/spec/install/yanked_spec.rb
+++ b/bundler/spec/install/yanked_spec.rb
@@ -30,7 +30,29 @@ RSpec.context "when installing a bundle that includes yanked gems" do
     expect(err).to include("Your bundle is locked to foo (10.0.0)")
   end
 
-  context "when a re-resolve is necessary, and a yanked version is considered by the resolver" do
+  context "when a platform specific yanked version is included in the lockfile, and a generic variant is available remotely" do
+    let(:original_lockfile) do
+      <<~L
+        GEM
+          remote: https://gem.repo4/
+          specs:
+            actiontext (6.1.6)
+              nokogiri (>= 1.8)
+            foo (1.0.0)
+            nokogiri (1.13.8-#{Bundler.local_platform})
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          actiontext (= 6.1.6)
+          foo (= 1.0.0)
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+    end
+
     before do
       skip "Materialization on Windows is not yet strict, so the example does not detect the gem has been yanked" if Gem.win_platform?
 
@@ -51,29 +73,33 @@ RSpec.context "when installing a bundle that includes yanked gems" do
 
       gemfile <<~G
         source "https://gem.repo4"
-        gem "foo", "1.0.1"
+        gem "foo", "1.0.0"
         gem "actiontext", "6.1.6"
       G
 
-      lockfile <<~L
-        GEM
-          remote: https://gem.repo4/
-          specs:
-            actiontext (6.1.6)
-              nokogiri (>= 1.8)
-            foo (1.0.0)
-            nokogiri (1.13.8-#{Bundler.local_platform})
+      lockfile original_lockfile
+    end
 
-        PLATFORMS
-          #{lockfile_platforms}
+    context "and a re-resolve is necessary" do
+      before do
+        gemfile gemfile.sub('"foo", "1.0.0"', '"foo", "1.0.1"')
+      end
 
-        DEPENDENCIES
-          actiontext (= 6.1.6)
-          foo (= 1.0.0)
+      it "reresolves, and replaces the yanked gem with the generic version, printing a warning, when the old index is used" do
+        bundle "install", artifice: "endpoint", verbose: true
 
-        BUNDLED WITH
-           #{Bundler::VERSION}
-      L
+        expect(out).to include("Installing nokogiri 1.13.8").and include("Installing foo 1.0.1")
+        expect(lockfile).to eq(original_lockfile.sub("nokogiri (1.13.8-#{Bundler.local_platform})", "nokogiri (1.13.8)").gsub("1.0.0", "1.0.1"))
+        expect(err).to include("Some locked specs have possibly been yanked (nokogiri-1.13.8-#{Bundler.local_platform}). Ignoring them...")
+      end
+
+      it "reresolves, and replaces the yanked gem with the generic version, printing a warning, when the compact index API is used" do
+        bundle "install", artifice: "compact_index", verbose: true
+
+        expect(out).to include("Installing nokogiri 1.13.8").and include("Installing foo 1.0.1")
+        expect(lockfile).to eq(original_lockfile.sub("nokogiri (1.13.8-#{Bundler.local_platform})", "nokogiri (1.13.8)").gsub("1.0.0", "1.0.1"))
+        expect(err).to include("Some locked specs have possibly been yanked (nokogiri-1.13.8-#{Bundler.local_platform}). Ignoring them...")
+      end
     end
 
     it "reports the yanked gem properly when the old index is used" do

--- a/bundler/spec/install/yanked_spec.rb
+++ b/bundler/spec/install/yanked_spec.rb
@@ -77,7 +77,7 @@ RSpec.context "when installing a bundle that includes yanked gems" do
     end
 
     it "reports the yanked gem properly when the old index is used" do
-      bundle "install", artifice: "endpoint", raise_on_error: false, verbose: true
+      bundle "install", artifice: "endpoint", raise_on_error: false
 
       expect(err).to include("Your bundle is locked to nokogiri (1.13.8-#{Bundler.local_platform})")
     end

--- a/bundler/spec/install/yanked_spec.rb
+++ b/bundler/spec/install/yanked_spec.rb
@@ -50,14 +50,14 @@ RSpec.context "when installing a bundle that includes yanked gems" do
       end
 
       gemfile <<~G
-        source "#{source_uri}"
+        source "https://gem.repo4"
         gem "foo", "1.0.1"
         gem "actiontext", "6.1.6"
       G
 
       lockfile <<~L
         GEM
-          remote: #{source_uri}/
+          remote: https://gem.repo4/
           specs:
             actiontext (6.1.6)
               nokogiri (>= 1.8)
@@ -76,24 +76,16 @@ RSpec.context "when installing a bundle that includes yanked gems" do
       L
     end
 
-    context "and the old index is used" do
-      let(:source_uri) { "https://gem.repo4" }
+    it "reports the yanked gem properly when the old index is used" do
+      bundle "install", artifice: "endpoint", raise_on_error: false, verbose: true
 
-      it "reports the yanked gem properly" do
-        bundle "install", artifice: "endpoint", raise_on_error: false, verbose: true
-
-        expect(err).to include("Your bundle is locked to nokogiri (1.13.8-#{Bundler.local_platform})")
-      end
+      expect(err).to include("Your bundle is locked to nokogiri (1.13.8-#{Bundler.local_platform})")
     end
 
-    context "and the compact index API is used" do
-      let(:source_uri) { "https://gem.repo4" }
+    it "reports the yanked gem properly when the compact index API is used" do
+      bundle "install", artifice: "compact_index", raise_on_error: false
 
-      it "reports the yanked gem properly" do
-        bundle "install", artifice: "compact_index", raise_on_error: false
-
-        expect(err).to include("Your bundle is locked to nokogiri (1.13.8-#{Bundler.local_platform})")
-      end
+      expect(err).to include("Your bundle is locked to nokogiri (1.13.8-#{Bundler.local_platform})")
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Some users like to frequently switch between the latest Ruby version, and a dev version of the next Ruby. These users are normally super nice citizens, because they proactively run using the current -dev ruby version in order to test improvements and report bugs.

It's common though for native gems, like nokogiri, to have different requirements for their generic versions (which allow any Ruby) and their platform specific versions (which normally have an upper bound on the version of Ruby).

Bundler is not currently great at switching between these rubies. Even if both variants are included in a lockfile, Bundler will revert back to locking the generic version only when using the .dev version of Ruby, and then the latest version won't add the version specific variant back, because it respects the lockfile that includes only the generic variant.

What should happen instead is that both variants are always kept in the lockfile, and Bundler chooses the generic version or the platform specific version as necessary, depending on the Ruby version that uses the lockfile. 

## What is your fix for the problem, implemented in this PR?

This PR implements several refactorings in order to accomplish this. In particular, it makes sure all lockfile validations are done over the original resolution (not after the fact over the set of already materialized specifications), and starts accepting "partially missing materializations" (situations where not all of the relevant locked variants of a gem could be materialized), instead of detecting those cases as "incomplete" and re-resolving without the specs that could not be materialized.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
