### PR TITLE
Add credentials file path to "gem env".

### DIFF
--- a/lib/rubygems/commands/environment_command.rb
+++ b/lib/rubygems/commands/environment_command.rb
@@ -15,6 +15,7 @@ class Gem::Commands::EnvironmentCommand < Gem::Command
           version         display the gem format version
           remotesources   display the remote gem servers
           platform        display the supported gem platforms
+          credentials     display the path where credentials are stored
           <omitted>       display everything
     EOF
     args.gsub(/^\s+/, "")
@@ -88,6 +89,8 @@ lib/rubygems/defaults/operating_system.rb
         Gem.sources.to_a.join("\n")
       when /^platform/ then
         Gem.platforms.join(File::PATH_SEPARATOR)
+      when /^credentials/, /^creds/ then
+        Gem.configuration.credentials_path
       when nil then
         show_environment
       else
@@ -113,6 +116,8 @@ lib/rubygems/defaults/operating_system.rb
     out << "  - INSTALLATION DIRECTORY: #{Gem.dir}\n"
 
     out << "  - USER INSTALLATION DIRECTORY: #{Gem.user_dir}\n"
+
+    out << "  - CREDENTIALS FILE: #{Gem.configuration.credentials_path}\n"
 
     out << "  - RUBYGEMS PREFIX: #{Gem.prefix}\n" unless Gem.prefix.nil?
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

`gem signin` can store credentials in 3 possible locations, and this can lead to confusion:

- `$HOME/.gem/credentials`
- `$XDG_DATA_HOME/gem/credentials`
- `$HOME/.local/share/gem/credentials`

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

I made `gem env` include the credentials path in its output, and `gem env credentials`/`gem env creds` print the credentials path.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
