### PR TITLE
Switch Dependabot to run monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
     groups:
       artifacts:
         patterns:
@@ -13,7 +13,7 @@ updates:
       - '/test/rubygems/test_gem_ext_cargo_builder/custom_name/ext/custom_name_lib'
       - '/test/rubygems/test_gem_ext_cargo_builder/rust_ruby_example'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
     groups:
       rb-sys:
         patterns:
@@ -21,4 +21,4 @@ updates:
   - package-ecosystem: 'pip'
     directory: '/.github/workflows/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes I feel Dependabot opens too many PRs.

I think it's good to keep these up to date, but weekly feels a bit too much maybe?

## What is your fix for the problem, implemented in this PR?

Switch to monthly.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
