### PR TITLE
Remove explicit test dependency on logger

### DIFF
--- a/bundler/spec/install/gems/dependency_api_fallback_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_fallback_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../support/silent_logger"
-
 RSpec.describe "gemcutter's dependency API" do
   context "when Gemcutter API takes too long to respond" do
     before do
@@ -11,6 +9,7 @@ RSpec.describe "gemcutter's dependency API" do
       @server_uri = "http://127.0.0.1:#{port}"
 
       require_relative "../../support/artifice/endpoint_timeout"
+      require_relative "../../support/silent_logger"
 
       require "rackup/server"
 

--- a/bundler/spec/realworld/gemfile_source_header_spec.rb
+++ b/bundler/spec/realworld/gemfile_source_header_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../support/silent_logger"
-
 RSpec.describe "fetching dependencies with a mirrored source", realworld: true do
   let(:mirror) { "https://server.example.org" }
   let(:original) { "http://127.0.0.1:#{@port}" }
@@ -38,6 +36,7 @@ RSpec.describe "fetching dependencies with a mirrored source", realworld: true d
     @server_uri = "http://127.0.0.1:#{@port}"
 
     require_relative "../support/artifice/endpoint_mirror_source"
+    require_relative "../support/silent_logger"
 
     require "rackup/server"
 

--- a/bundler/spec/realworld/mirror_probe_spec.rb
+++ b/bundler/spec/realworld/mirror_probe_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../support/silent_logger"
-
 RSpec.describe "fetching dependencies with a not available mirror", realworld: true do
   let(:mirror) { @mirror_uri }
   let(:original) { @server_uri }
@@ -111,6 +109,7 @@ RSpec.describe "fetching dependencies with a not available mirror", realworld: t
     @server_uri = "http://#{host}:#{@server_port}"
 
     require_relative "../support/artifice/endpoint"
+    require_relative "../support/silent_logger"
 
     require "rackup/server"
 

--- a/bundler/spec/support/silent_logger.rb
+++ b/bundler/spec/support/silent_logger.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "logger"
+require "webrick"
 module Spec
-  class SilentLogger
-    (::Logger.instance_methods - Object.instance_methods).each do |logger_instance_method|
-      define_method(logger_instance_method) {|*args, &blk| }
+  class SilentLogger < WEBrick::BasicLog
+    def initialize(log_file = nil, level = nil)
+      super(log_file, level || FATAL)
     end
   end
 end

--- a/tool/bundler/dev_gems.rb
+++ b/tool/bundler/dev_gems.rb
@@ -13,7 +13,6 @@ gem "rspec-core", "~> 3.12"
 gem "rspec-expectations", "~> 3.12"
 gem "rspec-mocks", "~> 3.12"
 gem "uri", "~> 0.13.0"
-gem "logger", "~> 1.6.5"
 
 group :doc do
   gem "ronn-ng", "~> 0.10.1", platform: :ruby

--- a/tool/bundler/dev_gems.rb.lock
+++ b/tool/bundler/dev_gems.rb.lock
@@ -6,7 +6,6 @@ GEM
       rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    logger (1.6.5)
     mini_portile2 (2.8.8)
     mustache (1.1.1)
     nokogiri (1.18.1)
@@ -74,7 +73,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  logger (~> 1.6.5)
   parallel (~> 1.19)
   parallel_tests (~> 4.7)
   rake (~> 13.1)
@@ -91,7 +89,6 @@ CHECKSUMS
   diff-lcs (1.5.1) sha256=273223dfb40685548436d32b4733aa67351769c7dea621da7d9dd4813e63ddfe
   kramdown (2.5.1) sha256=87bbb6abd9d3cebe4fc1f33e367c392b4500e6f8fa19dd61c0972cf4afe7368c
   kramdown-parser-gfm (1.1.0) sha256=fb39745516427d2988543bf01fc4cf0ab1149476382393e0e9c48592f6581729
-  logger (1.6.5) sha256=c3cfe56d01656490ddd103d38b8993d73d86296adebc5f58cefc9ec03741e56b
   mini_portile2 (2.8.8) sha256=8e47136cdac04ce81750bb6c09733b37895bf06962554e4b4056d78168d70a75
   mustache (1.1.1) sha256=90891fdd50b53919ca334c8c1031eada1215e78d226d5795e523d6123a2717d0
   nokogiri (1.18.1) sha256=df18be7e96c34736b6abfdeda80c6e845134fb9afe2fe5d4fbc1cf1f89c68475

