### PR TITLE
Start testing with Ruby 3.4 on every PR

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -32,6 +32,7 @@ jobs:
           - { name: ruby-3.1, value: 3.1.6 }
           - { name: ruby-3.2, value: 3.2.6 }
           - { name: ruby-3.3, value: 3.3.6 }
+          - { name: ruby-3.4, value: 3.4.0-preview2 }
 
         bundler:
           - { name: 2, value: '' }
@@ -41,6 +42,7 @@ jobs:
           - { os: { name: macOS, value: macos-14 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.6 }, timeout: 90 }
           - { os: { name: macOS, value: macos-14 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.2, value: 3.2.6 }, timeout: 90 }
           - { os: { name: macOS, value: macos-14 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.3, value: 3.3.6 }, timeout: 90 }
+          - { os: { name: macOS, value: macos-14 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.4, value: 3.4.0-preview2 }, timeout: 90 }
 
           - { os: { name: Windows, value: windows-2022 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.6 }, timeout: 150 }
           - { os: { name: Windows, value: windows-2022 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.2, value: 3.2.6 }, timeout: 150 }

--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -25,6 +25,7 @@ jobs:
           - { name: "3.1", value: 3.1.6 }
           - { name: "3.2", value: 3.2.6 }
           - { name: "3.3", value: 3.3.6 }
+          - { name: "3.4", value: 3.4.0-preview2 }
           - { name: jruby, value: jruby-9.4.9.0 }
           - { name: truffleruby, value: truffleruby-24.0.1 }
         openssl:

--- a/.github/workflows/realworld-bundler.yml
+++ b/.github/workflows/realworld-bundler.yml
@@ -28,6 +28,7 @@ jobs:
           - { name: ruby-3.1, value: 3.1.6 }
           - { name: ruby-3.2, value: 3.2.6 }
           - { name: ruby-3.3, value: 3.3.6 }
+          - { name: ruby-3.4, value: 3.4.0-preview2 }
 
         bundler:
           - { name: 2, value: '' }
@@ -37,6 +38,7 @@ jobs:
           - { os: { name: macOS, value: macos-14 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.6 } }
           - { os: { name: macOS, value: macos-14 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.2, value: 3.2.6 } }
           - { os: { name: macOS, value: macos-14 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.3, value: 3.3.6 } }
+          - { os: { name: macOS, value: macos-14 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.4, value: 3.4.0-preview2 } }
     env:
       RGV: ..
       RUBYOPT: --disable-gems
@@ -71,9 +73,11 @@ jobs:
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.6 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.2, value: 3.2.6 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.3, value: 3.3.6 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.4, value: 3.4.0-preview2 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.1, value: 3.1.6 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.2, value: 3.2.6 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.3, value: 3.3.6 } }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.4, value: 3.4.0-preview2 } }
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup ruby
@@ -104,7 +108,7 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@a2bbe5b1b236842c1cb7dd11e8e3b51e0a616acc # v1.202.0
         with:
-          ruby-version: 3.3.6
+          ruby-version: 3.4.0-preview2
           bundler: none
       - name: Prepare dependencies
         run: bin/rake setup

--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -38,6 +38,12 @@ jobs:
           - ruby: { name: truffleruby, value: truffleruby-24.0.1 }
             os: { name: Ubuntu, value: ubuntu-24.04 }
 
+          - ruby: { name: "3.4", value: 3.4.0-preview2 }
+            os: { name: Ubuntu, value: ubuntu-24.04 }
+
+          - ruby: { name: "3.4", value: 3.4.0-preview2 }
+            os: { name: macOS, value: macos-14 }
+
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup ruby
@@ -54,7 +60,7 @@ jobs:
         if: matrix.ruby.name != 'truffleruby' && matrix.ruby.name != 'jruby'
       - name: Run Test isolatedly
         run: bin/rake test:isolated
-        if: matrix.ruby.name == '3.3' && matrix.os.name != 'Windows'
+        if: matrix.ruby.name == '3.4' && matrix.os.name != 'Windows'
       - name: Run Test (JRuby)
         run: JRUBY_OPTS=--debug bin/rake test
         if: startsWith(matrix.ruby.name, 'jruby')

--- a/.github/workflows/system-rubygems-bundler.yml
+++ b/.github/workflows/system-rubygems-bundler.yml
@@ -32,9 +32,11 @@ jobs:
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.6 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.2, value: 3.2.6 } }
           - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.3, value: 3.3.6 } }
+          - { bundler: { name: 2, value: '' }, ruby: { name: ruby-3.4, value: 3.4.0-preview2 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.1, value: 3.1.6 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.2, value: 3.2.6 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.3, value: 3.3.6 } }
+          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.4, value: 3.4.0-preview2 } }
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup ruby
@@ -63,10 +65,10 @@ jobs:
         with:
           path: bundler/tmp/rubygems
           ref: ${{ env.RGV }}
-        if: matrix.ruby.name != 'ruby-3.3'
+        if: matrix.ruby.name != 'ruby-3.4'
       - name: Run Rubygems Requirement tests against local bundler, to make sure bundler monkeypatches preserve the behaviour
         run: |
           ruby -I../../lib:lib:test test/rubygems/test_gem_requirement.rb
         working-directory: ./bundler/tmp/rubygems
-        if: matrix.ruby.name != 'ruby-3.3'
+        if: matrix.ruby.name != 'ruby-3.4'
     timeout-minutes: 60

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - { name: ruby, value: 3.3.6 }
+          - { name: ruby, value: 3.4.0-preview2 }
           - { name: truffleruby, value: truffleruby-24.0.1 }
     env:
       RUBYOPT: -Ilib

--- a/bundler/lib/bundler/process_lock.rb
+++ b/bundler/lib/bundler/process_lock.rb
@@ -6,7 +6,7 @@ module Bundler
       lock_file_path = File.join(bundle_path, "bundler.lock")
       base_lock_file_path = lock_file_path.delete_suffix(".lock")
 
-      require "fileutils" if Bundler.rubygems.provides?("< 3.5.23")
+      require "fileutils" if Bundler.rubygems.provides?("< 3.6.0")
 
       begin
         SharedHelpers.filesystem_access(lock_file_path, :write) do

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -442,7 +442,7 @@ module Gem
     end
   end
 
-  unless Gem.rubygems_version >= Gem::Version.new("3.5.23")
+  if Gem.rubygems_version < Gem::Version.new("3.6.0")
     class Package; end
     require "rubygems/package/tar_reader"
     require "rubygems/package/tar_reader/entry"

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1554,7 +1554,7 @@ end
       RUBY
 
       expect(last_command.stdboth).not_to include "FAIL"
-      expect(err).to include "private method `gem'"
+      expect(err).to match(/private method [`']gem'/)
     end
 
     it "keeps Kernel#require private" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In preparation for final Bundler 2.6.0 and RubyGems 3.6.0 releases, I'd like to make sure everything works with Ruby 3.4.

## What is your fix for the problem, implemented in this PR?

Add 3.4.0-preview2 to our CI.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
