### PR TITLE
Normalize command flag documentation and make sure all flags are documented

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -228,7 +228,7 @@ module Bundler
     method_option "standalone", type: :array, lazy_default: [], banner: "Make a bundle that can work without the Bundler runtime"
     method_option "system", type: :boolean, banner: "Install to the system location ($BUNDLE_PATH or $GEM_HOME) even if the bundle was previously installed somewhere else for this application"
     method_option "trust-policy", alias: "P", type: :string, banner: "Gem trust policy (like gem install -P). Must be one of #{Bundler.rubygems.security_policy_keys.join("|")}"
-    method_option "target-rbconfig", type: :string, banner: "rbconfig.rb for the deployment target platform"
+    method_option "target-rbconfig", type: :string, banner: "Path to rbconfig.rb for the deployment target platform"
     method_option "without", type: :array, banner: "Exclude gems that are part of the specified named group."
     method_option "with", type: :array, banner: "Include gems that are part of the specified named group."
     def install

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -217,7 +217,7 @@ module Bundler
     method_option "full-index", type: :boolean, banner: "Fall back to using the single-file index of all gems"
     method_option "gemfile", type: :string, banner: "Use the specified gemfile instead of Gemfile"
     method_option "jobs", aliases: "-j", type: :numeric, banner: "Specify the number of jobs to run in parallel"
-    method_option "local", type: :boolean, banner:       "Do not attempt to fetch gems remotely and use the gem cache instead"
+    method_option "local", type: :boolean, banner: "Do not attempt to fetch gems remotely and use the gem cache instead"
     method_option "prefer-local", type: :boolean, banner: "Only attempt to fetch gems remotely if not present locally, even if newer versions are available remotely"
     method_option "no-cache", type: :boolean, banner: "Don't update the existing gem cache."
     method_option "redownload", type: :boolean, aliases: "--force", banner: "Force downloading every gem."
@@ -227,10 +227,8 @@ module Bundler
     method_option "shebang", type: :string, banner: "Specify a different shebang executable name than the default (usually 'ruby')"
     method_option "standalone", type: :array, lazy_default: [], banner: "Make a bundle that can work without the Bundler runtime"
     method_option "system", type: :boolean, banner: "Install to the system location ($BUNDLE_PATH or $GEM_HOME) even if the bundle was previously installed somewhere else for this application"
-    method_option "trust-policy", alias: "P", type: :string, banner:       "Gem trust policy (like gem install -P). Must be one of " +
-                                                                           Bundler.rubygems.security_policy_keys.join("|")
+    method_option "trust-policy", alias: "P", type: :string, banner: "Gem trust policy (like gem install -P). Must be one of #{Bundler.rubygems.security_policy_keys.join("|")}"
     method_option "target-rbconfig", type: :string, banner: "rbconfig.rb for the deployment target platform"
-
     method_option "without", type: :array, banner: "Exclude gems that are part of the specified named group."
     method_option "with", type: :array, banner: "Include gems that are part of the specified named group."
     def install
@@ -288,10 +286,8 @@ module Bundler
       Show lists the names and versions of all gems that are required by your Gemfile.
       Calling show with [GEM] will list the exact location of that gem on your machine.
     D
-    method_option "paths", type: :boolean,
-                           banner: "List the paths of all gems that are required by your Gemfile."
-    method_option "outdated", type: :boolean,
-                              banner: "Show verbose output including whether gems are outdated."
+    method_option "paths", type: :boolean, banner: "List the paths of all gems that are required by your Gemfile."
+    method_option "outdated", type: :boolean, banner: "Show verbose output including whether gems are outdated."
     def show(gem_name = nil)
       if ARGV.include?("--outdated")
         message = "the `--outdated` flag to `bundle show` was undocumented and will be removed without replacement"
@@ -400,9 +396,7 @@ module Bundler
     end
 
     desc "cache [OPTIONS]", "Locks and then caches all of the gems into vendor/cache"
-    method_option "all", type: :boolean,
-                         default: Bundler.feature_flag.cache_all?,
-                         banner: "Include all sources (including path and git)."
+    method_option "all", type: :boolean, default: Bundler.feature_flag.cache_all?, banner: "Include all sources (including path and git)."
     method_option "all-platforms", type: :boolean, banner: "Include gems for all platforms present in the lockfile, not only the current one"
     method_option "cache-path", type: :string, banner: "Specify a different cache path than the default (vendor/cache)."
     method_option "gemfile", type: :string, banner: "Use the specified gemfile instead of Gemfile"
@@ -540,23 +534,15 @@ module Bundler
     desc "gem NAME [OPTIONS]", "Creates a skeleton for creating a rubygem"
     method_option :exe, type: :boolean, default: false, aliases: ["--bin", "-b"], desc: "Generate a binary executable for your library."
     method_option :coc, type: :boolean, desc: "Generate a code of conduct file. Set a default with `bundle config set --global gem.coc true`."
-    method_option :edit, type: :string, aliases: "-e", required: false, banner: "EDITOR",
-                         lazy_default: [ENV["BUNDLER_EDITOR"], ENV["VISUAL"], ENV["EDITOR"]].find {|e| !e.nil? && !e.empty? },
-                         desc: "Open generated gemspec in the specified editor (defaults to $EDITOR or $BUNDLER_EDITOR)"
+    method_option :edit, type: :string, aliases: "-e", required: false, banner: "EDITOR", lazy_default: [ENV["BUNDLER_EDITOR"], ENV["VISUAL"], ENV["EDITOR"]].find {|e| !e.nil? && !e.empty? }, desc: "Open generated gemspec in the specified editor (defaults to $EDITOR or $BUNDLER_EDITOR)"
     method_option :ext, type: :string, desc: "Generate the boilerplate for C extension code.", enum: EXTENSIONS
     method_option :git, type: :boolean, default: true, desc: "Initialize a git repo inside your library."
     method_option :mit, type: :boolean, desc: "Generate an MIT license file. Set a default with `bundle config set --global gem.mit true`."
     method_option :rubocop, type: :boolean, desc: "Add rubocop to the generated Rakefile and gemspec. Set a default with `bundle config set --global gem.rubocop true`."
     method_option :changelog, type: :boolean, desc: "Generate changelog file. Set a default with `bundle config set --global gem.changelog true`."
-    method_option :test, type: :string, lazy_default: Bundler.settings["gem.test"] || "", aliases: "-t", banner: "Use the specified test framework for your library",
-                         enum: %w[rspec minitest test-unit],
-                         desc: "Generate a test directory for your library, either rspec, minitest or test-unit. Set a default with `bundle config set --global gem.test (rspec|minitest|test-unit)`."
-    method_option :ci, type: :string, lazy_default: Bundler.settings["gem.ci"] || "",
-                       enum: %w[github gitlab circle],
-                       desc: "Generate CI configuration, either GitHub Actions, GitLab CI or CircleCI. Set a default with `bundle config set --global gem.ci (github|gitlab|circle)`"
-    method_option :linter, type: :string, lazy_default: Bundler.settings["gem.linter"] || "",
-                           enum: %w[rubocop standard],
-                           desc: "Add a linter and code formatter, either RuboCop or Standard. Set a default with `bundle config set --global gem.linter (rubocop|standard)`"
+    method_option :test, type: :string, lazy_default: Bundler.settings["gem.test"] || "", aliases: "-t", banner: "Use the specified test framework for your library", enum: %w[rspec minitest test-unit], desc: "Generate a test directory for your library, either rspec, minitest or test-unit. Set a default with `bundle config set --global gem.test (rspec|minitest|test-unit)`."
+    method_option :ci, type: :string, lazy_default: Bundler.settings["gem.ci"] || "", enum: %w[github gitlab circle], desc: "Generate CI configuration, either GitHub Actions, GitLab CI or CircleCI. Set a default with `bundle config set --global gem.ci (github|gitlab|circle)`"
+    method_option :linter, type: :string, lazy_default: Bundler.settings["gem.linter"] || "", enum: %w[rubocop standard], desc: "Add a linter and code formatter, either RuboCop or Standard. Set a default with `bundle config set --global gem.linter (rubocop|standard)`"
     method_option :github_username, type: :string, default: Bundler.settings["gem.github_username"], banner: "Set your username on GitHub", desc: "Fill in GitHub username on README so that you don't have to do it manually. Set a default with `bundle config set --global gem.github_username <your_username>`."
 
     def gem(name)

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -434,8 +434,8 @@ module Bundler
     map aliases_for("cache")
 
     desc "exec [OPTIONS]", "Run the command in context of the bundle"
-    method_option :keep_file_descriptors, type: :boolean, default: true
-    method_option :gemfile, type: :string, required: false
+    method_option :keep_file_descriptors, type: :boolean, default: true, banner: "Passes all file descriptors to the new processes. Default is true, and setting it to false is deprecated"
+    method_option :gemfile, type: :string, required: false, banner: "Use the specified gemfile instead of Gemfile"
     long_desc <<-D
       Exec runs a command, providing it access to the gems in the bundle. While using
       bundle exec you can require and call the bundled gems as if they were installed

--- a/bundler/lib/bundler/man/bundle-add.1
+++ b/bundler/lib/bundler/man/bundle-add.1
@@ -9,31 +9,31 @@
 Adds the named gem to the [\fBGemfile(5)\fR][Gemfile(5)] and run \fBbundle install\fR\. \fBbundle install\fR can be avoided by using the flag \fB\-\-skip\-install\fR\.
 .SH "OPTIONS"
 .TP
-\fB\-\-version\fR, \fB\-v\fR
+\fB\-\-version=VERSION\fR, \fB\-v=VERSION\fR
 Specify version requirements(s) for the added gem\.
 .TP
-\fB\-\-group\fR, \fB\-g\fR
+\fB\-\-group=GROUP\fR, \fB\-g=GROUP\fR
 Specify the group(s) for the added gem\. Multiple groups should be separated by commas\.
 .TP
-\fB\-\-source\fR, \fB\-s\fR
+\fB\-\-source=SOURCE\fR, \fB\-s=SOURCE\fR
 Specify the source for the added gem\.
 .TP
-\fB\-\-require\fR, \fB\-r\fR
+\fB\-\-require=REQUIRE\fR, \fB\-r=REQUIRE\fR
 Adds require path to gem\. Provide false, or a path as a string\.
 .TP
-\fB\-\-path\fR
+\fB\-\-path=PATH\fR
 Specify the file system path for the added gem\.
 .TP
-\fB\-\-git\fR
+\fB\-\-git=GIT\fR
 Specify the git source for the added gem\.
 .TP
-\fB\-\-github\fR
+\fB\-\-github=GITHUB\fR
 Specify the github source for the added gem\.
 .TP
-\fB\-\-branch\fR
+\fB\-\-branch=BRANCH\fR
 Specify the git branch for the added gem\.
 .TP
-\fB\-\-ref\fR
+\fB\-\-ref=REF\fR
 Specify the git ref for the added gem\.
 .TP
 \fB\-\-glob=GLOB\fR

--- a/bundler/lib/bundler/man/bundle-add.1
+++ b/bundler/lib/bundler/man/bundle-add.1
@@ -36,6 +36,9 @@ Specify the git branch for the added gem\.
 \fB\-\-ref\fR
 Specify the git ref for the added gem\.
 .TP
+\fB\-\-glob=GLOB\fR
+Specify the location of a dependency's \.gemspec, expanded within Ruby (single quotes recommended)\.
+.TP
 \fB\-\-quiet\fR
 Do not print progress information to the standard output\.
 .TP

--- a/bundler/lib/bundler/man/bundle-add.1.ronn
+++ b/bundler/lib/bundler/man/bundle-add.1.ronn
@@ -14,31 +14,31 @@ Adds the named gem to the [`Gemfile(5)`][Gemfile(5)] and run `bundle install`.
 
 ## OPTIONS
 
-* `--version`, `-v`:
+* `--version=VERSION`, `-v=VERSION`:
   Specify version requirements(s) for the added gem.
 
-* `--group`, `-g`:
+* `--group=GROUP`, `-g=GROUP`:
   Specify the group(s) for the added gem. Multiple groups should be separated by commas.
 
-* `--source`, `-s`:
+* `--source=SOURCE`, `-s=SOURCE`:
   Specify the source for the added gem.
 
-* `--require`, `-r`:
+* `--require=REQUIRE`, `-r=REQUIRE`:
   Adds require path to gem. Provide false, or a path as a string.
 
-* `--path`:
+* `--path=PATH`:
   Specify the file system path for the added gem.
 
-* `--git`:
+* `--git=GIT`:
   Specify the git source for the added gem.
 
-* `--github`:
+* `--github=GITHUB`:
   Specify the github source for the added gem.
 
