### PR TITLE
Fix `bundle install` output sometimes getting interleaved 

### DIFF
--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -177,7 +177,7 @@ module Bundler
       end
     end
 
-    def replace_gem(specs, specs_by_name)
+    def replace_gem(specs_by_name)
       executables = nil
 
       [::Kernel.singleton_class, ::Kernel].each do |kernel_class|
@@ -274,7 +274,7 @@ module Bundler
       else
         Gem::BUNDLED_GEMS.replace_require(specs) if Gem::BUNDLED_GEMS.respond_to?(:replace_require)
       end
-      replace_gem(specs, specs_by_name)
+      replace_gem(specs_by_name)
       stub_rubygems(specs_by_name.values)
       replace_bin_path(specs_by_name)
 
@@ -293,7 +293,6 @@ module Bundler
         default_spec_name = default_spec.name
         next if specs_by_name.key?(default_spec_name)
 
-        specs << default_spec
         specs_by_name[default_spec_name] = default_spec
       end
 

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -83,6 +83,8 @@ module Bundler
     end
 
     def []=(key, value)
+      delete_by_name(key)
+
       add_spec(value)
     end
 

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -295,15 +295,12 @@ module Bundler
     end
 
     def sorted
-      rake = @specs.find {|s| s.name == "rake" }
-      begin
-        @sorted ||= ([rake] + tsort).compact.uniq
-      rescue TSort::Cyclic => error
-        cgems = extract_circular_gems(error)
-        raise CyclicDependencyError, "Your bundle requires gems that depend" \
-          " on each other, creating an infinite loop. Please remove either" \
-          " gem '#{cgems[0]}' or gem '#{cgems[1]}' and try again."
-      end
+      @sorted ||= ([@specs.find {|s| s.name == "rake" }] + tsort).compact.uniq
+    rescue TSort::Cyclic => error
+      cgems = extract_circular_gems(error)
+      raise CyclicDependencyError, "Your bundle requires gems that depend" \
+        " on each other, creating an infinite loop. Please remove either" \
+        " gem '#{cgems[0]}' or gem '#{cgems[1]}' and try again."
     end
 
     def extract_circular_gems(error)


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

We're seeing some flaky test failures recently. The `bundle install` command in the spec that fails seems to be finishing fine, but the output is interleaved, causing the assertion failure. I don't know if there could be some real end user problem behind this other than the interleaved output. And I'm not sure how and why this was introduced.

The errors read like this:

```diff
Diff:
@@ -1,8 +1,15 @@
-Using myrack 1.0.0
+Running `bundle install --local --standalone  --verbose` with bundler 2.7.0.dev
+Resolving dependencies because there's no lockfile
+Resolving dependencies...
+Using bundler 2.7.0.dev
+0:  bundler (2.7.0.dev) from /home/runner/work/ruby/ruby/src/tmp/2.2/gems/system/specifications/bundler-2.7.0.dev.gemspec
+0:  bundler (2.7.0.1:  myrack (1.0.0) from /home/runner/work/ruby/ruby/src/tmp/2.2/gems/system/specifications/myrack-1.0.0.gemspec
+Bundle complete! 1 Gemfile dependency, 2 gems now installed.
+Use `bundle info [gemname]` to see where a bundled gem is installed.
```

Somehow Bundler seems to be resolving to duplicate specifications for Bundler itself? 🤔.

## What is your fix for the problem, implemented in this PR?

I noticed that after resolving is done, the specification for bundler itself is added here:

https://github.com/rubygems/rubygems/blob/138974563124ec315e9db859f7495711bb93719a/bundler/lib/bundler/definition.rb#L718

But `SpecSet#[]=` does not reset a potential specs that may already exist in the `SpecSet` for Bundler itself.

So technically, a duplication may be possible.

So I made `SpecSet#[]=` reset any pre-existing specs for the name being set. While at it, I also refactored `SpecSet` to not reset all specifications every time is changed, so they don't need to be re-sorted.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
