### PR TITLE
Fix `bundle console` printing bug report template incorrectly

### DIFF
--- a/bundler/lib/bundler/dependency.rb
+++ b/bundler/lib/bundler/dependency.rb
@@ -31,7 +31,6 @@ module Bundler
       type = options["type"] || :runtime
       super(name, version, type)
 
-      @autorequire    = nil
       @groups         = Array(options["group"] || :default).map(&:to_sym)
       @source         = options["source"]
       @path           = options["path"]

--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -62,11 +62,14 @@ module Bundler
           begin
             Kernel.require required_file
           rescue LoadError => e
-            raise if dep.autorequire || e.path != required_file
-
-            if required_file.include?("-")
-              required_file = required_file.tr("-", "/")
-              retry
+            if dep.autorequire.nil? && e.path == required_file
+              if required_file.include?("-")
+                required_file = required_file.tr("-", "/")
+                retry
+              end
+            else
+              raise Bundler::GemRequireError.new e,
+                "There was an error while trying to load the gem '#{file}'."
             end
           rescue RuntimeError => e
             raise Bundler::GemRequireError.new e,

--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -64,7 +64,7 @@ module Bundler
           rescue LoadError => e
             raise if dep.autorequire || e.path != required_file
 
-            if dep.autorequire.nil? && required_file.include?("-")
+            if required_file.include?("-")
               required_file = required_file.tr("-", "/")
               retry
             end

--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -61,17 +61,13 @@ module Bundler
           file = dep.name if file == true
           required_file = file
           begin
-            Kernel.require file
+            Kernel.require required_file
           rescue LoadError => e
             raise if dep.autorequire || e.path != required_file
 
-            if dep.autorequire.nil? && dep.name.include?("-")
-              begin
-                namespaced_file = dep.name.tr("-", "/")
-                Kernel.require namespaced_file
-              rescue LoadError => e
-                raise if e.path != namespaced_file
-              end
+            if dep.autorequire.nil? && required_file.include?("-")
+              required_file = required_file.tr("-", "/")
+              retry
             end
           rescue RuntimeError => e
             raise Bundler::GemRequireError.new e,

--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -64,7 +64,6 @@ module Bundler
             begin
               Kernel.require file
             rescue RuntimeError => e
-              raise e if e.is_a?(LoadError) # we handle this a little later
               raise Bundler::GemRequireError.new e,
                 "There was an error while trying to load the gem '#{file}'."
             end

--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -50,7 +50,6 @@ module Bundler
       Plugin.hook(Plugin::Events::GEM_BEFORE_REQUIRE_ALL, dependencies)
 
       dependencies.each do |dep|
-        required_file = nil
         Plugin.hook(Plugin::Events::GEM_BEFORE_REQUIRE, dep)
 
         # Loop through all the specified autorequires for the

--- a/bundler/spec/commands/console_spec.rb
+++ b/bundler/spec/commands/console_spec.rb
@@ -36,106 +36,134 @@ RSpec.describe "bundle console", readline: true do
         RUBY
       end
     end
-
-    install_gemfile <<-G
-      source "https://gem.repo2"
-      gem "myrack"
-      gem "activesupport", :group => :test
-      gem "myrack_middleware", :group => :development
-    G
   end
 
-  it "starts IRB with the default group loaded" do
-    bundle "console" do |input, _, _|
-      input.puts("puts MYRACK")
-      input.puts("exit")
+  context "when the library has an unrelated error" do
+    before do
+      build_lib "loadfuuu", "1.0.0" do |s|
+        s.write "lib/loadfuuu.rb", "require_relative 'loadfuuu/bar'"
+        s.write "lib/loadfuuu/bar.rb", "require 'not-in-bundle'"
+      end
+
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        path "#{lib_path}" do
+          gem "loadfuuu", require: true
+        end
+      G
     end
-    expect(out).to include("0.9.1")
-  end
 
