### PR TITLE
Make ruby-core job use a non moving target

### DIFF
--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -23,21 +23,11 @@ jobs:
       matrix:
         target: [Rubygems, Bundler]
     steps:
-      - name: Set up latest ruby head
-        uses: ruby/setup-ruby@28c4deda893d5a96a6b2d958c5b47fc18d65c9d3 # v1.213.0
-        with:
-          ruby-version: head
-          bundler: none
-      - name: Save latest buildable revision to environment
-        run: echo "REF=$(ruby -v | cut -d')' -f1 | cut -d' ' -f5)" >> $GITHUB_ENV
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: ruby/ruby
           path: ruby/ruby
-          fetch-depth: 10
-      - name: Checkout the latest buildable revision
-        run: git switch -c ${{ env.REF }}
-        working-directory: ruby/ruby
+          ref: v3_4_1
       - name: Install libraries
         run: |
           set -x


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We originally added this in order to prevent us when making changes to our test setup to break the way ruby-core runs our tests.

However, the way it works now, it breaks too often due to changes in ruby/ruby because of running against a moving unstable target. We still want to find about that kind of breakage, but not on every PR. Our daily jobs achieve that.

## What is your fix for the problem, implemented in this PR?

This commit changes the ruby-core job to run against a fixed target (the tag for the latest ruby release), which should still catch the kind of issue we intend to catch here.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
