### PR TITLE
Changelogs for RubyGems 3.6.5 and Bundler 2.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 3.6.5 / 2025-02-20
+
+## Enhancements:
+
+* Installs bundler 2.6.5 as a default gem.
+
+## Documentation:
+
+* Removed `gem server` from `gem help`. Pull request
+  [#8507](https://github.com/rubygems/rubygems/pull/8507) by hsbt
+
 # 3.6.4 / 2025-02-17
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 2.6.5 (February 20, 2025)
+
+## Enhancements:
+
+  - Fix lockfile platforms inconveniently added on JRuby [#8494](https://github.com/rubygems/rubygems/pull/8494)
+
+## Bug fixes:
+
+  - Fix resolver issue due to ill-defined version ranges being created [#8503](https://github.com/rubygems/rubygems/pull/8503)
+  - Make sure empty gems are not reinstalled every time [#8502](https://github.com/rubygems/rubygems/pull/8502)
+
 # 2.6.4 (February 17, 2025)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.6.5 and Bundler 2.6.5 into master.