### PR TITLE
Enable a couple of performance cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,11 +46,6 @@ Naming/VariableNumber:
     - test/**/*
     - tool/**/*
 
-# Performance
-
-Performance/RegexpMatch:
-  Enabled: true
-
 # Style
 
 Style/ClassVars:
@@ -499,6 +494,11 @@ Naming/FileName:
     - "bundler/spec/realworld/fixtures/warbler/bin/warbler-example.rb"
 
 Naming/MemoizedInstanceVariableName:
+  Enabled: true
+
+# Performance
+
+Performance/RegexpMatch:
   Enabled: true
 
 Performance/MapCompact:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -501,6 +501,9 @@ Naming/FileName:
 Naming/MemoizedInstanceVariableName:
   Enabled: true
 
+Performance/MapCompact:
+  Enabled: true
+
 Performance/TimesMap:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -515,6 +515,7 @@ Performance/Casecmp:
 
 Performance/FlatMap:
   Enabled: true
+  EnabledForFlattenWithoutParams: true
 
 Performance/StartWith:
   Enabled: true

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -572,12 +572,12 @@ module Bundler
       Bundler.rubygems.load_plugins
 
       requested_path_gems = definition.requested_specs.select {|s| s.source.is_a?(Source::Path) }
-      path_plugin_files = requested_path_gems.map do |spec|
+      path_plugin_files = requested_path_gems.flat_map do |spec|
         spec.matches_for_glob("rubygems_plugin#{Bundler.rubygems.suffix_pattern}")
       rescue TypeError
         error_message = "#{spec.name} #{spec.version} has an invalid gemspec"
         raise Gem::InvalidSpecificationException, error_message
-      end.flatten
+      end
       Bundler.rubygems.load_plugin_files(path_plugin_files)
       Bundler.rubygems.load_env_plugins
       @load_plugins_ran = true

--- a/bundler/lib/bundler/cli/doctor.rb
+++ b/bundler/lib/bundler/cli/doctor.rb
@@ -89,11 +89,11 @@ module Bundler
 
       if broken_links.any?
         message = "The following gems are missing OS dependencies:"
-        broken_links.map do |spec, paths|
+        broken_links.flat_map do |spec, paths|
           paths.uniq.map do |path|
             "\n * #{spec.name}: #{path}"
           end
-        end.flatten.sort.each {|m| message += m }
+        end.sort.each {|m| message += m }
         raise ProductionError, message
       elsif !permissions_valid
         Bundler.ui.info "No issues found with the installed bundle"

--- a/bundler/lib/bundler/cli/doctor.rb
+++ b/bundler/lib/bundler/cli/doctor.rb
@@ -32,11 +32,11 @@ module Bundler
 
     def dylibs_ldd(path)
       output = `/usr/bin/ldd #{path.shellescape}`.chomp
-      output.split("\n").map do |l|
+      output.split("\n").filter_map do |l|
         match = l.match(LDD_REGEX)
         next if match.nil?
         match.captures[0]
-      end.compact
+      end
     end
 
     def dylibs(path)

--- a/bundler/lib/bundler/cli/info.rb
+++ b/bundler/lib/bundler/cli/info.rb
@@ -73,11 +73,11 @@ module Bundler
     end
 
     def gem_dependencies
-      @gem_dependencies ||= Bundler.definition.specs.map do |spec|
+      @gem_dependencies ||= Bundler.definition.specs.filter_map do |spec|
         dependency = spec.dependencies.find {|dep| dep.name == gem_name }
         next unless dependency
         "#{spec.name} (#{spec.version}) depends on #{gem_name} (#{dependency.requirements_list.join(", ")})"
-      end.compact.sort
+      end.sort
     end
   end
 end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -317,7 +317,7 @@ module Bundler
     end
 
     def groups
-      dependencies.map(&:groups).flatten.uniq
+      dependencies.flat_map(&:groups).uniq
     end
 
     def lock(file_or_preserve_unknown_sections = false, preserve_unknown_sections_or_unused = false)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -313,7 +313,7 @@ module Bundler
     end
 
     def spec_git_paths
-      sources.git_sources.map {|s| File.realpath(s.path) if File.exist?(s.path) }.compact
+      sources.git_sources.filter_map {|s| File.realpath(s.path) if File.exist?(s.path) }
     end
 
     def groups

