### PR TITLE
Fix daily Bundler CI

### DIFF
--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -478,9 +478,12 @@ RSpec.describe "bundle gem" do
 
     prepare_gemspec(bundled_app("newgem", "newgem.gemspec"))
 
-    gems = ["rake-#{rake_version}"]
+    build_repo2 do
+      build_dummy_irb "9.9.9"
+    end
+    gems = ["rake-#{rake_version}", "irb-9.9.9"]
     path = Bundler.feature_flag.default_install_uses_path? ? local_gem_path(base: bundled_app("newgem")) : system_gem_path
-    system_gems gems, path: path
+    system_gems gems, path: path, gem_repo: gem_repo2
     bundle "exec rake build", dir: bundled_app("newgem")
 
     expect(last_command.stdboth).not_to include("ERROR")

--- a/bundler/spec/commands/platform_spec.rb
+++ b/bundler/spec/commands/platform_spec.rb
@@ -941,8 +941,13 @@ G
 
   context "bundle console" do
     before do
+      build_repo2 do
+        build_dummy_irb
+      end
+
       install_gemfile <<-G
-        source "https://gem.repo1"
+        source "https://gem.repo2"
+        gem "irb"
         gem "myrack"
         gem "activesupport", :group => :test
         gem "myrack_middleware", :group => :development

--- a/bundler/spec/commands/platform_spec.rb
+++ b/bundler/spec/commands/platform_spec.rb
@@ -950,14 +950,7 @@ G
     end
 
     it "starts IRB with the default group loaded when ruby version matches", :readline do
-      gemfile <<-G
-        source "https://gem.repo1"
-        gem "myrack"
-        gem "activesupport", :group => :test
-        gem "myrack_middleware", :group => :development
-
-        #{ruby_version_correct}
-      G
+      gemfile gemfile + "\n\n#{ruby_version_correct}\n"
 
       bundle "console" do |input, _, _|
         input.puts("puts MYRACK")
@@ -967,14 +960,7 @@ G
     end
 
     it "starts IRB with the default group loaded when ruby version matches", :readline, :jruby_only do
-      gemfile <<-G
-        source "https://gem.repo1"
-        gem "myrack"
-        gem "activesupport", :group => :test
-        gem "myrack_middleware", :group => :development
-
-        #{ruby_version_correct_engineless}
-      G
+      gemfile gemfile + "\n\n#{ruby_version_correct_engineless}\n"
 
       bundle "console" do |input, _, _|
         input.puts("puts MYRACK")
@@ -984,56 +970,28 @@ G
     end
 
     it "fails when ruby version doesn't match" do
-      gemfile <<-G
-        source "https://gem.repo1"
-        gem "myrack"
-        gem "activesupport", :group => :test
-        gem "myrack_middleware", :group => :development
-
-        #{ruby_version_incorrect}
-      G
+      gemfile gemfile + "\n\n#{ruby_version_incorrect}\n"
 
       bundle "console", raise_on_error: false
       should_be_ruby_version_incorrect
     end
 
     it "fails when engine doesn't match" do
-      gemfile <<-G
-        source "https://gem.repo1"
-        gem "myrack"
-        gem "activesupport", :group => :test
-        gem "myrack_middleware", :group => :development
-
-        #{engine_incorrect}
-      G
+      gemfile gemfile + "\n\n#{engine_incorrect}\n"
 
       bundle "console", raise_on_error: false
       should_be_engine_incorrect
     end
 
     it "fails when engine version doesn't match", :jruby_only do
-      gemfile <<-G
-        source "https://gem.repo1"
-        gem "myrack"
-        gem "activesupport", :group => :test
-        gem "myrack_middleware", :group => :development
-
-        #{engine_version_incorrect}
-      G
+      gemfile gemfile + "\n\n#{engine_version_incorrect}\n"
 
       bundle "console", raise_on_error: false
       should_be_engine_version_incorrect
     end
 
     it "fails when patchlevel doesn't match" do
-      gemfile <<-G
-        source "https://gem.repo1"
-        gem "myrack"
-        gem "activesupport", :group => :test
-        gem "myrack_middleware", :group => :development
-
-        #{patchlevel_incorrect}
-      G
+      gemfile gemfile + "\n\n#{patchlevel_incorrect}\n"
 
       bundle "console", raise_on_error: false
       should_be_patchlevel_incorrect

--- a/bundler/spec/commands/platform_spec.rb
+++ b/bundler/spec/commands/platform_spec.rb
@@ -939,7 +939,7 @@ G
     end
   end
 
-  context "bundle console", bundler: "< 3" do
+  context "bundle console" do
     before do
       install_gemfile <<-G
         source "https://gem.repo1"

