### PR TITLE
Remove no longer used spec filter

### DIFF
--- a/bundler/spec/support/filters.rb
+++ b/bundler/spec/support/filters.rb
@@ -21,9 +21,6 @@ end
 RSpec.configure do |config|
   config.filter_run_excluding realworld: true
 
-  git_version = Bundler::Source::Git::GitProxy.new(nil, nil).version
-
-  config.filter_run_excluding git: RequirementChecker.against(git_version)
   config.filter_run_excluding bundler: RequirementChecker.against(Bundler::VERSION.split(".")[0])
   config.filter_run_excluding rubygems: RequirementChecker.against(Gem::VERSION)
   config.filter_run_excluding ruby_repo: !ENV["GEM_COMMAND"].nil?


### PR DESCRIPTION



## What was the end-user or developer problem that led to this PR?

I think we have consistent behavior regardless of the version of git being used, and I'd like to keep it like that.

## What is your fix for the problem, implemented in this PR?

I think we can remove the filter to discourage ourselves from introducing inconsistent behavior that depends on the version of git being used in the future.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
