### PR TITLE
Cleanup code about oldest possible RubyGems downgrade

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -107,15 +107,6 @@ class Gem::Commands::SetupCommand < Gem::Command
     @verbose = nil
   end
 
-  def check_ruby_version
-    required_version = Gem::Requirement.new ">= 2.6.0"
-
-    unless required_version.satisfied_by? Gem.ruby_version
-      alert_error "Expected Ruby version #{required_version}, is #{Gem.ruby_version}"
-      terminate_interaction 1
-    end
-  end
-
   def defaults_str # :nodoc:
     "--format-executable --document ri --regenerate-binstubs"
   end
@@ -147,8 +138,6 @@ By default, this RubyGems will install gem as:
 
   def execute
     @verbose = Gem.configuration.really_verbose
-
-    check_ruby_version
 
     require "fileutils"
     if Gem.configuration.really_verbose

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -323,10 +323,6 @@ command to remove old versions.
   #
   def oldest_supported_version
     @oldest_supported_version ||=
-      if Gem.ruby_version > Gem::Version.new("3.1.a")
-        Gem::Version.new("3.3.3")
-      else
-        Gem::Version.new("3.2.3")
-      end
+      Gem::Version.new("3.3.3")
   end
 end

--- a/lib/rubygems/commands/update_command.rb
+++ b/lib/rubygems/commands/update_command.rb
@@ -317,9 +317,7 @@ command to remove old versions.
 
   #
   # Oldest version we support downgrading to. This is the version that
-  # originally ships with the first patch version of each ruby, because we never
-  # test each ruby against older rubygems, so we can't really guarantee it
-  # works. Version list can be checked here: https://stdgems.org/rubygems
+  # originally ships with the oldest supported patch version of ruby.
   #
   def oldest_supported_version
     @oldest_supported_version ||=


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I noticed that we no longer follow what we say in the code comment about the oldest possible RubyGems version that you can downgrade to.

## What is your fix for the problem, implemented in this PR?

I considered fixing that but I decided to update the comment to explain what we are really doing, since it's been like that for a while and we haven't seeing any issues, and it's not trivial do to what we advertise without maintaining a hardcoded list that will get out of date.

I also cleaned up a few things that are not really necessary.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