-* `--branch`:
+* `--branch=BRANCH`:
   Specify the git branch for the added gem.
 
-* `--ref`:
+* `--ref=REF`:
   Specify the git ref for the added gem.
 
 * `--glob=GLOB`:

--- a/bundler/lib/bundler/man/bundle-add.1.ronn
+++ b/bundler/lib/bundler/man/bundle-add.1.ronn
@@ -41,6 +41,9 @@ Adds the named gem to the [`Gemfile(5)`][Gemfile(5)] and run `bundle install`.
 * `--ref`:
   Specify the git ref for the added gem.
 
+* `--glob=GLOB`:
+  Specify the location of a dependency's .gemspec, expanded within Ruby (single quotes recommended).
+
 * `--quiet`:
   Do not print progress information to the standard output.
 

--- a/bundler/lib/bundler/man/bundle-binstubs.1
+++ b/bundler/lib/bundler/man/bundle-binstubs.1
@@ -16,13 +16,13 @@ This command generates binstubs for executables in \fBGEM_NAME\fR\. Binstubs are
 \fB\-\-force\fR
 Overwrite existing binstubs if they exist\.
 .TP
-\fB\-\-path\fR
+\fB\-\-path[=PATH]\fR
 The location to install the specified binstubs to\. This defaults to \fBbin\fR\.
 .TP
 \fB\-\-standalone\fR
 Makes binstubs that can work without depending on Rubygems or Bundler at runtime\.
 .TP
-\fB\-\-shebang\fR
+\fB\-\-shebang=SHEBANG\fR
 Specify a different shebang executable name than the default (default 'ruby')
 .TP
 \fB\-\-all\fR

--- a/bundler/lib/bundler/man/bundle-binstubs.1
+++ b/bundler/lib/bundler/man/bundle-binstubs.1
@@ -4,7 +4,7 @@
 .SH "NAME"
 \fBbundle\-binstubs\fR \- Install the binstubs of the listed gems
 .SH "SYNOPSIS"
-\fBbundle binstubs\fR \fIGEM_NAME\fR [\-\-force] [\-\-path PATH] [\-\-standalone]
+\fBbundle binstubs\fR \fIGEM_NAME\fR [\-\-force] [\-\-path PATH] [\-\-standalone] [\-\-all\-platforms]
 .SH "DESCRIPTION"
 Binstubs are scripts that wrap around executables\. Bundler creates a small Ruby file (a binstub) that loads Bundler, runs the command, and puts it into \fBbin/\fR\. Binstubs are a shortcut\-or alternative\- to always using \fBbundle exec\fR\. This gives you a file that can be run directly, and one that will always run the correct gem version used by the application\.
 .P
@@ -27,4 +27,7 @@ Specify a different shebang executable name than the default (default 'ruby')
 .TP
 \fB\-\-all\fR
 Create binstubs for all gems in the bundle\.
+.TP
+\fB\-\-all\-platforms\fR
+Install binstubs for all platforms\.
 

--- a/bundler/lib/bundler/man/bundle-binstubs.1.ronn
+++ b/bundler/lib/bundler/man/bundle-binstubs.1.ronn
@@ -3,7 +3,7 @@ bundle-binstubs(1) -- Install the binstubs of the listed gems
 
 ## SYNOPSIS
 
-`bundle binstubs` <GEM_NAME> [--force] [--path PATH] [--standalone]
+`bundle binstubs` <GEM_NAME> [--force] [--path PATH] [--standalone] [--all-platforms]
 
 ## DESCRIPTION
 
@@ -39,3 +39,6 @@ Calling binstubs with [GEM [GEM]] will create binstubs for all given gems.
 
 * `--all`:
   Create binstubs for all gems in the bundle.
+
+* `--all-platforms`:
+  Install binstubs for all platforms.

--- a/bundler/lib/bundler/man/bundle-binstubs.1.ronn
+++ b/bundler/lib/bundler/man/bundle-binstubs.1.ronn
@@ -27,14 +27,14 @@ Calling binstubs with [GEM [GEM]] will create binstubs for all given gems.
 * `--force`:
   Overwrite existing binstubs if they exist.
 
-* `--path`:
+* `--path[=PATH]`:
   The location to install the specified binstubs to. This defaults to `bin`.
 
 * `--standalone`:
   Makes binstubs that can work without depending on Rubygems or Bundler at
   runtime.
 
-* `--shebang`:
+* `--shebang=SHEBANG`:
   Specify a different shebang executable name than the default (default 'ruby')
 
 * `--all`:

--- a/bundler/lib/bundler/man/bundle-cache.1
+++ b/bundler/lib/bundler/man/bundle-cache.1
@@ -4,11 +4,39 @@
 .SH "NAME"
 \fBbundle\-cache\fR \- Package your needed \fB\.gem\fR files into your application
 .SH "SYNOPSIS"
-\fBbundle cache\fR
+\fBbundle cache\fR [\fIOPTIONS\fR]
 .P
 alias: \fBpackage\fR, \fBpack\fR
 .SH "DESCRIPTION"
 Copy all of the \fB\.gem\fR files needed to run the application into the \fBvendor/cache\fR directory\. In the future, when running \fBbundle install(1)\fR \fIbundle\-install\.1\.html\fR, use the gems in the cache in preference to the ones on \fBrubygems\.org\fR\.
+.SH "OPTIONS"
+.TP
+\fB\-\-all\fR
+Include all sources (including path and git)\.
+.TP
+\fB\-\-all\-platforms\fR
+Include gems for all platforms present in the lockfile, not only the current one\.
+.TP
+\fB\-\-cache\-path=CACHE\-PATH\fR
+Specify a different cache path than the default (vendor/cache)\.
+.TP
+\fB\-\-gemfile=GEMFILE\fR
+Use the specified gemfile instead of Gemfile\.
+.TP
+\fB\-\-no\-install\fR
+Don't install the gems, only update the cache\.
+.TP
+\fB\-\-no\-prune\fR
+Don't remove stale gems from the cache\.
+.TP
+\fB\-\-path=PATH\fR
+Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME)\.
+.TP
+\fB\-\-quiet\fR
+Only output warnings and errors\.
+.TP
+\fB\-\-frozen\fR
+Do not allow the Gemfile\.lock to be updated after this bundle cache operation's install\.
 .SH "GIT AND PATH GEMS"
 The \fBbundle cache\fR command can also package \fB:git\fR and \fB:path\fR dependencies besides \.gem files\. This needs to be explicitly enabled via the \fB\-\-all\fR option\. Once used, the \fB\-\-all\fR option will be remembered\.
 .SH "SUPPORT FOR MULTIPLE PLATFORMS"

--- a/bundler/lib/bundler/man/bundle-cache.1.ronn
+++ b/bundler/lib/bundler/man/bundle-cache.1.ronn
@@ -3,7 +3,7 @@ bundle-cache(1) -- Package your needed `.gem` files into your application
 
 ## SYNOPSIS
 
-`bundle cache`
+`bundle cache` [*OPTIONS*]
 
 alias: `package`, `pack`
 
@@ -12,6 +12,35 @@ alias: `package`, `pack`
 Copy all of the `.gem` files needed to run the application into the
 `vendor/cache` directory. In the future, when running [`bundle install(1)`](bundle-install.1.html),
 use the gems in the cache in preference to the ones on `rubygems.org`.
+
+## OPTIONS
+
+* `--all`:
+  Include all sources (including path and git).
+
+* `--all-platforms`:
+  Include gems for all platforms present in the lockfile, not only the current one.
+
+* `--cache-path=CACHE-PATH`:
+  Specify a different cache path than the default (vendor/cache).
+
+* `--gemfile=GEMFILE`:
+  Use the specified gemfile instead of Gemfile.
+
+* `--no-install`:
+  Don't install the gems, only update the cache.
+
+* `--no-prune`:
+  Don't remove stale gems from the cache.
+
+* `--path=PATH`:
+  Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME).
+
+* `--quiet`:
+  Only output warnings and errors.
+
+* `--frozen`:
+  Do not allow the Gemfile.lock to be updated after this bundle cache operation's install.
 
 ## GIT AND PATH GEMS
 

--- a/bundler/lib/bundler/man/bundle-check.1
+++ b/bundler/lib/bundler/man/bundle-check.1
@@ -16,9 +16,9 @@ If the lockfile needs to be updated then it will be resolved using the gems inst
 \fB\-\-dry\-run\fR
 Locks the [\fBGemfile(5)\fR][Gemfile(5)] before running the command\.
 .TP
-\fB\-\-gemfile\fR
+\fB\-\-gemfile=GEMFILE\fR
 Use the specified gemfile instead of the [\fBGemfile(5)\fR][Gemfile(5)]\.
 .TP
-\fB\-\-path\fR
+\fB\-\-path=PATH\fR
 Specify a different path than the system default (\fB$BUNDLE_PATH\fR or \fB$GEM_HOME\fR)\. Bundler will remember this value for future installs on this machine\.
 

--- a/bundler/lib/bundler/man/bundle-check.1.ronn
+++ b/bundler/lib/bundler/man/bundle-check.1.ronn
@@ -22,8 +22,10 @@ installed on the local machine, if they satisfy the requirements.
 
 * `--dry-run`:
   Locks the [`Gemfile(5)`][Gemfile(5)] before running the command.
+
 * `--gemfile`:
   Use the specified gemfile instead of the [`Gemfile(5)`][Gemfile(5)].
+
 * `--path`:
   Specify a different path than the system default (`$BUNDLE_PATH` or `$GEM_HOME`).
   Bundler will remember this value for future installs on this machine.

--- a/bundler/lib/bundler/man/bundle-check.1.ronn
+++ b/bundler/lib/bundler/man/bundle-check.1.ronn
@@ -23,9 +23,9 @@ installed on the local machine, if they satisfy the requirements.
 * `--dry-run`:
   Locks the [`Gemfile(5)`][Gemfile(5)] before running the command.
 
-* `--gemfile`:
+* `--gemfile=GEMFILE`:
   Use the specified gemfile instead of the [`Gemfile(5)`][Gemfile(5)].
 
-* `--path`:
+* `--path=PATH`:
   Specify a different path than the system default (`$BUNDLE_PATH` or `$GEM_HOME`).
   Bundler will remember this value for future installs on this machine.

--- a/bundler/lib/bundler/man/bundle-doctor.1
+++ b/bundler/lib/bundler/man/bundle-doctor.1
@@ -25,6 +25,6 @@ Missing dependencies
 \fB\-\-quiet\fR
 Only output warnings and errors\.
 .TP
-\fB\-\-gemfile=<gemfile>\fR
+\fB\-\-gemfile=GEMFILE\fR
 The location of the Gemfile(5) which Bundler should use\. This defaults to a Gemfile(5) in the current working directory\. In general, Bundler will assume that the location of the Gemfile(5) is also the project's root and will try to find \fBGemfile\.lock\fR and \fBvendor/cache\fR relative to this location\.
 

--- a/bundler/lib/bundler/man/bundle-doctor.1.ronn
+++ b/bundler/lib/bundler/man/bundle-doctor.1.ronn
@@ -25,7 +25,7 @@ Examples of common problems caught by bundle-doctor include:
 * `--quiet`:
   Only output warnings and errors.
 
-* `--gemfile=<gemfile>`:
+* `--gemfile=GEMFILE`:
   The location of the Gemfile(5) which Bundler should use. This defaults
   to a Gemfile(5) in the current working directory. In general, Bundler
   will assume that the location of the Gemfile(5) is also the project's

--- a/bundler/lib/bundler/man/bundle-exec.1
+++ b/bundler/lib/bundler/man/bundle-exec.1
@@ -4,7 +4,7 @@
 .SH "NAME"
 \fBbundle\-exec\fR \- Execute a command in the context of the bundle
 .SH "SYNOPSIS"
-\fBbundle exec\fR [\-\-keep\-file\-descriptors] \fIcommand\fR
+\fBbundle exec\fR [\-\-keep\-file\-descriptors] [\-\-gemfile=GEMFILE] \fIcommand\fR
 .SH "DESCRIPTION"
 This command executes the command, making all gems specified in the [\fBGemfile(5)\fR][Gemfile(5)] available to \fBrequire\fR in Ruby programs\.
 .P
@@ -15,6 +15,9 @@ Note that \fBbundle exec\fR does not require that an executable is available on 
 .TP
 \fB\-\-keep\-file\-descriptors\fR
 Passes all file descriptors to the new processes\. Default is true from bundler version 2\.2\.26\. Setting it to false is now deprecated\.
