### PR TITLE
Fix `bundle remove` sometimes not removing gems

### DIFF
--- a/bundler/lib/bundler/injector.rb
+++ b/bundler/lib/bundler/injector.rb
@@ -184,7 +184,7 @@ module Bundler
     # @param [Array] gems            Array of names of gems to be removed.
     # @param [Pathname] gemfile_path The Gemfile from which to remove dependencies.
     def remove_gems_from_gemfile(gems, gemfile_path)
-      patterns = /gem\s+(['"])#{Regexp.union(gems)}\1|gem\s*\((['"])#{Regexp.union(gems)}\2\)/
+      patterns = /gem\s+(['"])#{Regexp.union(gems)}\1|gem\s*\((['"])#{Regexp.union(gems)}\2.*\)/
       new_gemfile = []
       multiline_removal = false
       File.readlines(gemfile_path).each do |line|

--- a/bundler/spec/commands/remove_spec.rb
+++ b/bundler/spec/commands/remove_spec.rb
@@ -729,4 +729,23 @@ RSpec.describe "bundle remove" do
       end
     end
   end
+
+  context "when gem definition has parentheses" do
+    it "removes the gem" do
+      gemfile <<-G
+        source "https://gem.repo1"
+
+        gem("myrack")
+        gem("myrack", ">= 0")
+        gem("myrack", require: false)
+      G
+
+      bundle "remove myrack"
+
+      expect(out).to include("myrack was removed.")
+      expect(gemfile).to eq <<~G
+        source "https://gem.repo1"
+      G
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/rubygems/rubygems/issues/6424.

## What was the end-user or developer problem that led to this PR?

`bundle remove` does not remove gems when their definition uses parentheses and arguments. For example `bundle remove mygem` does not remove the following gems:

```ruby
gem("mygem", ">= 0")
gem("mygem", require: false)
```

## What is your fix for the problem, implemented in this PR?

The code responsible for detecting gems to remove is in `Bundler::Injector#remove_gems_from_gemfile`, and uses a regex. Change the second part of the regex — the one that deals with parentheses — to match follow-up characters before the end of the parenthesis.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
