### PR TITLE
Support new rdoc plugin

### DIFF
--- a/test/rubygems/test_gem_rdoc.rb
+++ b/test/rubygems/test_gem_rdoc.rb
@@ -5,8 +5,6 @@ require_relative "helper"
 require "rubygems/rdoc"
 
 class TestGemRDoc < Gem::TestCase
-  Gem::RDoc.load_rdoc
-
   def setup
     super
 
@@ -20,10 +18,16 @@ class TestGemRDoc < Gem::TestCase
 
     install_gem @a
 
-    @hook = Gem::RDoc.new @a
+    hook_class = if defined?(RDoc::RubyGemsHook)
+      RDoc::RubyGemsHook
+    else
+      Gem::RDoc
+    end
+
+    @hook = hook_class.new @a
 
     begin
-      Gem::RDoc.load_rdoc
+      hook_class.load_rdoc
     rescue Gem::DocumentError => e
       pend e.message
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The next version of RDoc introduced `rubygems_plugin.rb`. But the current test case is broken with that feature. I added condition for new `RDoc::RubyGemsHook` and the current classes. 

Also see https://github.com/ruby/rdoc/pull/1171 and https://github.com/ruby/ruby/pull/12330

/cc @deivid-rodriguez 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
