### PR TITLE
Fix `gem info` tagging some non default gems as default

### DIFF
--- a/lib/rubygems/query_utils.rb
+++ b/lib/rubygems/query_utils.rb
@@ -311,7 +311,7 @@ module Gem::QueryUtils
       label = "Installed at"
       specs.each do |s|
         version = s.version.to_s
-        default = ", default" if s.default_gem?
+        default = s.default_gem? ? ", default" : ""
         entry << "\n" << "    #{label} (#{version}#{default}): #{s.base_dir}"
         label = " " * label.length
       end

--- a/test/rubygems/test_gem_commands_info_command.rb
+++ b/test/rubygems/test_gem_commands_info_command.rb
@@ -54,15 +54,15 @@ class TestGemCommandsInfoCommand < Gem::TestCase
       @cmd.execute
     end
 
-    expected = <<-EOF
+    expected = <<~EOF
 
-*** REMOTE GEMS ***
+      *** REMOTE GEMS ***
 
-coolgem (1.0)
-    Author: A User
-    Homepage: http://example.com
+      coolgem (1.0)
+          Author: A User
+          Homepage: http://example.com
 
-    this is a summary
+          this is a summary
     EOF
 
     assert_equal expected, @ui.output

--- a/test/rubygems/test_gem_commands_info_command.rb
+++ b/test/rubygems/test_gem_commands_info_command.rb
@@ -67,4 +67,39 @@ class TestGemCommandsInfoCommand < Gem::TestCase
 
     assert_equal expected, @ui.output
   end
+
+  def test_execute_with_default_gem
+    @gem = new_default_spec("foo", "1.0.0", nil, "default/gem.rb")
+
+    install_default_gems @gem
+
+    @cmd.handle_options %w[foo]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_include(@ui.output, "#{@gem.name} (#{@gem.version})\n")
+    assert_include(@ui.output, "Installed at (default): #{@gem.base_dir}\n")
+    assert_match "", @ui.error
+  end
+
+  def test_execute_with_default_gem_and_regular_gem
+    @default = new_default_spec("foo", "1.0.1", nil, "default/gem.rb")
+
+    install_default_gems @default
+
+    @regular = gem "foo", "1.0.0"
+
+    @cmd.handle_options %w[foo]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_include(@ui.output, "foo (1.0.1, 1.0.0)\n")
+    assert_include(@ui.output, "Installed at (1.0.1, default): #{@default.base_dir}\n")
+    assert_include(@ui.output, "             (1.0.0): #{@default.base_dir}\n")
+    assert_match "", @ui.error
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If there's a non default version of `foo` lower than a default version of `foo`, `gem info` tags both versions as "default".

## What is your fix for the problem, implemented in this PR?

Reset the variable that holds "default status" while looping through results.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