--- a/bundler/lib/bundler/dependency.rb
+++ b/bundler/lib/bundler/dependency.rb
@@ -62,7 +62,7 @@ module Bundler
     end
 
     def expanded_platforms
-      @expanded_platforms ||= @platforms.map {|pl| PLATFORM_MAP[pl] }.compact.flatten.uniq
+      @expanded_platforms ||= @platforms.filter_map {|pl| PLATFORM_MAP[pl] }.flatten.uniq
     end
 
     def should_include?

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -66,7 +66,7 @@ module Bundler
       development_group = opts[:development_group] || :development
       expanded_path     = gemfile_root.join(path)
 
-      gemspecs = Gem::Util.glob_files_in_dir("{,*}.gemspec", expanded_path).map {|g| Bundler.load_gemspec(g) }.compact
+      gemspecs = Gem::Util.glob_files_in_dir("{,*}.gemspec", expanded_path).filter_map {|g| Bundler.load_gemspec(g) }
       gemspecs.reject! {|s| s.name != name } if name
       specs_by_name_and_version = gemspecs.group_by {|s| [s.name, s.version] }
 

--- a/bundler/lib/bundler/gem_helpers.rb
+++ b/bundler/lib/bundler/gem_helpers.rb
@@ -63,7 +63,7 @@ module Bundler
     module_function :select_best_platform_match
 
     def select_best_local_platform_match(specs, force_ruby: false, most_specific_locked_platform: nil)
-      select_best_platform_match(specs, local_platform, force_ruby: force_ruby).map {|spec| spec.materialize_for_installation(most_specific_locked_platform) }.compact
+      select_best_platform_match(specs, local_platform, force_ruby: force_ruby).filter_map {|spec| spec.materialize_for_installation(most_specific_locked_platform) }
     end
     module_function :select_best_local_platform_match
 

--- a/bundler/lib/bundler/installer/standalone.rb
+++ b/bundler/lib/bundler/installer/standalone.rb
@@ -28,7 +28,7 @@ module Bundler
     private
 
     def paths
-      @specs.map do |spec|
+      @specs.flat_map do |spec|
         next if spec.name == "bundler"
         Array(spec.require_paths).map do |path|
           gem_path(path, spec).
@@ -36,7 +36,7 @@ module Bundler
             sub(extensions_dir, 'extensions/\k<platform>/#{Gem.extension_api_version}')
           # This is a static string intentionally. It's interpolated at a later time.
         end
-      end.flatten.compact
+      end.compact
     end
 
     def version_dir

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -417,7 +417,7 @@ module Bundler
     end
 
     def prepare_dependencies(requirements, packages)
-      to_dependency_hash(requirements, packages).map do |dep_package, dep_constraint|
+      to_dependency_hash(requirements, packages).filter_map do |dep_package, dep_constraint|
         name = dep_package.name
 
         next [dep_package, dep_constraint] if name == "bundler"
@@ -443,7 +443,7 @@ module Bundler
         next unless dep_package.current_platform?
 
         raise_not_found!(dep_package)
-      end.compact.to_h
+      end.to_h
     end
 
     def select_sorted_versions(package, range)

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -79,7 +79,7 @@ module Bundler
     def solve_versions(root:, logger:)
       solver = PubGrub::VersionSolver.new(source: self, root: root, logger: logger)
       result = solver.solve
-      resolved_specs = result.map {|package, version| version.to_specs(package) }.flatten
+      resolved_specs = result.flat_map {|package, version| version.to_specs(package) }
       resolved_specs |= @base.specs_compatible_with(SpecSet.new(resolved_specs))
     rescue PubGrub::SolveFailure => e
       incompatibility = e.incompatibility

--- a/bundler/lib/bundler/resolver/base.rb
+++ b/bundler/lib/bundler/resolver/base.rb
@@ -16,7 +16,7 @@ module Bundler
           hash[name] = Package.new(name, platforms, **options)
         end
 
-        @requirements = dependencies.map do |dep|
+        @requirements = dependencies.filter_map do |dep|
           dep_platforms = dep.gem_platforms(platforms)
 
           # Dependencies scoped to external platforms are ignored
