### PR TITLE
Raise error when lockfile is missing deps in frozen mode

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -638,6 +638,8 @@ module Bundler
       specs = begin
         resolve.materialize(dependencies)
       rescue IncorrectLockfileDependencies => e
+        raise if Bundler.frozen_bundle?
+
         spec = e.spec
         raise "Infinite loop while fixing lockfile dependencies" if incorrect_spec == spec
 

--- a/bundler/lib/bundler/errors.rb
+++ b/bundler/lib/bundler/errors.rb
@@ -254,6 +254,10 @@ module Bundler
       @spec = spec
     end
 
+    def message
+      "Bundler found incorrect dependencies in the lockfile for #{spec.full_name}"
+    end
+
     status_code(41)
   end
 end

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -1587,6 +1587,32 @@ RSpec.describe "the lockfile format" do
     L
   end
 
+  it "raises a clear error when frozen mode is set and lockfile is missing deps, and does not install any gems" do
+    lockfile <<-L
+      GEM
+        remote: https://gem.repo2/
+        specs:
+          myrack_middleware (1.0)
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        myrack_middleware
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    install_gemfile <<-G, env: { "BUNDLE_FROZEN" => "true" }, raise_on_error: false
+      source "https://gem.repo2"
+      gem "myrack_middleware"
+    G
+
+    expect(err).to eq("Bundler found incorrect dependencies in the lockfile for myrack_middleware-1.0")
+    expect(the_bundle).not_to include_gems "myrack_middleware 1.0"
+  end
+
   it "automatically fixes the lockfile when it's missing deps, they conflict with other locked deps, but conflicts are fixable" do
     build_repo4 do
       build_gem "other_dep", "0.9"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If a lockfile is missing dependencies, Bundler will normally re-resolve using remote dependencies and automatically fix the lockfile.

However, this is not appropriate in the more secure `frozen` mode, and Bundler currently ends up printing an unclear error when failing to write the lockfile, but installs the gems regardless.

## What is your fix for the problem, implemented in this PR?

My fix is to treat this as a hard error in frozen mode and avoid installing any gems.

Fixes https://github.com/rubygems/rubygems/issues/8475.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
