### PR TITLE
Improve log messages when lockfile platforms are added

### DIFF
--- a/bundler/lib/bundler/cli/lock.rb
+++ b/bundler/lib/bundler/cli/lock.rb
@@ -44,7 +44,8 @@ module Bundler
 
         Bundler::CLI::Common.configure_gem_version_promoter(definition, options) if options[:update]
 
-        options["remove-platform"].each do |platform|
+        options["remove-platform"].each do |platform_string|
+          platform = Gem::Platform.new(platform_string)
           definition.remove_platform(platform)
         end
 

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -623,7 +623,7 @@ module Bundler
       @resolution_packages ||= begin
         last_resolve = converge_locked_specs
         remove_invalid_platforms!
-        new_resolution_platforms = @current_platform_missing ? @new_platforms.append(local_platform) : @new_platforms
+        new_resolution_platforms = @current_platform_missing ? @new_platforms + [local_platform] : @new_platforms
         packages = Resolver::Base.new(source_requirements, expanded_dependencies, last_resolve, @platforms, locked_specs: @originally_locked_specs, unlock: @unlocking_all || @gems_to_unlock, prerelease: gem_version_promoter.pre?, prefer_local: @prefer_local, new_platforms: new_resolution_platforms)
         packages = additional_base_requirements_to_prevent_downgrades(packages)
         packages = additional_base_requirements_to_force_updates(packages)
@@ -797,7 +797,7 @@ module Bundler
         [@source_changes, "the list of sources changed"],
         [@dependency_changes, "the dependencies in your gemfile changed"],
         [@current_platform_missing, "your lockfile does not include the current platform"],
-        [@new_platforms.any?, "you added a new platform to your gemfile"],
+        [@new_platforms.any?, "you are adding a new platform to your lockfile"],
         [@path_changes, "the gemspecs for path gems changed"],
         [@local_changes, "the gemspecs for git local gems changed"],
         [@missing_lockfile_dep, "your lock file is missing \"#{@missing_lockfile_dep}\""],

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -625,7 +625,8 @@ module Bundler
       @resolution_packages ||= begin
         last_resolve = converge_locked_specs
         remove_invalid_platforms!
-        packages = Resolver::Base.new(source_requirements, expanded_dependencies, last_resolve, @platforms, locked_specs: @originally_locked_specs, unlock: @unlocking_all || @gems_to_unlock, prerelease: gem_version_promoter.pre?, prefer_local: @prefer_local, new_platforms: @new_platforms)
+        new_resolution_platforms = @current_platform_missing ? @new_platforms.append(local_platform) : @new_platforms
+        packages = Resolver::Base.new(source_requirements, expanded_dependencies, last_resolve, @platforms, locked_specs: @originally_locked_specs, unlock: @unlocking_all || @gems_to_unlock, prerelease: gem_version_promoter.pre?, prefer_local: @prefer_local, new_platforms: new_resolution_platforms)
         packages = additional_base_requirements_to_prevent_downgrades(packages)
         packages = additional_base_requirements_to_force_updates(packages)
         packages
@@ -768,7 +769,6 @@ module Bundler
       @most_specific_non_local_locked_platform = find_most_specific_locked_platform
       return if @most_specific_non_local_locked_platform
 
-      @new_platforms << local_platform
       @platforms << local_platform
       true
     end

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -1369,7 +1369,7 @@ RSpec.describe "bundle install with gem sources" do
       bundle "install --verbose"
 
       expect(out).to include("re-resolving dependencies because your lockfile does not include the current platform")
-      expect(out).not_to include("you added a new platform to your gemfile")
+      expect(out).not_to include("you are adding a new platform to your lockfile")
 
       expect(lockfile).to eq <<~L
         GEM

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -1369,6 +1369,7 @@ RSpec.describe "bundle install with gem sources" do
       bundle "install --verbose"
 
       expect(out).to include("re-resolving dependencies because your lockfile does not include the current platform")
+      expect(out).not_to include("you added a new platform to your gemfile")
 
       expect(lockfile).to eq <<~L
         GEM

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -761,8 +761,18 @@ RSpec.describe "bundle lock" do
     expect(lockfile).to end_with("BUNDLED WITH\n   99\n")
   end
 
-  it "supports adding new platforms" do
-    bundle "lock --add-platform java x86-mingw32"
+  it "supports adding new platforms when there's no previous lockfile" do
+    bundle "lock --add-platform java x86-mingw32 --verbose"
+    expect(out).to include("Resolving dependencies because there's no lockfile")
+
+    allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+    expect(the_bundle.locked_platforms).to match_array(default_platform_list("java", "x86-mingw32"))
+  end
+
+  it "supports adding new platforms when a previous lockfile exists" do
+    bundle "lock"
+    bundle "lock --add-platform java x86-mingw32 --verbose"
+    expect(out).to include("Found changes from the lockfile, re-resolving dependencies because you are adding a new platform to your lockfile")
 
     allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
     expect(the_bundle.locked_platforms).to match_array(default_platform_list("java", "x86-mingw32"))


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I noticed that since https://github.com/rubygems/rubygems/pull/8489, we will print the following log message when Bundler is adding the current platform to the lockfile:

> Found changes from the lockfile, re-resolving dependencies because your lockfile does not include the current platform, you added a new platform to your gemfile

while before it would print

> Found changes from the lockfile, re-resolving dependencies because your lockfile does not include the current platform

I think the previous message is better because you're not explicitly adding anything.

## What is your fix for the problem, implemented in this PR?

Restore the previous message by not adding the local platform to the `@new_platforms` array when the addition is not explicit.

On top of that, I changed the message when the addition is explicit (`bundle lock --add-platform`) from

> Found changes from the lockfile, re-resolving dependencies because you added a new platform to your gemfile

to

> Found changes from the lockfile, re-resolving dependencies because you are adding a new platform to your lockfile

Finally, I also included a few changes to make adding and removing platforms more consistent.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
