### PR TITLE
Fix platform specific gems sometimes being removed from the lockfile

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -1108,7 +1108,7 @@ module Bundler
       return resolution_packages if @explicit_unlocks.empty?
       full_update = dup_for_full_unlock.resolve
       @explicit_unlocks.each do |name|
-        version = full_update[name].first&.version
+        version = full_update.version_for(name)
         resolution_packages.base_requirements[name] = Gem::Requirement.new("= #{version}") if version
       end
       resolution_packages

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -742,7 +742,7 @@ module Bundler
 
       @platforms = result.add_extra_platforms!(platforms) if should_add_extra_platforms?
 
-      SpecSet.new(result.for(dependencies, @platforms))
+      SpecSet.new(result.for(dependencies, @platforms | [Gem::Platform::RUBY]))
     end
 
     def precompute_source_requirements_for_indirect_dependencies?

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -80,7 +80,8 @@ module Bundler
     def solve_versions(root:, logger:)
       solver = PubGrub::VersionSolver.new(source: self, root: root, logger: logger)
       result = solver.solve
-      result.flat_map {|package, version| version.to_specs(package, @most_specific_locked_platform) }
+      resolved_specs = result.flat_map {|package, version| version.to_specs(package, @most_specific_locked_platform) }
+      SpecSet.new(resolved_specs).specs_with_additional_variants_from(@base.locked_specs)
     rescue PubGrub::SolveFailure => e
       incompatibility = e.incompatibility
 

--- a/bundler/lib/bundler/resolver/base.rb
+++ b/bundler/lib/bundler/resolver/base.rb
@@ -5,10 +5,11 @@ require_relative "package"
 module Bundler
   class Resolver
     class Base
-      attr_reader :packages, :requirements, :source_requirements
+      attr_reader :packages, :requirements, :source_requirements, :locked_specs
 
       def initialize(source_requirements, dependencies, base, platforms, options)
         @source_requirements = source_requirements
+        @locked_specs = options[:locked_specs]
 
         @base = base
 

--- a/bundler/lib/bundler/resolver/package.rb
+++ b/bundler/lib/bundler/resolver/package.rb
@@ -18,7 +18,7 @@ module Bundler
       def initialize(name, platforms, locked_specs:, unlock:, prerelease: false, prefer_local: false, dependency: nil)
         @name = name
         @platforms = platforms
-        @locked_version = locked_specs[name].first&.version
+        @locked_version = locked_specs.version_for(name)
         @unlock = unlock
         @dependency = dependency || Dependency.new(name, @locked_version)
         @top_level = !dependency.nil?

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -133,8 +133,8 @@ module Bundler
       validation_set.incomplete_specs.any?
     end
 
-    def missing_specs_for(dependencies)
-      materialize_dependencies(dependencies)
+    def missing_specs_for(deps)
+      materialize_dependencies(deps)
 
       missing_specs
     end

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -163,6 +163,10 @@ module Bundler
       @specs.detect {|spec| spec.name == name && spec.match_platform(platform) }
     end
 
+    def specs_with_additional_variants_from(other)
+      sorted | additional_variants_from(other)
+    end
+
     def delete_by_name(name)
       @specs.reject! {|spec| spec.name == name }
 
@@ -275,6 +279,12 @@ module Bundler
 
     def all_platforms
       @specs.flat_map {|spec| spec.source.specs.search([spec.name, spec.version]).map(&:platform) }.uniq
+    end
+
+    def additional_variants_from(other)
+      other.select do |spec|
+        version_for(spec.name) == spec.version && valid_dependencies?(spec)
+      end
     end
 
     def valid_dependencies?(s)

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -169,6 +169,10 @@ module Bundler
       reset!
     end
 
+    def version_for(name)
+      self[name].first&.version
+    end
+
     def what_required(spec)
       unless req = find {|s| s.runtime_dependencies.any? {|d| d.name == spec.name } }
         return [spec]


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes Bundler removes platform specific gems from the lockfile, because under the currently running Ruby, it resolved to the non native variant.

However, it's unnecessary to remove those from the lockfile, and they could still come useful if the lockfile is used under a different ruby version, compatible with those platform specific gems.
 
## What is your fix for the problem, implemented in this PR?

After resolving, make sure to readd existing platform specific variants to the solution, if their dependencies are compatible with the rest of resolved gems.

Fixes #8393.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
