### PR TITLE
[DOC] Fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The release policy is somewhat similar to the release policy of Ruby itself:
 ## Documentation
 
 RubyGems uses [rdoc](https://github.com/rdoc/rdoc) for documentation. A compiled set of the docs
-can be viewed online at [rubydoc](https://www.rubydoc.info/github/rubygems/rubygems).
+can be viewed online at [docs.ruby-lang.org](https://docs.ruby-lang.org/en/master/Gem.html).
 
 RubyGems also provides a comprehensive set of guides which covers numerous topics such as
 creating a new gem, security practices and other resources at https://guides.rubygems.org

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -107,7 +107,7 @@ require_relative "rubygems/target_rbconfig"
 #
 # == License
 #
-# See {LICENSE.txt}[rdoc-ref:lib/rubygems/LICENSE.txt] for permissions.
+# See {LICENSE.txt}[https://github.com/rubygems/rubygems/blob/master/LICENSE.txt] for permissions.
 #
 # Thanks!
 #


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Not really, just spotted a broken `rdoc-ref` through https://github.com/ruby/rdoc/pull/1241

## What is your fix for the problem, implemented in this PR?

1. The `rubydoc.info` page doesn't exist anymore. And since `ruby/ruby`'s documentation include `rubygems`'s , I think we can link to its [page](https://docs.ruby-lang.org/en/master/Gem.html) on `docs.ruby-lang.org` instead.
2. The link to `LICENSE.txt` is broken as the file isn't synced to `ruby/ruby`. Since rubygems doesn't have its own API documentation atm (at least I couldn't find one), I think we can link to the source file on GitHub instead.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
