### PR TITLE
Revert RubyGems plugins getting loaded on `Bundler.require`

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -212,7 +212,6 @@ module Bundler
     #    Bundler.require(:test)   # requires second_gem
     #
     def require(*groups)
-      load_plugins
       setup(*groups).require(*groups)
     end
 
@@ -574,23 +573,6 @@ module Bundler
 
     def feature_flag
       @feature_flag ||= FeatureFlag.new(VERSION)
-    end
-
-    def load_plugins(definition = Bundler.definition)
-      return if defined?(@load_plugins_ran)
-
-      Bundler.rubygems.load_plugins
-
-      requested_path_gems = definition.requested_specs.select {|s| s.source.is_a?(Source::Path) }
-      path_plugin_files = requested_path_gems.flat_map do |spec|
-        spec.matches_for_glob("rubygems_plugin#{Bundler.rubygems.suffix_pattern}")
-      rescue TypeError
-        error_message = "#{spec.name} #{spec.version} has an invalid gemspec"
-        raise Gem::InvalidSpecificationException, error_message
-      end
-      Bundler.rubygems.load_plugin_files(path_plugin_files)
-      Bundler.rubygems.load_env_plugins
-      @load_plugins_ran = true
     end
 
     def reset!

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -134,18 +134,6 @@ module Bundler
       loaded_gem_paths.flatten
     end
 
-    def load_plugins
-      Gem.load_plugins
-    end
-
-    def load_plugin_files(plugin_files)
-      Gem.load_plugin_files(plugin_files)
-    end
-
-    def load_env_plugins
-      Gem.load_env_plugins
-    end
-
     def ui=(obj)
       Gem::DefaultUserInteraction.ui = obj
     end

--- a/bundler/spec/bundler/shared_helpers_spec.rb
+++ b/bundler/spec/bundler/shared_helpers_spec.rb
@@ -258,8 +258,7 @@ RSpec.describe Bundler::SharedHelpers do
 
       it "ensures bundler's ruby version lib path is in ENV['RUBYLIB']" do
         subject.set_bundle_environment
-        paths = (ENV["RUBYLIB"]).split(File::PATH_SEPARATOR)
-        expect(paths).to include(ruby_lib_path)
+        expect(rubylib).to include(ruby_lib_path)
       end
     end
 
@@ -276,8 +275,7 @@ RSpec.describe Bundler::SharedHelpers do
 
       subject.set_bundle_environment
 
-      paths = (ENV["RUBYLIB"]).split(File::PATH_SEPARATOR)
-      expect(paths.count(RbConfig::CONFIG["rubylibdir"])).to eq(0)
+      expect(rubylib.count(RbConfig::CONFIG["rubylibdir"])).to eq(0)
     end
 
     it "exits if bundle path contains the unix-like path separator" do
@@ -441,8 +439,7 @@ RSpec.describe Bundler::SharedHelpers do
 
       it "ENV['RUBYLIB'] should only contain one instance of bundler's ruby version lib path" do
         subject.set_bundle_environment
-        paths = (ENV["RUBYLIB"]).split(File::PATH_SEPARATOR)
-        expect(paths.count(ruby_lib_path)).to eq(1)
+        expect(rubylib.count(ruby_lib_path)).to eq(1)
       end
     end
   end

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -238,8 +238,7 @@ RSpec.describe "bundle install with gem sources" do
     it "loads env plugins" do
       plugin_msg = "hello from an env plugin!"
       create_file "plugins/rubygems_plugin.rb", "puts '#{plugin_msg}'"
-      rubylib = ENV["RUBYLIB"].to_s.split(File::PATH_SEPARATOR).unshift(bundled_app("plugins").to_s).join(File::PATH_SEPARATOR)
-      install_gemfile <<-G, env: { "RUBYLIB" => rubylib }
+      install_gemfile <<-G, env: { "RUBYLIB" => rubylib.unshift(bundled_app("plugins").to_s).join(File::PATH_SEPARATOR) }
         source "https://gem.repo1"
         gem "myrack"
       G

--- a/bundler/spec/runtime/require_spec.rb
+++ b/bundler/spec/runtime/require_spec.rb
@@ -431,6 +431,22 @@ RSpec.describe "Bundler.require" do
     expect(out).to eq("WIN")
   end
 
+  it "does not load plugins" do
+    install_gemfile <<-G
+      source "https://gem.repo1"
+      gem "myrack"
+    G
+
+    create_file "plugins/rubygems_plugin.rb", "puts 'FAIL'"
+
+    run <<~R, env: { "RUBYLIB" => rubylib.unshift(bundled_app("plugins").to_s).join(File::PATH_SEPARATOR) }
+      Bundler.require
+      puts "WIN"
+    R
+
+    expect(out).to eq("WIN")
+  end
+
   it "does not extract gemspecs from application cache packages" do
     gemfile <<-G
       source "https://gem.repo1"

--- a/bundler/spec/support/env.rb
+++ b/bundler/spec/support/env.rb
@@ -5,5 +5,9 @@ module Spec
     def ruby_core?
       File.exist?(File.expand_path("../../../lib/bundler/bundler.gemspec", __dir__))
     end
+
+    def rubylib
+      ENV["RUBYLIB"].to_s.split(File::PATH_SEPARATOR)
+    end
   end
 end


### PR DESCRIPTION


## What was the end-user or developer problem that led to this PR?

As reported in https://github.com/rubygems/rubygems/issues/8383, Bundler is not printing errors when failing to load plugins in situations where they would not happen previously.

## What is your fix for the problem, implemented in this PR?

@roberts1000's reproduction and @simi's bisection helped identify https://github.com/rubygems/rubygems/pull/3439 as the culprit.

That PR introduced several changes aimed at loading _RubyGems plugins_ at `Bundler.require` time.

That's what caused this issue and it seems unrelated to introducing new hooks for _Bundler plugins_.

I think RubyGems plugins were confused with Bundler plugins.

This PR reverts that change.

Fixes #8383.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
