### PR TITLE
Try fix flaky failures on Windows

### DIFF
--- a/bundler/lib/bundler/feature_flag.rb
+++ b/bundler/lib/bundler/feature_flag.rb
@@ -25,7 +25,7 @@ module Bundler
     end
     private_class_method :settings_method
 
-    (1..10).each {|v| define_method("bundler_#{v}_mode?") { major_version >= v } }
+    (1..10).each {|v| define_method("bundler_#{v}_mode?") { @major_version >= v } }
 
     settings_flag(:allow_offline_install) { bundler_3_mode? }
     settings_flag(:auto_clean_without_path) { bundler_3_mode? }
@@ -44,11 +44,7 @@ module Bundler
 
     def initialize(bundler_version)
       @bundler_version = Gem::Version.create(bundler_version)
+      @major_version = @bundler_version.segments.first
     end
-
-    def major_version
-      @bundler_version.segments.first
-    end
-    private :major_version
   end
 end


### PR DESCRIPTION
It seems same race condition, maybe some Ruby bug. Just hoping this tweak may skip it.

## What was the end-user or developer problem that led to this PR?

For a while, we've been sporadically getting a very strange test failure on Windows. Sometimes Bundler crashes in random specs with an error like this:

```
NoMethodError: undefined method `>=' for false
  D:/a/rubygems/rubygems/bundler/tmp/1.2/gems/system/gems/bundler-2.7.0.dev/lib/bundler/feature_flag.rb:28:in `block (2 levels) in <class:FeatureFlag>'
          D:/a/rubygems/rubygems/bundler/tmp/1.2/gems/system/gems/bundler-2.7.0.dev/lib/bundler/feature_flag.rb:35:in `block in <class:FeatureFlag>'
          D:/a/rubygems/rubygems/bundler/tmp/1.2/gems/system/gems/bundler-2.7.0.dev/lib/bundler/feature_flag.rb:22:in `instance_eval'
          D:/a/rubygems/rubygems/bundler/tmp/1.2/gems/system/gems/bundler-2.7.0.dev/lib/bundler/feature_flag.rb:22:in `block in settings_method'
          D:/a/rubygems/rubygems/bundler/tmp/1.2/gems/system/gems/bundler-2.7.0.dev/lib/bundler/source/rubygems.rb:494:in `download_cache_path'
          D:/a/rubygems/rubygems/bundler/tmp/1.2/gems/system/gems/bundler-2.7.0.dev/lib/bundler/source/rubygems.rb:429:in `fetch_gem'
          D:/a/rubygems/rubygems/bundler/tmp/1.2/gems/system/gems/bundler-2.7.0.dev/lib/bundler/source/rubygems.rb:420:in `fetch_gem_if_possible'
          D:/a/rubygems/rubygems/bundler/tmp/1.2/gems/system/gems/bundler-2.7.0.dev/lib/bundler/source/rubygems.rb:162:in `install'
          D:/a/rubygems/rubygems/bundler/tmp/1.2/gems/system/gems/bundler-2.7.0.dev/lib/bundler/installer/gem_installer.rb:55:in `install'
          D:/a/rubygems/rubygems/bundler/tmp/1.2/gems/system/gems/bundler-2.7.0.dev/lib/bundler/installer/gem_installer.rb:17:in `install_from_spec'
          D:/a/rubygems/rubygems/bundler/tmp/1.2/gems/system/gems/bundler-2.7.0.dev/lib/bundler/installer/parallel_installer.rb:133:in `do_install'
          D:/a/rubygems/rubygems/bundler/tmp/1.2/gems/system/gems/bundler-2.7.0.dev/lib/bundler/installer/parallel_installer.rb:124:in `block in worker_pool'
          D:/a/rubygems/rubygems/bundler/tmp/1.2/gems/system/gems/bundler-2.7.0.dev/lib/bundler/worker.rb:62:in `apply_func'
          D:/a/rubygems/rubygems/bundler/tmp/1.2/gems/system/gems/bundler-2.7.0.dev/lib/bundler/worker.rb:57:in `block in process_queue'
          <internal:kernel>:187:in `loop'
          D:/a/rubygems/rubygems/bundler/tmp/1.2/gems/system/gems/bundler-2.7.0.dev/lib/bundler/worker.rb:54:in `process_queue'
          D:/a/rubygems/rubygems/bundler/tmp/1.2/gems/system/gems/bundler-2.7.0.dev/lib/bundler/worker.rb:90:in `block (2 levels) in create_threads'

```
## What is your fix for the problem, implemented in this PR?

Well, this is not really a fix since I don't understand how the issue is triggered. But I'm expecting that with this little tweak, but eagerly setting `@major_version`, we may no longer run into the problem.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
