### PR TITLE
Changelogs for RubyGems 3.6.1 and Bundler 2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 3.6.1 / 2024-12-17
+
+## Enhancements:
+
+* Installs bundler 2.6.1 as a default gem.
+
+## Bug fixes:
+
+* Fix `gem info` tagging some non default gems as default. Pull request
+  [#8321](https://github.com/rubygems/rubygems/pull/8321) by
+  deivid-rodriguez
+
+## Documentation:
+
+* Fix broken links. Pull request
+  [#8327](https://github.com/rubygems/rubygems/pull/8327) by st0012
+
 # 3.6.0 / 2024-12-16
 
 ## Security:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.6.1 (December 17, 2024)
+
+## Bug fixes:
+
+  - Fix missing `Gem::Uri.redact` on some Ruby 3.1 versions [#8337](https://github.com/rubygems/rubygems/pull/8337)
+  - Fix `bundle lock --add-checksums` when gems are already installed [#8326](https://github.com/rubygems/rubygems/pull/8326)
+
 # 2.6.0 (December 16, 2024)
 
 ## Security:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.6.1 and Bundler 2.6.1 into master.