### PR TITLE
Fix more broken links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bundler-related-issue.md
+++ b/.github/ISSUE_TEMPLATE/bundler-related-issue.md
@@ -9,15 +9,9 @@ assignees: ''
 
 <!--
 
-Thank you for contributing to the [rubygems](https://github.com/rubygems/rubygems) repository, and specifically to the [Bundler](https://bundler.io/) gem.
+Thank you for contributing to the rubygems) repository, and specifically to the Bundler gem.
 
-Sometimes you can find a solution to your issue by reading some documentation.
-
-* Instructions for common Bundler uses can be found on the [Bundler documentation site](https://bundler.io/).
-* Detailed information about each Bundler command, including help with common problems, can be found in the [Bundler man pages](https://bundler.io/man/bundle.1.html) or [Bundler Command Line Reference](https://bundler.io/commands.html).
-* We also have a document detailing solutions to common problems: https://github.com/rubygems/rubygems/blob/master/bundler/doc/TROUBLESHOOTING.md.
-
-If you're still stuck, please fill in the following sections so we can process your issue as fast as possible:
+Please fill in the following sections so we can process your issue as fast as possible
 
 -->
 
@@ -53,7 +47,7 @@ Fill this with a list of steps maintainers can follow to reproduce your issue. N
 
 The more complete the steps to simulate your particular environment are, the easier it will be for maintainers to reproduce your issue on their machines.
 
-Ideally, we recommend you set up the list of steps as a [Dockerfile](https://docs.docker.com/get-started/). A Dockerfile provides a neutral environment that should give the same results, no matter where it's run.
+Ideally, we recommend you set up the list of steps as a Dockerfile. A Dockerfile provides a neutral environment that should give the same results, no matter where it's run.
 
 -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,6 @@ alternatives, explain why you end up choosing the current implementation -->
 ## Make sure the following tasks are checked
 
 - [ ] Describe the problem / feature
-- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
+- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
 - [ ] Write code to solve the problem
 - [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,6 @@
 <!--
 Thanks so much for the contribution!
 
-Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.
-
 To make reviewing this PR a bit easier, please fill out answers to the following questions.
 -->
 

--- a/bundler/README.md
+++ b/bundler/README.md
@@ -41,7 +41,7 @@ To get in touch with the Bundler core team and other Bundler users, please join 
 
 ### Contributing
 
-If you'd like to contribute to Bundler, that's awesome, and we <3 you. We've put together [the Bundler contributor guide](https://github.com/rubygems/rubygems/blob/master/bundler/doc/contributing/README.md) with all of the information you need to get started.
+If you'd like to contribute to Bundler, that's awesome, and we <3 you. We've put together [the Bundler contributor guide](https://github.com/rubygems/rubygems/blob/master/doc/bundler/contributing/README.md) with all of the information you need to get started.
 
 If you'd like to request a substantial change to Bundler or its documentation, refer to the [Bundler RFC process](https://github.com/rubygems/rfcs) for more information.
 

--- a/bundler/lib/bundler/cli/issue.rb
+++ b/bundler/lib/bundler/cli/issue.rb
@@ -10,7 +10,7 @@ module Bundler
         be sure to check out these resources:
 
         1. Check out our troubleshooting guide for quick fixes to common issues:
-        https://github.com/rubygems/rubygems/blob/master/bundler/doc/TROUBLESHOOTING.md
+        https://github.com/rubygems/rubygems/blob/master/doc/bundler/TROUBLESHOOTING.md
 
         2. Instructions for common Bundler uses can be found on the documentation
         site: https://bundler.io/

--- a/doc/bundler/contributing/README.md
+++ b/doc/bundler/contributing/README.md
@@ -5,9 +5,9 @@ Thank you for your interest in making Bundler better! We welcome contributions f
 Before submitting a contribution, read through the following guidelines:
 
 * [Bundler Code of Conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) (By participating in Bundler, you agree to abide by the terms laid out in the CoC.)
-* [Pull Request Guidelines](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md)
+* [Pull Request Guidelines](../development/PULL_REQUESTS.md)
 
-And be sure to [set up your development environment](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/SETUP.md).
+And be sure to [set up your development environment](../development/SETUP.md).
 
 ## Feature Requests
 

--- a/doc/bundler/playbooks/TEAM_CHANGES.md
+++ b/doc/bundler/playbooks/TEAM_CHANGES.md
@@ -1,6 +1,6 @@
 # Team changes
 
-This file documents how to add and remove team members. For the rules governing adding and removing team members, see [POLICIES][policies].
+This file documents how to add and remove team members. For the rules governing adding and removing team members, see [POLICIES](../POLICIES.md).
 
 ## Adding a new team member
 
@@ -9,7 +9,7 @@ Interested in adding someone to the team? Here's the process.
 1. An existing team member nominates a potential team member to the rest of the team.
 2. The existing team reaches consensus about whether to invite the potential member.
 3. The nominator asks the potential member if they would like to join the team.
-4. The nominator also sends the candidate a link to [POLICIES][policies] as an orientation for being on the team.
+4. The nominator also sends the candidate a link to [POLICIES](../POLICIES.md) as an orientation for being on the team.
 5. If the potential member accepts:
     - Invite them to the maintainers Slack channel
     - Add them to the [maintainers team][org_team] on GitHub
@@ -24,7 +24,7 @@ Interested in adding someone to the team? Here's the process.
 
 ## Removing a team member
 
-When the conditions in [POLICIES](https://github.com/rubygems/rubygems/blob/master/bundler/doc/POLICIES.md#maintainer-team-guidelines) are met, or when team members choose to retire, here's how to remove someone from the team.
+When the conditions in [POLICIES](../POLICIES.md#maintainer-team-guidelines) are met, or when team members choose to retire, here's how to remove someone from the team.
 
 - Remove them from the owners list on RubyGems.org by running
   ```
@@ -35,7 +35,6 @@ When the conditions in [POLICIES](https://github.com/rubygems/rubygems/blob/mast
 - Remove them from the [maintainers team][org_team] on GitHub
 - Remove them from the maintainers Slack channel
 
-[policies]: https://github.com/rubygems/rubygems/blob/master/bundler/doc/POLICIES.md#bundler-policies
 [org_team]: https://github.com/orgs/rubygems/teams/maintainers/members
 [team]: https://bundler.io/contributors.html
 [maintainers]: https://github.com/rubygems/bundler-site/blob/f00eb65da0697c2cb0e7b4d6e5ba47ecc1538eb2/source/contributors.html.haml#L25


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Broken links in Bundler documentation.

## What is your fix for the problem, implemented in this PR?

Fix the remaining broken links left around after https://github.com/rubygems/rubygems/pull/8159. 

Specifically for issue and pull request templates, I decided to remove the links that are not clickable altogether, because they need to be explicitly copy-pasted in order to be viewed and I think most users won't do this, and they should have read CONTRIBUTING docs anyways before contributing because Github's UI leads you there anyways.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
