### PR TITLE
Auto-heal empty installation directory

### DIFF
--- a/bundler/lib/bundler/cli/info.rb
+++ b/bundler/lib/bundler/cli/info.rb
@@ -39,8 +39,8 @@ module Bundler
         path = File.expand_path("../../..", __dir__)
       else
         path = spec.full_gem_path
-        if spec.deleted_gem?
-          return Bundler.ui.warn "The gem #{name} has been deleted. It was installed at: #{path}"
+        if spec.installation_missing?
+          return Bundler.ui.warn "The gem #{name} is missing. It should be installed at #{path}, but was not found"
         end
       end
 
@@ -65,8 +65,8 @@ module Bundler
       gem_info << "\tDefault Gem: yes\n" if spec.respond_to?(:default_gem?) && spec.default_gem?
       gem_info << "\tReverse Dependencies: \n\t\t#{gem_dependencies.join("\n\t\t")}" if gem_dependencies.any?
 
-      if name != "bundler" && spec.deleted_gem?
-        return Bundler.ui.warn "The gem #{name} has been deleted. Gemspec information is still available though:\n#{gem_info}"
+      if name != "bundler" && spec.installation_missing?
+        return Bundler.ui.warn "The gem #{name} is missing. Gemspec information is still available though:\n#{gem_info}"
       end
 
       Bundler.ui.info gem_info

--- a/bundler/lib/bundler/cli/show.rb
+++ b/bundler/lib/bundler/cli/show.rb
@@ -24,7 +24,7 @@ module Bundler
           return unless spec
           path = spec.full_gem_path
           unless File.directory?(path)
-            return Bundler.ui.warn "The gem #{gem_name} has been deleted. It was installed at: #{path}"
+            return Bundler.ui.warn "The gem #{gem_name} is missing. It should be installed at #{path}, but was not found"
           end
         end
         return Bundler.ui.info(path)

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -258,7 +258,7 @@ module Gem
       dependencies - development_dependencies
     end
 
-    def deleted_gem?
+    def installation_missing?
       !default_gem? && !File.directory?(full_gem_path)
     end
 

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -259,7 +259,7 @@ module Gem
     end
 
     def installation_missing?
-      !default_gem? && !File.directory?(full_gem_path)
+      !default_gem? && (!Dir.exist?(full_gem_path) || Dir.empty?(full_gem_path))
     end
 
     unless VALIDATES_FOR_RESOLUTION

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -454,7 +454,7 @@ module Bundler
       end
 
       def installed?(spec)
-        installed_specs[spec].any? && !spec.deleted_gem?
+        installed_specs[spec].any? && !spec.installation_missing?
       end
 
       def rubygems_dir

--- a/bundler/spec/commands/info_spec.rb
+++ b/bundler/spec/commands/info_spec.rb
@@ -56,12 +56,12 @@ RSpec.describe "bundle info" do
       expect(out).to eq("2.3.2")
     end
 
-    it "doesn't claim that bundler has been deleted, even if using a custom path without bundler there" do
+    it "doesn't claim that bundler is missing, even if using a custom path without bundler there" do
       bundle "config set --local path vendor/bundle"
       bundle "install"
       bundle "info bundler"
       expect(out).to include("\tPath: #{root}")
-      expect(err).not_to match(/The gem bundler has been deleted/i)
+      expect(err).not_to match(/The gem bundler is missing/i)
     end
 
     it "complains if gem not in bundle" do
@@ -69,20 +69,20 @@ RSpec.describe "bundle info" do
       expect(err).to eq("Could not find gem 'missing'.")
     end
 
-    it "warns if path no longer exists on disk" do
+    it "warns if path does not exist on disk, but specification is there" do
       FileUtils.rm_rf(default_bundle_path("gems", "rails-2.3.2"))
 
       bundle "info rails --path"
 
-      expect(err).to include("The gem rails has been deleted.")
+      expect(err).to include("The gem rails is missing.")
       expect(err).to include(default_bundle_path("gems", "rails-2.3.2").to_s)
 
       bundle "info rail --path"
-      expect(err).to include("The gem rails has been deleted.")
+      expect(err).to include("The gem rails is missing.")
       expect(err).to include(default_bundle_path("gems", "rails-2.3.2").to_s)
 
       bundle "info rails"
-      expect(err).to include("The gem rails has been deleted.")
+      expect(err).to include("The gem rails is missing.")
       expect(err).to include(default_bundle_path("gems", "rails-2.3.2").to_s)
     end
 

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -100,12 +100,23 @@ RSpec.describe "bundle install with gem sources" do
         gem 'myrack'
       G
 
-      FileUtils.rm_rf(default_bundle_path("gems/myrack-1.0.0"))
+      gem_dir = default_bundle_path("gems/myrack-1.0.0")
+
+      FileUtils.rm_rf(gem_dir)
 
       bundle "install --verbose"
 
       expect(out).to include("Installing myrack 1.0.0")
-      expect(default_bundle_path("gems/myrack-1.0.0")).to exist
+      expect(gem_dir).to exist
+      expect(the_bundle).to include_gems("myrack 1.0.0")
+
+      FileUtils.rm_rf(gem_dir)
+      Dir.mkdir(gem_dir)
+
+      bundle "install --verbose"
+
+      expect(out).to include("Installing myrack 1.0.0")
+      expect(gem_dir).to exist
       expect(the_bundle).to include_gems("myrack 1.0.0")
     end
 

--- a/bundler/spec/commands/show_spec.rb
+++ b/bundler/spec/commands/show_spec.rb
@@ -35,12 +35,12 @@ RSpec.describe "bundle show", bundler: "< 3" do
       expect(out).to eq(default_bundle_path("gems", "rails-2.3.2").to_s)
     end
 
-    it "warns if path no longer exists on disk" do
+    it "warns if specification is installed, but path does not exist on disk" do
       FileUtils.rm_rf(default_bundle_path("gems", "rails-2.3.2"))
 
       bundle "show rails"
 
-      expect(err).to match(/has been deleted/i)
+      expect(err).to match(/is missing/i)
       expect(err).to match(default_bundle_path("gems", "rails-2.3.2").to_s)
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

For some reason, ruby 3.5-dev currently creates an empty gem folder for net-smtp. This seems like a ruby-core issue, but it's easy to workaround on our side.
 
## What is your fix for the problem, implemented in this PR?

Add a small check to detect the empty folder and make sure it's reinstalled.

Fixes https://github.com/rubygems/rubygems/issues/8456.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
