### PR TITLE
more Windows support for bundle exec

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -495,16 +495,25 @@ module Bundler
     end
 
     def which(executable)
-      if File.file?(executable) && File.executable?(executable)
-        executable
-      elsif paths = ENV["PATH"]
+      executable_path = find_executable(executable)
+      return executable_path if executable_path
+
+      if (paths = ENV["PATH"])
         quote = '"'
         paths.split(File::PATH_SEPARATOR).find do |path|
           path = path[1..-2] if path.start_with?(quote) && path.end_with?(quote)
-          executable_path = File.expand_path(executable, path)
-          return executable_path if File.file?(executable_path) && File.executable?(executable_path)
+          executable_path = find_executable(File.expand_path(executable, path))
+          return executable_path if executable_path
         end
       end
+    end
+
+    def find_executable(path)
+      extensions = RbConfig::CONFIG["EXECUTABLE_EXTS"]&.split
+      extensions = [RbConfig::CONFIG["EXEEXT"]] unless extensions&.any?
+      candidates = extensions.map {|ext| "#{path}#{ext}" }
+
+      candidates.find {|candidate| File.file?(candidate) && File.executable?(candidate) }
     end
 
     def read_file(file)
@@ -559,7 +568,7 @@ module Bundler
 
     def git_present?
       return @git_present if defined?(@git_present)
-      @git_present = Bundler.which("git#{RbConfig::CONFIG["EXEEXT"]}")
+      @git_present = Bundler.which("git")
     end
 
     def feature_flag

--- a/bundler/spec/bundler/bundler_spec.rb
+++ b/bundler/spec/bundler/bundler_spec.rb
@@ -174,7 +174,13 @@ RSpec.describe Bundler do
       end
     end
 
-    let(:expected) { "executable" }
+    let(:expected) do
+      if Gem.win_platform?
+        "executable.exe"
+      else
+        "executable"
+      end
+    end
 
     before do
       ENV["PATH"] = path.join(File::PATH_SEPARATOR)
@@ -200,11 +206,12 @@ RSpec.describe Bundler do
     context "when the executable in inside a quoted path" do
       let(:expected) do
         if Gem.win_platform?
-          "C:/e/executable"
+          "C:/e/executable.exe"
         else
           "/e/executable"
         end
       end
+
       it_behaves_like "it returns the correct executable"
     end
 

--- a/bundler/spec/runtime/executable_spec.rb
+++ b/bundler/spec/runtime/executable_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe "Running bin/* commands" do
     expect(bundled_app("bin/myrackup")).to exist
   end
 
-  it "rewrites bins on binstubs (to maintain backwards compatibility)" do
+  it "rewrites bins on binstubs with '--force' option" do
     install_gemfile <<-G
       source "https://gem.repo1"
       gem "myrack"
@@ -134,7 +134,7 @@ RSpec.describe "Running bin/* commands" do
 
     create_file("bin/myrackup", "OMG")
 
-    bundle "binstubs myrack"
+    bundle "binstubs myrack", { force: true }
 
     expect(bundled_app("bin/myrackup").read).to_not eq("OMG")
   end


### PR DESCRIPTION
`cat` and `echo` are not usable on Windows. add stub scripts.

enable bat scripts to be created together with ruby scripts in test suite.

check if bat script exist to support loading on Windows.

update checking logic to check if file is executable using `EXEEXT`.

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

This can be used instead of https://github.com/rubygems/rubygems/pull/8224.

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