-  it "uses IRB as default console" do
-    bundle "console" do |input, _, _|
-      input.puts("__FILE__")
-      input.puts("exit")
-    end
-    expect(out).to include("(irb)")
-  end
-
-  it "starts another REPL if configured as such" do
-    install_gemfile <<-G
-      source "https://gem.repo2"
-      gem "pry"
-    G
-    bundle "config set console pry"
-
-    bundle "console" do |input, _, _|
-      input.puts("__method__")
-      input.puts("exit")
-    end
-    expect(out).to include(":__pry__")
-  end
-
-  it "falls back to IRB if the other REPL isn't available" do
-    bundle "config set console pry"
-    # make sure pry isn't there
-
-    bundle "console" do |input, _, _|
-      input.puts("__FILE__")
-      input.puts("exit")
-    end
-    expect(out).to include("(irb)")
-  end
-
-  it "doesn't load any other groups" do
-    bundle "console" do |input, _, _|
-      input.puts("puts ACTIVESUPPORT")
-      input.puts("exit")
-    end
-    expect(out).to include("NameError")
-  end
-
-  describe "when given a group" do
-    it "loads the given group" do
-      bundle "console test" do |input, _, _|
-        input.puts("puts ACTIVESUPPORT")
+    it "does not show the bug report template" do
+      bundle("console", raise_on_error: false) do |input, _, _|
         input.puts("exit")
       end
-      expect(out).to include("2.3.5")
+
+      expect(err).not_to include("ERROR REPORT TEMPLATE")
+    end
+  end
+
+  context "when the library does not have any errors" do
+    before do
+      install_gemfile <<-G
+        source "https://gem.repo2"
+        gem "myrack"
+        gem "activesupport", :group => :test
+        gem "myrack_middleware", :group => :development
+      G
     end
 
-    it "loads the default group" do
-      bundle "console test" do |input, _, _|
+    it "starts IRB with the default group loaded" do
+      bundle "console" do |input, _, _|
         input.puts("puts MYRACK")
         input.puts("exit")
       end
       expect(out).to include("0.9.1")
     end
 
-    it "doesn't load other groups" do
-      bundle "console test" do |input, _, _|
-        input.puts("puts MYRACK_MIDDLEWARE")
+    it "uses IRB as default console" do
+      bundle "console" do |input, _, _|
+        input.puts("__FILE__")
+        input.puts("exit")
+      end
+      expect(out).to include("(irb)")
+    end
+
+    it "starts another REPL if configured as such" do
+      install_gemfile <<-G
+        source "https://gem.repo2"
+        gem "pry"
+      G
+      bundle "config set console pry"
+
+      bundle "console" do |input, _, _|
+        input.puts("__method__")
+        input.puts("exit")
+      end
+      expect(out).to include(":__pry__")
+    end
+
+    it "falls back to IRB if the other REPL isn't available" do
+      bundle "config set console pry"
+      # make sure pry isn't there
+
+      bundle "console" do |input, _, _|
+        input.puts("__FILE__")
+        input.puts("exit")
+      end
+      expect(out).to include("(irb)")
+    end
+
+    it "doesn't load any other groups" do
+      bundle "console" do |input, _, _|
+        input.puts("puts ACTIVESUPPORT")
         input.puts("exit")
       end
       expect(out).to include("NameError")
     end
-  end
 
-  it "performs an automatic bundle install" do
-    gemfile <<-G
-      source "https://gem.repo2"
-      gem "myrack"
-      gem "activesupport", :group => :test
-      gem "myrack_middleware", :group => :development
-      gem "foo"
-    G
+    describe "when given a group" do
+      it "loads the given group" do
+        bundle "console test" do |input, _, _|
+          input.puts("puts ACTIVESUPPORT")
+          input.puts("exit")
+        end
+        expect(out).to include("2.3.5")
+      end
 
-    bundle "config set auto_install 1"
-    bundle :console do |input, _, _|
-      input.puts("puts 'hello'")
-      input.puts("exit")
+      it "loads the default group" do
+        bundle "console test" do |input, _, _|
+          input.puts("puts MYRACK")
+          input.puts("exit")
+        end
+        expect(out).to include("0.9.1")
+      end
+
+      it "doesn't load other groups" do
+        bundle "console test" do |input, _, _|
+          input.puts("puts MYRACK_MIDDLEWARE")
+          input.puts("exit")
+        end
+        expect(out).to include("NameError")
+      end
     end
