### PR TITLE
Fix incorrect error message when running `bundle update` in frozen mode

### DIFF
--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -694,28 +694,36 @@ RSpec.describe "bundle update" do
       bundle "update", all: true, raise_on_error: false
 
       expect(last_command).to be_failure
-      expect(err).to match(/Bundler is unlocking, but the lockfile can't be updated because frozen mode is set/)
-      expect(err).to match(/freeze by running `bundle config set frozen false`./)
+      expect(err).to eq <<~ERROR.strip
+        Bundler is unlocking, but the lockfile can't be updated because frozen mode is set
+
+        If this is a development machine, remove the Gemfile.lock freeze by running `bundle config set frozen false`.
+      ERROR
     end
 
     it "should fail loudly when frozen is set globally" do
       bundle "config set --global frozen 1"
       bundle "update", all: true, raise_on_error: false
-      expect(err).to match(/Bundler is unlocking, but the lockfile can't be updated because frozen mode is set/).
-        and match(/freeze by running `bundle config set frozen false`./)
+      expect(err).to eq <<~ERROR.strip
+        Bundler is unlocking, but the lockfile can't be updated because frozen mode is set
+
+        If this is a development machine, remove the Gemfile.lock freeze by running `bundle config set frozen false`.
+      ERROR
     end
 
     it "should fail loudly when deployment is set globally" do
       bundle "config set --global deployment true"
       bundle "update", all: true, raise_on_error: false
-      expect(err).to match(/Bundler is unlocking, but the lockfile can't be updated because frozen mode is set/).
-        and match(/freeze by running `bundle config set frozen false`./)
+      expect(err).to eq <<~ERROR.strip
+        Bundler is unlocking, but the lockfile can't be updated because frozen mode is set
+
+        If this is a development machine, remove the Gemfile.lock freeze by running `bundle config set frozen false`.
+      ERROR
     end
 
     it "should not suggest any command to unfreeze bundler if frozen is set through ENV" do
       bundle "update", all: true, raise_on_error: false, env: { "BUNDLE_FROZEN" => "true" }
-      expect(err).to match(/Bundler is unlocking, but the lockfile can't be updated because frozen mode is set/)
-      expect(err).not_to match(/by running/)
+      expect(err).to eq("Bundler is unlocking, but the lockfile can't be updated because frozen mode is set")
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If you run `bundle update` in frozen mode, Bundler will print the following error:

```
$ bundle update
Bundler is unlocking, but the lockfile can't be updated because frozen mode is set

You have added to the Gemfile:
* rails (~> 8.0.1)

Run `bundle install` elsewhere and add the updated Gemfile to version control.

If this is a development machine, remove the Gemfile.lock freeze by running `bundle config set frozen false`.
```

With one entry in the "You have added to the Gemfile" list for every entry in your Gemfile.

This is confusing because nothing has been added to the Gemfile.

Additionally, the suggestion to run `bundle install` is also confusing in this case, because it's `bundle update` what has been run.

## What is your fix for the problem, implemented in this PR?

My fix is to really consider gems in the lockfile when building the list of added dependencies by always using the actual list of locked dependencies, even when unlocking.

Additionally, skip the `bundle install` suggestion when unlocking.

Now the error reads like this:

```
$ bundle update
Bundler is unlocking, but the lockfile can't be updated because frozen mode is set

If this is a development machine, remove the Gemfile.lock freeze by running `bundle config set frozen false`.
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
