### PR TITLE
Improve error message when the same source is specified through `gemspec` and `path` 

### DIFF
--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -290,7 +290,7 @@ module Bundler
             @dependencies.delete(current)
           elsif dep.gemspec_dev_dep?
             return
-          elsif current.source != dep.source
+          elsif current.source.to_s != dep.source.to_s
             raise GemfileError, "You cannot specify the same gem twice coming from different sources.\n" \
                             "You specified that #{name} (#{dep.requirement}) should come from " \
                             "#{current.source || "an unspecified source"} and #{dep.source}\n"

--- a/bundler/lib/bundler/source/gemspec.rb
+++ b/bundler/lib/bundler/source/gemspec.rb
@@ -10,6 +10,10 @@ module Bundler
         super
         @gemspec = options["gemspec"]
       end
+
+      def to_s
+        "gemspec at `#{@path}`"
+      end
     end
   end
 end

--- a/bundler/lib/bundler/source/path.rb
+++ b/bundler/lib/bundler/source/path.rb
@@ -53,6 +53,8 @@ module Bundler
         "source at `#{@path}`"
       end
 
+      alias_method :identifier, :to_s
+
       alias_method :to_gemfile, :path
 
       def hash


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?
Closes #3190. 

## What is your fix for the problem, implemented in this PR?

The return values of the to_s method were made different between the Source::Gemspec class and the Source::Path class.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
