### PR TITLE
Remove respond_to? check for Thread#name=

### DIFF
--- a/bundler/lib/bundler/worker.rb
+++ b/bundler/lib/bundler/worker.rb
@@ -88,7 +88,7 @@ module Bundler
 
       @threads = Array.new(@size) do |i|
         Thread.start { process_queue(i) }.tap do |thread|
-          thread.name = "#{name} Worker ##{i}" if thread.respond_to?(:name=)
+          thread.name = "#{name} Worker ##{i}"
         end
       rescue ThreadError => e
         creation_errors << e


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This a housekeeping PR. Since bundler now requires 3.3.1, we no longer need to do respond_to? check before setting thread name.


## What is your fix for the problem, implemented in this PR?

I was browsing the source code to learn about thread pool implementations and noticed an obsolete check based on the required Ruby version.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
