### PR TITLE
Fix `bundle install --prefer-local` sometimes installing very old versions

### DIFF
--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -389,9 +389,18 @@ module Bundler
     end
 
     def filter_remote_specs(specs, package)
-      return specs unless package.prefer_local?
+      if package.prefer_local?
+        local_specs = specs.select {|s| s.is_a?(StubSpecification) }
 
-      specs.select {|s| s.is_a?(StubSpecification) }
+        if local_specs.empty?
+          package.consider_remote_versions!
+          specs
+        else
+          local_specs
+        end
+      else
+        specs
+      end
     end
 
     # Ignore versions that depend on themselves incorrectly

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -1606,6 +1606,26 @@ RSpec.describe "bundle install with gem sources" do
       expect(out).to include("Fetching foo 1.0.1").and include("Installing foo 1.0.1").and include("Fetching b 1.0.0").and include("Installing b 1.0.0")
       expect(last_command).to be_success
     end
+
+    it "resolves to the latest version if no gems are available locally" do
+      build_repo4 do
+        build_gem "myreline", "0.3.8"
+        build_gem "debug", "0.2.1"
+
+        build_gem "debug", "1.10.0" do |s|
+          s.add_dependency "myreline"
+        end
+      end
+
+      install_gemfile <<~G, "prefer-local": true, verbose: true
+        source "https://gem.repo4"
+
+        gem "debug"
+      G
+
+      expect(out).to include("Fetching debug 1.10.0").and include("Installing debug 1.10.0").and include("Fetching myreline 0.3.8").and include("Installing myreline 0.3.8")
+      expect(last_command).to be_success
+    end
   end
 
   context "with a symlinked configured as bundle path and a gem with symlinks" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If no locally installed gems are available, Bundler may end up resolving remotely, but to old versions of gems.

This is because we had a fallback to consider remote versions if no local versions are found, but only for direct dependencies. Indirect dependencies would still ignore remote versions, and there could be cases where a solution is still found. For example, the `debug` gem may end up being resolved to 0.2.1 if `reline` is not installed locally, because more recent versions depend on `reline` so would be discarded as not satisfiable locally.

## What is your fix for the problem, implemented in this PR?

Instead, for every dependency (direct or indirect), we should make sure to allow remote versions if no versions are installed locally.

Fixes #8479.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
