### PR TITLE
Skip rdoc hooks and their tests on newer rdoc versions

### DIFF
--- a/lib/rubygems/rdoc.rb
+++ b/lib/rubygems/rdoc.rb
@@ -6,8 +6,17 @@ begin
   require "rdoc/rubygems_hook"
   module Gem
     RDoc = ::RDoc::RubygemsHook
+
+    ##
+    # Returns whether RDoc defines its own install hooks through a RubyGems
+    # plugin. This and whatever is guarded by it can be removed once no
+    # supported Ruby ships with RDoc older than 6.9.0.
+
+    def self.rdoc_hooks_defined_via_plugin?
+      Gem::Version.new(::RDoc::VERSION) >= Gem::Version.new("6.9.0")
+    end
   end
 
-  Gem.done_installing(&Gem::RDoc.method(:generation_hook))
+  Gem.done_installing(&Gem::RDoc.method(:generation_hook)) unless Gem.rdoc_hooks_defined_via_plugin?
 rescue LoadError
 end

--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -10,7 +10,6 @@ require "fileutils"
 require_relative "../rubygems"
 require_relative "installer_uninstaller_utils"
 require_relative "dependency_list"
-require_relative "rdoc"
 require_relative "user_interaction"
 
 ##

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -16,8 +16,6 @@ class TestGemCommandsInstallCommand < Gem::TestCase
     @cmd.options[:document] = []
 
     @gemdeps = "tmp_install_gemdeps"
-
-    common_installer_setup
   end
 
   def teardown

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -665,7 +665,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
 
     assert_path_exist File.join(a2.doc_dir, "ri")
     assert_path_exist File.join(a2.doc_dir, "rdoc")
-  end if defined?(Gem::RDoc)
+  end unless Gem.rdoc_hooks_defined_via_plugin?
 
   def test_execute_rdoc_with_path
     specs = spec_fetcher do |fetcher|
@@ -701,7 +701,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
     wait_for_child_process_to_exit
 
     assert_path_exist "whatever/doc/a-2", "documentation not installed"
-  end if defined?(Gem::RDoc)
+  end unless Gem.rdoc_hooks_defined_via_plugin?
 
   def test_execute_saves_build_args
     specs = spec_fetcher do |fetcher|

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -506,7 +506,7 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
     a2 = @specs["a-2"]
 
     assert_path_exist File.join(a2.doc_dir, "rdoc")
-  end if defined?(Gem::RDoc)
+  end unless Gem.rdoc_hooks_defined_via_plugin?
 
   def test_execute_named
     spec_fetcher do |fetcher|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Currently several tests fail if you have RDoc 6.9.0 or higher installed. Example failures:

```
$ bin/rake test TESTOPTS=--name=test_execute_rdoc
Loaded suite /Users/deivid/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/rake_test_loader
Started

F
======================================================================================================================================================================================================================
Failure: test_execute_rdoc(TestGemCommandsInstallCommand): <"/Users/deivid/code/rubygems/rubygems/tmp/test_rubygems_20241218-76830-sdl4du/gemhome/doc/a-2/ri"> was expected to exist
/Users/deivid/code/rubygems/rubygems/test/rubygems/test_gem_commands_install_command.rb:668:in `test_execute_rdoc'
     665: 
     666:     wait_for_child_process_to_exit
     667: 
  => 668:     assert_path_exist File.join(a2.doc_dir, "ri")
     669:     assert_path_exist File.join(a2.doc_dir, "rdoc")
     670:   end if defined?(Gem::RDoc)
     671: 
======================================================================================================================================================================================================================
F
======================================================================================================================================================================================================================
Failure: test_execute_rdoc(TestGemCommandsUpdateCommand): <"/Users/deivid/code/rubygems/rubygems/tmp/test_rubygems_20241218-76830-7qcmp1/gemhome/doc/a-2/rdoc"> was expected to exist
/Users/deivid/code/rubygems/rubygems/test/rubygems/test_gem_commands_update_command.rb:508:in `test_execute_rdoc'
     505: 
     506:     a2 = @specs["a-2"]
     507: 
  => 508:     assert_path_exist File.join(a2.doc_dir, "rdoc")
     509:   end if defined?(Gem::RDoc)
     510: 
     511:   def test_execute_named
======================================================================================================================================================================================================================
Finished in 0.027159 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
2 tests, 7 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
0% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
73.64 tests/s, 257.74 assertions/s
```

Tests fail because those RDoc versions register post install hooks themselves through a rubygems plugin, and make the hook RubyGems uses a noop.

## What is your fix for the problem, implemented in this PR?

My fix is to skip these tests on those versions. This functionality is now responsibility of RDoc.

I also took the chance to remove/delay some requires and make some stuff more consistent.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
