### PR TITLE
Introduce Spec::Path.sinatra_dependency_paths for sinatra mock server

### DIFF
--- a/bundler/spec/support/artifice/endpoint_500.rb
+++ b/bundler/spec/support/artifice/endpoint_500.rb
@@ -2,7 +2,7 @@
 
 require_relative "../path"
 
-$LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gem_path.join("gems/{mustermann,rack,tilt,sinatra,ruby2_keywords,base64,logger}-*/lib")].map(&:to_s))
+$LOAD_PATH.unshift(*Spec::Path.sinatra_dependency_paths)
 
 require "sinatra/base"
 

--- a/bundler/spec/support/artifice/helpers/endpoint.rb
+++ b/bundler/spec/support/artifice/helpers/endpoint.rb
@@ -2,7 +2,7 @@
 
 require_relative "../../path"
 
-$LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gem_path.join("gems/{mustermann,rack,tilt,sinatra,ruby2_keywords,base64,logger}-*/lib")].map(&:to_s))
+$LOAD_PATH.unshift(*Spec::Path.sinatra_dependency_paths)
 
 require "sinatra/base"
 

--- a/bundler/spec/support/artifice/windows.rb
+++ b/bundler/spec/support/artifice/windows.rb
@@ -2,7 +2,7 @@
 
 require_relative "../path"
 
-$LOAD_PATH.unshift(*Dir[Spec::Path.base_system_gem_path.join("gems/{mustermann,rack,tilt,sinatra,ruby2_keywords,base64,logger}-*/lib")].map(&:to_s))
+$LOAD_PATH.unshift(*Spec::Path.sinatra_dependency_paths)
 
 require "sinatra/base"
 

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -280,6 +280,19 @@ module Spec
       Dir["#{base_system_gems}/#{Bundler.ruby_scope}/**/rake*.gem"].first
     end
 
+    def sinatra_dependency_paths
+      deps = %w[
+        mustermann
+        rack
+        tilt
+        sinatra
+        ruby2_keywords
+        base64
+        logger
+      ]
+      Dir[base_system_gem_path.join("gems/{#{deps.join(",")}}-*/lib")].map(&:to_s)
+    end
+
     private
 
     def git_ls_files(glob)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We need to add new dependency like logger to 3 places for sinatra mock server.

## What is your fix for the problem, implemented in this PR?

I introduced `Spec::Path.sinatra_dependency_paths` for that. After that, we can add new dependency to one-place.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
