### PR TITLE
Support "windows" as an OS platform

### DIFF
--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -297,7 +297,8 @@ module Gem
     MINGW = Gem::Platform.new("x86-mingw32")
     X64_MINGW = [Gem::Platform.new("x64-mingw32"),
                  Gem::Platform.new("x64-mingw-ucrt")].freeze
-    WINDOWS = [MSWIN, MSWIN64, MINGW, X64_MINGW].flatten.freeze
+    WINDOWS = [Gem::Platform.new("windows"),
+               MSWIN, MSWIN64, MINGW, X64_MINGW].flatten.freeze
     X64_LINUX = Gem::Platform.new("x86_64-linux")
     X64_LINUX_MUSL = Gem::Platform.new("x86_64-linux-musl")
 

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -291,6 +291,17 @@ RSpec.describe "bundle install with gem sources" do
           expect(the_bundle).to include_gems("platform_specific 1.0 x86-mswin32")
         end
       end
+
+      it "installs gems for arm64-windows" do
+        simulate_platform arm64_windows do
+          install_gemfile <<-G
+            source "https://gem.repo1"
+            gem "platform_specific"
+          G
+
+          expect(the_bundle).to include_gems("platform_specific 1.0 arm64-windows")
+        end
+      end
     end
 
     describe "doing bundle install foo" do

--- a/bundler/spec/support/platforms.rb
+++ b/bundler/spec/support/platforms.rb
@@ -44,8 +44,12 @@ module Spec
       Gem::Platform.new(["x64", "mingw", "ucrt"])
     end
 
+    def arm64_windows
+      Gem::Platform.new(["arm64", "windows", nil])
+    end
+
     def windows_platforms
-      [x86_mswin32, x64_mswin64, x86_mingw32, x64_mingw32, x64_mingw_ucrt]
+      [x86_mswin32, x64_mswin64, x86_mingw32, x64_mingw32, x64_mingw_ucrt, arm64_windows]
     end
 
     def all_platforms
@@ -59,7 +63,7 @@ module Spec
     def local_tag
       if RUBY_PLATFORM == "java"
         :jruby
-      elsif ["x64-mingw32", "x64-mingw-ucrt"].include?(RUBY_PLATFORM)
+      elsif RUBY_PLATFORM.match?(/windows|mingw|mswin/)
         :windows
       else
         :ruby

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -125,6 +125,7 @@ class Gem::Platform
                       when /^dotnet$/ then              ["dotnet",    nil]
                       when /^dotnet([\d.]*)/ then       ["dotnet",    $1]
                       when /linux-?(\w+)?/ then         ["linux",     $1]
+                      when /windows/ then               ["windows",   nil]
                       when /mingw32/ then               ["mingw32",   nil]
                       when /mingw-?(\w+)?/ then         ["mingw",     $1]
                       when /(mswin\d+)(\_(\d+))?/ then


### PR DESCRIPTION
Support "windows" as an OS platform, and add matching for it.

Needed for upcoming `arm64-windows` architecture. See this PR: https://github.com/oneclick/rubyinstaller2/pull/399
