### PR TITLE
Define a few `inspect` methods to help debugging

### DIFF
--- a/bundler/lib/bundler/endpoint_specification.rb
+++ b/bundler/lib/bundler/endpoint_specification.rb
@@ -120,6 +120,10 @@ module Bundler
       @remote_specification = spec
     end
 
+    def inspect
+      "#<#{self.class} @name=\"#{name}\" (#{full_name.delete_prefix("#{name}-")})>"
+    end
+
     private
 
     def _remote_specification

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -161,6 +161,10 @@ module Bundler
       search
     end
 
+    def inspect
+      "#<#{self.class} @name=\"#{name}\" (#{full_name.delete_prefix("#{name}-")})>"
+    end
+
     def to_s
       lock_name
     end

--- a/bundler/lib/bundler/stub_specification.rb
+++ b/bundler/lib/bundler/stub_specification.rb
@@ -116,6 +116,10 @@ module Bundler
       stub.raw_require_paths
     end
 
+    def inspect
+      "#<#{self.class} @name=\"#{name}\" (#{full_name.delete_prefix("#{name}-")})>"
+    end
+
     private
 
     def _remote_specification


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When print debugging Bundler I very commonly print collections of specs like `puts "resolve: #{resolve}"`. That prints an array with the inspected version of each specification which is veeeeery verbose and makes it not easy to find the actual information that you want to see.

## What is your fix for the problem, implemented in this PR?

In most cases, all you're interested is the `<name>-<version>-<platform>` tuple of the specification, and the class of it.

This PR defines inspect methods in specification classes that print just that.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
