### PR TITLE
[DOC] Fix missing single quote

### DIFF
--- a/lib/rubygems/request_set/gem_dependency_api.rb
+++ b/lib/rubygems/request_set/gem_dependency_api.rb
@@ -330,7 +330,7 @@ class Gem::RequestSet::GemDependencyAPI
   # git: ::
   #   Install this dependency from a git repository:
   #
-  #     gem 'private_gem', git: git@my.company.example:private_gem.git'
+  #     gem 'private_gem', git: 'git@my.company.example:private_gem.git'
   #
   # gist: ::
   #   Install this dependency from the gist ID:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In an example of `Kernel#gem` method, a single quote seems missing and a syntax error.

## What is your fix for the problem, implemented in this PR?

Add a single quote.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
