### PR TITLE
Removed ccache or sccache from args of Rust builder

### DIFF
--- a/lib/rubygems/ext/cargo_builder.rb
+++ b/lib/rubygems/ext/cargo_builder.rb
@@ -160,6 +160,8 @@ class Gem::Ext::CargoBuilder < Gem::Ext::Builder
   # mkmf work properly.
   def linker_args
     cc_flag = Shellwords.split(makefile_config("CC"))
+    # Avoid to sccache and ccache from Rust build
+    cc_flag = cc_flag.delete_if {|f| f.include?("ccache") }
     linker = cc_flag.shift
     link_args = cc_flag.flat_map {|a| ["-C", "link-arg=#{a}"] }
 

--- a/test/rubygems/test_gem_ext_cargo_builder.rb
+++ b/test/rubygems/test_gem_ext_cargo_builder.rb
@@ -137,6 +137,19 @@ class TestGemExtCargoBuilder < Gem::TestCase
     end
   end
 
+  def test_linker_args
+    orig_cc = RbConfig::CONFIG["CC"]
+    RbConfig::CONFIG["CC"] = "sccache clang"
+
+    builder = Gem::Ext::CargoBuilder.new
+    args = builder.send(:linker_args)
+
+    assert args[1], "linker=clang"
+    assert_nil args[2]
+  ensure
+    RbConfig::CONFIG["CC"] = orig_cc
+  end
+
   private
 
   def skip_unsupported_platforms!


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When users used `sccache` like cache tool for C compiler with `CC=sccache clang`, `TestGemExtCargoBuilder` was failed with the following:

```
 "  = note: some arguments are omitted. use `--verbose` to show all linker arguments\n" +
 "  = note: error: unexpected argument '-W' found\n" +
 "          \n" +
 "            tip: to pass '-W' as a value, use '-- -W'\n" +
 "          \n" +
 "          Usage: sccache [OPTIONS] <--dist-auth|--debug-preprocessor-cache|--dist-status|--show-stats|--show-adv-stats|--start-server|--stop-server|--zero-stats|--package-toolchain <EXE> <OUT>|CMD>\n" +
 "          \n" +
 "          For more information, try '--help'.\n" +
 "          \n" +
```

## What is your fix for the problem, implemented in this PR?

I removed cache tool from rustc arguments on `TestGemExtCargoBuilder`.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