-    expect(out).to include("Installing foo 1.0")
-    expect(out).to include("hello")
-    expect(the_bundle).to include_gems "foo 1.0"
+
+    it "performs an automatic bundle install" do
+      gemfile <<-G
+        source "https://gem.repo2"
+        gem "myrack"
+        gem "activesupport", :group => :test
+        gem "myrack_middleware", :group => :development
+        gem "foo"
+      G
+
+      bundle "config set auto_install 1"
+      bundle :console do |input, _, _|
+        input.puts("puts 'hello'")
+        input.puts("exit")
+      end
+      expect(out).to include("Installing foo 1.0")
+      expect(out).to include("hello")
+      expect(the_bundle).to include_gems "foo 1.0"
+    end
   end
 end

--- a/bundler/spec/runtime/require_spec.rb
+++ b/bundler/spec/runtime/require_spec.rb
@@ -119,11 +119,9 @@ RSpec.describe "Bundler.require" do
       end
     G
 
-    load_error_run <<-R, "fail"
-      Bundler.require
-    R
+    run "Bundler.require", raise_on_error: false
 
-    expect(err_without_deprecations).to eq("ZOMG LOAD ERROR")
+    expect(err_without_deprecations).to include("cannot load such file -- fail")
   end
 
   it "displays a helpful message if the required gem throws an error" do
@@ -155,16 +153,9 @@ RSpec.describe "Bundler.require" do
       end
     G
 
-    cmd = <<-RUBY
-      begin
-        Bundler.require
-      rescue LoadError => e
-        warn "ZOMG LOAD ERROR: \#{e.message}"
-      end
-    RUBY
-    run(cmd)
+    run "Bundler.require", raise_on_error: false
 
-    expect(err_without_deprecations).to eq("ZOMG LOAD ERROR: cannot load such file -- load-bar")
+    expect(err_without_deprecations).to include("cannot load such file -- load-bar")
   end
 
   describe "with namespaced gems" do
@@ -215,10 +206,9 @@ RSpec.describe "Bundler.require" do
         end
       G
 
-      load_error_run <<-R, "jquery-rails"
-        Bundler.require
-      R
-      expect(err_without_deprecations).to eq("ZOMG LOAD ERROR")
+      run "Bundler.require", raise_on_error: false
+
+      expect(err_without_deprecations).to include("cannot load such file -- jquery-rails")
     end
 
     it "handles the case where regex fails" do
@@ -233,16 +223,9 @@ RSpec.describe "Bundler.require" do
         end
       G
 
-      cmd = <<-RUBY
-        begin
-          Bundler.require
-        rescue LoadError => e
-          warn "ZOMG LOAD ERROR" if e.message.include?("Could not open library 'libfuuu-1.0'")
-        end
-      RUBY
-      run(cmd)
+      run "Bundler.require", raise_on_error: false
 
-      expect(err_without_deprecations).to eq("ZOMG LOAD ERROR")
+      expect(err_without_deprecations).to include("libfuuu-1.0").and include("cannot open shared object file")
     end
 
     it "doesn't swallow the error when the library has an unrelated error" do
@@ -257,16 +240,9 @@ RSpec.describe "Bundler.require" do
         end
       G
 
-      cmd = <<-RUBY
-        begin
-          Bundler.require
-        rescue LoadError => e
-          warn "ZOMG LOAD ERROR: \#{e.message}"
-        end
-      RUBY
-      run(cmd)
+      run "Bundler.require", raise_on_error: false
 
-      expect(err_without_deprecations).to eq("ZOMG LOAD ERROR: cannot load such file -- load-bar")
+      expect(err_without_deprecations).to include("cannot load such file -- load-bar")
     end
   end
 
@@ -375,10 +351,9 @@ RSpec.describe "Bundler.require" do
           gem "busted_require"
         G
 
-        load_error_run <<-R, "no_such_file_omg"
-          Bundler.require
-        R
-        expect(err_without_deprecations).to eq("ZOMG LOAD ERROR")
+        run "Bundler.require", raise_on_error: false
+
+        expect(err_without_deprecations).to include("cannot load such file -- no_such_file_omg")
       end
     end
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I run `bundle console` on an application and it crashed with a Bundler bug report template. However, there was not any issue in Bundler. The gem had a problem where a Ruby gem had been moved to a bundled gem and the dependency was not being declared in the gems gemspec. But that's an internal error, independent of Bundler, so it should not encourage users to report bugs to us.

## What is your fix for the problem, implemented in this PR?

My fix is to change `Bundler.require` to not raise `LoadError`'s but raise instead internal expected Bundler errors that are properly handled.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
