### PR TITLE
Fix `@licenses` array unmarshalling

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1322,7 +1322,7 @@ class Gem::Specification < Gem::BasicSpecification
     spec.instance_variable_set :@description,               array[13]
     spec.instance_variable_set :@homepage,                  array[14]
     spec.instance_variable_set :@has_rdoc,                  array[15]
-    spec.instance_variable_set :@licenses,                  [array[17]]
+    spec.instance_variable_set :@licenses,                  array[17]
     spec.instance_variable_set :@metadata,                  array[18]
     spec.instance_variable_set :@loaded,                    false
     spec.instance_variable_set :@activated,                 false

--- a/test/rubygems/test_gem_safe_marshal.rb
+++ b/test/rubygems/test_gem_safe_marshal.rb
@@ -353,7 +353,19 @@ class TestGemSafeMarshal < Gem::TestCase
 
     unmarshalled_spec = Gem::SafeMarshal.safe_load(Marshal.dump(spec))
 
-    assert_equal ["MIT"], unmarshalled_spec.license
+    assert_equal ["MIT"], unmarshalled_spec.licenses
+    assert_equal "MIT", unmarshalled_spec.license
+
+    spec = Gem::Specification.new do |s|
+      s.name = "hi"
+      s.version = "1.2.3"
+      s.licenses = ["MIT", "GPL2"]
+    end
+
+    unmarshalled_spec = Gem::SafeMarshal.safe_load(Marshal.dump(spec))
+
+    assert_equal ["MIT", "GPL2"], unmarshalled_spec.licenses
+    assert_equal "MIT", unmarshalled_spec.license
   end
 
   def test_gem_spec_unmarshall_required_ruby_rubygems_version


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Unmarshalling a specification incorrectly returns `spec.license` as an array (`["MIT"]`) and `spec.licenses` as a double array (`[["MIT"]]`). The former should return a string, and the latter should return and array of strings. The issue was introduced in PR #7975. Related issues: #7978 

## What is your fix for the problem, implemented in this PR?

Fixed unmarshalling to remove the wrapping array. Based on the implementation history of `specification.rb`, the value of `@licenses` has been marshaled as an array since it was added (exactly 🤯) 16 years ago, so we do not need to coerce it to an array: https://github.com/rubygems/rubygems/commit/5fd49042e55931597f5e01a4e53c1a0d5233b3db

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
