### PR TITLE
Make sure empty gems are not reinstalled every time

### DIFF
--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -259,7 +259,7 @@ module Gem
     end
 
     def installation_missing?
-      !default_gem? && (!Dir.exist?(full_gem_path) || Dir.empty?(full_gem_path))
+      !default_gem? && !File.directory?(full_gem_path)
     end
 
     unless VALIDATES_FOR_RESOLUTION

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -100,24 +100,30 @@ RSpec.describe "bundle install with gem sources" do
         gem 'myrack'
       G
 
-      gem_dir = default_bundle_path("gems/myrack-1.0.0")
-
-      FileUtils.rm_rf(gem_dir)
+      FileUtils.rm_rf(default_bundle_path("gems/myrack-1.0.0"))
 
       bundle "install --verbose"
 
       expect(out).to include("Installing myrack 1.0.0")
-      expect(gem_dir).to exist
+      expect(default_bundle_path("gems/myrack-1.0.0")).to exist
       expect(the_bundle).to include_gems("myrack 1.0.0")
+    end
 
-      FileUtils.rm_rf(gem_dir)
-      Dir.mkdir(gem_dir)
+    it "does not state that it's constantly reinstalling empty gems" do
+      build_repo4 do
+        build_gem "empty", "1.0.0", no_default: true, allowed_warning: "no files specified"
+      end
+
+      install_gemfile <<~G
+        source "https://gem.repo4"
+
+        gem "empty"
+      G
+      gem_dir = default_bundle_path("gems/empty-1.0.0")
+      expect(gem_dir).to be_empty
 
       bundle "install --verbose"
-
-      expect(out).to include("Installing myrack 1.0.0")
-      expect(gem_dir).to exist
-      expect(the_bundle).to include_gems("myrack 1.0.0")
+      expect(out).not_to include("Installing empty")
     end
 
     it "fetches gems when multiple versions are specified" do

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -530,10 +530,8 @@ module Spec
         when false
           # do nothing
         when :yaml
-          @spec.files << "#{name}.gemspec"
           @files["#{name}.gemspec"] = @spec.to_yaml
         else
-          @spec.files << "#{name}.gemspec"
           @files["#{name}.gemspec"] = @spec.to_ruby
         end
 

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -639,7 +639,7 @@ module Spec
         elsif opts[:skip_validation]
           @context.gem_command "build --force #{@spec.name}", dir: lib_path
         else
-          @context.gem_command "build #{@spec.name}", dir: lib_path
+          @context.gem_command "build #{@spec.name}", dir: lib_path, allowed_warning: opts[:allowed_warning]
         end
 
         gem_path = File.expand_path("#{@spec.full_name}.gem", lib_path)

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -194,9 +194,12 @@ module Spec
       # command is expired too. So give `gem install` commands a bit more time.
       options[:timeout] = 120
 
+      allowed_warning = options.delete(:allowed_warning)
+
       output = sys_exec("#{Path.gem_bin} #{command}", options)
       stderr = last_command.stderr
-      raise stderr if stderr.include?("WARNING") && !allowed_rubygems_warning?(stderr)
+
+      raise stderr if stderr.include?("WARNING") && !allowed_rubygems_warning?(stderr, allowed_warning)
       output
     end
 
@@ -548,8 +551,12 @@ module Spec
 
     private
 
-    def allowed_rubygems_warning?(text)
-      text.include?("open-ended") || text.include?("is a symlink") || text.include?("rake based") || text.include?("expected RubyGems version")
+    def allowed_rubygems_warning?(text, extra_allowed_warning)
+      allowed_warnings = ["open-ended", "is a symlink", "rake based", "expected RubyGems version"]
+      allowed_warnings << extra_allowed_warning if extra_allowed_warning
+      allowed_warnings.any? do |warning|
+        text.include?(warning)
+      end
     end
 
     def match_source(contents)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We added code to detect whether the installation directory of a gem is incorrectly empty, so that we can reinstall it and fix things.

This is to fix #8457, and workaround the real culprit, a ruby-core issue.

However, that fix does not account for the fact that some gems are actually empty, and are just there as a wrapper for other dependencies. One such gem is sorbet-static-and-runtime.

## What is your fix for the problem, implemented in this PR?

My fix is to revert the original fix because it turns out it's something not easy to get right, and it was just a workaround for an external issue, which is now fixed.

Fixes #8500.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
