### PR TITLE
Fix issue with git gems locking incorrect specs sometimes

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -960,19 +960,7 @@ module Bundler
 
         # Path sources have special logic
         if s.source.instance_of?(Source::Path) || s.source.instance_of?(Source::Gemspec)
-          new_specs = begin
-            s.source.specs
-          rescue PathError
-            # if we won't need the source (according to the lockfile),
-            # don't error if the path source isn't available
-            next if specs.
-                    for(requested_dependencies, false).
-                    none? {|locked_spec| locked_spec.source == s.source }
-
-            raise
-          end
-
-          new_spec = new_specs[s].first
+          new_spec = s.source.specs[s].first
           if new_spec
             s.dependencies.replace(new_spec.dependencies)
           else

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -971,7 +971,7 @@ module Bundler
         end
 
         if dep.nil? && requested_dependencies.find {|d| name == d.name }
-          @gems_to_unlock << s.name
+          @gems_to_unlock << name
         else
           converged << s
         end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -947,7 +947,6 @@ module Bundler
           gemfile_source = dep.source || default_source
 
           deps << dep if !dep.source || lockfile_source.include?(dep.source)
-          @gems_to_unlock << name if lockfile_source.include?(dep.source) && lockfile_source != gemfile_source
 
           # Replace the locked dependency's source with the equivalent source from the Gemfile
           s.source = gemfile_source
@@ -960,7 +959,7 @@ module Bundler
         next if @sources_to_unlock.include?(source.name)
 
         # Path sources have special logic
-        if source.instance_of?(Source::Path) || source.instance_of?(Source::Gemspec)
+        if source.instance_of?(Source::Path) || source.instance_of?(Source::Gemspec) || (source.instance_of?(Source::Git) && !@gems_to_unlock.include?(name) && deps.include?(dep))
           new_spec = source.specs[s].first
           if new_spec
             s.dependencies.replace(new_spec.dependencies)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -946,7 +946,7 @@ module Bundler
         if dep
           gemfile_source = dep.source || default_source
 
-          deps << dep if !dep.source || lockfile_source.include?(dep.source)
+          deps << dep if !dep.source || lockfile_source.include?(dep.source) || new_deps.include?(dep)
 
           # Replace the locked dependency's source with the equivalent source from the Gemfile
           s.source = gemfile_source

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -956,11 +956,12 @@ module Bundler
           s.source = default_source unless sources.get(lockfile_source)
         end
 
-        next if @sources_to_unlock.include?(s.source.name)
+        source = s.source
+        next if @sources_to_unlock.include?(source.name)
 
         # Path sources have special logic
-        if s.source.instance_of?(Source::Path) || s.source.instance_of?(Source::Gemspec)
-          new_spec = s.source.specs[s].first
+        if source.instance_of?(Source::Path) || source.instance_of?(Source::Gemspec)
+          new_spec = source.specs[s].first
           if new_spec
             s.dependencies.replace(new_spec.dependencies)
           else

--- a/bundler/spec/lock/git_spec.rb
+++ b/bundler/spec/lock/git_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "bundle lock with git gems" do
-  before :each do
+  let(:install_gemfile_with_foo_as_a_git_dependency) do
     build_git "foo"
 
     install_gemfile <<-G
@@ -11,10 +11,14 @@ RSpec.describe "bundle lock with git gems" do
   end
 
   it "doesn't break right after running lock" do
+    install_gemfile_with_foo_as_a_git_dependency
+
     expect(the_bundle).to include_gems "foo 1.0.0"
   end
 
   it "doesn't print errors even if running lock after removing the cache" do
+    install_gemfile_with_foo_as_a_git_dependency
+
     FileUtils.rm_rf(Dir[default_cache_path("git/foo-1.0-*")].first)
 
     bundle "lock --verbose"
@@ -23,6 +27,8 @@ RSpec.describe "bundle lock with git gems" do
   end
 
   it "prints a proper error when changing a locked Gemfile to point to a bad branch" do
+    install_gemfile_with_foo_as_a_git_dependency
+
     gemfile <<-G
       source "https://gem.repo1"
       gem 'foo', :git => "#{lib_path("foo-1.0")}", :branch => "bad"
@@ -34,6 +40,8 @@ RSpec.describe "bundle lock with git gems" do
   end
 
   it "prints a proper error when installing a Gemfile with a locked ref that does not exist" do
+    install_gemfile_with_foo_as_a_git_dependency
+
     lockfile <<~L
       GIT
         remote: #{lib_path("foo-1.0")}
@@ -61,6 +69,8 @@ RSpec.describe "bundle lock with git gems" do
   end
 
   it "locks a git source to the current ref" do
+    install_gemfile_with_foo_as_a_git_dependency
+
     update_git "foo"
     bundle :install
 
@@ -73,6 +83,8 @@ RSpec.describe "bundle lock with git gems" do
   end
 
   it "properly clones a git source locked to an out of date ref" do
+    install_gemfile_with_foo_as_a_git_dependency
+
     update_git "foo"
 
     bundle :install, env: { "BUNDLE_PATH" => "foo" }
@@ -80,6 +92,8 @@ RSpec.describe "bundle lock with git gems" do
   end
 
   it "properly fetches a git source locked to an unreachable ref" do
+    install_gemfile_with_foo_as_a_git_dependency
+
     # Create a commit and make it unreachable
     git "checkout -b foo ", lib_path("foo-1.0")
     unreachable_sha = update_git("foo").ref_for("HEAD")
@@ -118,6 +132,8 @@ RSpec.describe "bundle lock with git gems" do
   end
 
   it "properly fetches a git source locked to an annotated tag" do
+    install_gemfile_with_foo_as_a_git_dependency
+
     # Create an annotated tag
     git("tag -a v1.0 -m 'Annotated v1.0'", lib_path("foo-1.0"))
     annotated_tag = git("rev-parse v1.0", lib_path("foo-1.0"))
@@ -154,9 +170,54 @@ RSpec.describe "bundle lock with git gems" do
   end
 
   it "provides correct #full_gem_path" do
+    install_gemfile_with_foo_as_a_git_dependency
+
     run <<-RUBY
       puts Bundler.rubygems.find_name('foo').first.full_gem_path
     RUBY
     expect(out).to eq(bundle("info foo --path"))
+  end
+
+  it "does not lock versions that don't exist in the repository when changing a GEM transitive dep to a GIT direct dep" do
+    build_repo4 do
+      build_gem "activesupport", "8.0.0" do |s|
+        s.add_dependency "securerandom"
+      end
+
+      build_gem "securerandom", "0.3.1"
+    end
+
+    path = lib_path("securerandom")
+
+    build_git "securerandom", "0.3.2", path: path
+
+    lockfile <<~L
+      GEM
+        remote: https://gem.repo4/
+        specs:
+          activesupport (8.0.0)
+            securerandom
+          securerandom (0.3.1)
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        activesupport
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    gemfile <<~G
+      source "https://gem.repo4"
+
+      gem "activesupport"
+      gem "securerandom", git: "#{path}"
+    G
+
+    bundle "lock"
+
+    expect(lockfile).to include("securerandom (0.3.2)")
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When users change an indirect dependency locked to a rubygems registry to a direct dependency from a git source, Bundler will keep the previous version of the spec locked, and that version may not be available in the new source.
 
## What is your fix for the problem, implemented in this PR?

My fix is to make sure we don't keep the previously locked spec if the dependency has been added as a direct dependency.

Fixes #8238.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
