### PR TITLE
Add man page for 'bundle fund' command

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -107,6 +107,8 @@ bundler/lib/bundler/man/bundle-doctor.1
 bundler/lib/bundler/man/bundle-doctor.1.ronn
 bundler/lib/bundler/man/bundle-exec.1
 bundler/lib/bundler/man/bundle-exec.1.ronn
+bundler/lib/bundler/man/bundle-fund.1
+bundler/lib/bundler/man/bundle-fund.1.ronn
 bundler/lib/bundler/man/bundle-gem.1
 bundler/lib/bundler/man/bundle-gem.1.ronn
 bundler/lib/bundler/man/bundle-help.1

--- a/bundler/lib/bundler/man/bundle-fund.1
+++ b/bundler/lib/bundler/man/bundle-fund.1
@@ -1,0 +1,22 @@
+.\" generated with nRonn/v0.11.1
+.\" https://github.com/n-ronn/nronn/tree/0.11.1
+.TH "BUNDLE\-FUND" "1" "November 2024" ""
+.SH "NAME"
+\fBbundle\-fund\fR \- Lists information about gems seeking funding assistance
+.SH "SYNOPSIS"
+\fBbundle fund\fR [\fIOPTIONS\fR]
+.SH "DESCRIPTION"
+\fBbundle fund\fR lists information about gems seeking funding assistance\.
+.SH "OPTIONS"
+.TP
+\fB\-g\fR, \fB\-\-group=GROUP\fR
+Fetch funding information for a specific group\.
+.SH "EXAMPLES"
+.nf
+# Lists funding information for all gems
+bundle fund
+
+# Lists funding information for a specific group
+bundle fund \-\-group=security
+.fi
+

--- a/bundler/lib/bundler/man/bundle-fund.1.ronn
+++ b/bundler/lib/bundler/man/bundle-fund.1.ronn
@@ -1,0 +1,25 @@
+bundle-fund(1) -- Lists information about gems seeking funding assistance
+============================================================
+
+## SYNOPSIS
+
+`bundle fund` [*OPTIONS*]
+
+## DESCRIPTION
+
+**bundle fund** lists information about gems seeking funding assistance.
+
+## OPTIONS
+
+* `-g`, `--group=GROUP`:
+  Fetch funding information for a specific group.
+
+## EXAMPLES
+
+```
+# Lists funding information for all gems
+bundle fund
+
+# Lists funding information for a specific group
+bundle fund --group=security
+```

--- a/bundler/lib/bundler/man/index.txt
+++ b/bundler/lib/bundler/man/index.txt
@@ -9,6 +9,7 @@ bundle-config(1)      bundle-config.1
 bundle-console(1)     bundle-console.1
 bundle-doctor(1)      bundle-doctor.1
 bundle-exec(1)        bundle-exec.1
+bundle-fund(1)        bundle-fund.1
 bundle-gem(1)         bundle-gem.1
 bundle-help(1)        bundle-help.1
 bundle-info(1)        bundle-info.1

--- a/bundler/spec/commands/help_spec.rb
+++ b/bundler/spec/commands/help_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe "bundle help" do
   end
 
   it "still outputs the old help for commands that do not have man pages yet" do
-    bundle "help fund"
-    expect(out).to include("Lists information about gems seeking funding assistance")
+    bundle "help issue"
+    expect(out).to include("Learn how to report an issue in Bundler")
   end
 
   it "looks for a binary and executes it with --help option if it's named bundler-<task>" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

No man page for the `bundle fund` command, which also means it doesn't show up on the https://bundler.io/docs.html page

## What is your fix for the problem, implemented in this PR?

Added a man page for `bundle fund` and generated `bundle-fund.1` using nRonn

The only thing I'm not quite sure about is why `bundler/lib/bundler/man/index.txt` shows `#` next to `bundle-fund.1`, it was automatically updated when generating, I followed this guide: https://github.com/rubygems/rubygems/blob/master/doc/bundler/documentation/WRITING.md

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
