### PR TITLE
Fix `bundle console` unnecessarily trying to load IRB twice

### DIFF
--- a/bundler/lib/bundler/cli/console.rb
+++ b/bundler/lib/bundler/cli/console.rb
@@ -20,9 +20,14 @@ module Bundler
       require name
       get_constant(name)
     rescue LoadError
-      Bundler.ui.error "Couldn't load console #{name}, falling back to irb"
-      require "irb"
-      get_constant("irb")
+      if name == "irb"
+        Bundler.ui.error "#{name} is not available"
+        exit 1
+      else
+        Bundler.ui.error "Couldn't load console #{name}, falling back to irb"
+        name = "irb"
+        retry
+      end
     end
 
     def get_constant(name)

--- a/bundler/lib/bundler/cli/console.rb
+++ b/bundler/lib/bundler/cli/console.rb
@@ -32,9 +32,6 @@ module Bundler
         "irb" => :IRB,
       }[name]
       Object.const_get(const_name)
-    rescue NameError
-      Bundler.ui.error "Could not find constant #{const_name}"
-      exit 1
     end
   end
 end

--- a/bundler/spec/commands/console_spec.rb
+++ b/bundler/spec/commands/console_spec.rb
@@ -113,6 +113,17 @@ RSpec.describe "bundle console", readline: true do
       expect(out).to include("(irb)")
     end
 
+    it "does not try IRB twice if no console is configured and IRB is not available" do
+      create_file("irb.rb", "raise LoadError, 'irb is not available'")
+
+      bundle("console", env: { "RUBYOPT" => "-I#{bundled_app} #{ENV["RUBYOPT"]}" }, raise_on_error: false) do |input, _, _|
+        input.puts("puts ACTIVESUPPORT")
+        input.puts("exit")
+      end
+      expect(err).not_to include("falling back to irb")
+      expect(err).to include("irb is not available")
+    end
+
     it "doesn't load any other groups" do
       bundle "console" do |input, _, _|
         input.puts("puts ACTIVESUPPORT")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Ruby 3.5 moves irb to a bundled gem, so it may not always be available. If that happens, bundle console will try to load IRB again with the message

> Couldn't load console irb, falling back to irb

which makes little sense to do and will always fail.

## What is your fix for the problem, implemented in this PR?

Don't try to fallback to IRB if IRB was tried in the first place.

Fixes the little issue mentioned in https://github.com/rubygems/rubygems/issues/8396#issuecomment-2615802803.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
