### PR TITLE
Make Bundler never instantiate development dependencies

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -948,14 +948,6 @@ module Bundler
           next
         end
 
-        # Gem::Dependency#== matches Gem::Dependency#type. As the lockfile
-        # doesn't carry a notion of the dependency type, if you use
-        # add_development_dependency in a gemspec that's loaded with the gemspec
-        # directive, the lockfile dependencies and resolved dependencies end up
-        # with a mismatch on #type. Work around that by setting the type on the
-        # dep from the lockfile.
-        locked_dep.instance_variable_set(:@type, dep.type)
-
         # We already know the name matches from the hash lookup
         # so we only need to check the requirement now
         changes ||= dep.requirement != locked_dep.requirement

--- a/bundler/lib/bundler/dependency.rb
+++ b/bundler/lib/bundler/dependency.rb
@@ -111,7 +111,11 @@ module Bundler
     end
 
     def gemspec_dev_dep?
-      type == :development
+      @gemspec_dev_dep ||= @options.fetch("gemspec_dev_dep", false)
+    end
+
+    def gemfile_dep?
+      !gemspec_dev_dep?
     end
 
     def current_env?

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -82,7 +82,7 @@ module Bundler
         end
 
         spec.development_dependencies.each do |dep|
-          add_dependency dep.name, dep.requirement.as_list, "type" => :development, "group" => development_group
+          add_dependency dep.name, dep.requirement.as_list, "gemspec_dev_dep" => true, "group" => development_group
         end
       when 0
         raise InvalidOption, "There are no gemspecs at #{expanded_path}"
@@ -247,7 +247,7 @@ module Bundler
 
           gemspec_dep = [dep, current].find(&:gemspec_dev_dep?)
           if gemspec_dep
-            gemfile_dep = [dep, current].find(&:runtime?)
+            gemfile_dep = [dep, current].find(&:gemfile_dep?)
 
             if gemfile_dep && !current_requirement_open
               Bundler.ui.warn "A gemspec development dependency (#{gemspec_dep.name}, #{gemspec_dep.requirement}) is being overridden by a Gemfile dependency (#{gemfile_dep.name}, #{gemfile_dep.requirement}).\n" \
@@ -264,7 +264,7 @@ module Bundler
               if current_gemspec_range.intersects?(next_gemspec_range)
                 dep = Dependency.new(name, current.requirement.as_list + dep.requirement.as_list, options)
               else
-                raise GemfileError, "Two gemspecs have conflicting requirements on the same gem: #{dep} and #{current}"
+                raise GemfileError, "Two gemspec development dependencies have conflicting requirements on the same gem: #{dep} and #{current}"
               end
             end
           else

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -581,7 +581,7 @@ RSpec.describe "bundle install with gem sources" do
 
       bundle :install, raise_on_error: false
 
-      expect(err).to include("Two gemspecs have conflicting requirements on the same gem: rubocop (~> 1.36.0, development) and rubocop (~> 2.0, development). Bundler cannot continue.")
+      expect(err).to include("Two gemspec development dependencies have conflicting requirements on the same gem: rubocop (~> 1.36.0) and rubocop (~> 2.0). Bundler cannot continue.")
     end
 
     it "warns when a Gemfile dependency is overriding a gemspec development dependency, with different requirements" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

None, just want to make the code simpler and error messages read a bit better.

## What is your fix for the problem, implemented in this PR?

Bundler does not really have a concept of "development dependencies", like RubyGems has. Bundler has the more generic concept of "groups".

Under the hood, the `gemspec` DSL will put gemspec development dependencies under a `:development` Gemfile group, but there's no reason to instantiate these as development dependencies, they are regular runtime dependencies, except that they belong in a group named :development.

By never instantiating development dependencies at all, we avoid having to introduce hacks to "undo" the type Bundler does not know about, and I also think the error messages read better.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
