### PR TITLE
Fix `bundle outdated <GEM>` failing if not all gems are installed

### DIFF
--- a/bundler/lib/bundler/cli/outdated.rb
+++ b/bundler/lib/bundler/cli/outdated.rb
@@ -26,12 +26,14 @@ module Bundler
     def run
       check_for_deployment_mode!
 
-      gems.each do |gem_name|
-        Bundler::CLI::Common.select_spec(gem_name)
-      end
-
       Bundler.definition.validate_runtime!
       current_specs = Bundler.ui.silence { Bundler.definition.resolve }
+
+      gems.each do |gem_name|
+        if current_specs[gem_name].empty?
+          raise GemNotFound, "Could not find gem '#{gem_name}'."
+        end
+      end
 
       current_dependencies = Bundler.ui.silence do
         Bundler.load.dependencies.map {|dep| [dep.name, dep] }.to_h

--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -526,6 +526,44 @@ RSpec.describe "bundle outdated" do
 
       expect(out).to match(Regexp.new(expected_output))
     end
+
+    it "does not require gems to be installed" do
+      build_repo4 do
+        build_gem "zeitwerk", "1.0.0"
+        build_gem "zeitwerk", "2.0.0"
+      end
+
+      gemfile <<-G
+        source "https://gem.repo4"
+        gem "zeitwerk"
+      G
+
+      lockfile <<~L
+        GEM
+          remote: https://gem.repo4/
+          specs:
+            zeitwerk (1.0.0)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          zeitwerk
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "outdated zeitwerk", raise_on_error: false
+
+      expected_output = <<~TABLE.tr(".", "\.").strip
+        Gem       Current  Latest  Requested  Groups
+        zeitwerk  1.0.0    2.0.0   >= 0       default
+      TABLE
+
+      expect(out).to match(Regexp.new(expected_output))
+      expect(err).to be_empty
+    end
   end
 
   describe "pre-release gems" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bundle outdated <GEM>` fails if some gem is not installed.

## What is your fix for the problem, implemented in this PR?

Don't materialize unnecessarily. All we need is the resolution from the lockfile.

Fixes #8349.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
