### PR TITLE
Run CI with Ruby 3.4 on Windows

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -47,6 +47,7 @@ jobs:
           - { os: { name: Windows, value: windows-2022 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.6 }, timeout: 150 }
           - { os: { name: Windows, value: windows-2022 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.2, value: 3.2.6 }, timeout: 150 }
           - { os: { name: Windows, value: windows-2022 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.3, value: 3.3.6 }, timeout: 150 }
+          - { os: { name: Windows, value: windows-2022 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.4, value: 3.4.1 }, timeout: 150 }
 
     env:
       RGV: ..

--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -109,6 +109,7 @@ jobs:
           - { name: "3.1", value: 3.1.6 }
           - { name: "3.2", value: 3.2.6 }
           - { name: "3.3", value: 3.3.6 }
+          - { name: "3.4", value: 3.4.1 }
           - { name: jruby-9.4, value: jruby-9.4.9.0, rails-args: "--skip-webpack-install" }
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -30,6 +30,7 @@ jobs:
           - { name: "3.1", value: 3.1.6 }
           - { name: "3.2", value: 3.2.6 }
           - { name: "3.3", value: 3.3.6 }
+          - { name: "3.4", value: 3.4.1 }
 
         include:
           - ruby: { name: jruby, value: jruby-9.4.9.0 }
@@ -37,12 +38,6 @@ jobs:
 
           - ruby: { name: truffleruby, value: truffleruby-24.1.1 }
             os: { name: Ubuntu, value: ubuntu-24.04 }
-
-          - ruby: { name: "3.4", value: 3.4.1 }
-            os: { name: Ubuntu, value: ubuntu-24.04 }
-
-          - ruby: { name: "3.4", value: 3.4.1 }
-            os: { name: macOS, value: macos-14 }
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

RubyInstaller2 made Ruby 3.4 releases: https://github.com/oneclick/rubyinstaller2/releases/tag/RubyInstaller-3.4.1-1, so we should use them.

## What is your fix for the problem, implemented in this PR?

Update CI workflows to use it.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