@@ -27,7 +27,7 @@ module Bundler
           @packages[name] = Package.new(name, dep_platforms, **options.merge(dependency: dep))
 
           dep
-        end.compact
+        end
       end
 
       def specs_compatible_with(result)

--- a/bundler/lib/bundler/resolver/spec_group.rb
+++ b/bundler/lib/bundler/resolver/spec_group.rb
@@ -38,9 +38,9 @@ module Bundler
       end
 
       def dependencies
-        @dependencies ||= @specs.map do |spec|
+        @dependencies ||= @specs.flat_map do |spec|
           __dependencies(spec) + metadata_dependencies(spec)
-        end.flatten.uniq.sort
+        end.uniq.sort
       end
 
       def ==(other)

--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -263,10 +263,10 @@ module Bundler
 
     def setup_manpath
       # Add man/ subdirectories from activated bundles to MANPATH for man(1)
-      manuals = $LOAD_PATH.map do |path|
+      manuals = $LOAD_PATH.filter_map do |path|
         man_subdir = path.sub(/lib$/, "man")
         man_subdir unless Dir[man_subdir + "/man?/"].empty?
-      end.compact
+      end
 
       return if manuals.empty?
       Bundler::SharedHelpers.set_env "MANPATH", manuals.concat(

--- a/bundler/lib/bundler/source/path.rb
+++ b/bundler/lib/bundler/source/path.rb
@@ -214,7 +214,7 @@ module Bundler
 
         # Some gem authors put absolute paths in their gemspec
         # and we have to save them from themselves
-        spec.files = spec.files.map do |path|
+        spec.files = spec.files.filter_map do |path|
           next path unless /\A#{Pathname::SEPARATOR_PAT}/o.match?(path)
           next if File.directory?(path)
           begin
@@ -222,7 +222,7 @@ module Bundler
           rescue ArgumentError
             path
           end
-        end.compact
+        end
 
         installer = Path::Installer.new(
           spec,

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -91,7 +91,7 @@ module Bundler
     end
 
     def rubygems_remotes
-      rubygems_sources.map(&:remotes).flatten.uniq
+      rubygems_sources.flat_map(&:remotes).uniq
     end
 
     def all_sources

--- a/bundler/spec/support/artifice/helpers/compact_index.rb
+++ b/bundler/spec/support/artifice/helpers/compact_index.rb
@@ -67,14 +67,14 @@ class CompactIndexAPI < Endpoint
       @gems ||= {}
       @gems[gem_repo] ||= begin
         specs = Bundler::Deprecate.skip_during do
-          %w[specs.4.8 prerelease_specs.4.8].map do |filename|
+          %w[specs.4.8 prerelease_specs.4.8].flat_map do |filename|
             spec_index = gem_repo.join(filename)
             next [] unless File.exist?(spec_index)
 
             Marshal.load(File.binread(spec_index)).map do |name, version, platform|
               load_spec(name, version, platform, gem_repo)
             end
-          end.flatten
+          end
         end
 
         specs.group_by(&:name).map do |name, versions|

--- a/bundler/spec/support/artifice/helpers/endpoint.rb
+++ b/bundler/spec/support/artifice/helpers/endpoint.rb
@@ -66,7 +66,7 @@ class Endpoint < Sinatra::Base
         Marshal.load(File.binread(gem_repo.join(filename)))
       end.inject(:+)
 
-      all_specs.map do |name, version, platform|
+      all_specs.filter_map do |name, version, platform|
         spec = load_spec(name, version, platform, gem_repo)
         next unless gem_names.include?(spec.name)
         {
@@ -77,7 +77,7 @@ class Endpoint < Sinatra::Base
             [dep.name, dep.requirement.requirements.map {|a| a.join(" ") }.join(", ")]
           end,
         }
-      end.compact
+      end
     end
 
     def load_spec(name, version, platform, gem_repo)

--- a/bundler/spec/support/matchers.rb
+++ b/bundler/spec/support/matchers.rb
@@ -116,7 +116,7 @@ module Spec
         source = opts.delete(:source)
         groups = Array(opts.delete(:groups)).map(&:inspect).join(", ")
         opts[:raise_on_error] = false
-        @errors = names.map do |full_name|
+        @errors = names.filter_map do |full_name|
           name, version, platform = full_name.split(/\s+/)
           platform ||= "ruby"
           require_path = name.tr("-", "/")
@@ -159,7 +159,7 @@ module Spec
             next "Expected #{name} (#{version}) to be installed from `#{source}`, was actually from `#{actual_source}`"
           end
           next "Command to check for inclusion of gem #{full_name} failed"
-        end.compact
+        end
 
         @errors.empty?
       end
@@ -168,7 +168,7 @@ module Spec
         opts = names.last.is_a?(Hash) ? names.pop : {}
         groups = Array(opts.delete(:groups)).map(&:inspect).join(", ")
         opts[:raise_on_error] = false
-        @errors = names.map do |name|
+        @errors = names.filter_map do |name|
           name, version = name.split(/\s+/, 2)
           ruby <<-R, opts
             begin
@@ -194,7 +194,7 @@ module Spec
           next "command to check version of #{name} installed failed" unless exitstatus == 64
           next "expected #{name} to not be installed, but it was" if version.nil?
           next "expected #{name} (#{version}) not to be installed, but it was"
-        end.compact
+        end
 
         @errors.empty?
       end

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -496,9 +496,9 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
     gem_specifications = @gemdeps ? Gem.loaded_specs.values : Gem::Specification.stubs
 
-    files.concat gem_specifications.map {|spec|
+    files.concat gem_specifications.flat_map {|spec|
       spec.matches_for_glob("#{glob}#{Gem.suffix_pattern}")
-    }.flatten
+    }
 
     # $LOAD_PATH might contain duplicate entries or reference
     # the spec dirs directly, so we prune.
@@ -509,9 +509,9 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
   def self.find_files_from_load_path(glob) # :nodoc:
     glob_with_suffixes = "#{glob}#{Gem.suffix_pattern}"
-    $LOAD_PATH.map do |load_path|
+    $LOAD_PATH.flat_map do |load_path|
       Gem::Util.glob_files_in_dir(glob_with_suffixes, load_path)
-    end.flatten.select {|file| File.file? file }
+    end.select {|file| File.file? file }
   end
 
   ##
@@ -531,9 +531,9 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
     files = find_files_from_load_path glob if check_load_path
 
-    files.concat Gem::Specification.latest_specs(true).map {|spec|
+    files.concat Gem::Specification.latest_specs(true).flat_map {|spec|
       spec.matches_for_glob("#{glob}#{Gem.suffix_pattern}")
-    }.flatten
+    }
 
     # $LOAD_PATH might contain duplicate entries or reference
     # the spec dirs directly, so we prune.

--- a/lib/rubygems/commands/cleanup_command.rb
+++ b/lib/rubygems/commands/cleanup_command.rb
@@ -113,9 +113,9 @@ If no gems are named all gems in GEM_HOME are cleaned.
     @candidate_gems = if options[:args].empty?
       Gem::Specification.to_a
     else
-      options[:args].map do |gem_name|
+      options[:args].flat_map do |gem_name|
         Gem::Specification.find_all_by_name gem_name
-      end.flatten
+      end
     end
   end
 

--- a/lib/rubygems/commands/contents_command.rb
+++ b/lib/rubygems/commands/contents_command.rb
@@ -102,7 +102,7 @@ prefix or only the files that are requireable.
   end
 
   def files_in_default_gem(spec)
-    spec.files.map do |file|
+    spec.files.filter_map do |file|
       if file.start_with?("#{spec.bindir}/")
         [RbConfig::CONFIG["bindir"], file.delete_prefix("#{spec.bindir}/")]
       else
@@ -119,7 +119,7 @@ prefix or only the files that are requireable.
 
         [resolve.delete_suffix(requirable_part), requirable_part]
       end
-    end.compact
+    end
   end
 
   def gem_contents(name)

--- a/lib/rubygems/commands/contents_command.rb
+++ b/lib/rubygems/commands/contents_command.rb
@@ -189,8 +189,8 @@ prefix or only the files that are requireable.
   end
 
   def specification_directories # :nodoc:
-    options[:specdirs].map do |i|
+    options[:specdirs].flat_map do |i|
       [i, File.join(i, "specifications")]
-    end.flatten
+    end
   end
 end

--- a/lib/rubygems/commands/pristine_command.rb
+++ b/lib/rubygems/commands/pristine_command.rb
@@ -120,9 +120,9 @@ extensions will be restored.
     elsif options[:only_missing_extensions]
       specification_record.select(&:missing_extensions?)
     else
-      get_all_gem_names.sort.map do |gem_name|
+      get_all_gem_names.sort.flat_map do |gem_name|
         specification_record.find_all_by_name(gem_name, options[:version]).reverse
-      end.flatten
+      end
     end
 
     specs = specs.select {|spec| spec.platform == RUBY_ENGINE || Gem::Platform.local === spec.platform || spec.platform == Gem::Platform::RUBY }

--- a/lib/rubygems/commands/rdoc_command.rb
+++ b/lib/rubygems/commands/rdoc_command.rb
@@ -64,9 +64,9 @@ Use --overwrite to force rebuilding of documentation.
     specs = if options[:all]
       Gem::Specification.to_a
     else
-      get_all_gem_names.map do |name|
+      get_all_gem_names.flat_map do |name|
         Gem::Specification.find_by_name name, options[:version]
-      end.flatten.uniq
+      end.uniq
     end
 
     if specs.empty?

--- a/lib/rubygems/ext/cargo_builder.rb
+++ b/lib/rubygems/ext/cargo_builder.rb
@@ -252,8 +252,7 @@ EOF
 
   def rustc_dynamic_linker_flags(dest_dir, crate_name)
     split_flags("DLDFLAGS").
-      map {|arg| maybe_resolve_ldflag_variable(arg, dest_dir, crate_name) }.
-      compact.
+      filter_map {|arg| maybe_resolve_ldflag_variable(arg, dest_dir, crate_name) }.
       flat_map {|arg| ldflag_to_link_modifier(arg) }
   end
 

--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -183,7 +183,7 @@ class Gem::Resolver
   # Proceed with resolution! Returns an array of ActivationRequest objects.
 
   def resolve
-    Gem::Molinillo::Resolver.new(self, self).resolve(@needed.map {|d| DependencyRequest.new d, nil }).tsort.map(&:payload).compact
+    Gem::Molinillo::Resolver.new(self, self).resolve(@needed.map {|d| DependencyRequest.new d, nil }).tsort.filter_map(&:payload)
   rescue Gem::Molinillo::VersionConflict => e
     conflict = e.conflicts.values.first
     raise Gem::DependencyResolutionError, Conflict.new(conflict.requirement_trees.first.first, conflict.existing, conflict.requirement)

--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -59,7 +59,7 @@ class Gem::Resolver
   def self.compose_sets(*sets)
     sets.compact!
 
-    sets = sets.map do |set|
+    sets = sets.flat_map do |set|
       case set
       when Gem::Resolver::BestSet then
         set
@@ -68,7 +68,7 @@ class Gem::Resolver
       else
         set
       end
-    end.flatten
+    end
 
     case sets.length
     when 0 then

--- a/lib/rubygems/resolver/composed_set.rb
+++ b/lib/rubygems/resolver/composed_set.rb
@@ -44,16 +44,16 @@ class Gem::Resolver::ComposedSet < Gem::Resolver::Set
   end
 
   def errors
-    @errors + @sets.map(&:errors).flatten
+    @errors + @sets.flat_map(&:errors)
   end
 
   ##
   # Finds all specs matching +req+ in all sets.
 
   def find_all(req)
-    @sets.map do |s|
+    @sets.flat_map do |s|
       s.find_all req
-    end.flatten
+    end
   end
 
   ##

--- a/lib/rubygems/resolver/index_set.rb
+++ b/lib/rubygems/resolver/index_set.rb
@@ -65,11 +65,11 @@ class Gem::Resolver::IndexSet < Gem::Resolver::Set
 
       q.breakable
 
-      names = @all.values.map do |tuples|
+      names = @all.values.flat_map do |tuples|
         tuples.map do |_, tuple|
           tuple.full_name
         end
-      end.flatten
+      end
 
       q.seplist names do |name|
         q.text name

--- a/lib/rubygems/source/git.rb
+++ b/lib/rubygems/source/git.rb
@@ -201,7 +201,7 @@ class Gem::Source::Git < Gem::Source
     return [] unless install_dir
 
     Dir.chdir install_dir do
-      Dir["{,*,*/*}.gemspec"].map do |spec_file|
+      Dir["{,*,*/*}.gemspec"].filter_map do |spec_file|
         directory = File.dirname spec_file
         file      = File.basename spec_file
 
@@ -218,7 +218,7 @@ class Gem::Source::Git < Gem::Source
           end
           spec
         end
-      end.compact
+      end
     end
   end
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1014,7 +1014,7 @@ class Gem::Specification < Gem::BasicSpecification
   end
 
   def self.unresolved_specs
-    unresolved_deps.values.map(&:to_specs).flatten
+    unresolved_deps.values.flat_map(&:to_specs)
   end
   private_class_method :unresolved_specs
 
@@ -1073,7 +1073,7 @@ class Gem::Specification < Gem::BasicSpecification
       result[spec.name] = spec
     end
 
-    result.map(&:last).flatten.sort_by(&:name)
+    result.flat_map(&:last).sort_by(&:name)
   end
 
   ##
@@ -1770,7 +1770,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Returns all specs that matches this spec's runtime dependencies.
 
   def dependent_specs
-    runtime_dependencies.map(&:to_specs).flatten
+    runtime_dependencies.flat_map(&:to_specs)
   end
 
   ##

--- a/tool/bundler/lint_gems.rb
+++ b/tool/bundler/lint_gems.rb
@@ -3,4 +3,4 @@
 source "https://rubygems.org"
 
 gem "rubocop", ">= 1.52.1", "< 2"
-gem "rubocop-performance", "~> 1.14"
+gem "rubocop-performance", "~> 1.23"

--- a/tool/bundler/lint_gems.rb.lock
+++ b/tool/bundler/lint_gems.rb.lock
@@ -27,7 +27,7 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.31.2)
       parser (>= 3.3.0.4)
-    rubocop-performance (1.21.0)
+    rubocop-performance (1.23.0)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
@@ -43,7 +43,7 @@ PLATFORMS
 
 DEPENDENCIES
   rubocop (>= 1.52.1, < 2)
-  rubocop-performance (~> 1.14)
+  rubocop-performance (~> 1.23)
 
 CHECKSUMS
   ast (2.4.2) sha256=1e280232e6a33754cde542bc5ef85520b74db2aac73ec14acef453784447cc12
@@ -59,7 +59,7 @@ CHECKSUMS
   rexml (3.2.6) sha256=e0669a2d4e9f109951cb1fde723d8acd285425d81594a2ea929304af50282816
   rubocop (1.62.1) sha256=aeb1ec501aef5833617b3b6a1512303806218c349c28ce5b3ea72e3782ad4a35
   rubocop-ast (1.31.2) sha256=7c206fb094553779923eca862aceece3913ce384f1bf85730208228e884578ec
-  rubocop-performance (1.21.0) sha256=ec54fa8991c2d538af7bc958361d63bdb3df2e53032da393e9903ea5e4f74a9a
+  rubocop-performance (1.23.0) sha256=34ae78cb1bc5f1a0b34a34a1f9f6eec2cb8b8b9cafa2ce37982021e86fa49171
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   unicode-display_width (2.5.0) sha256=7e7681dcade1add70cb9fda20dd77f300b8587c81ebbd165d14fd93144ff0ab4
 

--- a/tool/release.rb
+++ b/tool/release.rb
@@ -304,12 +304,12 @@ class Release
   def unreleased_pr_ids
     stable_merge_commit_messages = `git log --format=%s --grep "^Merge pull request #" #{@previous_stable_branch}`.split("\n")
 
-    `git log --oneline --grep "^Merge pull request #" origin/master`.split("\n").map do |l|
+    `git log --oneline --grep "^Merge pull request #" origin/master`.split("\n").filter_map do |l|
       _sha, message = l.split(/\s/, 2)
 
       next if stable_merge_commit_messages.include?(message)
 
       /^Merge pull request #(\d+)/.match(message)[1].to_i
-    end.compact
+    end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

An easy performance speed up (flat_map over map + flatten) came up in the review of #8251.

## What is your fix for the problem, implemented in this PR?

Taking the opportunity to apply the rubocop cop that enforces that consistenly, and also applying another similar cop that I wanted to use while implementing #8251 (filter_map over map + compact).

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
