### PR TITLE
Silent verbose stdout for dependency of test gems

### DIFF
--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -150,7 +150,7 @@ module Spec
         ENV["BUNDLE_PATH__SYSTEM"] = "true"
       end
 
-      puts `#{Gem.ruby} #{File.expand_path("support/bundle.rb", Path.spec_dir)} install --verbose`
+      puts `#{Gem.ruby} #{File.expand_path("support/bundle.rb", Path.spec_dir)} install --quiet`
       raise unless $?.success?
     ensure
       if path


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The current preparation of test suite generates over 3k lines of verbose log. It's not useful to debug on GitHub Actions.

see https://github.com/ruby/ruby/actions/runs/11942634532/job/33290100573#step:13:28 

## What is your fix for the problem, implemented in this PR?

Suppress that verbose log qith `--quiet` option.

https://github.com/ruby/ruby/actions/runs/11943906194/job/33293858374?pr=12133#step:14:29

It's fast to show result or debug log on GitHub Actions 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
