### PR TITLE
Fix lockfile platforms inconveniently added on JRuby

### DIFF
--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         ruby:
           - { name: ruby, value: 3.4.1 }
+          - { name: jruby, value: jruby-9.4.12.0 }
           - { name: truffleruby, value: truffleruby-24.1.2 }
     env:
       RUBYOPT: -Ilib
@@ -39,8 +40,10 @@ jobs:
         run: bin/rake rubocop
       - name: Generate docs
         run: bin/rake docs
+        if: matrix.ruby.name != 'jruby'
       - name: Install & Check Dependencies
         run: bin/rake dev:frozen_deps
       - name: Misc checks
         run: bin/rake check_rvm_integration man:check vendor:check version:check check_rubygems_integration
+        if: matrix.ruby.name != 'jruby'
     timeout-minutes: 15


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When working with our repository on JRuby locally, I get the following changes when running `bin/rake setup` in all of our lockfiles

```diff
diff --git a/tool/bundler/dev_gems.rb.lock b/tool/bundler/dev_gems.rb.lock
index 362bf25690d..74550b2a408 100644
--- a/tool/bundler/dev_gems.rb.lock
+++ b/tool/bundler/dev_gems.rb.lock
@@ -66,6 +66,7 @@ PLATFORMS
   java
   ruby
   universal-java
+  universal-java-22
   x64-mingw-ucrt
   x86-linux
   x86_64-darwin
```

This is inconvenient.

## What is your fix for the problem, implemented in this PR?

I applied the same strategy we already use on non JRuby implementations to not add the current platform to the lockfile if a less specific platform is already there.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
