### PR TITLE
Fix `bundle lock --add-checksums` when gems are already installed

### DIFF
--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -1894,6 +1894,68 @@ RSpec.describe "bundle lock" do
     L
   end
 
+  it "adds checksums to an existing lockfile, when gems are already installed" do
+    build_repo4 do
+      build_gem "nokogiri", "1.14.2"
+      build_gem "nokogiri", "1.14.2" do |s|
+        s.platform = "x86_64-linux"
+      end
+    end
+
+    gemfile <<-G
+      source "https://gem.repo4"
+
+      gem "nokogiri"
+    G
+
+    lockfile <<~L
+      GEM
+        remote: https://gem.repo4/
+        specs:
+          nokogiri (1.14.2)
+          nokogiri (1.14.2-x86_64-linux)
+
+      PLATFORMS
+        ruby
+        x86_64-linux
+
+      DEPENDENCIES
+        nokogiri
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    simulate_platform "x86_64-linux" do
+      bundle "install"
+
+      bundle "lock --add-checksums"
+    end
+
+    checksums = checksums_section do |c|
+      c.checksum gem_repo4, "nokogiri", "1.14.2"
+      c.checksum gem_repo4, "nokogiri", "1.14.2", "x86_64-linux"
+    end
+
+    expect(lockfile).to eq <<~L
+      GEM
+        remote: https://gem.repo4/
+        specs:
+          nokogiri (1.14.2)
+          nokogiri (1.14.2-x86_64-linux)
+
+      PLATFORMS
+        ruby
+        x86_64-linux
+
+      DEPENDENCIES
+        nokogiri
+      #{checksums}
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+  end
+
   it "generates checksums by default if configured to do so" do
     build_repo4 do
       build_gem "nokogiri", "1.14.2"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If you run `bundle lock --add-checksums` in a situation were gems are already installed, no checksums are added.

## What is your fix for the problem, implemented in this PR?

Fix it by forcing remotely fetching gems when `--add-checksums` is given.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
