### PR TITLE
Bump truffleruby to 24.1.1 in CI

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -27,7 +27,7 @@ jobs:
           - { name: "3.3", value: 3.3.6 }
           - { name: "3.4", value: 3.4.0-rc1 }
           - { name: jruby, value: jruby-9.4.9.0 }
-          - { name: truffleruby, value: truffleruby-24.0.1 }
+          - { name: truffleruby, value: truffleruby-24.1.1 }
         openssl:
           - { name: "openssl", value: true }
           - { name: "no-openssl", value: false }

--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -35,7 +35,7 @@ jobs:
           - ruby: { name: jruby, value: jruby-9.4.9.0 }
             os: { name: Ubuntu, value: ubuntu-24.04 }
 
-          - ruby: { name: truffleruby, value: truffleruby-24.0.1 }
+          - ruby: { name: truffleruby, value: truffleruby-24.1.1 }
             os: { name: Ubuntu, value: ubuntu-24.04 }
 
           - ruby: { name: "3.4", value: 3.4.0-rc1 }

--- a/.github/workflows/truffleruby-bundler.yml
+++ b/.github/workflows/truffleruby-bundler.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf # v1.204.0
         with:
-          ruby-version: truffleruby-24.0.1
+          ruby-version: truffleruby-24.1.1
           bundler: none
       - name: Prepare dependencies
         run: |

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         ruby:
           - { name: ruby, value: 3.4.0-rc1 }
-          - { name: truffleruby, value: truffleruby-24.0.1 }
+          - { name: truffleruby, value: truffleruby-24.1.1 }
     env:
       RUBYOPT: -Ilib
     steps:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes truffleruby jobs crash.

## What is your fix for the problem, implemented in this PR?

Try upgrading truffleruby to see if it's better.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
