### PR TITLE
Fix test task name on generated readme when using test-unit

### DIFF
--- a/bundler/lib/bundler/templates/newgem/README.md.tt
+++ b/bundler/lib/bundler/templates/newgem/README.md.tt
@@ -26,7 +26,7 @@ TODO: Write usage instructions here
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies.<% if config[:test] %> Then, run `rake <%= config[:test].sub('mini', '').sub('rspec', 'spec') %>` to run the tests.<% end %> You can also run `bin/console` for an interactive prompt that will allow you to experiment.<% if config[:bin] %> Run `bundle exec <%= config[:name] %>` to use the gem in this directory, ignoring other installed copies of this gem.<% end %>
+After checking out the repo, run `bin/setup` to install dependencies.<% if config[:test] %> Then, run `rake <%= config[:test_task] %>` to run the tests.<% end %> You can also run `bin/console` for an interactive prompt that will allow you to experiment.<% if config[:bin] %> Run `bundle exec <%= config[:name] %>` to use the gem in this directory, ignoring other installed copies of this gem.<% end %>
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 <% if config[:git] -%>

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -428,6 +428,22 @@ RSpec.describe "bundle gem" do
         expect(bundled_app("#{gem_name}/README.md").read).not_to include("github.com/bundleuser")
       end
     end
+
+    describe "test task name on readme" do
+      shared_examples_for "test task name on readme" do |framework, task_name|
+        before do
+          bundle "gem #{gem_name} --test=#{framework}"
+        end
+
+        it "renders with correct name" do
+          expect(bundled_app("#{gem_name}/README.md").read).to include("Then, run `rake #{task_name}` to run the tests.")
+        end
+      end
+
+      it_behaves_like "test task name on readme", "test-unit", "test"
+      it_behaves_like "test task name on readme", "minitest", "test"
+      it_behaves_like "test task name on readme", "rspec", "spec"
+    end
   end
 
   it "creates a new git repository" do


### PR DESCRIPTION
This fixes the name of the test task on the rendered readme generated by the `bundle gem --test test-unit ...` command.

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

`bundle gem --test test-unit <gem_name>` will produce a readme like this:

```
... Then, run `rake test-unit` to run the tests. ...
```

... whereas the correct name of the test is `test`, not `test-unit`.

This problem is not seen when using minitest or RSpec.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

This makes it use `config[:test_task]` instead of `config[:test].sub('mini', '').sub('rspec', 'spec')`.
The correct test name `config[:test_task]` is set in `bundler/lib/bundler/cli/gem.rb` around line 127:

```ruby
        when "test-unit"
          templates.merge!(
            "test/test-unit/test_helper.rb.tt" => "test/test_helper.rb",
            "test/test-unit/newgem_test.rb.tt" => "test/#{namespaced_path}_test.rb"
          )
          config[:test_task] = :test
        end
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
