### PR TITLE
Fix restarting with locked version when `$PROGRAM_NAME` has been changed 

### DIFF
--- a/bundler/lib/bundler/self_manager.rb
+++ b/bundler/lib/bundler/self_manager.rb
@@ -84,8 +84,8 @@ module Bundler
         require "shellwords"
         cmd = [*Shellwords.shellsplit(bundler_spec_original_cmd), *ARGV]
       else
-        cmd = [$PROGRAM_NAME, *ARGV]
-        cmd.unshift(Gem.ruby) unless File.executable?($PROGRAM_NAME)
+        cmd = [Process.argv0, *ARGV]
+        cmd.unshift(Gem.ruby) unless File.executable?(Process.argv0)
       end
 
       Bundler.with_original_env do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If a ruby process has changed it's name for ease of understanding in `ps` or `top` output, and then loads bundler, but the correct bundler is not installed, then the error message the user sees is very confusing.

Links:
https://github.com/phusion/passenger/issues/2567
https://github.com/phusion/passenger/issues/2577

## What is your fix for the problem, implemented in this PR?

Use `Process.argv0` instead of `$PROGRAM_NAME` because `$PROGRAM_NAME` is liable to be changed but `Process.argv0` is not.

Links: 
- Ruby docs mentioning that `$0`/`$PROCESS_NAME` may be reassigned: https://docs.ruby-lang.org/en/3.3/globals_rdoc.html#label-240
- `Process.argv0` docs indicating that it is not reassigned with `$0`/`$PROCESS_NAME` : https://docs.ruby-lang.org/en/master/Process.html#method-c-argv0

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)

Sorry I didn't write any tests, I have no idea how to setup the required failing environment in your test environment. I've created a minimal reproduction environment below, which I used to verify the fix.

If you create all of these files, then run the following commands, you can trigger the bad error message, and then if you patch the `/usr/local/lib/ruby/site_ruby/3.2.0/bundler/self_manager.rb` file in the container and run `ruby test.rb` again, you will get a good error message.

```
docker build -t bundler_bug .
docker run -it bundler_bug
docker run -it bundler_bug bash
# edit /usr/local/lib/ruby/site_ruby/3.2.0/bundler/self_manager.rb
ruby test.rb
```

## Dockerfile:
```Dockerfile
FROM ruby:3.2.6

WORKDIR /root
COPY test.rb /root/test.rb
COPY Gemfile /root/Gemfile
COPY Gemfile.lock /root/Gemfile.lock

RUN gem update --system
RUN bundle config set --local deployment "true"
RUN bundle config set --local path vendor/ruby
RUN bundle install
RUN rm -rf /root/vendor/ruby/ruby/3.2.0/gems/bundler-2.5.12

CMD ["ruby", "test.rb"]
```

## Gemfile:
```ruby
# frozen_string_literal: true

source "https://rubygems.org"

ruby '3.2.6'
```

## Gemfile.lock:
```
GEM
  remote: https://rubygems.org/
  specs:

PLATFORMS
  arm64-darwin-23
  ruby

DEPENDENCIES

RUBY VERSION
   ruby 3.2.6p234

BUNDLED WITH
   2.5.12
```

## test.rb
```ruby
#!/usr/bin/env ruby
$0 = "this is the program name"
require 'bundler/setup'
```