--- a/tool/bundler/rubocop_gems.rb
+++ b/tool/bundler/rubocop_gems.rb
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "rubocop", ">= 1.52.1", "< 2"
 
 gem "minitest"
+gem "irb"
 gem "rake"
 gem "rake-compiler"
 gem "rspec"

--- a/tool/bundler/rubocop_gems.rb.lock
+++ b/tool/bundler/rubocop_gems.rb.lock
@@ -2,7 +2,16 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    date (3.4.1)
+    date (3.4.1-java)
     diff-lcs (1.5.1)
+    io-console (0.8.0)
+    io-console (0.8.0-java)
+    irb (1.15.1)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
+    jar-dependencies (0.5.5)
     json (2.9.1)
     json (2.9.1-java)
     language_server-protocol (3.17.0.3)
@@ -12,6 +21,15 @@ GEM
       ast (~> 2.4.1)
       racc
     power_assert (2.0.3)
+    pp (0.6.2)
+      prettyprint
+    prettyprint (0.2.0)
+    psych (5.2.3)
+      date
+      stringio
+    psych (5.2.3-java)
+      date
+      jar-dependencies (>= 0.1.7)
     racc (1.8.1)
     racc (1.8.1-java)
     rainbow (3.1.1)
@@ -19,7 +37,11 @@ GEM
     rake-compiler (1.2.7)
       rake
     rb_sys (0.9.91)
+    rdoc (6.12.0)
+      psych (>= 4.0.0)
     regexp_parser (2.10.0)
+    reline (0.6.0)
+      io-console (~> 0.5)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -46,6 +68,7 @@ GEM
     rubocop-ast (1.37.0)
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
+    stringio (3.1.5)
     test-unit (3.6.2)
       power_assert
     unicode-display_width (3.1.4)
@@ -63,6 +86,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  irb
   minitest
   rake
   rake-compiler
@@ -73,7 +97,13 @@ DEPENDENCIES
 
 CHECKSUMS
   ast (2.4.2) sha256=1e280232e6a33754cde542bc5ef85520b74db2aac73ec14acef453784447cc12
+  date (3.4.1) sha256=bf268e14ef7158009bfeaec40b5fa3c7271906e88b196d958a89d4b408abe64f
+  date (3.4.1-java) sha256=74740d914c65a922a15657c25ff0e203c16f1d0f7aa910a9ebed712afe9819c4
   diff-lcs (1.5.1) sha256=273223dfb40685548436d32b4733aa67351769c7dea621da7d9dd4813e63ddfe
+  io-console (0.8.0) sha256=cd6a9facbc69871d69b2cb8b926fc6ea7ef06f06e505e81a64f14a470fddefa2
+  io-console (0.8.0-java) sha256=3cc6fd5c66e587145c1fdf8dc40c2e3d851e90722a5d0cc3f38da352f06fe1bd
+  irb (1.15.1) sha256=d9bca745ac4207a8b728a52b98b766ca909b86ff1a504bcde3d6f8c84faae890
+  jar-dependencies (0.5.5) sha256=2972b9fcba4b014e6446a84b5c09674a3e8648b95b71768e729f0e8e40568059
   json (2.9.1) sha256=d2bdef4644052fad91c1785d48263756fe32fcac08b96a20bb15840e96550d11
   json (2.9.1-java) sha256=88de8c79b54fee6ae1b4854bc48b8d7089f524cbacaf4596df24f86b10896ee8
   language_server-protocol (3.17.0.3) sha256=3d5c58c02f44a20d972957a9febe386d7e7468ab3900ce6bd2b563dd910c6b3f
@@ -81,13 +111,19 @@ CHECKSUMS
   parallel (1.26.3) sha256=d86babb7a2b814be9f4b81587bf0b6ce2da7d45969fab24d8ae4bf2bb4d4c7ef
   parser (3.3.6.0) sha256=25d4e67cc4f0f7cab9a2ae1f38e2005b6904d2ea13c34734511d0faad038bc3b
   power_assert (2.0.3) sha256=cd5e13c267370427c9804ce6a57925d6030613e341cb48e02eec1f3c772d4cf8
+  pp (0.6.2) sha256=947ec3120c6f92195f8ee8aa25a7b2c5297bb106d83b41baa02983686577b6ff
+  prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
+  psych (5.2.3) sha256=84a54bb952d14604fea22d99938348814678782f58b12648fcdfa4d2fce859ee
+  psych (5.2.3-java) sha256=3e5425b9e8a2f41cc2707d5ef14fdc1ae908abbafb12fe45727bd63900056585
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   racc (1.8.1-java) sha256=54f2e6d1e1b91c154013277d986f52a90e5ececbe91465d29172e49342732b98
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.2.1) sha256=46cb38dae65d7d74b6020a4ac9d48afed8eb8149c040eccf0523bec91907059d
   rake-compiler (1.2.7) sha256=5176f8527bbf86db4b333915335eb5fa0b4f578cb82428c3e5e47e48179f0dee
   rb_sys (0.9.91) sha256=8c6ad8f97fd86f80530e942f1a904c229a510ca372c6b92dc05270a84e51ecda
