### PR TITLE
Prevent a warning: net/http: Content-Type did not set

### DIFF
--- a/test/rubygems/utilities.rb
+++ b/test/rubygems/utilities.rb
@@ -115,6 +115,7 @@ class Gem::FakeFetcher
 
     # Ensure multipart request bodies are generated
     socket = FakeSocket.new
+    last_request.content_type ||= "application/x-www-form-urlencoded"
     last_request.exec socket.binmode, "1.1", last_request.path
     _, last_request.body = socket.string.split("\r\n\r\n", 2)
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`make test-all RUBYOPT=-w` in the ruby/ruby repo printed the warning.

https://rubyci.s3.amazonaws.com/debian11/ruby-master/log/20241125T033003Z.log.html.gz
```
[ 9827/32001] TestGemCommandsOwnerCommand#test_add_owners_unathorized_api_key/home/chkbuild/chkbuild/tmp/build/20241125T033003Z/ruby/lib/rubygems/vendor/net-http/lib/net/http/generic_request.rb:263: warning: net/http: Content-Type did not set; using application/x-www-form-urlencoded
 = 0.01 s
```

## What is your fix for the problem, implemented in this PR?

This change prevents the warning by specifying the content-type explicitly.

A follow-up to b70c1bb1503df69716312ce5b0ad89e9be02d44b

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
