### PR TITLE
Restart using `Process.argv0` only if `$PROGRAM_NAME` is not a script

### DIFF
--- a/bundler/lib/bundler/self_manager.rb
+++ b/bundler/lib/bundler/self_manager.rb
@@ -84,8 +84,9 @@ module Bundler
         require "shellwords"
         cmd = [*Shellwords.shellsplit(bundler_spec_original_cmd), *ARGV]
       else
-        cmd = [Process.argv0, *ARGV]
-        cmd.unshift(Gem.ruby) unless File.executable?(Process.argv0)
+        argv0 = File.exist?($PROGRAM_NAME) ? $PROGRAM_NAME : Process.argv0
+        cmd = [argv0, *ARGV]
+        cmd.unshift(Gem.ruby) unless File.executable?(argv0)
       end
 
       Bundler.with_original_env do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The change proposed by #8320 made sense in principle, but after seeing some [issues](https://github.com/rubygems/rubygems/issues/8339) caused by it, it no longer seems like a good change.

If `$0` is changed, it should be assumed that further re-executions will use the assigned value.

From passenger's maintainers [explanation](https://github.com/phusion/passenger/issues/2577#issuecomment-2525105583) of their investigation, they want to re-assign `$0` just to get a friendlier `ps` output, but that's what [Process.setproctitle](https://rubyapi.org/3.3/o/process#method-c-setproctitle) is for, so passenger should be changed to use that.

## What is your fix for the problem, implemented in this PR?

Revert #8320.

Fixes #8339.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
