### PR TITLE
Fix installs of subdependencies of unlocked dependencies to be conservative

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -961,7 +961,7 @@ module Bundler
     def converge_locked_specs
       converged = converge_specs(@locked_specs)
 
-      resolve = SpecSet.new(converged.reject {|s| @gems_to_unlock.include?(s.name) })
+      resolve = SpecSet.new(converged)
 
       diff = nil
 
@@ -1021,7 +1021,7 @@ module Bundler
         end
       end
 
-      filter_specs(converged, deps)
+      filter_specs(converged, deps).reject {|s| @gems_to_unlock.include?(s.name) }
     end
 
     def metadata_dependencies

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -1014,11 +1014,12 @@ module Bundler
           end
         end
 
-        if dep.nil? && requested_dependencies.find {|d| name == d.name }
+        if dep.nil? && requested_dep = requested_dependencies.find {|d| name == d.name }
           @gems_to_unlock << name
-        else
-          converged << s
+          deps << requested_dep
         end
+
+        converged << s
       end
 
       filter_specs(converged, deps, skips: @gems_to_unlock)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -619,8 +619,8 @@ module Bundler
       end
     end
 
-    def filter_specs(specs, deps)
-      SpecSet.new(specs).for(deps, platforms)
+    def filter_specs(specs, deps, skips: [])
+      SpecSet.new(specs).for(deps, platforms, skips: skips)
     end
 
     def materialize(dependencies)
@@ -1021,7 +1021,7 @@ module Bundler
         end
       end
 
-      filter_specs(converged, deps).reject {|s| @gems_to_unlock.include?(s.name) }
+      filter_specs(converged, deps, skips: @gems_to_unlock)
     end
 
     def metadata_dependencies

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -11,7 +11,7 @@ module Bundler
       @specs = specs
     end
 
-    def for(dependencies, platforms_or_legacy_check = [nil], legacy_platforms = [nil])
+    def for(dependencies, platforms_or_legacy_check = [nil], legacy_platforms = [nil], skips: [])
       platforms = if [true, false].include?(platforms_or_legacy_check)
         Bundler::SharedHelpers.major_deprecation 2,
           "SpecSet#for received a `check` parameter, but that's no longer used and deprecated. " \
@@ -23,7 +23,7 @@ module Bundler
         platforms_or_legacy_check
       end
 
-      materialize_dependencies(dependencies, platforms)
+      materialize_dependencies(dependencies, platforms, skips: skips)
 
       @materializations.flat_map(&:specs).uniq
     end
@@ -206,7 +206,7 @@ module Bundler
 
     private
 
-    def materialize_dependencies(dependencies, platforms = [nil])
+    def materialize_dependencies(dependencies, platforms = [nil], skips: [])
       handled = ["bundler"].product(platforms).map {|k| [k, true] }.to_h
       deps = dependencies.product(platforms)
       @materializations = []
@@ -227,7 +227,7 @@ module Bundler
 
         deps.concat(materialization.dependencies) if materialization.complete?
 
-        @materializations << materialization
+        @materializations << materialization unless skips.include?(name)
       end
 
       @materializations

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -1931,7 +1931,7 @@ RSpec.describe "bundle update conservative" do
 
       bundle "install"
 
-      expect(the_bundle).to include_gems "isolated_owner 1.0.2", "isolated_dep 2.0.2", "shared_dep 5.0.1", "shared_owner_a 3.0.2", "shared_owner_b 4.0.1"
+      expect(the_bundle).to include_gems "isolated_owner 1.0.2", "isolated_dep 2.0.1", "shared_dep 5.0.1", "shared_owner_a 3.0.2", "shared_owner_b 4.0.1"
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If a user changes a gem in the `Gemfile` to a requirement that no longer matches the `Gemfile.lock` file, running `bundle install` will cause also dependencies of this gem to be unlocked.

`bundle install` is documented to be conservative, so versions of dependencies should be preserved if possible.

## What is your fix for the problem, implemented in this PR?

My fix is, when converging specification to pass the set of versions that should be preserved from the lockfile during resolution, we should make sure all top level gems are considered, and only exclude those gems themselves (and not their dependencies) if their locked versions happen to not be satisfied by an edited Gemfile.

This fix led to a spec failure in `bundle update` specs. The spec reads "should match bundle install conservative update behavior when not eagerly unlocking" and was making sure that transitive dependencies are actually updated in this situation. However, this spec was originally added at https://github.com/rubygems/bundler/commit/ad80a9238f4e98e73a9978ca747c4d24fddc7767 just to make sure that `bundle install` matches the behaviour of `bundle update --conservative`. In fact, these two started to not have the same behavior in https://github.com/rubygems/rubygems/pull/4692, when this same issue was fixed for `bundle update --conservative`. So this patch also make these two have consistent behavior again, which what the specs tried to enforce.

Fixes #8092.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
