### PR TITLE
Keep platform variants in `vendor/cache` even if incompatible with the current Ruby version

### DIFF
--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -122,8 +122,6 @@ module Bundler
     end
 
     def materialize_strictly
-      source.local!
-
       materialize(self) do |matching_specs|
         choose_compatible(matching_specs)
       end

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -124,7 +124,7 @@ module Bundler
     def materialize_for_cache
       source.remote!
 
-      materialize_strictly
+      materialize(self, &:first)
     end
 
     def materialized_for_installation
@@ -137,7 +137,9 @@ module Bundler
       source.local!
 
       if use_exact_resolved_specifications?
-        materialize_strictly
+        materialize(self) do |matching_specs|
+          choose_compatible(matching_specs)
+        end
       else
         materialize([name, version]) do |matching_specs|
           target_platform = source.is_a?(Source::Path) ? platform : local_platform
@@ -183,12 +185,6 @@ module Bundler
       generic_platform = generic_local_platform == Gem::Platform::JAVA ? Gem::Platform::JAVA : Gem::Platform::RUBY
 
       (most_specific_locked_platform != generic_platform) || force_ruby_platform || Bundler.settings[:force_ruby_platform]
-    end
-
-    def materialize_strictly
-      materialize(self) do |matching_specs|
-        choose_compatible(matching_specs)
-      end
     end
 
     def materialize(query)

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -121,10 +121,10 @@ module Bundler
       out
     end
 
-    def materialize_strictly
-      materialize(self) do |matching_specs|
-        choose_compatible(matching_specs)
-      end
+    def materialize_for_cache
+      source.remote!
+
+      materialize_strictly
     end
 
     def materialized_for_installation
@@ -183,6 +183,12 @@ module Bundler
       generic_platform = generic_local_platform == Gem::Platform::JAVA ? Gem::Platform::JAVA : Gem::Platform::RUBY
 
       (most_specific_locked_platform != generic_platform) || force_ruby_platform || Bundler.settings[:force_ruby_platform]
+    end
+
+    def materialize_strictly
+      materialize(self) do |matching_specs|
+        choose_compatible(matching_specs)
+      end
     end
 
     def materialize(query)

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -117,8 +117,7 @@ module Bundler
     def materialized_for_all_platforms
       @specs.map do |s|
         next s unless s.is_a?(LazySpecification)
-        s.source.remote!
-        spec = s.materialize_strictly
+        spec = s.materialize_for_cache
         raise GemNotFound, "Could not find #{s.full_name} in any of the sources" unless spec
         spec
       end

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -482,6 +482,53 @@ RSpec.describe "bundle install with gem sources" do
       expect(the_bundle).to include_gems("platform_specific 1.0 ruby")
     end
 
+    it "keeps gems that are locked and cached for the current platform, even if incompatible with the current ruby" do
+      build_repo4 do
+        build_gem "bcrypt_pbkdf", "1.1.1"
+        build_gem "bcrypt_pbkdf", "1.1.1" do |s|
+          s.platform = "arm64-darwin"
+          s.required_ruby_version = "< #{current_ruby_minor}"
+        end
+      end
+
+      app_cache = bundled_app("vendor/cache")
+      FileUtils.mkdir_p app_cache
+      FileUtils.cp gem_repo4("gems/bcrypt_pbkdf-1.1.1-arm64-darwin.gem"), app_cache
+      FileUtils.cp gem_repo4("gems/bcrypt_pbkdf-1.1.1.gem"), app_cache
+
+      bundle "config cache_all_platforms true"
+
+      lockfile <<~L
+        GEM
+          remote: https://gem.repo4/
+          specs:
+            bcrypt_pbkdf (1.1.1)
+            bcrypt_pbkdf (1.1.1-arm64-darwin)
+
+        PLATFORMS
+          arm64-darwin
+          ruby
+
+        DEPENDENCIES
+          bcrypt_pbkdf
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      simulate_platform "arm64-darwin-23" do
+        install_gemfile <<~G, verbose: true
+          source "https://gem.repo4"
+          gem "bcrypt_pbkdf"
+        G
+
+        expect(out).to include("Updating files in vendor/cache")
+        expect(err).to be_empty
+        expect(app_cache.join("bcrypt_pbkdf-1.1.1-arm64-darwin.gem")).to exist
+        expect(app_cache.join("bcrypt_pbkdf-1.1.1.gem")).to exist
+      end
+    end
+
     it "does not update the cache if --no-cache is passed" do
       gemfile <<-G
         source "https://gem.repo1"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When users switch rubies in applications with a local gem cache, and configured to materialize all platform variants, `bundle install` may fail.

## What is your fix for the problem, implemented in this PR?

My fix is to not materialize gems strictly when updating `vendor/cache`, i.e., keep platform specific gems even if incompatible with the current ruby.

Fixes #8451.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
