### PR TITLE
Add support for mise version manager file

### DIFF
--- a/bundler/lib/bundler/ruby_dsl.rb
+++ b/bundler/lib/bundler/ruby_dsl.rb
@@ -43,7 +43,16 @@ module Bundler
     def normalize_ruby_file(filename)
       file_content = Bundler.read_file(gemfile.dirname.join(filename))
       # match "ruby-3.2.2", ruby = "3.2.2" or "ruby   3.2.2" capturing version string up to the first space or comment
-      if /^ruby[\s-]*(?:=\s*)?"?([^\s#"]+)"?/.match(file_content)
+      if /^                    # Start of line
+         ruby                  # Literal "ruby"
+         [\s-]*                # Optional whitespace or hyphens (for "ruby-3.2.2" format)
+         (?:=\s*)?             # Optional equals sign with whitespace (for ruby = "3.2.2" format)
+         "?                    # Optional opening quote
+         (                     # Start capturing group
+           [^\s#"]+            # One or more chars that aren't spaces, #, or quotes
+         )                     # End capturing group
+         "?                    # Optional closing quote
+         /x.match(file_content)
         $1
       else
         file_content.strip

--- a/bundler/lib/bundler/ruby_dsl.rb
+++ b/bundler/lib/bundler/ruby_dsl.rb
@@ -42,9 +42,9 @@ module Bundler
     # Loads the file relative to the dirname of the Gemfile itself.
     def normalize_ruby_file(filename)
       file_content = Bundler.read_file(gemfile.dirname.join(filename))
-      # match "ruby-3.2.2" or "ruby   3.2.2" capturing version string up to the first space or comment
-      if /^ruby(-|\s+)([^\s#]+)/.match(file_content)
-        $2
+      # match "ruby-3.2.2", ruby = "3.2.2" or "ruby   3.2.2" capturing version string up to the first space or comment
+      if /^ruby[\s-]*(?:=\s*)?"?([^\s#"]+)"?/.match(file_content)
+        $1
       else
         file_content.strip
       end

--- a/bundler/spec/bundler/ruby_dsl_spec.rb
+++ b/bundler/spec/bundler/ruby_dsl_spec.rb
@@ -172,6 +172,19 @@ RSpec.describe Bundler::RubyDsl do
         end
       end
 
+      context "with a mise.toml file format" do
+        let(:file) { "mise.toml" }
+        let(:ruby_version_arg) { nil }
+        let(:file_content) do
+          <<~TOML
+            [tools]
+            ruby = "#{version}"
+          TOML
+        end
+
+        it_behaves_like "it stores the ruby version"
+      end
+
       context "with a .tool-versions file format" do
         let(:file) { ".tool-versions" }
         let(:ruby_version_arg) { nil }


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Mise as version manager is on the rise and it makes sense to support this file as we do for `.ruby-version` and `.tools-versions`.

## What is your fix for the problem, implemented in this PR?

I adjusted the regex to account for TOML format and added a test

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
