### PR TITLE
Fix Gem::SafeMarshal buffer overrun when given lengths larger than fit into a byte

### DIFF
--- a/lib/rubygems/safe_marshal/visitors/to_ruby.rb
+++ b/lib/rubygems/safe_marshal/visitors/to_ruby.rb
@@ -98,16 +98,20 @@ module Gem::SafeMarshal
             end
 
             s = e.object.binary_string
+            raise TimeTooLargeError.new("binary string too large", stack: formatted_stack) if s.bytesize > 122
+            raise TimeTooLargeError.new("too many internal ivars", stack: formatted_stack) if internal.size > 122
 
             marshal_string = "\x04\bIu:\tTime".b
-            marshal_string.concat(s.size + 5)
+            marshal_string.concat(s.bytesize + 5)
             marshal_string << s
             marshal_string.concat(internal.size + 5)
 
             internal.each do |k, v|
+              k = k.name
               marshal_string.concat(":")
-              marshal_string.concat(k.size + 5)
-              marshal_string.concat(k.to_s)
+              marshal_string.concat(k.bytesize + 5)
+              raise TimeTooLargeError.new("ivar name too large", stack: formatted_stack) if k.bytesize > 122
+              marshal_string.concat(k)
               dumped = Marshal.dump(v)
               dumped[0, 2] = ""
               marshal_string.concat(dumped)
@@ -374,6 +378,12 @@ module Gem::SafeMarshal
       end
 
       class Error < StandardError
+      end
+
+      class TimeTooLargeError < Error
+        def initialize(message, stack:)
+          super "#{message} @ #{stack.join "."}"
+        end
       end
 
       class UnpermittedSymbolError < Error

--- a/test/rubygems/test_gem_safe_marshal.rb
+++ b/test/rubygems/test_gem_safe_marshal.rb
@@ -275,16 +275,17 @@ class TestGemSafeMarshal < Gem::TestCase
   end
 
   def test_time_user_marshal
-    payload =
-      "#{Marshal::MAJOR_VERSION.chr}#{Marshal::MINOR_VERSION.chr}" \
-      "I" + # TYPE_IVAR
-      "u" + # TYPE_USERDEF
-      Marshal.dump(:Time)[2..-1] +
-      Marshal.dump(0xfb - 5)[3..-1] +
-      Marshal.dump(1)[3..-1] +
-      Marshal.dump(:zone)[2..-1] +
-      Marshal.dump(UserMarshal.new)[2..-1] +
+    payload = [
+      Marshal::MAJOR_VERSION.chr, Marshal::MINOR_VERSION.chr,
+      "I", # TYPE_IVAR
+      "u", # TYPE_USERDEF
+      Marshal.dump(:Time)[2..-1],
+      Marshal.dump(0xfb - 5)[3..-1],
+      Marshal.dump(1)[3..-1],
+      Marshal.dump(:zone)[2..-1],
+      Marshal.dump(UserMarshal.new)[2..-1],
       ("\x00" * (236 - UserMarshal.name.bytesize))
+    ].join
 
     assert_raise(Gem::SafeMarshal::Visitors::ToRuby::TimeTooLargeError, TypeError) { Gem::SafeMarshal.safe_load(payload) }
   end
@@ -414,6 +415,38 @@ class TestGemSafeMarshal < Gem::TestCase
       Gem::SafeMarshal.safe_load("\x04\x08[\x06")
     end
     assert_equal e.message, "Unexpected EOF"
+
+    e = assert_raise(Gem::SafeMarshal::Reader::EOFError) do
+      Gem::SafeMarshal.safe_load("\004\010:\012")
+    end
+    assert_equal e.message, "expected 5 bytes, got EOF"
+
+    e = assert_raise(Gem::SafeMarshal::Reader::EOFError) do
+      Gem::SafeMarshal.safe_load("\x04\x08i\x01")
+    end
+    assert_equal e.message, "Unexpected EOF"
+    e = assert_raise(Gem::SafeMarshal::Reader::EOFError) do
+      Gem::SafeMarshal.safe_load("\x04\x08\"\x06")
+    end
+    assert_equal e.message, "expected 1 bytes, got EOF"
+  end
+
+  def test_negative_length
+    assert_raise(Gem::SafeMarshal::Reader::NegativeLengthError) do
+      Gem::SafeMarshal.safe_load("\004\010}\325")
+    end
+    assert_raise(Gem::SafeMarshal::Reader::NegativeLengthError) do
+      Gem::SafeMarshal.safe_load("\004\010:\325")
+    end
+    assert_raise(Gem::SafeMarshal::Reader::NegativeLengthError) do
+      Gem::SafeMarshal.safe_load("\004\010\"\325")
+    end
+    assert_raise(IndexError) do
+      Gem::SafeMarshal.safe_load("\004\010;\325")
+    end
+    assert_raise(Gem::SafeMarshal::Reader::EOFError) do
+      Gem::SafeMarshal.safe_load("\004\010@\377")
+    end
   end
 
   def assert_safe_load_marshal(dumped, additional_methods: [], permitted_ivars: nil, equality: true, marshal_dump_equality: true,

--- a/test/rubygems/test_gem_safe_marshal.rb
+++ b/test/rubygems/test_gem_safe_marshal.rb
@@ -265,6 +265,30 @@ class TestGemSafeMarshal < Gem::TestCase
     end
   end
 
+  class UserMarshal
+    def marshal_load(*)
+      throw "#{self.class}#marshal_load called"
+    end
+
+    def marshal_dump
+    end
+  end
+
+  def test_time_user_marshal
+    payload =
+      "#{Marshal::MAJOR_VERSION.chr}#{Marshal::MINOR_VERSION.chr}" \
+      "I" + # TYPE_IVAR
+      "u" + # TYPE_USERDEF
+      Marshal.dump(:Time)[2..-1] +
+      Marshal.dump(0xfb - 5)[3..-1] +
+      Marshal.dump(1)[3..-1] +
+      Marshal.dump(:zone)[2..-1] +
+      Marshal.dump(UserMarshal.new)[2..-1] +
+      ("\x00" * (236 - UserMarshal.name.bytesize))
+
+    assert_raise(Gem::SafeMarshal::Visitors::ToRuby::TimeTooLargeError, TypeError) { Gem::SafeMarshal.safe_load(payload) }
+  end
+
   class StringSubclass < ::String
   end
 


### PR DESCRIPTION
Fixes https://nastystereo.com/security/ruby-safe-marshal-escape.html

Signed-off-by: Samuel Giddins <segiddins@segiddins.me>

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)