+  rdoc (6.12.0) sha256=7d6f706e070bffa5d18a448f24076cbfb34923a99c1eab842aa18e6ca69f56e0
   regexp_parser (2.10.0) sha256=cb6f0ddde88772cd64bff1dbbf68df66d376043fe2e66a9ef77fcb1b0c548c61
+  reline (0.6.0) sha256=57620375dcbe56ec09bac7192bfb7460c716bbf0054dc94345ecaa5438e539d2
   rspec (3.13.0) sha256=d490914ac1d5a5a64a0e1400c1d54ddd2a501324d703b8cfe83f458337bab993
   rspec-core (3.13.0) sha256=557792b4e88da883d580342b263d9652b6a10a12d5bda9ef967b01a48f15454c
   rspec-expectations (3.13.0) sha256=621d48c62262f955421eaa418130744760802cad47e781df70dba4d9f897102e
@@ -96,6 +132,7 @@ CHECKSUMS
   rubocop (1.70.0) sha256=96751f8440b36a0ac6e9a8ab596900803118d83d6b83f2037bf8b3d7a5bc440e
   rubocop-ast (1.37.0) sha256=9513ac88aaf113d04b52912533ffe46475de1362d4aa41141b51b2455827c080
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  stringio (3.1.5) sha256=bca92461515a131535743bc81d5559fa1de7d80cff9a654d6c0af6f9f27e35c8
   test-unit (3.6.2) sha256=3ce480c23990ca504a3f0d6619be2a560e21326cefd1b86d0f9433c387f26039
   unicode-display_width (3.1.4) sha256=8caf2af1c0f2f07ec89ef9e18c7d88c2790e217c482bfc78aaa65eadd5415ac1
   unicode-emoji (4.0.4) sha256=2c2c4ef7f353e5809497126285a50b23056cc6e61b64433764a35eff6c36532a

--- a/tool/bundler/standard_gems.rb
+++ b/tool/bundler/standard_gems.rb
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "standard", "~> 1.0"
 
 gem "minitest"
+gem "irb"
 gem "rake"
 gem "rake-compiler"
 gem "rspec"

--- a/tool/bundler/standard_gems.rb.lock
+++ b/tool/bundler/standard_gems.rb.lock
@@ -2,7 +2,16 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    date (3.4.1)
+    date (3.4.1-java)
     diff-lcs (1.5.1)
+    io-console (0.8.0)
+    io-console (0.8.0-java)
+    irb (1.15.1)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
+    jar-dependencies (0.5.5)
     json (2.7.1)
     json (2.7.1-java)
     language_server-protocol (3.17.0.3)
@@ -13,6 +22,15 @@ GEM
       ast (~> 2.4.1)
       racc
     power_assert (2.0.3)
+    pp (0.6.2)
+      prettyprint
+    prettyprint (0.2.0)
+    psych (5.2.3)
+      date
+      stringio
+    psych (5.2.3-java)
+      date
+      jar-dependencies (>= 0.1.7)
     racc (1.7.3)
     racc (1.7.3-java)
     rainbow (3.1.1)
@@ -20,7 +38,11 @@ GEM
     rake-compiler (1.2.7)
       rake
     rb_sys (0.9.91)
+    rdoc (6.12.0)
+      psych (>= 4.0.0)
     regexp_parser (2.9.0)
+    reline (0.6.0)
+      io-console (~> 0.5)
     rexml (3.2.6)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -64,6 +86,7 @@ GEM
     standard-performance (1.3.1)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.20.2)
+    stringio (3.1.5)
     test-unit (3.6.2)
       power_assert
     unicode-display_width (2.5.0)
@@ -79,6 +102,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  irb
   minitest
   rake
   rake-compiler
@@ -89,7 +113,13 @@ DEPENDENCIES
 
 CHECKSUMS
   ast (2.4.2) sha256=1e280232e6a33754cde542bc5ef85520b74db2aac73ec14acef453784447cc12
+  date (3.4.1) sha256=bf268e14ef7158009bfeaec40b5fa3c7271906e88b196d958a89d4b408abe64f
+  date (3.4.1-java) sha256=74740d914c65a922a15657c25ff0e203c16f1d0f7aa910a9ebed712afe9819c4
   diff-lcs (1.5.1) sha256=273223dfb40685548436d32b4733aa67351769c7dea621da7d9dd4813e63ddfe
