### PR TITLE
Fix `--prefer-local` not respecting default gems

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -220,6 +220,8 @@ module Bundler
 
     def prefer_local!
       @prefer_local = true
+
+      sources.prefer_local!
     end
 
     # For given dependency list returns a SpecSet with Gemspec of all the required

--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -193,7 +193,7 @@ module Bundler
     def install(options)
       standalone = options[:standalone]
       force = options[:force]
-      local = options[:local]
+      local = options[:local] || options[:"prefer-local"]
       jobs = installation_parallelization
       spec_installations = ParallelInstaller.call(self, @definition.specs, jobs, standalone, force, local: local)
       spec_installations.each do |installation|

--- a/bundler/lib/bundler/source.rb
+++ b/bundler/lib/bundler/source.rb
@@ -35,6 +35,8 @@ module Bundler
       spec.source == self
     end
 
+    def prefer_local!; end
+
     def local!; end
 
     def local_only!; end

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -19,6 +19,7 @@ module Bundler
         @allow_remote = false
         @allow_cached = false
         @allow_local = options["allow_local"] || false
+        @prefer_local = false
         @checksum_store = Checksum::Store.new
 
         Array(options["remotes"]).reverse_each {|r| add_remote(r) }
@@ -30,11 +31,19 @@ module Bundler
         @caches ||= [cache_path, *Bundler.rubygems.gem_cache]
       end
 
+      def prefer_local!
+        @prefer_local = true
+      end
+
       def local_only!
         @specs = nil
         @allow_local = true
         @allow_cached = false
         @allow_remote = false
+      end
+
+      def local_only?
+        @allow_local && !@allow_remote
       end
 
       def local!
@@ -139,9 +148,15 @@ module Bundler
           index.merge!(cached_specs) if @allow_cached
           index.merge!(installed_specs) if @allow_local
 
-          # complete with default specs, only if not already available in the
-          # index through remote, cached, or installed specs
-          index.use(default_specs) if @allow_local
+          if @allow_local
+            if @prefer_local
+              index.merge!(default_specs)
+            else
+              # complete with default specs, only if not already available in the
+              # index through remote, cached, or installed specs
+              index.use(default_specs)
+            end
+          end
 
           index
         end

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -141,6 +141,10 @@ module Bundler
       different_sources?(lock_sources, replacement_sources)
     end
 
+    def prefer_local!
+      all_sources.each(&:prefer_local!)
+    end
+
     def local_only!
       all_sources.each(&:local_only!)
     end

--- a/bundler/spec/cache/gems_spec.rb
+++ b/bundler/spec/cache/gems_spec.rb
@@ -113,6 +113,11 @@ RSpec.describe "bundle cache" do
         expect(out).to include("Using json #{default_json_version}")
       end
 
+      it "does not use remote gems when installing with --prefer-local flag" do
+        install_gemfile %(source "https://gem.repo2"; gem 'json', '#{default_json_version}'), verbose: true, "prefer-local": true
+        expect(out).to include("Using json #{default_json_version}")
+      end
+
       it "caches remote and builtin gems" do
         install_gemfile <<-G
           source "https://gem.repo2"

--- a/bundler/spec/cache/gems_spec.rb
+++ b/bundler/spec/cache/gems_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe "bundle cache" do
         G
 
         bundle :cache, raise_on_error: false
-        expect(exitstatus).to_not eq(0)
+        expect(last_command).to be_failure
         expect(err).to include("json-#{default_json_version} is built in to Ruby, and can't be cached")
       end
     end

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -1068,7 +1068,7 @@ RSpec.describe "bundle install with git sources" do
       gem "foo", :git => "#{lib_path("foo-1.0")}"
     G
 
-    expect(exitstatus).to_not eq(0)
+    expect(last_command).to be_failure
     expect(err).to include("Bundler could not install a gem because it " \
                            "needs to create a directory, but a file exists " \
                            "- #{default_bundle_path("bundler")}")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When `bundle install --prefer-local` is run, Bundler will install a remote gem even if the same gem is available as a default gem.

## What is your fix for the problem, implemented in this PR?

Make sure to always prefer default gems over remote gems when `--prefer-local` is given.

Closes https://github.com/rubygems/rubygems/issues/8180.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
