### PR TITLE
Restore the previous cache format for git sources

### DIFF
--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -139,6 +139,11 @@ module Bundler
         spec.source.cache(spec, custom_path) if spec.source.respond_to?(:cache)
       end
 
+      Dir[cache_path.join("*/.git")].each do |git_dir|
+        FileUtils.rm_rf(git_dir)
+        FileUtils.touch(File.expand_path("../.bundlecache", git_dir))
+      end
+
       prune_cache(cache_path) unless Bundler.settings[:no_prune]
     end
 

--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -136,7 +136,11 @@ module Bundler
       specs_to_cache.each do |spec|
         next if spec.name == "bundler"
         next if spec.source.is_a?(Source::Gemspec)
-        spec.source.cache(spec, custom_path) if spec.source.respond_to?(:cache)
+        if spec.source.respond_to?(:migrate_cache)
+          spec.source.migrate_cache(custom_path, local: local)
+        elsif spec.source.respond_to?(:cache)
+          spec.source.cache(spec, custom_path)
+        end
       end
 
       Dir[cache_path.join("*/.git")].each do |git_dir|

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -219,7 +219,6 @@ module Bundler
       def cache(spec, custom_path = nil)
         app_cache_path = app_cache_path(custom_path)
         return unless Bundler.feature_flag.cache_all?
-        return if install_path == app_cache_path
         return if cache_path == app_cache_path
         cached!
         FileUtils.rm_rf(app_cache_path)

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -102,7 +102,7 @@ module Bundler
       end
 
       def identifier
-        uri_with_specifiers([humanized_ref, cached_revision, glob_for_display])
+        uri_with_specifiers([humanized_ref, locked_revision, glob_for_display])
       end
 
       def uri_with_specifiers(specifiers)
@@ -176,10 +176,10 @@ module Bundler
             "#{current_branch} but Gemfile specifies #{branch}"
         end
 
-        changed = cached_revision && cached_revision != revision
+        changed = locked_revision && locked_revision != revision
 
-        if !Bundler.settings[:disable_local_revision_check] && changed && !@unlocked && !git_proxy.contains?(cached_revision)
-          raise GitError, "The Gemfile lock is pointing to revision #{shortref_for_display(cached_revision)} " \
+        if !Bundler.settings[:disable_local_revision_check] && changed && !@unlocked && !git_proxy.contains?(locked_revision)
+          raise GitError, "The Gemfile lock is pointing to revision #{shortref_for_display(locked_revision)} " \
             "but the current branch in your local override for #{name} does not contain such commit. " \
             "Please make sure your branch is up to date."
         end
@@ -249,7 +249,7 @@ module Bundler
       end
 
       def app_cache_dirname
-        "#{base_name}-#{shortref_for_path(cached_revision || revision)}"
+        "#{base_name}-#{shortref_for_path(locked_revision || revision)}"
       end
 
       def revision
@@ -326,7 +326,7 @@ module Bundler
       end
 
       def has_app_cache?
-        cached_revision && super
+        locked_revision && super
       end
 
       def use_app_cache?
@@ -334,11 +334,11 @@ module Bundler
       end
 
       def requires_checkout?
-        allow_git_ops? && !local? && !cached_revision_checked_out?
+        allow_git_ops? && !local? && !locked_revision_checked_out?
       end
 
-      def cached_revision_checked_out?
-        cached_revision && cached_revision == revision && install_path.exist?
+      def locked_revision_checked_out?
+        locked_revision && locked_revision == revision && install_path.exist?
       end
 
       def base_name
@@ -375,7 +375,7 @@ module Bundler
         Bundler::Digest.sha1(input)
       end
 
-      def cached_revision
+      def locked_revision
         options["revision"]
       end
 
@@ -384,7 +384,7 @@ module Bundler
       end
 
       def git_proxy
