### PR TITLE
Set $0 to exe when running `gem exec` to fix name in CLI output

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -93,6 +93,9 @@ jobs:
         run: |
           gem install nexus:1.5.2
           gem nexus --help
+      - name: Check gem exec preserves app name
+        run: gem exec kamal help | grep -q 'kamal help'
+        if: matrix.ruby.name != 'truffleruby' && matrix.ruby.name != 'jruby'
     timeout-minutes: 10
 
   install_rubygems_windows:

--- a/lib/rubygems/commands/exec_command.rb
+++ b/lib/rubygems/commands/exec_command.rb
@@ -222,8 +222,11 @@ to the same gem path as user-installed gems.
       terminate_interaction 1
     end
 
+    old_exe = $0
+    $0 = exe
     load Gem.activate_bin_path(contains_executable.first.name, exe, ">= 0.a")
   ensure
+    $0 = old_exe if old_exe
     ARGV.replace argv
   end
 


### PR DESCRIPTION
The $0 value is used in many CLI libraries to determine the name of the application, when displaying help and error messages.

Without setting this value, it defaults to `gem` which can be confusing.

Before:

```
$ gem exec kamal help
Commands:
  gem accessory           # Manage accessories (db/redis/search)
  gem app                 # Manage application
  gem audit               # Show audit log from servers
  gem build               # Build application image
  gem config              # Show combined config (including secrets!)
  gem deploy              # Deploy app to servers
  gem details             # Show details about all containers
  gem docs [SECTION]      # Show Kamal configuration documentation
  gem help [COMMAND]      # Describe available commands or one specific command
  gem init                # Create config stub in config/deploy.yml and secrets stub in .kamal
  gem lock                # Manage the deploy lock
  gem proxy               # Manage kamal-proxy
  gem prune               # Prune old application images and containers
  gem redeploy            # Deploy app to servers without bootstrapping servers, starting kamal-proxy, pruning, and registry login
  gem registry            # Login and -out of the image registry
  gem remove              # Remove kamal-proxy, app, accessories, and registry session from servers
  gem rollback [VERSION]  # Rollback app to VERSION
  gem secrets             # Helpers for extracting secrets
  gem server              # Bootstrap servers with curl and Docker
  gem setup               # Setup all accessories, push the env, and deploy app to servers
  gem upgrade             # Upgrade from Kamal 1.x to 2.0
  gem version             # Show Kamal version
```

After:

```
$ gem exec kamal help
Commands:
  kamal accessory           # Manage accessories (db/redis/search)
  kamal app                 # Manage application
  kamal audit               # Show audit log from servers
  kamal build               # Build application image
  kamal config              # Show combined config (including secrets!)
  kamal deploy              # Deploy app to servers
  kamal details             # Show details about all containers
  kamal docs [SECTION]      # Show Kamal configuration documentation
  kamal help [COMMAND]      # Describe available commands or one specific command
  kamal init                # Create config stub in config/deploy.yml and secrets stub in .kamal
  kamal lock                # Manage the deploy lock
  kamal proxy               # Manage kamal-proxy
  kamal prune               # Prune old application images and containers
  kamal redeploy            # Deploy app to servers without bootstrapping servers, starting kamal-proxy, pruning, and registry login
  kamal registry            # Login and -out of the image registry
  kamal remove              # Remove kamal-proxy, app, accessories, and registry session from servers
  kamal rollback [VERSION]  # Rollback app to VERSION
  kamal secrets             # Helpers for extracting secrets
  kamal server              # Bootstrap servers with curl and Docker
  kamal setup               # Setup all accessories, push the env, and deploy app to servers
  kamal upgrade             # Upgrade from Kamal 1.x to 2.0
  kamal version             # Show Kamal version
```

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Some commands would output `gem` in their help, causing confusion if you didn't look closely. Did the command run? Why are you getting gem help?

## What is your fix for the problem, implemented in this PR?

$0 is the program name, and is often used by CLI tools to determine currently running exe. We can override this value for the duration of the exec all, and reset it when complete.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
