### PR TITLE
Start running the only pending exec spec

### DIFF
--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -963,23 +963,30 @@ RSpec.describe "bundle exec" do
         puts "__FILE__: #{__FILE__.inspect}"
       RUBY
 
-      let(:expected) { super() + <<~EOS.chomp }
+      context "when the path is absolute" do
+        let(:expected) { super() + <<~EOS.chomp }
 
-        $0: #{path.to_s.inspect}
-        __FILE__: #{path.to_s.inspect}
-      EOS
+          $0: #{path.to_s.inspect}
+          __FILE__: #{path.to_s.inspect}
+        EOS
 
-      it "runs" do
-        skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
+        it "runs" do
+          skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
 
-        subject
-        expect(exitstatus).to eq(exit_code)
-        expect(err).to eq(expected_err)
-        expect(out).to eq(expected)
+          subject
+          expect(exitstatus).to eq(exit_code)
+          expect(err).to eq(expected_err)
+          expect(out).to eq(expected)
+        end
       end
 
       context "when the path is relative" do
         let(:path) { super().relative_path_from(bundled_app) }
+        let(:expected) { super() + <<~EOS.chomp }
+
+          $0: #{path.to_s.inspect}
+          __FILE__: #{path.to_s.inspect}
+        EOS
 
         it "runs" do
           skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
@@ -993,8 +1000,20 @@ RSpec.describe "bundle exec" do
 
       context "when the path is relative with a leading ./" do
         let(:path) { Pathname.new("./#{super().relative_path_from(bundled_app)}") }
+        let(:expected) { super() + <<~EOS.chomp }
 
-        pending "relative paths with ./ have absolute __FILE__"
+          $0: #{path.to_s.inspect}
+          __FILE__: #{File.expand_path(path, bundled_app).inspect}
+        EOS
+
+        it "runs" do
+          skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
+
+          subject
+          expect(exitstatus).to eq(exit_code)
+          expect(err).to eq(expected_err)
+          expect(out).to eq(expected)
+        end
       end
     end
 

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -723,8 +723,6 @@ RSpec.describe "bundle exec" do
     RUBY
 
     before do
-      system_gems(%w[myrack-1.0.0 myrack-0.9.1], path: default_bundle_path)
-
       bundled_app(path).open("w") {|f| f << executable }
       bundled_app(path).chmod(0o755)
 
@@ -870,8 +868,10 @@ RSpec.describe "bundle exec" do
       end
     end
 
-    context "when Bundler.setup fails", bundler: "< 3" do
+    context "when Bundler.setup fails" do
       before do
+        system_gems(%w[myrack-1.0.0 myrack-0.9.1], path: default_bundle_path)
+
         gemfile <<-G
           source "https://gem.repo1"
           gem 'myrack', '2'
@@ -886,35 +886,6 @@ Could not find gem 'myrack (= 2)' in locally installed gems.
 
 The source contains the following gems matching 'myrack':
   * myrack-0.9.1
-  * myrack-1.0.0
-Run `bundle install` to install missing gems.
-      EOS
-
-      it "runs" do
-        skip "https://github.com/rubygems/rubygems/issues/3351" if Gem.win_platform?
-
-        subject
-        expect(exitstatus).to eq(exit_code)
-        expect(err).to eq(expected_err)
-        expect(out).to eq(expected)
-      end
-    end
-
-    context "when Bundler.setup fails", bundler: "3" do
-      before do
-        gemfile <<-G
-          source "https://gem.repo1"
-          gem 'myrack', '2'
-        G
-        ENV["BUNDLER_FORCE_TTY"] = "true"
-      end
-
-      let(:exit_code) { Bundler::GemNotFound.new.status_code }
-      let(:expected) { "" }
-      let(:expected_err) { <<-EOS.strip }
-Could not find gem 'myrack (= 2)' in locally installed gems.
-
-The source contains the following gems matching 'myrack':
   * myrack-1.0.0
 Run `bundle install` to install missing gems.
       EOS

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -881,13 +881,13 @@ RSpec.describe "bundle exec" do
 
       let(:exit_code) { Bundler::GemNotFound.new.status_code }
       let(:expected) { "" }
-      let(:expected_err) { <<-EOS.strip }
-Could not find gem 'myrack (= 2)' in locally installed gems.
+      let(:expected_err) { <<~EOS.strip }
+        Could not find gem 'myrack (= 2)' in locally installed gems.
 
-The source contains the following gems matching 'myrack':
-  * myrack-0.9.1
-  * myrack-1.0.0
-Run `bundle install` to install missing gems.
+        The source contains the following gems matching 'myrack':
+          * myrack-0.9.1
+          * myrack-1.0.0
+        Run `bundle install` to install missing gems.
       EOS
 
       it "runs" do
@@ -963,10 +963,10 @@ Run `bundle install` to install missing gems.
         puts "__FILE__: #{__FILE__.inspect}"
       RUBY
 
-      let(:expected) { super() + <<-EOS.chomp }
+      let(:expected) { super() + <<~EOS.chomp }
 
-$0: #{path.to_s.inspect}
-__FILE__: #{path.to_s.inspect}
+        $0: #{path.to_s.inspect}
+        __FILE__: #{path.to_s.inspect}
       EOS
 
       it "runs" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

While reviewing #8294, I noticed we have one exec spec set as pending, but I don't think we can ever fix it, since that's how Ruby works and I don't think that's going to change. I asked ruby-core though just in case: https://bugs.ruby-lang.org/issues/20920.

## What is your fix for the problem, implemented in this PR?

Run the spec and accept how things work now.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
