### PR TITLE
Removed not working script for Bundler 3

### DIFF
--- a/bundler/bin/bundle3
+++ b/bundler/bin/bundle3
@@ -1,8 +1,0 @@
-#!/usr/bin/env ruby
-# frozen_string_literal: true
-
-module Bundler
-  VERSION = "3.0.0"
-end
-
-load File.expand_path("bundle", __dir__)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bundle3` script is not working now and this is not required the current development workflow.

```
❯ bin/bundle3
bin/bundle3:8:in 'Kernel#load': cannot load such file -- /Users/hsbt/Documents/github.com/rubygems/rubygems/bundler/bin/bundle (LoadError)
        from bin/bundle3:8:in '<main>'
```


## What is your fix for the problem, implemented in this PR?

Removed from this repository. When we need to that again, we should revert this PR.


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