--- a/tool/bundler/test_gems.rb.lock
+++ b/tool/bundler/test_gems.rb.lock
@@ -4,15 +4,16 @@ GEM
     base64 (0.2.0)
     builder (3.3.0)
     compact_index (0.15.0)
-    logger (1.6.1)
+    logger (1.6.5)
     mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
     rack (3.1.8)
-    rack-protection (4.1.0)
+    rack-protection (4.1.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
       rack (>= 3.0.0, < 4)
-    rack-session (2.0.0)
+    rack-session (2.1.0)
+      base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)
       rack (>= 1.3)
@@ -24,14 +25,14 @@ GEM
     ruby2_keywords (0.0.5)
     rubygems-generate_index (1.1.3)
       compact_index (~> 0.15.0)
-    sinatra (4.1.0)
+    sinatra (4.1.1)
       logger (>= 1.6.0)
       mustermann (~> 3.0)
       rack (>= 3.0.0, < 4)
-      rack-protection (= 4.1.0)
+      rack-protection (= 4.1.1)
       rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
-    tilt (2.4.0)
+    tilt (2.5.0)
     webrick (1.9.0)
 
 PLATFORMS
@@ -59,19 +60,19 @@ CHECKSUMS
   base64 (0.2.0) sha256=0f25e9b21a02a0cc0cea8ef92b2041035d39350946e8789c562b2d1a3da01507
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   compact_index (0.15.0) sha256=5c6c404afca8928a7d9f4dde9524f6e1610db17e675330803055db282da84a8b
-  logger (1.6.1) sha256=3ad9587ed3940bf7897ea64a673971415523f4f7d6b22c5e3af5219705669653
+  logger (1.6.5) sha256=c3cfe56d01656490ddd103d38b8993d73d86296adebc5f58cefc9ec03741e56b
   mustermann (3.0.3) sha256=d1f8e9ba2ddaed47150ddf81f6a7ea046826b64c672fbc92d83bce6b70657e88
   rack (3.1.8) sha256=d3fbcbca43dc2b43c9c6d7dfbac01667ae58643c42cea10013d0da970218a1b1
-  rack-protection (4.1.0) sha256=c32350d08b28f53df08c9e7c770900fa863593826e9f4f3cdd02ec685902ac30
-  rack-session (2.0.0) sha256=db04b2063e180369192a9046b4559af311990af38c6a93d4c600cee4eb6d4e81
+  rack-protection (4.1.1) sha256=51a254a5d574a7f0ca4f0672025ce2a5ef7c8c3bd09c431349d683e825d7d16a
+  rack-session (2.1.0) sha256=437c3916535b58ef71c816ce4a2dee0a01c8a52ae6077dc2b6cd19085760a290
   rack-test (2.1.0) sha256=0c61fc61904049d691922ea4bb99e28004ed3f43aa5cfd495024cc345f125dfb
   rackup (2.1.0) sha256=6ecb884a581990332e45ee17bdfdc14ccbee46c2f710ae1566019907869a6c4d
   rake (13.2.1) sha256=46cb38dae65d7d74b6020a4ac9d48afed8eb8149c040eccf0523bec91907059d
   rb_sys (0.9.102) sha256=6ed736cc0d0bc236327e233f349ba16913231051df1c886c471ed268ce0e623b
   ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
   rubygems-generate_index (1.1.3) sha256=3571424322666598e9586a906485e1543b617f87644913eaf137d986a3393f5c
-  sinatra (4.1.0) sha256=27d3217f6d83d49c8a9326ae8b688c253ecce2d39582cff24660b0e34b3e9df7
-  tilt (2.4.0) sha256=df74f29a451daed26591a85e8e0cebb198892cb75b6573394303acda273fba4d
+  sinatra (4.1.1) sha256=4e997b859aa1b5d2e624f85d5b0fd0f0b3abc0da44daa6cbdf10f7c0da9f4d00
+  tilt (2.5.0) sha256=3c871a9ffb0fd8191944d8bbd776a371ba1eeb683483cecf1b2572b292293b15
   webrick (1.9.0) sha256=9ee50c57006489960b2a07544f68de6f23dfbee30e7b424167b5c14b72ace964
 
 BUNDLED WITH


### PR DESCRIPTION




## What was the end-user or developer problem that led to this PR?

None, just trying to reduce dependencies.

## What is your fix for the problem, implemented in this PR?

I think logger is only used to figure out which methods need to be made noops in order to silence webrick during tests.

However, it seems possible to do the same using webrick's builtin logger and the current method does not seem even correct since it's not guaranteed that the logger gem and webrick's logger will use the same methods.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
