### PR TITLE
Fix broken links in the documents

### DIFF
--- a/bundler/README.md
+++ b/bundler/README.md
@@ -29,7 +29,7 @@ See [bundler.io](https://bundler.io) for the full documentation.
 
 ### Troubleshooting
 
-For help with common problems, see [TROUBLESHOOTING](doc/TROUBLESHOOTING.md).
+For help with common problems, see [TROUBLESHOOTING](../doc/bundler/TROUBLESHOOTING.md).
 
 Still stuck? Try [filing an issue](https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md).
 

--- a/doc/bundler/contributing/BUG_TRIAGE.md
+++ b/doc/bundler/contributing/BUG_TRIAGE.md
@@ -37,7 +37,7 @@ Everyone is welcome and encouraged to fix any open bug, improve an error message
   3. Commit the code with at least one test covering your changes to a named branch in your fork.
   4. Send us a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) from your bugfix branch.
 
-You do not have to update [CHANGELOG](../../CHANGELOG.md) in your PR. Our release scripts will automatically prepare it from the title of each PR.
+You do not have to update [CHANGELOG](../../../bundler/CHANGELOG.md) in your PR. Our release scripts will automatically prepare it from the title of each PR.
 
 ## Duplicates!
 

--- a/doc/bundler/contributing/README.md
+++ b/doc/bundler/contributing/README.md
@@ -17,11 +17,11 @@ To request substantial changes to Bundler and/or Bundler documentation, please r
 
 Here are the different ways you can start contributing to the Bundler project:
 
-* [First contribution suggestions](/bundler/doc/contributing/HOW_YOU_CAN_HELP.md)
-* [Adding new features](/bundler/doc/development/NEW_FEATURES.md)
-* [Triaging bugs](/bundler/doc/contributing/BUG_TRIAGE.md)
-* [Writing documentation](/bundler/doc/documentation/WRITING.md)
-* [Community engagement](/bundler/doc/contributing/COMMUNITY.md)
+* [First contribution suggestions](HOW_YOU_CAN_HELP.md)
+* [Adding new features](../development/NEW_FEATURES.md)
+* [Triaging bugs](BUG_TRIAGE.md)
+* [Writing documentation](../documentation/WRITING.md)
+* [Community engagement](COMMUNITY.md)
 
 ## Supporting Bundler
 

--- a/doc/rubygems/POLICIES.md
+++ b/doc/rubygems/POLICIES.md
@@ -95,7 +95,7 @@ the version in all version files, synchronizes both changelogs to include all
 backported changes and commits that change on top of the cherry-picks.
 
 Note that this task requires all user facing pull requests to be tagged with
-specific labels. See [Merging a PR](/bundler/doc/playbooks/MERGING_A_PR.md) for details.
+specific labels. See [Merging a PR](../bundler/playbooks/MERGING_A_PR.md) for details.
 
 Also note that when this task cherry-picks, it cherry-picks the merge commits
 using the following command:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Some links cannot be followed due to incorrect paths.

## What is your fix for the problem, implemented in this PR?

I have corrected the link paths.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
