### PR TITLE
Add man page for 'bundle issue' command

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -121,6 +121,8 @@ bundler/lib/bundler/man/bundle-inject.1
 bundler/lib/bundler/man/bundle-inject.1.ronn
 bundler/lib/bundler/man/bundle-install.1
 bundler/lib/bundler/man/bundle-install.1.ronn
+bundler/lib/bundler/man/bundle-issue.1
+bundler/lib/bundler/man/bundle-issue.1.ronn
 bundler/lib/bundler/man/bundle-list.1
 bundler/lib/bundler/man/bundle-list.1.ronn
 bundler/lib/bundler/man/bundle-lock.1

--- a/bundler/lib/bundler/man/bundle-issue.1
+++ b/bundler/lib/bundler/man/bundle-issue.1
@@ -1,0 +1,45 @@
+.\" generated with nRonn/v0.11.1
+.\" https://github.com/n-ronn/nronn/tree/0.11.1
+.TH "BUNDLE\-ISSUE" "1" "November 2024" ""
+.SH "NAME"
+\fBbundle\-issue\fR \- Get help reporting Bundler issues
+.SH "SYNOPSIS"
+\fBbundle issue\fR
+.SH "DESCRIPTION"
+Provides guidance on reporting Bundler issues and outputs detailed system information that should be included when filing a bug report\. This command:
+.IP "1." 4
+Displays links to troubleshooting resources
+.IP "2." 4
+Shows instructions for reporting issues
+.IP "3." 4
+Outputs comprehensive environment information needed for debugging
+.IP "" 0
+.P
+The command helps ensure that bug reports include all necessary system details for effective troubleshooting\.
+.SH "OUTPUT"
+The command outputs several sections:
+.IP "\(bu" 4
+Troubleshooting links and resources
+.IP "\(bu" 4
+Link to the GitHub issue template
+.IP "\(bu" 4
+Environment information including: Bundler version and platforms, Ruby version and configuration, RubyGems version and paths, Development tool versions (Git, RVM, rbenv, chruby)
+.IP "\(bu" 4
+Bundler build metadata
+.IP "\(bu" 4
+Current Bundler settings
+.IP "\(bu" 4
+Bundle Doctor output
+.IP "" 0
+.SH "EXAMPLES"
+Get issue reporting information:
+.IP "" 4
+.nf
+$ bundle issue
+.fi
+.IP "" 0
+.SH "SEE ALSO"
+.IP "\(bu" 4
+bundle\-doctor(1)
+.IP "" 0
+

--- a/bundler/lib/bundler/man/bundle-issue.1.ronn
+++ b/bundler/lib/bundler/man/bundle-issue.1.ronn
@@ -1,0 +1,37 @@
+bundle-issue(1) -- Get help reporting Bundler issues
+=====================================================
+
+## SYNOPSIS
+
+`bundle issue`
+
+## DESCRIPTION
+
+Provides guidance on reporting Bundler issues and outputs detailed system information that should be included when filing a bug report. This command:
+
+1. Displays links to troubleshooting resources
+2. Shows instructions for reporting issues
+3. Outputs comprehensive environment information needed for debugging
+
+The command helps ensure that bug reports include all necessary system details for effective troubleshooting.
+
+## OUTPUT
+
+The command outputs several sections:
+
+* Troubleshooting links and resources
+* Link to the GitHub issue template
+* Environment information including: Bundler version and platforms, Ruby version and configuration, RubyGems version and paths, Development tool versions (Git, RVM, rbenv, chruby)
+* Bundler build metadata
+* Current Bundler settings
+* Bundle Doctor output
+
+## EXAMPLES
+
+Get issue reporting information:
+
+    $ bundle issue
+
+## SEE ALSO
+
+* bundle-doctor(1)

--- a/bundler/lib/bundler/man/index.txt
+++ b/bundler/lib/bundler/man/index.txt
@@ -16,6 +16,7 @@ bundle-info(1)        bundle-info.1
 bundle-init(1)        bundle-init.1
 bundle-inject(1)      bundle-inject.1
 bundle-install(1)     bundle-install.1
+bundle-issue(1)       bundle-issue.1
 bundle-list(1)        bundle-list.1
 bundle-lock(1)        bundle-lock.1
 bundle-open(1)        bundle-open.1

--- a/bundler/spec/commands/help_spec.rb
+++ b/bundler/spec/commands/help_spec.rb
@@ -29,11 +29,6 @@ RSpec.describe "bundle help" do
     expect(out).to match(/bundle-install/)
   end
 
-  it "still outputs the old help for commands that do not have man pages yet" do
-    bundle "help issue"
-    expect(out).to include("Learn how to report an issue in Bundler")
-  end
-
   it "looks for a binary and executes it with --help option if it's named bundler-<task>" do
     skip "Could not find command testtasks, probably because not a windows friendly executable" if Gem.win_platform?
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Missing man page for `bundle issue` command https://github.com/rubygems/rubygems/issues/8268

## What is your fix for the problem, implemented in this PR?

Add a man page for `bundle issue` command 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
