### PR TITLE
Serialize gemspec when caching git source

### DIFF
--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -282,6 +282,7 @@ module Bundler
         FileUtils.rm_rf(app_cache_path)
         git_proxy.checkout if migrate || requires_checkout?
         git_proxy.copy_to(app_cache_path, @submodules)
+        serialize_gemspecs_in(app_cache_path)
       end
 
       def checkout

--- a/bundler/spec/cache/git_spec.rb
+++ b/bundler/spec/cache/git_spec.rb
@@ -358,6 +358,26 @@ RSpec.describe "bundle cache with git" do
     expect(the_bundle).to include_gems "has_submodule 1.0"
   end
 
+  it "caches pre-evaluated gemspecs" do
+    git = build_git "foo"
+
+    # Insert a gemspec method that shells out
+    spec_lines = lib_path("foo-1.0/foo.gemspec").read.split("\n")
+    spec_lines.insert(-2, "s.description = `echo bob`")
+    update_git("foo") {|s| s.write "foo.gemspec", spec_lines.join("\n") }
+
+    install_gemfile <<-G
+      source "https://gem.repo1"
+      gem "foo", :git => '#{lib_path("foo-1.0")}'
+    G
+    bundle "config set cache_all true"
+    bundle :cache
+
+    ref = git.ref_for("main", 11)
+    gemspec = bundled_app("vendor/cache/foo-1.0-#{ref}/foo.gemspec").read
+    expect(gemspec).to_not match("`echo bob`")
+  end
+
   it "can install after bundle cache with git not installed" do
     build_git "foo"
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When updating from bundler 2.4.22 to 2.6.2, installs no longer succeeded since none of our deployments had `git` installed, and cached git sources no longer serialized their gemspecs

#8402 

## What is your fix for the problem, implemented in this PR?

#4469 removed the `serialize_gemspecs_in` call within the cache method - this PR simply re-adds it.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