+  io-console (0.8.0) sha256=cd6a9facbc69871d69b2cb8b926fc6ea7ef06f06e505e81a64f14a470fddefa2
+  io-console (0.8.0-java) sha256=3cc6fd5c66e587145c1fdf8dc40c2e3d851e90722a5d0cc3f38da352f06fe1bd
+  irb (1.15.1) sha256=d9bca745ac4207a8b728a52b98b766ca909b86ff1a504bcde3d6f8c84faae890
+  jar-dependencies (0.5.5) sha256=2972b9fcba4b014e6446a84b5c09674a3e8648b95b71768e729f0e8e40568059
   json (2.7.1) sha256=187ea312fb58420ff0c40f40af1862651d4295c8675267c6a1c353f1a0ac3265
   json (2.7.1-java) sha256=bfd628c0f8357058c2cf848febfa6f140f70f94ec492693a31a0a1933038a61b
   language_server-protocol (3.17.0.3) sha256=3d5c58c02f44a20d972957a9febe386d7e7468ab3900ce6bd2b563dd910c6b3f
@@ -98,13 +128,19 @@ CHECKSUMS
   parallel (1.24.0) sha256=5bf38efb9b37865f8e93d7a762727f8c5fc5deb19949f4040c76481d5eee9397
   parser (3.3.0.5) sha256=7748313e505ca87045dc0465c776c802043f777581796eb79b1654c5d19d2687
   power_assert (2.0.3) sha256=cd5e13c267370427c9804ce6a57925d6030613e341cb48e02eec1f3c772d4cf8
+  pp (0.6.2) sha256=947ec3120c6f92195f8ee8aa25a7b2c5297bb106d83b41baa02983686577b6ff
+  prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
+  psych (5.2.3) sha256=84a54bb952d14604fea22d99938348814678782f58b12648fcdfa4d2fce859ee
+  psych (5.2.3-java) sha256=3e5425b9e8a2f41cc2707d5ef14fdc1ae908abbafb12fe45727bd63900056585
   racc (1.7.3) sha256=b785ab8a30ec43bce073c51dbbe791fd27000f68d1c996c95da98bf685316905
   racc (1.7.3-java) sha256=b2ad737e788cfa083263ce7c9290644bb0f2c691908249eb4f6eb48ed2815dbf
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.2.1) sha256=46cb38dae65d7d74b6020a4ac9d48afed8eb8149c040eccf0523bec91907059d
   rake-compiler (1.2.7) sha256=5176f8527bbf86db4b333915335eb5fa0b4f578cb82428c3e5e47e48179f0dee
   rb_sys (0.9.91) sha256=8c6ad8f97fd86f80530e942f1a904c229a510ca372c6b92dc05270a84e51ecda
+  rdoc (6.12.0) sha256=7d6f706e070bffa5d18a448f24076cbfb34923a99c1eab842aa18e6ca69f56e0
   regexp_parser (2.9.0) sha256=81a00ba141cec0d4b4bf58cb80cd9193e5180836d3fa6ef623f7886d3ba8bdd9
+  reline (0.6.0) sha256=57620375dcbe56ec09bac7192bfb7460c716bbf0054dc94345ecaa5438e539d2
   rexml (3.2.6) sha256=e0669a2d4e9f109951cb1fde723d8acd285425d81594a2ea929304af50282816
   rspec (3.13.0) sha256=d490914ac1d5a5a64a0e1400c1d54ddd2a501324d703b8cfe83f458337bab993
   rspec-core (3.13.0) sha256=557792b4e88da883d580342b263d9652b6a10a12d5bda9ef967b01a48f15454c
@@ -118,6 +154,7 @@ CHECKSUMS
   standard (1.35.1) sha256=69a633610864f76e84b438d44b605fda020a3fc9b31a2d50d3487edb77a572ad
   standard-custom (1.0.2) sha256=424adc84179a074f1a2a309bb9cf7cd6bfdb2b6541f20c6bf9436c0ba22a652b
   standard-performance (1.3.1) sha256=0e813d7347fc116b395ae4a6bffcece3ad3114b06e537436a76da79b9194d119
+  stringio (3.1.5) sha256=bca92461515a131535743bc81d5559fa1de7d80cff9a654d6c0af6f9f27e35c8
   test-unit (3.6.2) sha256=3ce480c23990ca504a3f0d6619be2a560e21326cefd1b86d0f9433c387f26039
   unicode-display_width (2.5.0) sha256=7e7681dcade1add70cb9fda20dd77f300b8587c81ebbd165d14fd93144ff0ab4
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

IRB will no longer be a default gem in Ruby 3.5.

This means, among other consequences, that `bundle console` may not work at all under some circumstances, and that our current `bundle console` specs are broken with Ruby 3.5-dev.

## What is your fix for the problem, implemented in this PR?

This PR fixes the broken tests by using a "dummy" irb gem to check the functionality, making specs independent of presence of the real irb gem.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
