### PR TITLE
Fix test failure when running tests with ENV["EDITOR"] set

### DIFF
--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -9,7 +9,14 @@ if File.expand_path(__FILE__) =~ %r{([^\w/\.:\-])}
   abort "The bundler specs cannot be run from a path that contains special characters (particularly #{$1.inspect})"
 end
 
+# Bundler CLI will have different help text depending on whether this variable
+# is set, since the `-e` flag `bundle gem` with require an explicit value if
+# `EDITOR` is not set, but will use `EDITOR` by default is set. So make sure
+# it's `nil` before loading bundler to get a consistent help text, since some
+# tests rely on that.
+ENV["EDITOR"] = nil
 require "bundler"
+
 require "rspec/core"
 require "rspec/expectations"
 require "rspec/mocks"
@@ -82,7 +89,6 @@ RSpec.configure do |config|
     ENV["RUBYGEMS_GEMDEPS"] = nil
     ENV["XDG_CONFIG_HOME"] = nil
     ENV["GEMRC"] = nil
-    ENV["EDITOR"] = nil
 
     # Don't wrap output in tests
     ENV["THOR_COLUMNS"] = "10000"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes the value of `ENV["EDITOR"]` affects our tests.

## What is your fix for the problem, implemented in this PR?

Make our tests independent from `ENV["EDITOR"]`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
