### PR TITLE
RDoc is no longer a default gem in Ruby 3.5

### DIFF
--- a/bundler/spec/commands/info_spec.rb
+++ b/bundler/spec/commands/info_spec.rb
@@ -88,8 +88,8 @@ RSpec.describe "bundle info" do
 
     context "given a default gem shippped in ruby", :ruby_repo do
       it "prints information about the default gem" do
-        bundle "info rdoc"
-        expect(out).to include("* rdoc")
+        bundle "info json"
+        expect(out).to include("* json")
         expect(out).to include("Default Gem: yes")
       end
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Daily Bundler CI started failing. There's a failing test with a "Could not find gem 'rdoc'."

## What is your fix for the problem, implemented in this PR?

Use a different default gem for the failing test, because RDoc is no longer a default gem in Ruby 3.5.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
