### PR TITLE
Deprecate `CurrentRuby#maglev?` and other related maglev methods:

### DIFF
--- a/bundler/lib/bundler/current_ruby.rb
+++ b/bundler/lib/bundler/current_ruby.rb
@@ -50,6 +50,18 @@ module Bundler
     end
 
     def maglev?
+      message =
+        "`CurrentRuby#maglev?` is deprecated with no replacement. Please use the " \
+        "built-in Ruby `RUBY_ENGINE` constant to check the Ruby implementation you are running on."
+      removed_message =
+        "`CurrentRuby#maglev?` was removed with no replacement. Please use the " \
+        "built-in Ruby `RUBY_ENGINE` constant to check the Ruby implementation you are running on."
+      internally_exempted = caller_locations(1, 1).first.path == __FILE__
+
+      unless internally_exempted
+        SharedHelpers.major_deprecation(2, message, removed_message: removed_message, print_caller_location: true)
+      end
+
       RUBY_ENGINE == "maglev"
     end
 
@@ -71,11 +83,23 @@ module Bundler
         RUBY_VERSION.start_with?("#{version}.")
       end
 
-      all_platforms = PLATFORM_MAP.keys << "maglev"
-      all_platforms.each do |platform|
+      PLATFORM_MAP.keys.each do |platform|
         define_method(:"#{platform}_#{trimmed_version}?") do
           send(:"#{platform}?") && send(:"on_#{trimmed_version}?")
         end
+      end
+
+      define_method(:"maglev_#{trimmed_version}?") do
+        message =
+          "`CurrentRuby##{__method__}` is deprecated with no replacement. Please use the " \
+          "built-in Ruby `RUBY_ENGINE` and `RUBY_VERSION` constants to perform a similar check."
+        removed_message =
+          "`CurrentRuby##{__method__}` was removed with no replacement. Please use the " \
+          "built-in Ruby `RUBY_ENGINE` and `RUBY_VERSION` constants to perform a similar check."
+
+        SharedHelpers.major_deprecation(2, message, removed_message: removed_message, print_caller_location: true)
+
+        send(:"maglev?") && send(:"on_#{trimmed_version}?")
       end
     end
   end

--- a/bundler/spec/bundler/current_ruby_spec.rb
+++ b/bundler/spec/bundler/current_ruby_spec.rb
@@ -137,4 +137,20 @@ RSpec.describe Bundler::CurrentRuby do
       expect(subject).to eq(platforms.merge(deprecated))
     end
   end
+
+  describe "Deprecated platform" do
+    it "Outputs a deprecation warning when calling maglev?", bundler: "< 3" do
+      expect(Bundler.ui).to receive(:warn).with(/`CurrentRuby#maglev\?` is deprecated with no replacement./)
+
+      Bundler.current_ruby.maglev?
+    end
+
+    it "Outputs a deprecation warning when calling maglev_31?", bundler: "< 3" do
+      expect(Bundler.ui).to receive(:warn).with(/`CurrentRuby#maglev_31\?` is deprecated with no replacement./)
+
+      Bundler.current_ruby.maglev_31?
+    end
+
+    pending "is removed and shows a helpful error message about it", bundler: "3"
+  end
 end


### PR DESCRIPTION


## What was the end-user or developer problem that led to this PR?

Follow up to https://github.com/rubygems/rubygems/pull/8430#discussion_r1927239555.

The maglev platform was not supported by Bundler, so calling `gem "foo", platforms: ["maglev"]` would raise an error.

The helpers added in the `CurrentRuby` class were used at a time when maglev was supported (as explained in 45ec86e2e5288cc0302783a1c9ad9c5a15b4a6a2). Support of maglev was most likely dropped at some point and the helpers in the `CurrentRuby` class were not deprecated/removed.

We decided to deprecate them now.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
