### PR TITLE
Fix gemfury credentials written to logs in verbose mode

### DIFF
--- a/bundler/lib/bundler/uri_credentials_filter.rb
+++ b/bundler/lib/bundler/uri_credentials_filter.rb
@@ -16,7 +16,7 @@ module Bundler
 
       if uri.userinfo
         # oauth authentication
-        if uri.password == "x-oauth-basic" || uri.password == "x"
+        if uri.password == "x-oauth-basic" || uri.password == "x" || uri.password.nil?
           # URI as string does not display with password if no user is set
           oauth_designation = uri.password
           uri.user = oauth_designation

--- a/bundler/spec/bundler/fetcher/downloader_spec.rb
+++ b/bundler/spec/bundler/fetcher/downloader_spec.rb
@@ -154,35 +154,39 @@ RSpec.describe Bundler::Fetcher::Downloader do
         context "that contains cgi escaped characters" do
           let(:uri) { Gem::URI("http://username:password%24@www.uri-to-fetch.com/api/v2/endpoint") }
 
-          it "should request basic authentication with the username and password" do
+          it "should request basic authentication with the username and password, and log the HTTP GET request to debug, without the password" do
             expect(net_http_get).to receive(:basic_auth).with("username", "password$")
+            expect(Bundler).to receive_message_chain(:ui, :debug).with("HTTP GET http://username@www.uri-to-fetch.com/api/v2/endpoint")
             subject.request(uri, options)
           end
         end
 
         context "that is all unescaped characters" do
           let(:uri) { Gem::URI("http://username:password@www.uri-to-fetch.com/api/v2/endpoint") }
-          it "should request basic authentication with the username and proper cgi compliant password" do
+          it "should request basic authentication with the username and proper cgi compliant password, and log the HTTP GET request to debug, without the password" do
             expect(net_http_get).to receive(:basic_auth).with("username", "password")
+            expect(Bundler).to receive_message_chain(:ui, :debug).with("HTTP GET http://username@www.uri-to-fetch.com/api/v2/endpoint")
             subject.request(uri, options)
           end
         end
       end
 
-      context "and there is no password provided" do
+      context "and it's used as the authentication token" do
         let(:uri) { Gem::URI("http://username@www.uri-to-fetch.com/api/v2/endpoint") }
 
-        it "should request basic authentication with just the user" do
+        it "should request basic authentication with just the user, and log the HTTP GET request to debug, without the token" do
           expect(net_http_get).to receive(:basic_auth).with("username", nil)
+          expect(Bundler).to receive_message_chain(:ui, :debug).with("HTTP GET http://www.uri-to-fetch.com/api/v2/endpoint")
           subject.request(uri, options)
         end
       end
 
-      context "that contains cgi escaped characters" do
+      context "and it's used as the authentication token, and contains cgi escaped characters" do
         let(:uri) { Gem::URI("http://username%24@www.uri-to-fetch.com/api/v2/endpoint") }
 
-        it "should request basic authentication with the proper cgi compliant password user" do
+        it "should request basic authentication with the proper cgi compliant password user, and log the HTTP GET request to debug, without the token" do
           expect(net_http_get).to receive(:basic_auth).with("username$", nil)
+          expect(Bundler).to receive_message_chain(:ui, :debug).with("HTTP GET http://www.uri-to-fetch.com/api/v2/endpoint")
           subject.request(uri, options)
         end
       end

--- a/bundler/spec/bundler/uri_credentials_filter_spec.rb
+++ b/bundler/spec/bundler/uri_credentials_filter_spec.rb
@@ -31,6 +31,16 @@ RSpec.describe Bundler::URICredentialsFilter do
 
           it_behaves_like "original type of uri is maintained"
         end
+
+        context "specified without empty username" do
+          let(:credentials) { "oauth_token@" }
+
+          it "returns the uri without the oauth token" do
+            expect(subject.credential_filtered_uri(uri).to_s).to eq(Gem::URI("https://github.com/company/private-repo").to_s)
+          end
+
+          it_behaves_like "original type of uri is maintained"
+        end
       end
 
       context "authentication using login credentials" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I noticed that in the case of gemfury registry, which use [only the authentication token](https://gemfury.com/help/install-gems/#keep-your-privates-private-bundler-18) as credentials, we print the credential to logs in verbose mode.

## What is your fix for the problem, implemented in this PR?

Special case the "no username" case when hiding URL credentials.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
