### PR TITLE
Add basic tapioca check to CI

### DIFF
--- a/.github/workflows/realworld-bundler.yml
+++ b/.github/workflows/realworld-bundler.yml
@@ -63,6 +63,24 @@ jobs:
           path: ./bundler/spec/support/artifice/used_cassettes.txt
     timeout-minutes: 20
 
+  tapioca:
+    name: Tapioca
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup ruby
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # v1.207.0
+        with:
+          ruby-version: 3.4.1
+          bundler: none
+      - name: Prepare tapioca
+        run: ruby ../../../support/bundle.rb install
+        working-directory: bundler/spec/realworld/fixtures/tapioca
+      - name: Run tapioca
+        run: ruby ../../../support/bundle.rb exec tapioca init
+        working-directory: bundler/spec/realworld/fixtures/tapioca
+    timeout-minutes: 20
+
   system_rubygems_bundler:
     name: Realworld Bundler ${{ matrix.bundler.name }} against system Rubygems (${{ matrix.ruby.name }})
     runs-on: ubuntu-24.04

--- a/bundler/spec/realworld/fixtures/tapioca/Gemfile
+++ b/bundler/spec/realworld/fixtures/tapioca/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "tapioca"

--- a/bundler/spec/realworld/fixtures/tapioca/Gemfile.lock
+++ b/bundler/spec/realworld/fixtures/tapioca/Gemfile.lock
@@ -1,0 +1,49 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    erubi (1.13.1)
+    netrc (0.11.0)
+    parallel (1.26.3)
+    prism (1.3.0)
+    rbi (0.2.2)
+      prism (~> 1.0)
+      sorbet-runtime (>= 0.5.9204)
+    sorbet (0.5.11725)
+      sorbet-static (= 0.5.11725)
+    sorbet-runtime (0.5.11725)
+    sorbet-static (0.5.11725-aarch64-linux)
+    sorbet-static (0.5.11725-universal-darwin)
+    sorbet-static (0.5.11725-x86_64-linux)
+    sorbet-static-and-runtime (0.5.11725)
+      sorbet (= 0.5.11725)
+      sorbet-runtime (= 0.5.11725)
+    spoom (1.5.0)
+      erubi (>= 1.10.0)
+      prism (>= 0.28.0)
+      sorbet-static-and-runtime (>= 0.5.10187)
+      thor (>= 0.19.2)
+    tapioca (0.16.6)
+      bundler (>= 2.2.25)
+      netrc (>= 0.11.0)
+      parallel (>= 1.21.0)
+      rbi (~> 0.2)
+      sorbet-static-and-runtime (>= 0.5.11087)
+      spoom (>= 1.2.0)
+      thor (>= 1.2.0)
+      yard-sorbet
+    thor (1.3.2)
+    yard (0.9.37)
+    yard-sorbet (0.9.0)
+      sorbet-runtime
+      yard
+
+PLATFORMS
+  aarch64-linux
+  universal-darwin
+  x86_64-linux
+
+DEPENDENCIES
+  tapioca
+
+BUNDLED WITH
+   2.7.0.dev


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Internal changes in Bundler 2.6 broken tapioca. I'd like to be aware of this kind of breakage before introducing changes.

## What is your fix for the problem, implemented in this PR?

Add a basic tapioca check to CI.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
