### PR TITLE
Deprecate legacy windows platforms (mswin, mingw) in the Bundler DSL in favor of using `platform :windows`

### DIFF
--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -413,6 +413,7 @@ module Bundler
         next if VALID_PLATFORMS.include?(p)
         raise GemfileError, "`#{p}` is not a valid platform. The available options are: #{VALID_PLATFORMS.inspect}"
       end
+      deprecate_legacy_windows_platforms(platforms)
 
       # Save sources passed in a key
       if opts.key?("source")
@@ -491,6 +492,16 @@ module Bundler
       else
         raise GemfileError, "Unknown source '#{source}'"
       end
+    end
+
+    def deprecate_legacy_windows_platforms(platforms)
+      windows_platforms = platforms.select {|pl| pl.to_s.match?(/mingw|mswin/) }
+      return if windows_platforms.empty?
+
+      windows_platforms = windows_platforms.map! {|pl| ":#{pl}" }.join(", ")
+      message = "Platform #{windows_platforms} is deprecated. Please use platform :windows instead."
+      removed_message = "Platform #{windows_platforms} has been removed. Please use platform :windows instead."
+      Bundler::SharedHelpers.major_deprecation 2, message, removed_message: removed_message
     end
 
     def check_path_source_safety

--- a/bundler/spec/bundler/dsl_spec.rb
+++ b/bundler/spec/bundler/dsl_spec.rb
@@ -221,6 +221,11 @@ RSpec.describe Bundler::Dsl do
         to raise_error(Bundler::GemfileError, /is not a valid platform/)
     end
 
+    it "raises a deprecation warning for legacy windows platforms" do
+      expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(2, /\APlatform :mswin, :x64_mingw is deprecated/, removed_message: /\APlatform :mswin, :x64_mingw has been removed/)
+      subject.gem("foo", platforms: [:mswin, :jruby, :x64_mingw])
+    end
+
     it "rejects empty gem name" do
       expect { subject.gem("") }.
         to raise_error(Bundler::GemfileError, /an empty gem name is not valid/)
@@ -282,6 +287,15 @@ RSpec.describe Bundler::Dsl do
       subject.gem("foo", branch: "test", test_source: "bundler/bundler")
       dep = subject.dependencies.last
       expect(dep.name).to eq "foo"
+    end
+  end
+
+  describe "#platforms" do
+    it "raises a deprecation warning for legacy windows platforms" do
+      expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(2, /\APlatform :mswin64, :mingw is deprecated/, removed_message: /\APlatform :mswin64, :mingw has been removed/)
+      subject.platforms(:mswin64, :jruby, :mingw) do
+        subject.gem("foo")
+      end
     end
   end
 

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -221,14 +221,26 @@ RSpec.describe "bundle cache" do
       expect(bundled_app("vendor/cache/myrack-1.0.0.gem")).to exist
     end
 
-    it "puts the gems in vendor/cache even for legacy windows rubies" do
+    it "puts the gems in vendor/cache even for legacy windows rubies, but prints a warning", bundler: "< 3" do
       gemfile <<-D
         source "https://gem.repo1"
         gem 'myrack', :platforms => [:ruby_20, :x64_mingw_20]
       D
 
       bundle "cache --all-platforms"
+      expect(err).to include("deprecated")
       expect(bundled_app("vendor/cache/myrack-1.0.0.gem")).to exist
+    end
+
+    it "prints an error when using legacy windows rubies", bundler: "3" do
+      gemfile <<-D
+        source "https://gem.repo1"
+        gem 'myrack', :platforms => [:ruby_20, :x64_mingw_20]
+      D
+
+      bundle "cache --all-platforms", raise_on_error: false
+      expect(err).to include("removed")
+      expect(bundled_app("vendor/cache/myrack-1.0.0.gem")).not_to exist
     end
 
     it "does not attempt to install gems in without groups" do

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -570,7 +570,7 @@ RSpec.describe "bundle install with platform conditionals" do
     gemfile <<-G
       source "https://gem.repo1"
 
-      gem "myrack", :platform => [:windows, :mswin, :mswin64, :mingw, :x64_mingw, :jruby]
+      gem "myrack", :platform => [:windows, :jruby]
     G
 
     bundle "install"

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -1000,7 +1000,7 @@ RSpec.describe "bundle install with specific platforms" do
 
       gem "nokogiri"
 
-      gem "tzinfo", "~> 1.2", platforms: %i[mingw mswin x64_mingw jruby]
+      gem "tzinfo", "~> 1.2", platforms: %i[windows jruby]
     G
 
     checksums = checksums_section_when_enabled do |c|

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -373,7 +373,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
     simulate_platform "x86-mswin32" do
       install_gemfile <<-G
         source "https://gem.repo1"
-        gem "nokogiri", :platforms => [:windows, :mswin, :mswin64, :mingw, :x64_mingw, :jruby]
+        gem "nokogiri", :platforms => [:windows, :jruby]
         gem "platform_specific"
       G
 


### PR DESCRIPTION
Replaces PR #8379

### Background

For over 2 years, [Rails has included ](https://github.com/rails/rails/commit/b7e809a96e786e197423b2f13df0b90ef7e149b3) `gem "tzinfo-data", platforms: %i[ windows jruby ]` in its default Gemfile. The usage of `:windows` as a platform value is being widely adopted.

### The Change

In the Gemfile DSL, this PR deprecates platform the following platform values `:mswin, :mswin64, :mingw, :x64_mingw` in favor of `:windows`. In addition, some related aliased methods are commented as deprecated.

This PR does not change/remove any actual functionality.