### PR TITLE
Allow noop `bundle install` to work on read-only or protected folders

### DIFF
--- a/bundler/lib/bundler/errors.rb
+++ b/bundler/lib/bundler/errors.rb
@@ -193,6 +193,24 @@ module Bundler
     status_code(31)
   end
 
+  class ReadOnlyFileSystemError < PermissionError
+    def message
+      "There was an error while trying to #{action} `#{@path}`. " \
+      "File system is read-only."
+    end
+
+    status_code(42)
+  end
+
+  class OperationNotPermittedError < PermissionError
+    def message
+      "There was an error while trying to #{action} `#{@path}`. " \
+      "Underlying OS system call raised an EPERM error."
+    end
+
+    status_code(43)
+  end
+
   class GenericSystemCallError < BundlerError
     attr_reader :underlying_error
 

--- a/bundler/lib/bundler/plugin/index.rb
+++ b/bundler/lib/bundler/plugin/index.rb
@@ -31,7 +31,7 @@ module Bundler
 
         begin
           load_index(global_index_file, true)
-        rescue GenericSystemCallError
+        rescue PermissionError
           # no need to fail when on a read-only FS, for example
           nil
         rescue ArgumentError => e

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -115,6 +115,10 @@ module Bundler
       raise NoSpaceOnDeviceError.new(path, action)
     rescue Errno::ENOTSUP
       raise OperationNotSupportedError.new(path, action)
+    rescue Errno::EPERM
+      raise OperationNotPermittedError.new(path, action)
+    rescue Errno::EROFS
+      raise ReadOnlyFileSystemError.new(path, action)
     rescue Errno::EEXIST, Errno::ENOENT
       raise
     rescue SystemCallError => e

--- a/bundler/spec/install/process_lock_spec.rb
+++ b/bundler/spec/install/process_lock_spec.rb
@@ -21,19 +21,36 @@ RSpec.describe "process lock spec" do
       expect(the_bundle).to include_gems "myrack 1.0"
     end
 
+    context "when creating a lock raises Errno::ENOTSUP" do
+      before { allow(File).to receive(:open).and_raise(Errno::ENOTSUP) }
+
+      it "skips creating the lock file and yields" do
+        processed = false
+        Bundler::ProcessLock.lock(default_bundle_path) { processed = true }
+
+        expect(processed).to eq true
+      end
+    end
+
     context "when creating a lock raises Errno::EPERM" do
       before { allow(File).to receive(:open).and_raise(Errno::EPERM) }
 
-      it "raises a friendly error" do
-        expect { Bundler::ProcessLock.lock(default_bundle_path) }.to raise_error(Bundler::GenericSystemCallError)
+      it "skips creating the lock file and yields" do
+        processed = false
+        Bundler::ProcessLock.lock(default_bundle_path) { processed = true }
+
+        expect(processed).to eq true
       end
     end
 
     context "when creating a lock raises Errno::EROFS" do
       before { allow(File).to receive(:open).and_raise(Errno::EROFS) }
 
-      it "raises a friendly error" do
-        expect { Bundler::ProcessLock.lock(default_bundle_path) }.to raise_error(Bundler::GenericSystemCallError)
+      it "skips creating the lock file and yields" do
+        processed = false
+        Bundler::ProcessLock.lock(default_bundle_path) { processed = true }
+
+        expect(processed).to eq true
       end
     end
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

While addressing @segiddins concern at https://github.com/rubygems/rubygems/pull/5920#discussion_r1964060159, I noticed that a [recent change](https://github.com/rubygems/rubygems/pull/8168) degraded the experience a bit on read-only or protected file systems.

## What is your fix for the problem, implemented in this PR?

This PR implements the specialized errors suggested by @segiddins while also restoring the `bundle install` experience on read-only or protected filesystems prior to Bundler 2.6.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
