### PR TITLE
make pretty_print tests whitespace agnostic

### DIFF
--- a/test/rubygems/test_gem_source_git.rb
+++ b/test/rubygems/test_gem_source_git.rb
@@ -293,9 +293,7 @@ class TestGemSourceGit < Gem::TestCase
   end
 
   def test_pretty_print
-    assert_equal "#<Gem::Source::Git[Git: \n" \
-                 "   #{@repository}\n" \
-                 "   HEAD]>\n", @source.pretty_inspect
+    assert_equal "#<Gem::Source::Git[Git: #{@repository} HEAD]>", @source.pretty_inspect.gsub(/\s+/, " ").strip
   end
 
   def test_uri_hash

--- a/test/rubygems/test_gem_source_installed.rb
+++ b/test/rubygems/test_gem_source_installed.rb
@@ -35,6 +35,6 @@ class TestGemSourceInstalled < Gem::TestCase
 
   def test_pretty_print
     local = Gem::Source::Installed.new
-    assert_equal "#<Gem::Source::Installed[Installed]>\n", local.pretty_inspect
+    assert_equal "#<Gem::Source::Installed[Installed]>", local.pretty_inspect.gsub(/\s+/, " ").strip
   end
 end

--- a/test/rubygems/test_gem_source_local.rb
+++ b/test/rubygems/test_gem_source_local.rb
@@ -107,6 +107,6 @@ class TestGemSourceLocal < Gem::TestCase
 
   def test_pretty_print
     local = Gem::Source::Local.new
-    assert_equal "#<Gem::Source::Local[Local gems: ]>\n", local.pretty_inspect
+    assert_equal "#<Gem::Source::Local[Local gems: ]>", local.pretty_inspect.gsub(/\s+/, " ").strip
   end
 end

--- a/test/rubygems/test_gem_source_specific_file.rb
+++ b/test/rubygems/test_gem_source_specific_file.rb
@@ -75,6 +75,6 @@ class TestGemSourceSpecificFile < Gem::TestCase
   end
 
   def test_pretty_print
-    assert_equal "#<Gem::Source::SpecificFile[SpecificFile:\n   #{@sf.path}]>\n", @sf.pretty_inspect
+    assert_equal "#<Gem::Source::SpecificFile[SpecificFile: #{@sf.path}]>", @sf.pretty_inspect.gsub(/\s+/, " ").strip
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

As mentioned in #7994, various tests were dependent on terminal size and/or COLUMNS environment variable setting. Thanks to @nobu for pointing this out.

## What is your fix for the problem, implemented in this PR?

As per @nobu's suggestion, in brittle assertions using pretty_inspect, replace runs of whitespace with a single space and strip trailing/leading whitespace.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
