### PR TITLE
Retry gracefully on blank partial response in compact index

### DIFF
--- a/bundler/lib/bundler/compact_index_client/updater.rb
+++ b/bundler/lib/bundler/compact_index_client/updater.rb
@@ -37,7 +37,8 @@ module Bundler
           file.digests = parse_digests(response)
           # server may ignore Range and return the full response
           if response.is_a?(Gem::Net::HTTPPartialContent)
-            break false unless file.append(response.body.byteslice(1..-1))
+            tail = response.body.byteslice(1..-1)
+            break false unless tail && file.append(tail)
           else
             file.write(response.body)
           end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In #5578 I uncovered a problem in the compact index that seemingly doesn't happen in the wild. Nonetheless, it is a bug and we should handle it cleanly.

## What is your fix for the problem, implemented in this PR?

If a ranged request received a partial response from the compact index, but the response is empty, fail gracefully as if the digest check was merely wrong.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
