### PR TITLE
Don't print a bunch of blank lines when setting up dependencies

### DIFF
--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -150,6 +150,7 @@ module Spec
         ENV["BUNDLE_PATH__SYSTEM"] = "true"
       end
 
+      # We don't use `Open3` here because it does not work on JRuby + Windows
       output = `#{Gem.ruby} #{File.expand_path("support/bundle.rb", Path.spec_dir)} install`
       raise output unless $?.success?
     ensure

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -150,7 +150,7 @@ module Spec
         ENV["BUNDLE_PATH__SYSTEM"] = "true"
       end
 
-      output = `#{Gem.ruby} #{File.expand_path("support/bundle.rb", Path.spec_dir)} install --quiet`
+      output = `#{Gem.ruby} #{File.expand_path("support/bundle.rb", Path.spec_dir)} install`
       raise output unless $?.success?
     ensure
       if path

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -150,8 +150,8 @@ module Spec
         ENV["BUNDLE_PATH__SYSTEM"] = "true"
       end
 
-      puts `#{Gem.ruby} #{File.expand_path("support/bundle.rb", Path.spec_dir)} install --quiet`
-      raise unless $?.success?
+      output = `#{Gem.ruby} #{File.expand_path("support/bundle.rb", Path.spec_dir)} install --quiet`
+      raise output unless $?.success?
     ensure
       if path
         ENV["BUNDLE_PATH"] = old_path

--- a/doc/rubygems/CONTRIBUTING.md
+++ b/doc/rubygems/CONTRIBUTING.md
@@ -70,13 +70,11 @@ And to run an individual test method named `test_default` within a test file, yo
 
 ### Running bundler tests
 
-Everything needs to be run from the `bundler/` subfolder.
-
 To setup bundler tests:
 
     bin/rake spec:parallel_deps
 
-To run the entire bundler test suite in parallel (it takes a while):
+To run the entire bundler test suite in parallel (it takes a while), run the following from the `bundler/` subfolder:
 
     bin/parallel_rspec
 
@@ -84,7 +82,7 @@ There are some realworld higher level specs run in CI, but not run by `bin/paral
 
     bin/rake spec:realworld
 
-To run an individual test file location for example in `spec/install/gems/standalone_spec.rb` you can use:
+To run an individual test file location for example in `spec/install/gems/standalone_spec.rb` you can use the following from the `bundler/` subfolder:
 
     bin/rspec spec/install/gems/standalone_spec.rb
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since https://github.com/rubygems/rubygems/pull/8277, you get a bunch of blank lines printed to output when setting up dependencies.

## What is your fix for the problem, implemented in this PR?

Clean the output by not printing blank lines when dependencies are properly installed.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
