### PR TITLE
Raise a simpler error when RubyGems fails to activate a dependency

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1415,13 +1415,11 @@ class Gem::Specification < Gem::BasicSpecification
         raise e
       end
 
-      begin
-        specs = spec_dep.to_specs.uniq(&:full_name)
-      rescue Gem::MissingSpecError => e
-        raise Gem::MissingSpecError.new(e.name, e.requirement, "at: #{spec_file}")
-      end
+      specs = spec_dep.matching_specs(true).uniq(&:full_name)
 
-      if specs.size == 1
+      if specs.size == 0
+        raise Gem::MissingSpecError.new(spec_dep.name, spec_dep.requirement, "at: #{spec_file}")
+      elsif specs.size == 1
         specs.first.activate
       else
         name = spec_dep.name

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -652,6 +652,17 @@ end
     end
   end
 
+  def test_self_activate_missing_deps_does_not_raise_nested_exceptions
+    a = util_spec "a", "1.0", "b" => ">= 1.0"
+    install_specs a
+
+    e = assert_raise Gem::MissingSpecError do
+      a.activate
+    end
+
+    refute e.cause
+  end
+
   def test_self_all_equals
     a = util_spec "foo", "1", nil, "lib/foo.rb"
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -564,7 +564,6 @@ end
   #         [B] ~> 1.0
   #
   # and should resolve using b-1.0
-  # TODO: move these to specification
 
   def test_self_activate_over
     a = util_spec "a", "1.0", "b" => ">= 1.0", "c" => "= 1.0"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I forcefully removed `activesupport` from my system while investigating some issues, then forgot about it, and a few days after, I received the following error when running `rails --version`:

```
$ rails --version
/Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/site_ruby/3.4.0/rubygems/specification.rb:1421:in 'block in Gem::Specification#activate_dependencies': Could not find 'activesupport' (= 8.0.1) among 478 total gem(s) (Gem::MissingSpecError)
Checked in 'GEM_PATH=/Users/deivid/.local/share/gem/ruby/3.4.0:/Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/gems/3.4.0' at: /Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/specifications/railties-8.0.1.gemspec, execute `gem env` for more information
	from /Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/site_ruby/3.4.0/rubygems/specification.rb:1407:in 'Array#each'
	from /Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/site_ruby/3.4.0/rubygems/specification.rb:1407:in 'Gem::Specification#activate_dependencies'
	from /Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/site_ruby/3.4.0/rubygems/specification.rb:1389:in 'Gem::Specification#activate'
	from /Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/site_ruby/3.4.0/rubygems.rb:283:in 'block in Gem.activate_bin_path'
	from /Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/site_ruby/3.4.0/rubygems.rb:282:in 'Thread::Mutex#synchronize'
	from /Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/site_ruby/3.4.0/rubygems.rb:282:in 'Gem.activate_bin_path'
	from /Users/deivid/.asdf/installs/ruby/3.4.1/bin/rails:25:in '<main>'
/Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/site_ruby/3.4.0/rubygems/dependency.rb:303:in 'Gem::Dependency#to_specs': Could not find 'activesupport' (= 8.0.1) - did find: [activesupport-7.1.3,activesupport-7.0.8.7] (Gem::MissingSpecVersionError)
Checked in 'GEM_PATH=/Users/deivid/.local/share/gem/ruby/3.4.0:/Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/gems/3.4.0' , execute `gem env` for more information
	from /Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/site_ruby/3.4.0/rubygems/specification.rb:1419:in 'block in Gem::Specification#activate_dependencies'
	from /Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/site_ruby/3.4.0/rubygems/specification.rb:1407:in 'Array#each'
	from /Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/site_ruby/3.4.0/rubygems/specification.rb:1407:in 'Gem::Specification#activate_dependencies'
	from /Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/site_ruby/3.4.0/rubygems/specification.rb:1389:in 'Gem::Specification#activate'
	from /Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/site_ruby/3.4.0/rubygems.rb:283:in 'block in Gem.activate_bin_path'
	from /Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/site_ruby/3.4.0/rubygems.rb:282:in 'Thread::Mutex#synchronize'
	from /Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/site_ruby/3.4.0/rubygems.rb:282:in 'Gem.activate_bin_path'
	from /Users/deivid/.asdf/installs/ruby/3.4.1/bin/rails:25:in '<main>'
```

I figured that error could use some cleanup to make it easier to parse.

## What is your fix for the problem, implemented in this PR?

Avoid raising nested exceptions. It also makes our code use less exceptions for control flow which feels good.

Now the error reads like this:

```
$ rails --version
/Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/site_ruby/3.4.0/rubygems/specification.rb:1421:in 'block in Gem::Specification#activate_dependencies': Could not find 'activesupport' (= 8.0.1) among 478 total gem(s) (Gem::MissingSpecError)
Checked in 'GEM_PATH=/Users/deivid/.local/share/gem/ruby/3.4.0:/Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/gems/3.4.0' at: /Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/specifications/railties-8.0.1.gemspec, execute `gem env` for more information
	from /Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/site_ruby/3.4.0/rubygems/specification.rb:1407:in 'Array#each'
	from /Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/site_ruby/3.4.0/rubygems/specification.rb:1407:in 'Gem::Specification#activate_dependencies'
	from /Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/site_ruby/3.4.0/rubygems/specification.rb:1389:in 'Gem::Specification#activate'
	from /Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/site_ruby/3.4.0/rubygems.rb:283:in 'block in Gem.activate_bin_path'
	from /Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/site_ruby/3.4.0/rubygems.rb:282:in 'Thread::Mutex#synchronize'
	from /Users/deivid/.asdf/installs/ruby/3.4.1/lib/ruby/site_ruby/3.4.0/rubygems.rb:282:in 'Gem.activate_bin_path'
	from /Users/deivid/.asdf/installs/ruby/3.4.1/bin/rails:25:in '<main>'
```

This error could still be made easier to understand, but I decided to stop here.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
