### PR TITLE
Fix regression when running `bundle update <foo>` would sometimes downgrade a top level dependency

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -626,7 +626,7 @@ module Bundler
         last_resolve = converge_locked_specs
         remove_invalid_platforms!
         packages = Resolver::Base.new(source_requirements, expanded_dependencies, last_resolve, @platforms, locked_specs: @originally_locked_specs, unlock: @unlocking_all || @gems_to_unlock, prerelease: gem_version_promoter.pre?, prefer_local: @prefer_local, new_platforms: @new_platforms)
-        packages = additional_base_requirements_to_prevent_downgrades(packages, last_resolve)
+        packages = additional_base_requirements_to_prevent_downgrades(packages)
         packages = additional_base_requirements_to_force_updates(packages)
         packages
       end
@@ -1093,9 +1093,9 @@ module Bundler
       current == proposed
     end
 
-    def additional_base_requirements_to_prevent_downgrades(resolution_packages, last_resolve)
+    def additional_base_requirements_to_prevent_downgrades(resolution_packages)
       return resolution_packages unless @locked_gems && !sources.expired_sources?(@locked_gems.sources)
-      converge_specs(@originally_locked_specs - last_resolve).each do |locked_spec|
+      converge_specs(@originally_locked_specs).each do |locked_spec|
         next if locked_spec.source.is_a?(Source::Path)
         resolution_packages.base_requirements[locked_spec.name] = Gem::Requirement.new(">= #{locked_spec.version}")
       end

--- a/bundler/spec/install/gems/flex_spec.rb
+++ b/bundler/spec/install/gems/flex_spec.rb
@@ -295,6 +295,30 @@ RSpec.describe "bundle flex_install" do
 
     it "should work when you update" do
       bundle "update myrack"
+
+      checksums = checksums_section_when_enabled do |c|
+        c.checksum gem_repo1, "myrack", "0.9.1"
+        c.checksum gem_repo1, "myrack-obama", "1.0"
+      end
+
+      expect(lockfile).to eq <<~L
+        GEM
+          remote: https://gem.repo1/
+          specs:
+            myrack (0.9.1)
+            myrack-obama (1.0)
+              myrack
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          myrack (= 0.9.1)
+          myrack-obama
+        #{checksums}
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes, running `bundle update <foo>` would downgrade a top level dependency. Regression was introduced by https://github.com/rubygems/rubygems/commit/d0f789970fd27b668426307571af89976c0e29ec.

## What is your fix for the problem, implemented in this PR?

The fix is to avoid calling `converge_specs` when adding lower bound extra requirements to prevent downgrades. Using this method was causing the extra requirements to sometimes not be added.

Fixes #8474.

This PR builds on top of #8489, so that PR should be merged first.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
