### PR TITLE
Revert "Fix manifest in gem package using incorrect platform sometimes"

### DIFF
--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -438,33 +438,6 @@ class TestGemPackage < Gem::Package::TarTestCase
     assert_equal %w[lib/code.rb], reader.contents
   end
 
-  def test_build_modified_platform
-    spec = quick_gem "a", "1" do |s|
-      s.files = %w[lib/code.rb]
-      s.platform = Gem::Platform.new "x86_64-linux"
-    end
-
-    spec.platform = Gem::Platform.new "java"
-
-    FileUtils.mkdir "lib"
-
-    File.open "lib/code.rb", "w" do |io|
-      io.write "# lib/code.rb"
-    end
-
-    package = Gem::Package.new spec.file_name
-    package.spec = spec
-
-    package.build
-
-    assert_path_exist spec.file_name
-
-    reader = Gem::Package.new spec.file_name
-    assert reader.verify
-
-    assert_equal spec, reader.spec
-  end
-
   def test_raw_spec
     data_tgz = util_tar_gz {}
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I confirmed a [report](https://github.com/rubygems/rubygems.org/issues/5355) to `rubygems.org` where building a gem with the latest rubygems version is preventing it from being pushed.

The offending commit is ecd5cd4547390027912013300c660e670c265da0.

## What is your fix for the problem, implemented in this PR?

I'll investigate the actual root cause but for startes I'm reverting the change because final Ruby 3.4 release is very close and I want it to ship with a version that does not have this problem.

Fixes https://github.com/rubygems/rubygems.org/issues/5355.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
