### PR TITLE
Removed `gem server` from `gem help`

### DIFF
--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -650,9 +650,6 @@ RubyGems is a package manager for Ruby.
     gem help platforms           gem platforms guide
     gem help <COMMAND>           show help on COMMAND
                                    (e.g. 'gem help install')
-    gem server                   present a web page at
-                                 http://localhost:8808/
-                                 with info about installed gems
   Further information:
     https://guides.rubygems.org
   HELP


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This is nit-pick. `gem server` command is extracted from RubyGems core feature today. We don't show that from example of help.

## What is your fix for the problem, implemented in this PR?

Removed example for `gem server`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
