### PR TITLE
Move require location of build_metadata

### DIFF
--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -16,7 +16,6 @@ require "rspec/mocks"
 require "rspec/support/differ"
 
 require_relative "support/builders"
-require_relative "support/build_metadata"
 require_relative "support/checksums"
 require_relative "support/filters"
 require_relative "support/helpers"

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -3,6 +3,8 @@
 require "bundler/shared_helpers"
 require "shellwords"
 
+require_relative "build_metadata"
+
 module Spec
   module Builders
     def self.extended(mod)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The current code is broken to call Spec::Builders#build_* method directly. I found this case at https://github.com/ruby/ruby/pull/12111

## What is your fix for the problem, implemented in this PR?

I make explicitly load build_metadata.rb because Spec::BuildMetadata is only called from BundlerBuilder.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