+.TP
+\fB\-\-gemfile=GEMFILE\fR
+Use the specified gemfile instead of [\fBGemfile(5)\fR][Gemfile(5)]\.
 .SH "BUNDLE INSTALL \-\-BINSTUBS"
 If you use the \fB\-\-binstubs\fR flag in bundle install(1) \fIbundle\-install\.1\.html\fR, Bundler will automatically create a directory (which defaults to \fBapp_root/bin\fR) containing all of the executables available from gems in the bundle\.
 .P

--- a/bundler/lib/bundler/man/bundle-exec.1.ronn
+++ b/bundler/lib/bundler/man/bundle-exec.1.ronn
@@ -3,7 +3,7 @@ bundle-exec(1) -- Execute a command in the context of the bundle
 
 ## SYNOPSIS
 
-`bundle exec` [--keep-file-descriptors] <command>
+`bundle exec` [--keep-file-descriptors] [--gemfile=GEMFILE] <command>
 
 ## DESCRIPTION
 
@@ -23,6 +23,9 @@ available on your shell's `$PATH`.
 * `--keep-file-descriptors`:
   Passes all file descriptors to the new processes. Default is true from
   bundler version 2.2.26. Setting it to false is now deprecated.
+
+* `--gemfile=GEMFILE`:
+  Use the specified gemfile instead of [`Gemfile(5)`][Gemfile(5)].
 
 ## BUNDLE INSTALL --BINSTUBS
 

--- a/bundler/lib/bundler/man/bundle-fund.1
+++ b/bundler/lib/bundler/man/bundle-fund.1
@@ -9,7 +9,7 @@
 \fBbundle fund\fR lists information about gems seeking funding assistance\.
 .SH "OPTIONS"
 .TP
-\fB\-g\fR, \fB\-\-group=GROUP\fR
+\fB\-\-group=<list>\fR, \fB\-g=<list>\fR
 Fetch funding information for a specific group\.
 .SH "EXAMPLES"
 .nf

--- a/bundler/lib/bundler/man/bundle-fund.1.ronn
+++ b/bundler/lib/bundler/man/bundle-fund.1.ronn
@@ -11,7 +11,7 @@ bundle-fund(1) -- Lists information about gems seeking funding assistance
 
 ## OPTIONS
 
-* `-g`, `--group=GROUP`:
+* `--group=<list>`, `-g=<list>`:
   Fetch funding information for a specific group.
 
 ## EXAMPLES

--- a/bundler/lib/bundler/man/bundle-gem.1
+++ b/bundler/lib/bundler/man/bundle-gem.1
@@ -28,6 +28,10 @@ The generated project skeleton can be customized with OPTIONS, as explained belo
 .IP "\(bu" 4
 \fB\-\-no\-coc\fR: Do not create a \fBCODE_OF_CONDUCT\.md\fR (overrides \fB\-\-coc\fR specified in the global config)\.
 .IP "\(bu" 4
