### PR TITLE
Remove no longer existing paths from rubocop exclusions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,13 +7,6 @@ AllCops:
     - pkg/**/*
     - tmp/**/*
     - bundler/tmp/**/*
-    - lib/rubygems/resolver/molinillo/**/*
-    - lib/rubygems/tsort/**/*
-    - lib/rubygems/timeout/**/*
-    - lib/rubygems/resolv/**/*
-    - lib/rubygems/optparse/**/*
-    - lib/rubygems/net-protocol/**/*
-    - lib/rubygems/net-http/**/*
     - lib/rubygems/vendor/**/*
     - bundler/lib/bundler/vendor/**/*
   CacheRootDirectory: tmp/rubocop


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Found these paths in rubocop configuration that no longer exist.

## What is your fix for the problem, implemented in this PR?

Remove them.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
