### PR TITLE
Fix crash on read-only filesystems in Ruby 3.4

### DIFF
--- a/.github/workflows/read-only.yml
+++ b/.github/workflows/read-only.yml
@@ -1,0 +1,39 @@
+name: read-only
+
+on:
+  pull_request:
+
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: ci-${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  read-only:
+    name: Bundler on read-only system (${{ matrix.ruby.name }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - { name: ruby-3.1, value: 3.1.6 }
+          - { name: ruby-3.2, value: 3.2.6 }
+          - { name: ruby-3.3, value: 3.3.6 }
+          - { name: ruby-3.4, value: 3.4.1 }
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Basic usage on a read-only filesystem
+        run: docker run --mount type=bind,source=.,target=/rubygems --rm --read-only ruby:${{ matrix.ruby.value }} ruby -I/rubygems/bundler/lib -r'bundler/inline' -e 'gemfile {}; puts :ok'
+
+    timeout-minutes: 15

--- a/bundler/lib/bundler/plugin/index.rb
+++ b/bundler/lib/bundler/plugin/index.rb
@@ -34,6 +34,10 @@ module Bundler
         rescue GenericSystemCallError
           # no need to fail when on a read-only FS, for example
           nil
+        rescue ArgumentError => e
+          # ruby 3.4 checks writability in Dir.tmpdir
+          raise unless e.message&.include?("could not find a temporary directory")
+          nil
         end
         load_index(local_index_file) if SharedHelpers.in_bundle?
       end

--- a/bundler/spec/bundler/plugin/index_spec.rb
+++ b/bundler/spec/bundler/plugin/index_spec.rb
@@ -193,12 +193,4 @@ RSpec.describe Bundler::Plugin::Index do
       include_examples "it cleans up"
     end
   end
-
-  describe "readonly disk without home" do
-    it "ignores being unable to create temp home dir" do
-      expect_any_instance_of(Bundler::Plugin::Index).to receive(:global_index_file).
-        and_raise(Bundler::GenericSystemCallError.new("foo", "bar"))
-      Bundler::Plugin::Index.new
-    end
-  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?
This fixes #8369.

When running with readonly filesystem and no tmp directory on ruby 3.4 bundler raises exception on start

## What is your fix for the problem, implemented in this PR?

While trying to check global installed plugins bundler internally tries to create tmp user home, which is not needed in this case. Added flag `writable` to `Bundler.user_bundle_path`(default true to keep previous behavior) to be able to determine whether intent is to have a writeable directory or `nil` will suffice.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