-        @git_proxy ||= GitProxy.new(cache_path, uri, options, cached_revision, self)
+        @git_proxy ||= GitProxy.new(cache_path, uri, options, locked_revision, self)
       end
 
       def fetch

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -217,9 +217,11 @@ module Bundler
       end
 
       def cache(spec, custom_path = nil)
-        app_cache_path = app_cache_path(custom_path)
         return unless Bundler.feature_flag.cache_all?
+
+        app_cache_path = app_cache_path(custom_path)
         return if cache_path == app_cache_path
+
         cached!
         FileUtils.rm_rf(app_cache_path)
         git_proxy.checkout if requires_checkout?

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -84,12 +84,6 @@ module Bundler
           end
         end
 
-        def not_a_repository?
-          _, status = git_null("rev-parse", "--resolve-git-dir", path.to_s, dir: path)
-
-          !status.success?
-        end
-
         def contains?(commit)
           allowed_with_path do
             result, status = git_null("branch", "--contains", commit, dir: path)

--- a/bundler/spec/cache/git_spec.rb
+++ b/bundler/spec/cache/git_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe "bundle cache with git" do
     expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist
     expect(bundled_app("vendor/cache/foo-1.0-#{ref}/.git")).not_to exist
     expect(bundled_app("vendor/cache/foo-1.0-#{ref}/.bundlecache")).to be_file
-    expect(Dir.glob(bundled_app("vendor/cache/foo-1.0-#{ref}/hooks/*.sample"))).to be_empty
 
     FileUtils.rm_rf lib_path("foo-1.0")
     expect(the_bundle).to include_gems "foo 1.0"
@@ -240,7 +239,7 @@ RSpec.describe "bundle cache with git" do
     expect(the_bundle).to include_gem "foo 1.0"
   end
 
-  it "copies repository to vendor cache" do
+  it "copies repository to vendor cache, including submodules" do
     # CVE-2022-39253: https://lore.kernel.org/lkml/xmqq4jw1uku5.fsf@gitster.g/
     system(*%W[git config --global protocol.file.allow always])
 
@@ -265,6 +264,7 @@ RSpec.describe "bundle cache with git" do
     bundle :cache
 
     expect(bundled_app("vendor/cache/has_submodule-1.0-#{ref}")).to exist
+    expect(bundled_app("vendor/cache/has_submodule-1.0-#{ref}/submodule-1.0")).to exist
     expect(the_bundle).to include_gems "has_submodule 1.0"
   end
 
@@ -275,7 +275,6 @@ RSpec.describe "bundle cache with git" do
       source "https://gem.repo1"
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
-    bundle "config set path vendor/bundle"
     bundle "config set cache_all true"
     bundle :cache, "all-platforms" => true, :install => false
 

--- a/bundler/spec/cache/git_spec.rb
+++ b/bundler/spec/cache/git_spec.rb
@@ -239,6 +239,96 @@ RSpec.describe "bundle cache with git" do
     expect(the_bundle).to include_gem "foo 1.0"
   end
 
