### PR TITLE
Fix resolver issue due to ill-defined version ranges being created

### DIFF
--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -237,7 +237,7 @@ module Bundler
             sorted_versions[high]
           end
 
-        range = PubGrub::VersionRange.new(min: low, max: high, include_min: true)
+        range = PubGrub::VersionRange.new(min: low, max: high, include_min: !low.nil?)
 
         self_constraint = PubGrub::VersionConstraint.new(package, range: range)
 

--- a/bundler/spec/resolver/basic_spec.rb
+++ b/bundler/spec/resolver/basic_spec.rb
@@ -379,4 +379,44 @@ RSpec.describe "Resolving" do
 
     should_resolve_without_dependency_api %w[myrack-3.0.0 standalone_migrations-2.0.4]
   end
+
+  it "resolves fine cases that need joining unbounded disjoint ranges" do
+    @index = build_index do
+      gem "inspec", "5.22.3" do
+        dep "ruby", ">= 3.2.2"
+        dep "train-kubernetes", ">= 0.1.7"
+      end
+
+      gem "ruby", "3.2.2"
+
+      gem "train-kubernetes", "0.1.12" do
+        dep "k8s-ruby", ">= 0.14.0"
+      end
+
+      gem "train-kubernetes", "0.1.10" do
+        dep "k8s-ruby", "= 0.10.5"
+      end
+
+      gem "train-kubernetes", "0.1.7" do
+        dep "k8s-ruby", ">= 0.10.5"
+      end
+
+      gem "k8s-ruby", "0.10.5" do
+        dep "ruby","< 3.2.2"
+      end
+
+      gem "k8s-ruby", "0.11.0" do
+        dep "ruby", ">= 3.2.2"
+      end
+
+      gem "k8s-ruby", "0.14.0" do
+        dep "ruby", "< 3.2.2"
+      end
+    end
+
+    dep "inspec", "5.22.3"
+    dep "ruby", "3.2.2"
+
+    should_resolve_as %w[inspec-5.22.3 ruby-3.2.2 train-kubernetes-0.1.7 k8s-ruby-0.11.0]
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes, Bundler does not resolve versions properly.

This was first reported at https://github.com/rubygems/rubygems/issues/6686. However, some of the versions being involved in that issue at the time have been yanked, so that particular realworld issue is not happening anymore.

I only decided to get to the bottom of this because when making some changes in the resolver, I run into an issue that seemed like a pub grub bug, and this is the only pub grub bug known so far.

## What is your fix for the problem, implemented in this PR?

It's a long story, see related pub grub PRs https://github.com/jhawthorn/pub_grub/pull/35 and https://github.com/jhawthorn/pub_grub/pull/36. But the gist of the fix is that Bundler (and pub grub's builtin package source as well) was creating some version ranges not very well defined (they had `min == nil`, so no lower bound, but `include_min == true`). This was causing internal pubgrub logic to create unions of version ranges to sometimes not work fine.

The fix is to make sure we always create "sane" version ranges.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