+\fB\-\-changelog\fR Add a \fBCHANGELOG\.md\fR file to the root of the generated project\. If this option is unspecified, an interactive prompt will be displayed and the answer will be saved in Bundler's global config for future \fBbundle gem\fR use\.
+.IP "\(bu" 4
+\fB\-\-no\-changelog\fR: Do not create a \fBCHANGELOG\.md\fR (overrides \fB\-\-changelog\fR specified in the global config)\.
+.IP "\(bu" 4
 \fB\-\-ext=c\fR, \fB\-\-ext=rust\fR Add boilerplate for C or Rust (currently magnus \fIhttps://docs\.rs/magnus\fR based) extension code to the generated project\. This behavior is disabled by default\.
 .IP "\(bu" 4
 \fB\-\-no\-ext\fR: Do not add extension code (overrides \fB\-\-ext\fR specified in the global config)\.

--- a/bundler/lib/bundler/man/bundle-gem.1
+++ b/bundler/lib/bundler/man/bundle-gem.1
@@ -20,7 +20,7 @@ The generated project skeleton can be customized with OPTIONS, as explained belo
 .IP "" 0
 .SH "OPTIONS"
 .IP "\(bu" 4
-\fB\-\-exe\fR or \fB\-b\fR or \fB\-\-bin\fR: Specify that Bundler should create a binary executable (as \fBexe/GEM_NAME\fR) in the generated rubygem project\. This binary will also be added to the \fBGEM_NAME\.gemspec\fR manifest\. This behavior is disabled by default\.
+\fB\-\-exe\fR, \fB\-\-bin\fR, \fB\-b\fR: Specify that Bundler should create a binary executable (as \fBexe/GEM_NAME\fR) in the generated rubygem project\. This binary will also be added to the \fBGEM_NAME\.gemspec\fR manifest\. This behavior is disabled by default\.
 .IP "\(bu" 4
 \fB\-\-no\-exe\fR: Do not create a binary (overrides \fB\-\-exe\fR specified in the global config)\.
 .IP "\(bu" 4
@@ -32,7 +32,7 @@ The generated project skeleton can be customized with OPTIONS, as explained belo
 .IP "\(bu" 4
 \fB\-\-no\-changelog\fR: Do not create a \fBCHANGELOG\.md\fR (overrides \fB\-\-changelog\fR specified in the global config)\.
 .IP "\(bu" 4
-\fB\-\-ext=c\fR, \fB\-\-ext=rust\fR Add boilerplate for C or Rust (currently magnus \fIhttps://docs\.rs/magnus\fR based) extension code to the generated project\. This behavior is disabled by default\.
+\fB\-\-ext=c\fR, \fB\-\-ext=rust\fR: Add boilerplate for C or Rust (currently magnus \fIhttps://docs\.rs/magnus\fR based) extension code to the generated project\. This behavior is disabled by default\.
 .IP "\(bu" 4
 \fB\-\-no\-ext\fR: Do not add extension code (overrides \fB\-\-ext\fR specified in the global config)\.
 .IP "\(bu" 4
@@ -56,7 +56,7 @@ When Bundler is unconfigured, an interactive prompt will be displayed and the an
 .IP "\(bu" 4
 \fB\-\-changelog\fR: Generate changelog file\. Set a default with \fBbundle config set \-\-global gem\.changelog true\fR\.
 .IP "\(bu" 4
-\fB\-\-ci\fR, \fB\-\-ci=github\fR, \fB\-\-ci=gitlab\fR, \fB\-\-ci=circle\fR: Specify the continuous integration service that Bundler should use when generating the project\. Acceptable values are \fBgithub\fR, \fBgitlab\fR and \fBcircle\fR\. A configuration file will be generated in the project directory\. Given no option is specified:
+\fB\-\-ci\fR, \fB\-\-ci=circle\fR, \fB\-\-ci=github\fR, \fB\-\-ci=gitlab\fR: Specify the continuous integration service that Bundler should use when generating the project\. Acceptable values are \fBgithub\fR, \fBgitlab\fR and \fBcircle\fR\. A configuration file will be generated in the project directory\. Given no option is specified:
 .IP
 When Bundler is configured to generate CI files, this defaults to Bundler's global config setting \fBgem\.ci\fR\.
 .IP
@@ -78,7 +78,7 @@ When Bundler is unconfigured, an interactive prompt will be displayed and the an
 .IP "\(bu" 4
 \fB\-\-rubocop\fR: Add rubocop to the generated Rakefile and gemspec\. Set a default with \fBbundle config set \-\-global gem\.rubocop true\fR\.
 .IP "\(bu" 4
-\fB\-e\fR, \fB\-\-edit[=EDITOR]\fR: Open the resulting GEM_NAME\.gemspec in EDITOR, or the default editor if not specified\. The default is \fB$BUNDLER_EDITOR\fR, \fB$VISUAL\fR, or \fB$EDITOR\fR\.
+\fB\-\-edit=EDIT\fR, \fB\-e=EDIT\fR: Open the resulting GEM_NAME\.gemspec in EDIT, or the default editor if not specified\. The default is \fB$BUNDLER_EDITOR\fR, \fB$VISUAL\fR, or \fB$EDITOR\fR\.
 .IP "" 0
 .SH "SEE ALSO"
 .IP "\(bu" 4

--- a/bundler/lib/bundler/man/bundle-gem.1
+++ b/bundler/lib/bundler/man/bundle-gem.1
@@ -32,6 +32,10 @@ The generated project skeleton can be customized with OPTIONS, as explained belo
 .IP "\(bu" 4
 \fB\-\-no\-ext\fR: Do not add extension code (overrides \fB\-\-ext\fR specified in the global config)\.
 .IP "\(bu" 4
+\fB\-\-git\fR: Initialize a git repo inside your library\.
+.IP "\(bu" 4
+\fB\-\-github\-username=GITHUB_USERNAME\fR: Fill in GitHub username on README so that you don't have to do it manually\. Set a default with \fBbundle config set \-\-global gem\.github_username <your_username>\fR\.
+.IP "\(bu" 4
 \fB\-\-mit\fR: Add an MIT license to a \fBLICENSE\.txt\fR file in the root of the generated project\. Your name from the global git config is used for the copyright statement\. If this option is unspecified, an interactive prompt will be displayed and the answer will be saved in Bundler's global config for future \fBbundle gem\fR use\.
 .IP "\(bu" 4
 \fB\-\-no\-mit\fR: Do not create a \fBLICENSE\.txt\fR (overrides \fB\-\-mit\fR specified in the global config)\.
@@ -45,6 +49,8 @@ When Bundler is configured to not generate tests, an interactive prompt will be 
 When Bundler is unconfigured, an interactive prompt will be displayed and the answer will be saved in Bundler's global config for future \fBbundle gem\fR use\.
 .IP "\(bu" 4
 \fB\-\-no\-test\fR: Do not use a test framework (overrides \fB\-\-test\fR specified in the global config)\.
+.IP "\(bu" 4
+\fB\-\-changelog\fR: Generate changelog file\. Set a default with \fBbundle config set \-\-global gem\.changelog true\fR\.
 .IP "\(bu" 4
 \fB\-\-ci\fR, \fB\-\-ci=github\fR, \fB\-\-ci=gitlab\fR, \fB\-\-ci=circle\fR: Specify the continuous integration service that Bundler should use when generating the project\. Acceptable values are \fBgithub\fR, \fBgitlab\fR and \fBcircle\fR\. A configuration file will be generated in the project directory\. Given no option is specified:
 .IP
@@ -65,6 +71,8 @@ When Bundler is configured not to add a linter, an interactive prompt will be di
 When Bundler is unconfigured, an interactive prompt will be displayed and the answer will be saved in Bundler's global config for future \fBbundle gem\fR use\.
 .IP "\(bu" 4
 \fB\-\-no\-linter\fR: Do not add a linter (overrides \fB\-\-linter\fR specified in the global config)\.
+.IP "\(bu" 4
+\fB\-\-rubocop\fR: Add rubocop to the generated Rakefile and gemspec\. Set a default with \fBbundle config set \-\-global gem\.rubocop true\fR\.
 .IP "\(bu" 4
 \fB\-e\fR, \fB\-\-edit[=EDITOR]\fR: Open the resulting GEM_NAME\.gemspec in EDITOR, or the default editor if not specified\. The default is \fB$BUNDLER_EDITOR\fR, \fB$VISUAL\fR, or \fB$EDITOR\fR\.
 .IP "" 0

--- a/bundler/lib/bundler/man/bundle-gem.1.ronn
+++ b/bundler/lib/bundler/man/bundle-gem.1.ronn
@@ -24,7 +24,7 @@ configuration file using the following names:
 
 ## OPTIONS
 
-* `--exe` or `-b` or `--bin`:
+* `--exe`, `--bin`, `-b`:
   Specify that Bundler should create a binary executable (as `exe/GEM_NAME`)
   in the generated rubygem project. This binary will also be added to the
   `GEM_NAME.gemspec` manifest. This behavior is disabled by default.
@@ -50,7 +50,7 @@ configuration file using the following names:
   Do not create a `CHANGELOG.md` (overrides `--changelog` specified in the
   global config).
 
-* `--ext=c`, `--ext=rust`
+* `--ext=c`, `--ext=rust`:
   Add boilerplate for C or Rust (currently [magnus](https://docs.rs/magnus) based) extension code to the generated project. This behavior
   is disabled by default.
 
@@ -98,7 +98,7 @@ configuration file using the following names:
 * `--changelog`:
   Generate changelog file. Set a default with `bundle config set --global gem.changelog true`.
 
-* `--ci`, `--ci=github`, `--ci=gitlab`, `--ci=circle`:
+* `--ci`, `--ci=circle`, `--ci=github`, `--ci=gitlab`:
   Specify the continuous integration service that Bundler should use when
   generating the project. Acceptable values are `github`, `gitlab`
   and `circle`. A configuration file will be generated in the project directory.
@@ -140,8 +140,8 @@ configuration file using the following names:
 * `--rubocop`:
   Add rubocop to the generated Rakefile and gemspec. Set a default with `bundle config set --global gem.rubocop true`.
 
-* `-e`, `--edit[=EDITOR]`:
-  Open the resulting GEM_NAME.gemspec in EDITOR, or the default editor if not
+* `--edit=EDIT`, `-e=EDIT`:
+  Open the resulting GEM_NAME.gemspec in EDIT, or the default editor if not
   specified. The default is `$BUNDLER_EDITOR`, `$VISUAL`, or `$EDITOR`.
 
 ## SEE ALSO

--- a/bundler/lib/bundler/man/bundle-gem.1.ronn
+++ b/bundler/lib/bundler/man/bundle-gem.1.ronn
@@ -41,6 +41,15 @@ configuration file using the following names:
   Do not create a `CODE_OF_CONDUCT.md` (overrides `--coc` specified in the
   global config).
 
+* `--changelog`
+  Add a `CHANGELOG.md` file to the root of the generated project. If
+  this option is unspecified, an interactive prompt will be displayed and the
+  answer will be saved in Bundler's global config for future `bundle gem` use.
+
+* `--no-changelog`:
+  Do not create a `CHANGELOG.md` (overrides `--changelog` specified in the
+  global config).
+
 * `--ext=c`, `--ext=rust`
   Add boilerplate for C or Rust (currently [magnus](https://docs.rs/magnus) based) extension code to the generated project. This behavior
   is disabled by default.

--- a/bundler/lib/bundler/man/bundle-gem.1.ronn
+++ b/bundler/lib/bundler/man/bundle-gem.1.ronn
@@ -49,6 +49,12 @@ configuration file using the following names:
   Do not add extension code (overrides `--ext` specified in the global
   config).
 
+* `--git`:
+  Initialize a git repo inside your library.
+
+* `--github-username=GITHUB_USERNAME`:
+  Fill in GitHub username on README so that you don't have to do it manually. Set a default with `bundle config set --global gem.github_username <your_username>`.
+
 * `--mit`:
   Add an MIT license to a `LICENSE.txt` file in the root of the generated
   project. Your name from the global git config is used for the copyright
@@ -79,6 +85,9 @@ configuration file using the following names:
 * `--no-test`:
   Do not use a test framework (overrides `--test` specified in the global
   config).
+
+* `--changelog`:
+  Generate changelog file. Set a default with `bundle config set --global gem.changelog true`.
 
 * `--ci`, `--ci=github`, `--ci=gitlab`, `--ci=circle`:
   Specify the continuous integration service that Bundler should use when
@@ -118,6 +127,9 @@ configuration file using the following names:
 
 * `--no-linter`:
   Do not add a linter (overrides `--linter` specified in the global config).
+
+* `--rubocop`:
+  Add rubocop to the generated Rakefile and gemspec. Set a default with `bundle config set --global gem.rubocop true`.
 
 * `-e`, `--edit[=EDITOR]`:
   Open the resulting GEM_NAME.gemspec in EDITOR, or the default editor if not

--- a/bundler/lib/bundler/man/bundle-info.1
+++ b/bundler/lib/bundler/man/bundle-info.1
@@ -4,11 +4,14 @@
 .SH "NAME"
 \fBbundle\-info\fR \- Show information for the given gem in your bundle
 .SH "SYNOPSIS"
-\fBbundle info\fR [GEM_NAME] [\-\-path]
+\fBbundle info\fR [GEM_NAME] [\-\-path] [\-\-version]
 .SH "DESCRIPTION"
 Given a gem name present in your bundle, print the basic information about it such as homepage, version, path and summary\.
 .SH "OPTIONS"
 .TP
 \fB\-\-path\fR
 Print the path of the given gem
+.TP
+\fB\-\-version\fR
+Print gem version
 

--- a/bundler/lib/bundler/man/bundle-info.1.ronn
+++ b/bundler/lib/bundler/man/bundle-info.1.ronn
@@ -5,6 +5,7 @@ bundle-info(1) -- Show information for the given gem in your bundle
 
 `bundle info` [GEM_NAME]
               [--path]
+              [--version]
 
 ## DESCRIPTION
 
@@ -15,3 +16,6 @@ Given a gem name present in your bundle, print the basic information about it
 
 * `--path`:
   Print the path of the given gem
+
+* `--version`:
+  Print gem version

--- a/bundler/lib/bundler/man/bundle-info.1.ronn
+++ b/bundler/lib/bundler/man/bundle-info.1.ronn
@@ -14,4 +14,4 @@ Given a gem name present in your bundle, print the basic information about it
 ## OPTIONS
 
 * `--path`:
-Print the path of the given gem
+  Print the path of the given gem

--- a/bundler/lib/bundler/man/bundle-init.1
+++ b/bundler/lib/bundler/man/bundle-init.1
@@ -9,10 +9,10 @@
 Init generates a default [\fBGemfile(5)\fR][Gemfile(5)] in the current working directory\. When adding a [\fBGemfile(5)\fR][Gemfile(5)] to a gem with a gemspec, the \fB\-\-gemspec\fR option will automatically add each dependency listed in the gemspec file to the newly created [\fBGemfile(5)\fR][Gemfile(5)]\.
 .SH "OPTIONS"
 .TP
-\fB\-\-gemspec\fR
+\fB\-\-gemspec=GEMSPEC\fR
 Use the specified \.gemspec to create the [\fBGemfile(5)\fR][Gemfile(5)]
 .TP
-\fB\-\-gemfile\fR
+\fB\-\-gemfile=GEMFILE\fR
 Use the specified name for the gemfile instead of \fBGemfile\fR
 .SH "FILES"
 Included in the default [\fBGemfile(5)\fR][Gemfile(5)] generated is the line \fB# frozen_string_literal: true\fR\. This is a magic comment supported for the first time in Ruby 2\.3\. The presence of this line results in all string literals in the file being implicitly frozen\.

--- a/bundler/lib/bundler/man/bundle-init.1.ronn
+++ b/bundler/lib/bundler/man/bundle-init.1.ronn
@@ -16,6 +16,7 @@ created [`Gemfile(5)`][Gemfile(5)].
 
 * `--gemspec`:
   Use the specified .gemspec to create the [`Gemfile(5)`][Gemfile(5)]
+
 * `--gemfile`:
   Use the specified name for the gemfile instead of `Gemfile`
 

--- a/bundler/lib/bundler/man/bundle-init.1.ronn
+++ b/bundler/lib/bundler/man/bundle-init.1.ronn
@@ -14,10 +14,10 @@ created [`Gemfile(5)`][Gemfile(5)].
 
 ## OPTIONS
 
-* `--gemspec`:
+* `--gemspec=GEMSPEC`:
   Use the specified .gemspec to create the [`Gemfile(5)`][Gemfile(5)]
 
-* `--gemfile`:
+* `--gemfile=GEMFILE`:
   Use the specified name for the gemfile instead of `Gemfile`
 
 ## FILES

--- a/bundler/lib/bundler/man/bundle-inject.1
+++ b/bundler/lib/bundler/man/bundle-inject.1
@@ -4,7 +4,7 @@
 .SH "NAME"
 \fBbundle\-inject\fR \- Add named gem(s) with version requirements to Gemfile
 .SH "SYNOPSIS"
-\fBbundle inject\fR [GEM] [VERSION]
+\fBbundle inject\fR [GEM] [VERSION] [\-\-source=SOURCE] [\-\-group=GROUP]
 .SH "DESCRIPTION"
 Adds the named gem(s) with their version requirements to the resolved [\fBGemfile(5)\fR][Gemfile(5)]\.
 .P
@@ -21,3 +21,11 @@ bundle inject 'rack' '> 0'
 This will inject the 'rack' gem with a version greater than 0 in your [\fBGemfile(5)\fR][Gemfile(5)] and Gemfile\.lock\.
 .P
 The \fBbundle inject\fR command was deprecated in Bundler 2\.1 and will be removed in Bundler 3\.0\.
+.SH "OPTIONS"
+.TP
+\fB\-\-source=SOURCE\fR
+Install gem from the given source\.
+.TP
+\fB\-\-group=GROUP\fR
+Install gem into a bundler group\.
+

--- a/bundler/lib/bundler/man/bundle-inject.1.ronn
+++ b/bundler/lib/bundler/man/bundle-inject.1.ronn
@@ -3,7 +3,7 @@ bundle-inject(1) -- Add named gem(s) with version requirements to Gemfile
 
 ## SYNOPSIS
 
-`bundle inject` [GEM] [VERSION]
+`bundle inject` [GEM] [VERSION] [--source=SOURCE] [--group=GROUP]
 
 ## DESCRIPTION
 
@@ -22,3 +22,11 @@ This will inject the 'rack' gem with a version greater than 0 in your
 [`Gemfile(5)`][Gemfile(5)] and Gemfile.lock.
 
 The `bundle inject` command was deprecated in Bundler 2.1 and will be removed in Bundler 3.0.
+
+## OPTIONS
+
+* `--source=SOURCE`:
+  Install gem from the given source.
+
+* `--group=GROUP`:
+  Install gem into a bundler group.

--- a/bundler/lib/bundler/man/bundle-install.1
+++ b/bundler/lib/bundler/man/bundle-install.1
@@ -4,7 +4,7 @@
 .SH "NAME"
 \fBbundle\-install\fR \- Install the dependencies specified in your Gemfile
 .SH "SYNOPSIS"
-\fBbundle install\fR [\-\-binstubs[=DIRECTORY]] [\-\-clean] [\-\-deployment] [\-\-frozen] [\-\-full\-index] [\-\-gemfile=GEMFILE] [\-\-jobs=NUMBER] [\-\-local] [\-\-no\-cache] [\-\-no\-prune] [\-\-path PATH] [\-\-prefer\-local] [\-\-quiet] [\-\-redownload] [\-\-retry=NUMBER] [\-\-shebang] [\-\-standalone[=GROUP[ GROUP\|\.\|\.\|\.]]] [\-\-system] [\-\-trust\-policy=POLICY] [\-\-with=GROUP[ GROUP\|\.\|\.\|\.]] [\-\-without=GROUP[ GROUP\|\.\|\.\|\.]]
+\fBbundle install\fR [\-\-binstubs[=DIRECTORY]] [\-\-clean] [\-\-deployment] [\-\-frozen] [\-\-full\-index] [\-\-gemfile=GEMFILE] [\-\-jobs=NUMBER] [\-\-local] [\-\-no\-cache] [\-\-no\-prune] [\-\-path PATH] [\-\-prefer\-local] [\-\-quiet] [\-\-redownload] [\-\-retry=NUMBER] [\-\-shebang] [\-\-standalone[=GROUP[ GROUP\|\.\|\.\|\.]]] [\-\-system] [\-\-trust\-policy=POLICY] [\-\-target\-rbconfig=TARGET\-RBCONFIG] [\-\-with=GROUP[ GROUP\|\.\|\.\|\.]] [\-\-without=GROUP[ GROUP\|\.\|\.\|\.]]
 .SH "DESCRIPTION"
 Install the gems specified in your Gemfile(5)\. If this is the first time you run bundle install (and a \fBGemfile\.lock\fR does not exist), Bundler will fetch all remote sources, resolve dependencies and install all needed gems\.
 .P
@@ -86,6 +86,9 @@ This option is deprecated in favor of the \fBsystem\fR setting\.
 .TP
 \fB\-\-trust\-policy=[<policy>]\fR
 Apply the Rubygems security policy \fIpolicy\fR, where policy is one of \fBHighSecurity\fR, \fBMediumSecurity\fR, \fBLowSecurity\fR, \fBAlmostNoSecurity\fR, or \fBNoSecurity\fR\. For more details, please see the Rubygems signing documentation linked below in \fISEE ALSO\fR\.
+.TP
+\fB\-\-target\-rbconfig=TARGET\-RBCONFIG\fR
+Path to rbconfig\.rb for the deployment target platform\.
 .TP
 \fB\-\-with=<list>\fR
 A space\-separated list of groups referencing gems to install\. If an optional group is given it is installed\. If a group is given that is in the remembered list of groups given to \-\-without, it is removed from that list\.

--- a/bundler/lib/bundler/man/bundle-install.1
+++ b/bundler/lib/bundler/man/bundle-install.1
@@ -4,7 +4,7 @@
 .SH "NAME"
 \fBbundle\-install\fR \- Install the dependencies specified in your Gemfile
 .SH "SYNOPSIS"
-\fBbundle install\fR [\-\-binstubs[=DIRECTORY]] [\-\-clean] [\-\-deployment] [\-\-frozen] [\-\-full\-index] [\-\-gemfile=GEMFILE] [\-\-jobs=NUMBER] [\-\-local] [\-\-no\-cache] [\-\-no\-prune] [\-\-path PATH] [\-\-prefer\-local] [\-\-quiet] [\-\-redownload] [\-\-retry=NUMBER] [\-\-shebang] [\-\-standalone[=GROUP[ GROUP\|\.\|\.\|\.]]] [\-\-system] [\-\-trust\-policy=POLICY] [\-\-target\-rbconfig=TARGET\-RBCONFIG] [\-\-with=GROUP[ GROUP\|\.\|\.\|\.]] [\-\-without=GROUP[ GROUP\|\.\|\.\|\.]]
+\fBbundle install\fR [\-\-binstubs[=DIRECTORY]] [\-\-clean] [\-\-deployment] [\-\-frozen] [\-\-full\-index] [\-\-gemfile=GEMFILE] [\-\-jobs=NUMBER] [\-\-local] [\-\-no\-cache] [\-\-no\-prune] [\-\-path PATH] [\-\-prefer\-local] [\-\-quiet] [\-\-redownload] [\-\-retry=NUMBER] [\-\-shebang=SHEBANG] [\-\-standalone[=GROUP[ GROUP\|\.\|\.\|\.]]] [\-\-system] [\-\-trust\-policy=TRUST\-POLICY] [\-\-target\-rbconfig=TARGET\-RBCONFIG] [\-\-with=GROUP[ GROUP\|\.\|\.\|\.]] [\-\-without=GROUP[ GROUP\|\.\|\.\|\.]]
 .SH "DESCRIPTION"
 Install the gems specified in your Gemfile(5)\. If this is the first time you run bundle install (and a \fBGemfile\.lock\fR does not exist), Bundler will fetch all remote sources, resolve dependencies and install all needed gems\.
 .P
@@ -14,10 +14,10 @@ If a \fBGemfile\.lock\fR does exist, and you have updated your Gemfile(5), Bundl
 .SH "OPTIONS"
 The \fB\-\-clean\fR, \fB\-\-deployment\fR, \fB\-\-frozen\fR, \fB\-\-no\-prune\fR, \fB\-\-path\fR, \fB\-\-shebang\fR, \fB\-\-system\fR, \fB\-\-without\fR and \fB\-\-with\fR options are deprecated because they only make sense if they are applied to every subsequent \fBbundle install\fR run automatically and that requires \fBbundler\fR to silently remember them\. Since \fBbundler\fR will no longer remember CLI flags in future versions, \fBbundle config\fR (see bundle\-config(1)) should be used to apply them permanently\.
 .TP
-\fB\-\-binstubs[=<directory>]\fR
+\fB\-\-binstubs[=BINSTUBS]\fR
 Binstubs are scripts that wrap around executables\. Bundler creates a small Ruby file (a binstub) that loads Bundler, runs the command, and puts it in \fBbin/\fR\. This lets you link the binstub inside of an application to the exact gem version the application needs\.
 .IP
-Creates a directory (defaults to \fB~/bin\fR) and places any executables from the gem there\. These executables run in Bundler's context\. If used, you might add this directory to your environment's \fBPATH\fR variable\. For instance, if the \fBrails\fR gem comes with a \fBrails\fR executable, this flag will create a \fBbin/rails\fR executable that ensures that all referred dependencies will be resolved using the bundled gems\.
+Creates a directory (defaults to \fB~/bin\fR when the option is used without a value, or to the given \fB<BINSTUBS>\fR directory otherwise) and places any executables from the gem there\. These executables run in Bundler's context\. If used, you might add this directory to your environment's \fBPATH\fR variable\. For instance, if the \fBrails\fR gem comes with a \fBrails\fR executable, this flag will create a \fBbin/rails\fR executable that ensures that all referred dependencies will be resolved using the bundled gems\.
 .TP
 \fB\-\-clean\fR
 On finishing the installation Bundler is going to remove any gems not present in the current Gemfile(5)\. Don't worry, gems currently in use will not be removed\.
@@ -29,7 +29,7 @@ In \fIdeployment mode\fR, Bundler will 'roll\-out' the bundle for production or 
 .IP
 This option is deprecated in favor of the \fBdeployment\fR setting\.
 .TP
-\fB\-\-redownload\fR
+\fB\-\-redownload\fR, \fB\-\-force\fR
 Force download every gem, even if the required versions are already available locally\.
 .TP
 \fB\-\-frozen\fR
@@ -40,10 +40,10 @@ This option is deprecated in favor of the \fBfrozen\fR setting\.
 \fB\-\-full\-index\fR
 Bundler will not call Rubygems' API endpoint (default) but download and cache a (currently big) index file of all gems\. Performance can be improved for large bundles that seldom change by enabling this option\.
 .TP
-\fB\-\-gemfile=<gemfile>\fR
+\fB\-\-gemfile=GEMFILE\fR
 The location of the Gemfile(5) which Bundler should use\. This defaults to a Gemfile(5) in the current working directory\. In general, Bundler will assume that the location of the Gemfile(5) is also the project's root and will try to find \fBGemfile\.lock\fR and \fBvendor/cache\fR relative to this location\.
 .TP
-\fB\-\-jobs=[<number>]\fR, \fB\-j[<number>]\fR
+\fB\-\-jobs=<number>\fR, \fB\-j=<number>\fR
 The maximum number of parallel download and install jobs\. The default is the number of available processors\.
 .TP
 \fB\-\-local\fR
@@ -60,7 +60,7 @@ Don't remove stale gems from the cache when the installation finishes\.
 .IP
 This option is deprecated in favor of the \fBno_prune\fR setting\.
 .TP
-\fB\-\-path=<path>\fR
+\fB\-\-path=PATH\fR
 The location to install the specified gems to\. This defaults to Rubygems' setting\. Bundler shares this location with Rubygems, \fBgem install \|\.\|\.\|\.\fR will have gem installed there, too\. Therefore, gems installed without a \fB\-\-path \|\.\|\.\|\.\fR setting will show up by calling \fBgem list\fR\. Accordingly, gems installed to other locations will not get listed\.
 .IP
 This option is deprecated in favor of the \fBpath\fR setting\.
@@ -71,20 +71,20 @@ Do not print progress information to the standard output\.
 \fB\-\-retry=[<number>]\fR
 Retry failed network or git requests for \fInumber\fR times\.
 .TP
-\fB\-\-shebang=<ruby\-executable>\fR
+\fB\-\-shebang=SHEBANG\fR
 Uses the specified ruby executable (usually \fBruby\fR) to execute the scripts created with \fB\-\-binstubs\fR\. In addition, if you use \fB\-\-binstubs\fR together with \fB\-\-shebang jruby\fR these executables will be changed to execute \fBjruby\fR instead\.
 .IP
 This option is deprecated in favor of the \fBshebang\fR setting\.
 .TP
 \fB\-\-standalone[=<list>]\fR
-Makes a bundle that can work without depending on Rubygems or Bundler at runtime\. A space separated list of groups to install has to be specified\. Bundler creates a directory named \fBbundle\fR and installs the bundle there\. It also generates a \fBbundle/bundler/setup\.rb\fR file to replace Bundler's own setup in the manner required\. Using this option implicitly sets \fBpath\fR, which is a [remembered option][REMEMBERED OPTIONS]\.
+Makes a bundle that can work without depending on Rubygems or Bundler at runtime\. A space separated list of groups to install can be specified\. Bundler creates a directory named \fBbundle\fR and installs the bundle there\. It also generates a \fBbundle/bundler/setup\.rb\fR file to replace Bundler's own setup in the manner required\. Using this option implicitly sets \fBpath\fR, which is a [remembered option][REMEMBERED OPTIONS]\.
 .TP
 \fB\-\-system\fR
 Installs the gems specified in the bundle to the system's Rubygems location\. This overrides any previous configuration of \fB\-\-path\fR\.
 .IP
 This option is deprecated in favor of the \fBsystem\fR setting\.
 .TP
-\fB\-\-trust\-policy=[<policy>]\fR
+\fB\-\-trust\-policy=TRUST\-POLICY\fR
 Apply the Rubygems security policy \fIpolicy\fR, where policy is one of \fBHighSecurity\fR, \fBMediumSecurity\fR, \fBLowSecurity\fR, \fBAlmostNoSecurity\fR, or \fBNoSecurity\fR\. For more details, please see the Rubygems signing documentation linked below in \fISEE ALSO\fR\.
 .TP
 \fB\-\-target\-rbconfig=TARGET\-RBCONFIG\fR

--- a/bundler/lib/bundler/man/bundle-install.1.ronn
+++ b/bundler/lib/bundler/man/bundle-install.1.ronn
@@ -22,6 +22,7 @@ bundle-install(1) -- Install the dependencies specified in your Gemfile
                  [--standalone[=GROUP[ GROUP...]]]
                  [--system]
                  [--trust-policy=POLICY]
+                 [--target-rbconfig=TARGET-RBCONFIG]
                  [--with=GROUP[ GROUP...]]
                  [--without=GROUP[ GROUP...]]
 
@@ -168,6 +169,9 @@ automatically and that requires `bundler` to silently remember them. Since
   `HighSecurity`, `MediumSecurity`, `LowSecurity`, `AlmostNoSecurity`, or
   `NoSecurity`. For more details, please see the Rubygems signing documentation
   linked below in [SEE ALSO][].
+
+* `--target-rbconfig=TARGET-RBCONFIG`:
+  Path to rbconfig.rb for the deployment target platform.
 
 * `--with=<list>`:
   A space-separated list of groups referencing gems to install. If an

--- a/bundler/lib/bundler/man/bundle-install.1.ronn
+++ b/bundler/lib/bundler/man/bundle-install.1.ronn
@@ -18,10 +18,10 @@ bundle-install(1) -- Install the dependencies specified in your Gemfile
                  [--quiet]
                  [--redownload]
                  [--retry=NUMBER]
-                 [--shebang]
+                 [--shebang=SHEBANG]
                  [--standalone[=GROUP[ GROUP...]]]
                  [--system]
-                 [--trust-policy=POLICY]
+                 [--trust-policy=TRUST-POLICY]
                  [--target-rbconfig=TARGET-RBCONFIG]
                  [--with=GROUP[ GROUP...]]
                  [--without=GROUP[ GROUP...]]
@@ -52,18 +52,19 @@ automatically and that requires `bundler` to silently remember them. Since
 `bundler` will no longer remember CLI flags in future versions, `bundle config`
 (see bundle-config(1)) should be used to apply them permanently.
 
-* `--binstubs[=<directory>]`:
+* `--binstubs[=BINSTUBS]`:
   Binstubs are scripts that wrap around executables. Bundler creates a small Ruby
   file (a binstub) that loads Bundler, runs the command, and puts it in `bin/`.
   This lets you link the binstub inside of an application to the exact gem
   version the application needs.
 
-  Creates a directory (defaults to `~/bin`) and places any executables from the
-  gem there. These executables run in Bundler's context. If used, you might add
-  this directory to your environment's `PATH` variable. For instance, if the
-  `rails` gem comes with a `rails` executable, this flag will create a
-  `bin/rails` executable that ensures that all referred dependencies will be
-  resolved using the bundled gems.
+  Creates a directory (defaults to `~/bin` when the option is used without a
+  value, or to the given `<BINSTUBS>` directory otherwise) and places any
+  executables from the gem there. These executables run in Bundler's context. If
+  used, you might add this directory to your environment's `PATH` variable. For
+  instance, if the `rails` gem comes with a `rails` executable, this flag will
+  create a `bin/rails` executable that ensures that all referred dependencies
+  will be resolved using the bundled gems.
 
 * `--clean`:
   On finishing the installation Bundler is going to remove any gems not present
@@ -79,7 +80,7 @@ automatically and that requires `bundler` to silently remember them. Since
 
   This option is deprecated in favor of the `deployment` setting.
 
-* `--redownload`:
+* `--redownload`, `--force`:
   Force download every gem, even if the required versions are already available
   locally.
 
@@ -94,14 +95,14 @@ automatically and that requires `bundler` to silently remember them. Since
   a (currently big) index file of all gems. Performance can be improved for
   large bundles that seldom change by enabling this option.
 
-* `--gemfile=<gemfile>`:
+* `--gemfile=GEMFILE`:
   The location of the Gemfile(5) which Bundler should use. This defaults
   to a Gemfile(5) in the current working directory. In general, Bundler
   will assume that the location of the Gemfile(5) is also the project's
   root and will try to find `Gemfile.lock` and `vendor/cache` relative
   to this location.
 
-* `--jobs=[<number>]`, `-j[<number>]`:
+* `--jobs=<number>`, `-j=<number>`:
   The maximum number of parallel download and install jobs. The default is the
   number of available processors.
 
@@ -127,7 +128,7 @@ automatically and that requires `bundler` to silently remember them. Since
 
   This option is deprecated in favor of the `no_prune` setting.
 
-* `--path=<path>`:
+* `--path=PATH`:
   The location to install the specified gems to. This defaults to Rubygems'
   setting. Bundler shares this location with Rubygems, `gem install ...` will
   have gem installed there, too. Therefore, gems installed without a
@@ -142,7 +143,7 @@ automatically and that requires `bundler` to silently remember them. Since
 * `--retry=[<number>]`:
   Retry failed network or git requests for <number> times.
 
-* `--shebang=<ruby-executable>`:
+* `--shebang=SHEBANG`:
   Uses the specified ruby executable (usually `ruby`) to execute the scripts
   created with `--binstubs`. In addition, if you use `--binstubs` together with
   `--shebang jruby` these executables will be changed to execute `jruby`
@@ -152,7 +153,7 @@ automatically and that requires `bundler` to silently remember them. Since
 
 * `--standalone[=<list>]`:
   Makes a bundle that can work without depending on Rubygems or Bundler at
-  runtime. A space separated list of groups to install has to be specified.
+  runtime. A space separated list of groups to install can be specified.
   Bundler creates a directory named `bundle` and installs the bundle there. It
   also generates a `bundle/bundler/setup.rb` file to replace Bundler's own setup
   in the manner required. Using this option implicitly sets `path`, which is a
@@ -164,7 +165,7 @@ automatically and that requires `bundler` to silently remember them. Since
 
   This option is deprecated in favor of the `system` setting.
 
-* `--trust-policy=[<policy>]`:
+* `--trust-policy=TRUST-POLICY`:
   Apply the Rubygems security policy <policy>, where policy is one of
   `HighSecurity`, `MediumSecurity`, `LowSecurity`, `AlmostNoSecurity`, or
   `NoSecurity`. For more details, please see the Rubygems signing documentation

--- a/bundler/lib/bundler/man/bundle-list.1.ronn
+++ b/bundler/lib/bundler/man/bundle-list.1.ronn
@@ -25,9 +25,12 @@ bundle list --only-group dev test --paths
 
 * `--name-only`:
   Print only the name of each gem.
+
 * `--paths`:
   Print the path to each gem in the bundle.
+
 * `--without-group=<list>`:
   A space-separated list of groups of gems to skip during printing.
+
 * `--only-group=<list>`:
   A space-separated list of groups of gems to print.

--- a/bundler/lib/bundler/man/bundle-lock.1
+++ b/bundler/lib/bundler/man/bundle-lock.1
@@ -9,7 +9,7 @@
 Lock the gems specified in Gemfile\.
 .SH "OPTIONS"
 .TP
-\fB\-\-update=<*gems>\fR
+\fB\-\-update[=<list>]\fR
 Ignores the existing lockfile\. Resolve then updates lockfile\. Taking a list of gems or updating all gems if no list is given\.
 .TP
 \fB\-\-bundler[=BUNDLER]\fR
@@ -21,7 +21,7 @@ Do not attempt to connect to \fBrubygems\.org\fR\. Instead, Bundler will use the
 \fB\-\-print\fR
 Prints the lockfile to STDOUT instead of writing to the file system\.
 .TP
-\fB\-\-lockfile=<path>\fR
+\fB\-\-lockfile=LOCKFILE\fR
 The path where the lockfile should be written to\.
 .TP
 \fB\-\-full\-index\fR
@@ -33,10 +33,10 @@ Use the specified gemfile instead of [\fBGemfile(5)\fR][Gemfile(5)]\.
 \fB\-\-add\-checksums\fR
 Add checksums to the lockfile\.
 .TP
-\fB\-\-add\-platform\fR
+\fB\-\-add\-platform=<list>\fR
 Add a new platform to the lockfile, re\-resolving for the addition of that platform\.
 .TP
-\fB\-\-remove\-platform\fR
+\fB\-\-remove\-platform=<list>\fR
 Remove a platform from the lockfile\.
 .TP
 \fB\-\-normalize\-platforms\fR

--- a/bundler/lib/bundler/man/bundle-lock.1
+++ b/bundler/lib/bundler/man/bundle-lock.1
@@ -4,13 +4,16 @@
 .SH "NAME"
 \fBbundle\-lock\fR \- Creates / Updates a lockfile without installing
 .SH "SYNOPSIS"
-\fBbundle lock\fR [\-\-update] [\-\-local] [\-\-print] [\-\-lockfile=PATH] [\-\-full\-index] [\-\-gemfile=GEMFILE] [\-\-add\-platform] [\-\-remove\-platform] [\-\-patch] [\-\-minor] [\-\-major] [\-\-strict] [\-\-conservative]
+\fBbundle lock\fR [\-\-update] [\-\-bundler[=BUNDLER]] [\-\-local] [\-\-print] [\-\-lockfile=PATH] [\-\-full\-index] [\-\-gemfile=GEMFILE] [\-\-add\-checkums] [\-\-add\-platform] [\-\-remove\-platform] [\-\-normalize\-platforms] [\-\-patch] [\-\-minor] [\-\-major] [\-\-pre] [\-\-strict] [\-\-conservative]
 .SH "DESCRIPTION"
 Lock the gems specified in Gemfile\.
 .SH "OPTIONS"
 .TP
 \fB\-\-update=<*gems>\fR
 Ignores the existing lockfile\. Resolve then updates lockfile\. Taking a list of gems or updating all gems if no list is given\.
+.TP
+\fB\-\-bundler[=BUNDLER]\fR
+Update the locked version of bundler to the given version or the latest version if no version is given\.
 .TP
 \fB\-\-local\fR
 Do not attempt to connect to \fBrubygems\.org\fR\. Instead, Bundler will use the gems already present in Rubygems' cache or in \fBvendor/cache\fR\. Note that if a appropriate platform\-specific gem exists on \fBrubygems\.org\fR it will not be found\.
@@ -27,11 +30,17 @@ Fall back to using the single\-file index of all gems\.
 \fB\-\-gemfile=GEMFILE\fR
 Use the specified gemfile instead of [\fBGemfile(5)\fR][Gemfile(5)]\.
 .TP
+\fB\-\-add\-checksums\fR
+Add checksums to the lockfile\.
+.TP
 \fB\-\-add\-platform\fR
 Add a new platform to the lockfile, re\-resolving for the addition of that platform\.
 .TP
 \fB\-\-remove\-platform\fR
 Remove a platform from the lockfile\.
+.TP
+\fB\-\-normalize\-platforms\fR
+Normalize lockfile platforms\.
 .TP
 \fB\-\-patch\fR
 If updating, prefer updating only to next patch version\.
@@ -41,6 +50,9 @@ If updating, prefer updating only to next minor version\.
 .TP
 \fB\-\-major\fR
 If updating, prefer updating to next major version (default)\.
+.TP
+\fB\-\-pre\fR
+If updating, always choose the highest allowed version, regardless of prerelease status\.
 .TP
 \fB\-\-strict\fR
 If updating, do not allow any gem to be updated past latest \-\-patch | \-\-minor | \-\-major\.

--- a/bundler/lib/bundler/man/bundle-lock.1
+++ b/bundler/lib/bundler/man/bundle-lock.1
@@ -4,7 +4,7 @@
 .SH "NAME"
 \fBbundle\-lock\fR \- Creates / Updates a lockfile without installing
 .SH "SYNOPSIS"
-\fBbundle lock\fR [\-\-update] [\-\-local] [\-\-print] [\-\-lockfile=PATH] [\-\-full\-index] [\-\-add\-platform] [\-\-remove\-platform] [\-\-patch] [\-\-minor] [\-\-major] [\-\-strict] [\-\-conservative]
+\fBbundle lock\fR [\-\-update] [\-\-local] [\-\-print] [\-\-lockfile=PATH] [\-\-full\-index] [\-\-gemfile=GEMFILE] [\-\-add\-platform] [\-\-remove\-platform] [\-\-patch] [\-\-minor] [\-\-major] [\-\-strict] [\-\-conservative]
 .SH "DESCRIPTION"
 Lock the gems specified in Gemfile\.
 .SH "OPTIONS"
@@ -23,6 +23,9 @@ The path where the lockfile should be written to\.
 .TP
 \fB\-\-full\-index\fR
 Fall back to using the single\-file index of all gems\.
+.TP
+\fB\-\-gemfile=GEMFILE\fR
+Use the specified gemfile instead of [\fBGemfile(5)\fR][Gemfile(5)]\.
 .TP
 \fB\-\-add\-platform\fR
 Add a new platform to the lockfile, re\-resolving for the addition of that platform\.

--- a/bundler/lib/bundler/man/bundle-lock.1.ronn
+++ b/bundler/lib/bundler/man/bundle-lock.1.ronn
@@ -27,7 +27,7 @@ Lock the gems specified in Gemfile.
 
 ## OPTIONS
 
-* `--update=<*gems>`:
+* `--update[=<list>]`:
   Ignores the existing lockfile. Resolve then updates lockfile. Taking a list
   of gems or updating all gems if no list is given.
 
@@ -44,7 +44,7 @@ Lock the gems specified in Gemfile.
 * `--print`:
   Prints the lockfile to STDOUT instead of writing to the file system.
 
-* `--lockfile=<path>`:
+* `--lockfile=LOCKFILE`:
   The path where the lockfile should be written to.
 
 * `--full-index`:
@@ -56,11 +56,11 @@ Lock the gems specified in Gemfile.
 * `--add-checksums`:
   Add checksums to the lockfile.
 
-* `--add-platform`:
+* `--add-platform=<list>`:
   Add a new platform to the lockfile, re-resolving for the addition of that
   platform.
 
-* `--remove-platform`:
+* `--remove-platform=<list>`:
   Remove a platform from the lockfile.
 
 * `--normalize-platforms`:

--- a/bundler/lib/bundler/man/bundle-lock.1.ronn
+++ b/bundler/lib/bundler/man/bundle-lock.1.ronn
@@ -4,16 +4,20 @@ bundle-lock(1) -- Creates / Updates a lockfile without installing
 ## SYNOPSIS
 
 `bundle lock` [--update]
+              [--bundler[=BUNDLER]]
               [--local]
               [--print]
               [--lockfile=PATH]
               [--full-index]
               [--gemfile=GEMFILE]
+              [--add-checkums]
               [--add-platform]
               [--remove-platform]
+              [--normalize-platforms]
               [--patch]
               [--minor]
               [--major]
+              [--pre]
               [--strict]
               [--conservative]
 
@@ -26,6 +30,10 @@ Lock the gems specified in Gemfile.
 * `--update=<*gems>`:
   Ignores the existing lockfile. Resolve then updates lockfile. Taking a list
   of gems or updating all gems if no list is given.
+
+* `--bundler[=BUNDLER]`:
+  Update the locked version of bundler to the given version or the latest
+  version if no version is given.
 
 * `--local`:
   Do not attempt to connect to `rubygems.org`. Instead, Bundler will use the
@@ -45,12 +53,18 @@ Lock the gems specified in Gemfile.
 * `--gemfile=GEMFILE`:
   Use the specified gemfile instead of [`Gemfile(5)`][Gemfile(5)].
 
+* `--add-checksums`:
+  Add checksums to the lockfile.
+
 * `--add-platform`:
   Add a new platform to the lockfile, re-resolving for the addition of that
   platform.
 
 * `--remove-platform`:
   Remove a platform from the lockfile.
+
+* `--normalize-platforms`:
+  Normalize lockfile platforms.
 
 * `--patch`:
   If updating, prefer updating only to next patch version.
@@ -60,6 +74,9 @@ Lock the gems specified in Gemfile.
 
 * `--major`:
   If updating, prefer updating to next major version (default).
+
+* `--pre`:
+  If updating, always choose the highest allowed version, regardless of prerelease status.
 
 * `--strict`:
   If updating, do not allow any gem to be updated past latest --patch | --minor | --major.

--- a/bundler/lib/bundler/man/bundle-lock.1.ronn
+++ b/bundler/lib/bundler/man/bundle-lock.1.ronn
@@ -8,6 +8,7 @@ bundle-lock(1) -- Creates / Updates a lockfile without installing
               [--print]
               [--lockfile=PATH]
               [--full-index]
+              [--gemfile=GEMFILE]
               [--add-platform]
               [--remove-platform]
               [--patch]
@@ -40,6 +41,9 @@ Lock the gems specified in Gemfile.
 
 * `--full-index`:
   Fall back to using the single-file index of all gems.
+
+* `--gemfile=GEMFILE`:
+  Use the specified gemfile instead of [`Gemfile(5)`][Gemfile(5)].
 
 * `--add-platform`:
   Add a new platform to the lockfile, re-resolving for the addition of that

--- a/bundler/lib/bundler/man/bundle-open.1
+++ b/bundler/lib/bundler/man/bundle-open.1
@@ -27,6 +27,6 @@ bundle open 'rack' \-\-path 'README\.md'
 Will open the README\.md file of the 'rack' gem source in your bundle\.
 .SH "OPTIONS"
 .TP
-\fB\-\-path\fR
+\fB\-\-path[=PATH]\fR
 Specify GEM source relative path to open\.
 

--- a/bundler/lib/bundler/man/bundle-open.1.ronn
+++ b/bundler/lib/bundler/man/bundle-open.1.ronn
@@ -23,5 +23,6 @@ Will open the source directory for the 'rack' gem in your bundle.
 Will open the README.md file of the 'rack' gem source in your bundle.
 
 ## OPTIONS
+
 * `--path`:
   Specify GEM source relative path to open.

--- a/bundler/lib/bundler/man/bundle-open.1.ronn
+++ b/bundler/lib/bundler/man/bundle-open.1.ronn
@@ -24,5 +24,5 @@ Will open the README.md file of the 'rack' gem source in your bundle.
 
 ## OPTIONS
 
-* `--path`:
+* `--path[=PATH]`:
   Specify GEM source relative path to open.

--- a/bundler/lib/bundler/man/bundle-outdated.1
+++ b/bundler/lib/bundler/man/bundle-outdated.1
@@ -15,7 +15,7 @@ Do not attempt to fetch gems remotely and use the gem cache instead\.
 \fB\-\-pre\fR
 Check for newer pre\-release gems\.
 .TP
-\fB\-\-source\fR
+\fB\-\-source=<list>\fR
 Check against a specific source\.
 .TP
 \fB\-\-filter\-strict\fR, \fB\-\-strict\fR
@@ -27,7 +27,7 @@ Strict conservative resolution, do not allow any gem to be updated past latest \
 \fB\-\-parseable\fR, \fB\-\-porcelain\fR
 Use minimal formatting for more parseable output\.
 .TP
-\fB\-\-group\fR
+\fB\-\-group=GROUP\fR
 List gems from a specific group\.
 .TP
 \fB\-\-groups\fR

--- a/bundler/lib/bundler/man/bundle-outdated.1
+++ b/bundler/lib/bundler/man/bundle-outdated.1
@@ -4,7 +4,7 @@
 .SH "NAME"
 \fBbundle\-outdated\fR \- List installed gems with newer versions available
 .SH "SYNOPSIS"
-\fBbundle outdated\fR [GEM] [\-\-local] [\-\-pre] [\-\-source] [\-\-strict] [\-\-parseable | \-\-porcelain] [\-\-group=GROUP] [\-\-groups] [\-\-patch|\-\-minor|\-\-major] [\-\-filter\-major] [\-\-filter\-minor] [\-\-filter\-patch] [\-\-only\-explicit]
+\fBbundle outdated\fR [GEM] [\-\-local] [\-\-pre] [\-\-source] [\-\-filter\-strict | \-\-strict] [\-\-update\-strict] [\-\-parseable | \-\-porcelain] [\-\-group=GROUP] [\-\-groups] [\-\-patch|\-\-minor|\-\-major] [\-\-filter\-major] [\-\-filter\-minor] [\-\-filter\-patch] [\-\-only\-explicit]
 .SH "DESCRIPTION"
 Outdated lists the names and versions of gems that have a newer version available in the given source\. Calling outdated with [GEM [GEM]] will only check for newer versions of the given gems\. Prerelease gems are ignored by default\. If your gems are up to date, Bundler will exit with a status of 0\. Otherwise, it will exit 1\.
 .SH "OPTIONS"
@@ -18,8 +18,11 @@ Check for newer pre\-release gems\.
 \fB\-\-source\fR
 Check against a specific source\.
 .TP
-\fB\-\-strict\fR
+\fB\-\-filter\-strict\fR, \fB\-\-strict\fR
 Only list newer versions allowed by your Gemfile requirements, also respecting conservative update flags (\-\-patch, \-\-minor, \-\-major)\.
+.TP
+\fB\-\-update\-strict\fR
+Strict conservative resolution, do not allow any gem to be updated past latest \-\-patch | \-\-minor | \-\-major\.
 .TP
 \fB\-\-parseable\fR, \fB\-\-porcelain\fR
 Use minimal formatting for more parseable output\.

--- a/bundler/lib/bundler/man/bundle-outdated.1.ronn
+++ b/bundler/lib/bundler/man/bundle-outdated.1.ronn
@@ -6,7 +6,8 @@ bundle-outdated(1) -- List installed gems with newer versions available
 `bundle outdated` [GEM] [--local]
                         [--pre]
                         [--source]
-                        [--strict]
+                        [--filter-strict | --strict]
+                        [--update-strict]
                         [--parseable | --porcelain]
                         [--group=GROUP]
                         [--groups]
@@ -34,8 +35,11 @@ are up to date, Bundler will exit with a status of 0. Otherwise, it will exit 1.
 * `--source`:
   Check against a specific source.
 
-* `--strict`:
+* `--filter-strict`, `--strict`:
   Only list newer versions allowed by your Gemfile requirements, also respecting conservative update flags (--patch, --minor, --major).
+
+* `--update-strict`:
+  Strict conservative resolution, do not allow any gem to be updated past latest --patch | --minor | --major.
 
 * `--parseable`, `--porcelain`:
    Use minimal formatting for more parseable output.

--- a/bundler/lib/bundler/man/bundle-outdated.1.ronn
+++ b/bundler/lib/bundler/man/bundle-outdated.1.ronn
@@ -32,7 +32,7 @@ are up to date, Bundler will exit with a status of 0. Otherwise, it will exit 1.
 * `--pre`:
   Check for newer pre-release gems.
 
-* `--source`:
+* `--source=<list>`:
   Check against a specific source.
 
 * `--filter-strict`, `--strict`:
@@ -44,7 +44,7 @@ are up to date, Bundler will exit with a status of 0. Otherwise, it will exit 1.
 * `--parseable`, `--porcelain`:
    Use minimal formatting for more parseable output.
 
-* `--group`:
+* `--group=GROUP`:
   List gems from a specific group.
 
 * `--groups`:

--- a/bundler/lib/bundler/man/bundle-show.1
+++ b/bundler/lib/bundler/man/bundle-show.1
@@ -4,7 +4,7 @@
 .SH "NAME"
 \fBbundle\-show\fR \- Shows all the gems in your bundle, or the path to a gem
 .SH "SYNOPSIS"
-\fBbundle show\fR [GEM] [\-\-paths]
+\fBbundle show\fR [GEM] [\-\-paths] [\-\-outdated]
 .SH "DESCRIPTION"
 Without the [GEM] option, \fBshow\fR will print a list of the names and versions of all gems that are required by your [\fBGemfile(5)\fR][Gemfile(5)], sorted by name\.
 .P
@@ -13,4 +13,7 @@ Calling show with [GEM] will list the exact location of that gem on your machine
 .TP
 \fB\-\-paths\fR
 List the paths of all gems that are required by your [\fBGemfile(5)\fR][Gemfile(5)], sorted by gem name\.
+.TP
+\fB\-\-outdated\fR
+Show verbose output including whether gems are outdated\.
 

--- a/bundler/lib/bundler/man/bundle-show.1.ronn
+++ b/bundler/lib/bundler/man/bundle-show.1.ronn
@@ -5,6 +5,7 @@ bundle-show(1) -- Shows all the gems in your bundle, or the path to a gem
 
 `bundle show` [GEM]
               [--paths]
+              [--outdated]
 
 ## DESCRIPTION
 
@@ -19,3 +20,6 @@ machine.
 * `--paths`:
   List the paths of all gems that are required by your [`Gemfile(5)`][Gemfile(5)],
   sorted by gem name.
+
+* `--outdated`:
+  Show verbose output including whether gems are outdated.

--- a/bundler/lib/bundler/man/bundle-update.1
+++ b/bundler/lib/bundler/man/bundle-update.1
@@ -4,7 +4,7 @@
 .SH "NAME"
 \fBbundle\-update\fR \- Update your gems to the latest available versions
 .SH "SYNOPSIS"
-\fBbundle update\fR \fI*gems\fR [\-\-all] [\-\-group=NAME] [\-\-source=NAME] [\-\-local] [\-\-ruby] [\-\-bundler[=VERSION]] [\-\-full\-index] [\-\-gemfile=GEMFILE] [\-\-jobs=JOBS] [\-\-quiet] [\-\-patch|\-\-minor|\-\-major] [\-\-redownload] [\-\-strict] [\-\-conservative]
+\fBbundle update\fR \fI*gems\fR [\-\-all] [\-\-group=NAME] [\-\-source=NAME] [\-\-local] [\-\-ruby] [\-\-bundler[=VERSION]] [\-\-full\-index] [\-\-gemfile=GEMFILE] [\-\-jobs=JOBS] [\-\-quiet] [\-\-patch|\-\-minor|\-\-major] [\-\-pre] [\-\-redownload] [\-\-strict] [\-\-conservative]
 .SH "DESCRIPTION"
 Update the gems specified (all gems, if \fB\-\-all\fR flag is used), ignoring the previously installed gems specified in the \fBGemfile\.lock\fR\. In general, you should use bundle install(1) \fIbundle\-install\.1\.html\fR to install the same exact gems and versions across machines\.
 .P
@@ -55,6 +55,9 @@ Prefer updating only to next minor version\.
 .TP
 \fB\-\-major\fR
 Prefer updating to next major version (default)\.
+.TP
+\fB\-\-pre\fR
+Always choose the highest allowed version, regardless of prerelease status\.
 .TP
 \fB\-\-strict\fR
 Do not allow any gem to be updated past latest \fB\-\-patch\fR | \fB\-\-minor\fR | \fB\-\-major\fR\.

--- a/bundler/lib/bundler/man/bundle-update.1
+++ b/bundler/lib/bundler/man/bundle-update.1
@@ -4,7 +4,7 @@
 .SH "NAME"
 \fBbundle\-update\fR \- Update your gems to the latest available versions
 .SH "SYNOPSIS"
-\fBbundle update\fR \fI*gems\fR [\-\-all] [\-\-group=NAME] [\-\-source=NAME] [\-\-local] [\-\-ruby] [\-\-bundler[=VERSION]] [\-\-full\-index] [\-\-jobs=JOBS] [\-\-quiet] [\-\-patch|\-\-minor|\-\-major] [\-\-redownload] [\-\-strict] [\-\-conservative]
+\fBbundle update\fR \fI*gems\fR [\-\-all] [\-\-group=NAME] [\-\-source=NAME] [\-\-local] [\-\-ruby] [\-\-bundler[=VERSION]] [\-\-full\-index] [\-\-gemfile=GEMFILE] [\-\-jobs=JOBS] [\-\-quiet] [\-\-patch|\-\-minor|\-\-major] [\-\-redownload] [\-\-strict] [\-\-conservative]
 .SH "DESCRIPTION"
 Update the gems specified (all gems, if \fB\-\-all\fR flag is used), ignoring the previously installed gems specified in the \fBGemfile\.lock\fR\. In general, you should use bundle install(1) \fIbundle\-install\.1\.html\fR to install the same exact gems and versions across machines\.
 .P
@@ -31,6 +31,9 @@ Update the locked version of bundler to the invoked bundler version\.
 .TP
 \fB\-\-full\-index\fR
 Fall back to using the single\-file index of all gems\.
+.TP
+\fB\-\-gemfile=GEMFILE\fR
+Use the specified gemfile instead of [\fBGemfile(5)\fR][Gemfile(5)]\.
 .TP
 \fB\-\-jobs=[<number>]\fR, \fB\-j[<number>]\fR
 Specify the number of jobs to run in parallel\. The default is the number of available processors\.

--- a/bundler/lib/bundler/man/bundle-update.1
+++ b/bundler/lib/bundler/man/bundle-update.1
@@ -4,7 +4,7 @@
 .SH "NAME"
 \fBbundle\-update\fR \- Update your gems to the latest available versions
 .SH "SYNOPSIS"
-\fBbundle update\fR \fI*gems\fR [\-\-all] [\-\-group=NAME] [\-\-source=NAME] [\-\-local] [\-\-ruby] [\-\-bundler[=VERSION]] [\-\-full\-index] [\-\-gemfile=GEMFILE] [\-\-jobs=JOBS] [\-\-quiet] [\-\-patch|\-\-minor|\-\-major] [\-\-pre] [\-\-redownload] [\-\-strict] [\-\-conservative]
+\fBbundle update\fR \fI*gems\fR [\-\-all] [\-\-group=NAME] [\-\-source=NAME] [\-\-local] [\-\-ruby] [\-\-bundler[=VERSION]] [\-\-full\-index] [\-\-gemfile=GEMFILE] [\-\-jobs=NUMBER] [\-\-quiet] [\-\-patch|\-\-minor|\-\-major] [\-\-pre] [\-\-redownload] [\-\-strict] [\-\-conservative]
 .SH "DESCRIPTION"
 Update the gems specified (all gems, if \fB\-\-all\fR flag is used), ignoring the previously installed gems specified in the \fBGemfile\.lock\fR\. In general, you should use bundle install(1) \fIbundle\-install\.1\.html\fR to install the same exact gems and versions across machines\.
 .P
@@ -14,10 +14,10 @@ You would use \fBbundle update\fR to explicitly update the version of a gem\.
 \fB\-\-all\fR
 Update all gems specified in Gemfile\.
 .TP
-\fB\-\-group=<name>\fR, \fB\-g=[<name>]\fR
+\fB\-\-group=<list>\fR, \fB\-g=<list>\fR
 Only update the gems in the specified group\. For instance, you can update all gems in the development group with \fBbundle update \-\-group development\fR\. You can also call \fBbundle update rails \-\-group test\fR to update the rails gem and all gems in the test group, for example\.
 .TP
-\fB\-\-source=<name>\fR
+\fB\-\-source=<list>\fR
 The name of a \fB:git\fR or \fB:path\fR source used in the Gemfile(5)\. For instance, with a \fB:git\fR source of \fBhttp://github\.com/rails/rails\.git\fR, you would call \fBbundle update \-\-source rails\fR
 .TP
 \fB\-\-local\fR
@@ -26,7 +26,7 @@ Do not attempt to fetch gems remotely and use the gem cache instead\.
 \fB\-\-ruby\fR
 Update the locked version of Ruby to the current version of Ruby\.
 .TP
-\fB\-\-bundler\fR
+\fB\-\-bundler[=BUNDLER]\fR
 Update the locked version of bundler to the invoked bundler version\.
 .TP
 \fB\-\-full\-index\fR
@@ -35,7 +35,7 @@ Fall back to using the single\-file index of all gems\.
 \fB\-\-gemfile=GEMFILE\fR
 Use the specified gemfile instead of [\fBGemfile(5)\fR][Gemfile(5)]\.
 .TP
-\fB\-\-jobs=[<number>]\fR, \fB\-j[<number>]\fR
+\fB\-\-jobs=<number>\fR, \fB\-j=<number>\fR
 Specify the number of jobs to run in parallel\. The default is the number of available processors\.
 .TP
 \fB\-\-retry=[<number>]\fR
@@ -44,7 +44,7 @@ Retry failed network or git requests for \fInumber\fR times\.
 \fB\-\-quiet\fR
 Only output warnings and errors\.
 .TP
-\fB\-\-redownload\fR
+\fB\-\-redownload\fR, \fB\-\-force\fR
 Force downloading every gem\.
 .TP
 \fB\-\-patch\fR

--- a/bundler/lib/bundler/man/bundle-update.1.ronn
+++ b/bundler/lib/bundler/man/bundle-update.1.ronn
@@ -14,6 +14,7 @@ bundle-update(1) -- Update your gems to the latest available versions
                         [--jobs=JOBS]
                         [--quiet]
                         [--patch|--minor|--major]
+                        [--pre]
                         [--redownload]
                         [--strict]
                         [--conservative]
@@ -80,6 +81,9 @@ gem.
 
 * `--major`:
   Prefer updating to next major version (default).
+
+* `--pre`:
+  Always choose the highest allowed version, regardless of prerelease status.
 
 * `--strict`:
   Do not allow any gem to be updated past latest `--patch` | `--minor` | `--major`.

--- a/bundler/lib/bundler/man/bundle-update.1.ronn
+++ b/bundler/lib/bundler/man/bundle-update.1.ronn
@@ -11,7 +11,7 @@ bundle-update(1) -- Update your gems to the latest available versions
                         [--bundler[=VERSION]]
                         [--full-index]
                         [--gemfile=GEMFILE]
-                        [--jobs=JOBS]
+                        [--jobs=NUMBER]
                         [--quiet]
                         [--patch|--minor|--major]
                         [--pre]
@@ -34,13 +34,13 @@ gem.
 * `--all`:
   Update all gems specified in Gemfile.
 
-* `--group=<name>`, `-g=[<name>]`:
+* `--group=<list>`, `-g=<list>`:
   Only update the gems in the specified group. For instance, you can update all gems
   in the development group with `bundle update --group development`. You can also
   call `bundle update rails --group test` to update the rails gem and all gems in
   the test group, for example.
 
-* `--source=<name>`:
+* `--source=<list>`:
   The name of a `:git` or `:path` source used in the Gemfile(5). For
   instance, with a `:git` source of `http://github.com/rails/rails.git`,
   you would call `bundle update --source rails`
@@ -51,7 +51,7 @@ gem.
 * `--ruby`:
   Update the locked version of Ruby to the current version of Ruby.
 
-* `--bundler`:
+* `--bundler[=BUNDLER]`:
   Update the locked version of bundler to the invoked bundler version.
 
 * `--full-index`:
@@ -60,7 +60,7 @@ gem.
 * `--gemfile=GEMFILE`:
   Use the specified gemfile instead of [`Gemfile(5)`][Gemfile(5)].
 
-* `--jobs=[<number>]`, `-j[<number>]`:
+* `--jobs=<number>`, `-j=<number>`:
   Specify the number of jobs to run in parallel. The default is the number of
   available processors.
 
@@ -70,7 +70,7 @@ gem.
 * `--quiet`:
   Only output warnings and errors.
 
-* `--redownload`:
+* `--redownload`, `--force`:
   Force downloading every gem.
 
 * `--patch`:

--- a/bundler/lib/bundler/man/bundle-update.1.ronn
+++ b/bundler/lib/bundler/man/bundle-update.1.ronn
@@ -10,6 +10,7 @@ bundle-update(1) -- Update your gems to the latest available versions
                         [--ruby]
                         [--bundler[=VERSION]]
                         [--full-index]
+                        [--gemfile=GEMFILE]
                         [--jobs=JOBS]
                         [--quiet]
                         [--patch|--minor|--major]
@@ -54,6 +55,9 @@ gem.
 
 * `--full-index`:
   Fall back to using the single-file index of all gems.
+
+* `--gemfile=GEMFILE`:
+  Use the specified gemfile instead of [`Gemfile(5)`][Gemfile(5)].
 
 * `--jobs=[<number>]`, `-j[<number>]`:
   Specify the number of jobs to run in parallel. The default is the number of

--- a/bundler/lib/bundler/man/bundle-viz.1
+++ b/bundler/lib/bundler/man/bundle-viz.1
@@ -13,10 +13,10 @@ The associated gems must also be installed via \fBbundle install(1)\fR \fIbundle
 \fBviz\fR command was deprecated in Bundler 2\.2\. Use bundler\-graph plugin \fIhttps://github\.com/rubygems/bundler\-graph\fR instead\.
 .SH "OPTIONS"
 .TP
-\fB\-\-file\fR, \fB\-f\fR
+\fB\-\-file=FILE\fR, \fB\-f=FILE\fR
 The name to use for the generated file\. See \fB\-\-format\fR option
 .TP
-\fB\-\-format\fR, \fB\-F\fR
+\fB\-\-format=FORMAT\fR, \fB\-F=FORMAT\fR
 This is output format option\. Supported format is png, jpg, svg, dot \|\.\|\.\|\.
 .TP
 \fB\-\-requirements\fR, \fB\-R\fR
@@ -25,6 +25,6 @@ Set to show the version of each required dependency\.
 \fB\-\-version\fR, \fB\-v\fR
 Set to show each gem version\.
 .TP
-\fB\-\-without\fR, \fB\-W\fR
+\fB\-\-without=<list>\fR, \fB\-W=<list>\fR
 Exclude gems that are part of the specified named group\.
 

--- a/bundler/lib/bundler/man/bundle-viz.1.ronn
+++ b/bundler/lib/bundler/man/bundle-viz.1.ronn
@@ -22,11 +22,15 @@ The associated gems must also be installed via [`bundle install(1)`](bundle-inst
 
 * `--file`, `-f`:
   The name to use for the generated file. See `--format` option
+
 * `--format`, `-F`:
   This is output format option. Supported format is png, jpg, svg, dot ...
+
 * `--requirements`, `-R`:
   Set to show the version of each required dependency.
+
 * `--version`, `-v`:
   Set to show each gem version.
+
 * `--without`, `-W`:
   Exclude gems that are part of the specified named group.

--- a/bundler/lib/bundler/man/bundle-viz.1.ronn
+++ b/bundler/lib/bundler/man/bundle-viz.1.ronn
@@ -20,10 +20,10 @@ The associated gems must also be installed via [`bundle install(1)`](bundle-inst
 
 ## OPTIONS
 
-* `--file`, `-f`:
+* `--file=FILE`, `-f=FILE`:
   The name to use for the generated file. See `--format` option
 
-* `--format`, `-F`:
+* `--format=FORMAT`, `-F=FORMAT`:
   This is output format option. Supported format is png, jpg, svg, dot ...
 
 * `--requirements`, `-R`:
@@ -32,5 +32,5 @@ The associated gems must also be installed via [`bundle install(1)`](bundle-inst
 * `--version`, `-v`:
   Set to show each gem version.
 
-* `--without`, `-W`:
+* `--without=<list>`, `-W=<list>`:
   Exclude gems that are part of the specified named group.

--- a/bundler/spec/other/cli_man_pages_spec.rb
+++ b/bundler/spec/other/cli_man_pages_spec.rb
@@ -9,7 +9,53 @@ RSpec.describe "bundle commands" do
     end
   end
 
+  it "expects all commands to have all options documented" do
+    Bundler::CLI.all_commands.each do |command_name, command|
+      next if command_name == "cli_help"
+
+      man_page_content = man_page(command_name).read
+
+      command.options.each do |_, option|
+        aliases = option.aliases
+        formatted_aliases = aliases.sort.map {|name| "`#{name}`" }.join(", ") if aliases
+
+        help = if option.type == :boolean
+          "* #{append_aliases("`#{option.switch_name}`", formatted_aliases)}:"
+        elsif option.enum
+          formatted_aliases = "`#{option.switch_name}`" if aliases.empty? && option.lazy_default
+          "* #{prepend_aliases(option.enum.sort.map {|enum| "`#{option.switch_name}=#{enum}`" }.join(", "), formatted_aliases)}:"
+        else
+          names = [option.switch_name, *aliases]
+          value =
+            case option.type
+            when :array then "<list>"
+            when :numeric then "<number>"
+            else option.name.upcase
+            end
+
+          value = option.type != :numeric && option.lazy_default ? "[=#{value}]" : "=#{value}"
+
+          "* #{names.map {|name| "`#{name}#{value}`" }.join(", ")}:"
+        end
+
+        expect(man_page_content).to include(help)
+      end
+    end
+  end
+
   private
+
+  def append_aliases(text, aliases)
+    return text if aliases.empty?
+
+    "#{text}, #{aliases}"
+  end
+
+  def prepend_aliases(text, aliases)
+    return text if aliases.empty?
+
+    "#{aliases}, #{text}"
+  end
 
   def man_page(command_name)
     source_root.join("lib/bundler/man/bundle-#{command_name}.1.ronn")

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -82,6 +82,7 @@ RSpec.configure do |config|
     ENV["RUBYGEMS_GEMDEPS"] = nil
     ENV["XDG_CONFIG_HOME"] = nil
     ENV["GEMRC"] = nil
+    ENV["EDITOR"] = nil
 
     # Don't wrap output in tests
     ENV["THOR_COLUMNS"] = "10000"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

While preparing final releases, I noticed we have quite a few command flags undocumented.

## What is your fix for the problem, implemented in this PR?

I started fixing the ones I found initially: `bundle lock --add-checksums`, `bundle lock --normalize-platforms`, and `bundle install --target-rbconfig`, but in the end I decided to fix this kind of thing once and for all.

So this PR makes sure all flags of all commands are documented, and adds a basic test for it, so that it stays like that.

Supersedes #8298.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
