### PR TITLE
Add `irb` to a Gemfile for a newly created gem

### DIFF
--- a/bundler/lib/bundler/templates/newgem/Gemfile.tt
+++ b/bundler/lib/bundler/templates/newgem/Gemfile.tt
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in <%= config[:name] %>.gemspec
 gemspec
 
+gem "irb"
 gem "rake", "~> 13.0"
 <%- if config[:ext] -%>
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bin/console` shows the following warning when using with Ruby 3.4

```
./bin/console:10: warning: irb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add irb to your Gemfile or gemspec to silence this warning.
```

## What is your fix for the problem, implemented in this PR?

To silence the above warning, this PR adds `irb`  to a Gemfile for a newly created gem

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