+  it "installs properly a bundler 2.5.17-2.5.23 cache as a bare repository without cloning remote repositories" do
+    git = build_git "foo"
+
+    short_ref = git.ref_for("main", 11)
+    cache_dir = bundled_app("vendor/cache/foo-1.0-#{short_ref}")
+
+    gemfile <<-G
+      source "https://gem.repo1"
+      gem "foo", :git => '#{lib_path("foo-1.0")}'
+    G
+    bundle "config set global_gem_cache false"
+    bundle "config set cache_all true"
+    bundle "config path vendor/bundle"
+    bundle :install
+
+    # Simulate old cache by copying the real cache folder to vendor/cache
+    FileUtils.mkdir_p bundled_app("vendor/cache")
+    FileUtils.cp_r "#{Dir.glob(vendored_gems("cache/bundler/git/foo-1.0-*")).first}/.", cache_dir
+    FileUtils.rm_rf bundled_app("vendor/bundle")
+
+    bundle "install --local --verbose"
+    expect(err).to include("Installing from cache in old \"bare repository\" format for compatibility")
+
+    expect(out).to_not include("Fetching")
+
+    # leaves old cache alone
+    expect(cache_dir.join("lib/foo.rb")).not_to exist
+    expect(cache_dir.join("HEAD")).to exist
+
+    expect(the_bundle).to include_gem "foo 1.0"
+  end
+
+  it "migrates a bundler 2.5.17-2.5.23 cache as a bare repository when not running with --local" do
+    git = build_git "foo"
+
+    short_ref = git.ref_for("main", 11)
+    cache_dir = bundled_app("vendor/cache/foo-1.0-#{short_ref}")
+
+    gemfile <<-G
+      source "https://gem.repo1"
+      gem "foo", :git => '#{lib_path("foo-1.0")}'
+    G
+    bundle "config set global_gem_cache false"
+    bundle "config set cache_all true"
+    bundle "config path vendor/bundle"
+    bundle :install
+
+    # Simulate old cache by copying the real cache folder to vendor/cache
+    FileUtils.mkdir_p bundled_app("vendor/cache")
+    FileUtils.cp_r "#{Dir.glob(vendored_gems("cache/bundler/git/foo-1.0-*")).first}/.", cache_dir
+    FileUtils.rm_rf bundled_app("vendor/bundle")
+
+    bundle "install --verbose"
+    expect(out).to include("Fetching")
+
+    # migrates old cache alone
+    expect(cache_dir.join("lib/foo.rb")).to exist
+    expect(cache_dir.join("HEAD")).not_to exist
+
+    expect(the_bundle).to include_gem "foo 1.0"
+  end
+
+  it "migrates a bundler 2.5.17-2.5.23 cache as a bare repository when running `bundle cache`, even if gems already installed" do
+    git = build_git "foo"
+
+    short_ref = git.ref_for("main", 11)
+    cache_dir = bundled_app("vendor/cache/foo-1.0-#{short_ref}")
+
+    gemfile <<-G
+      source "https://gem.repo1"
+      gem "foo", :git => '#{lib_path("foo-1.0")}'
+    G
+    bundle "config set global_gem_cache false"
+    bundle "config set cache_all true"
+    bundle "config path vendor/bundle"
+    bundle :install
+
+    # Simulate old cache by copying the real cache folder to vendor/cache
+    FileUtils.mkdir_p bundled_app("vendor/cache")
+    FileUtils.cp_r "#{Dir.glob(vendored_gems("cache/bundler/git/foo-1.0-*")).first}/.", cache_dir
+
+    bundle "cache"
+
+    # migrates old cache alone
+    expect(cache_dir.join("lib/foo.rb")).to exist
+    expect(cache_dir.join("HEAD")).not_to exist
+
+    expect(the_bundle).to include_gem "foo 1.0"
+  end
+
   it "copies repository to vendor cache, including submodules" do
     # CVE-2022-39253: https://lore.kernel.org/lkml/xmqq4jw1uku5.fsf@gitster.g/
     system(*%W[git config --global protocol.file.allow always])


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We recently migrated git sources in `vendor/cache` to be bare repository clones. However, that makes installing from `vendor/cache` always need `git`. Not needing git to install from `vendor/cache` was a feature that had its own spec testing it, so users expected that to work.

The regression was unnoticed unfortunately.

In addition to this, changing the cache present additional challenges like Heroku or Dependabot not playing well with it.

## What is your fix for the problem, implemented in this PR?

This PR restores the previous cache format, since it's not really necessary to fix the issues I wanted to fix originally.

It also provides some compatibility with the cache generated by Bundler 2.5.17-2.5.23. The idea is that `bundle install --local` is still able to install from this "bare clone" cache, and that `bundle install` (without local) migrates the cache back to what it was before.

Fixes #8284.
Fixes #8274.
Fixes #8217.
Fixes https://github.com/rubygems/rubygems/issues/8069#issuecomment-2486778414.
Unblocks https://github.com/dependabot/dependabot-core/pull/10746.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
