### PR TITLE
Add /info_checksums compact index endpoint

### DIFF
--- a/bundler/lib/bundler/compact_index_client/cache.rb
+++ b/bundler/lib/bundler/compact_index_client/cache.rb
@@ -26,6 +26,10 @@ module Bundler
         fetch("versions", versions_path, versions_etag_path)
       end
 
+      def info_checksums
+        fetch("info_checksums", info_checksums_path, info_checksums_etag_path)
+      end
+
       def info(name, remote_checksum = nil)
         path = info_path(name)
 
@@ -47,6 +51,8 @@ module Bundler
       def names_etag_path = directory.join("names.etag")
       def versions_path = directory.join("versions")
       def versions_etag_path = directory.join("versions.etag")
+      def info_checksums_path = directory.join("info_checksums")
+      def info_checksums_etag_path = directory.join("info_checksums.etag")
 
       def info_path(name)
         name = name.to_s

--- a/bundler/lib/bundler/fetcher/compact_index.rb
+++ b/bundler/lib/bundler/fetcher/compact_index.rb
@@ -51,7 +51,7 @@ module Bundler
           Bundler.ui.debug("FIPS mode is enabled, bundler can't use the CompactIndex API")
           return nil
         end
-        # Read info file checksums out of /versions, so we can know if gems are up to date
+        # Read info file checksums out of /info_checksums or /versions, so we can know if gems are up to date
         compact_index_client.available?
       rescue CompactIndexClient::Updater::MismatchedChecksumError => e
         Bundler.ui.debug(e.message)

--- a/bundler/lib/bundler/friendly_errors.rb
+++ b/bundler/lib/bundler/friendly_errors.rb
@@ -100,7 +100,8 @@ module Bundler
     end
 
     def issues_url(exception)
-      message = exception.message.lines.first.tr(":", " ").chomp
+      lines = exception.message.lines
+      message = lines.first&.tr(":", " ")&.chomp || ""
       message = message.split("-").first if exception.is_a?(Errno)
       require "cgi"
       "https://github.com/rubygems/rubygems/search?q=" \

--- a/bundler/spec/support/artifice/compact_index_checksum_mismatch.rb
+++ b/bundler/spec/support/artifice/compact_index_checksum_mismatch.rb
@@ -9,6 +9,13 @@ class CompactIndexChecksumMismatch < CompactIndexAPI
     content_type "text/plain"
     body "content does not match the checksum"
   end
+
+  get "/info_checksums" do
+    headers "Repr-Digest" => "sha-256=:ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0=:"
+    headers "Surrogate-Control" => "max-age=2592000, stale-while-revalidate=60"
+    content_type "text/plain"
+    body "content does not match the checksum"
+  end
 end
 
 require_relative "helpers/artifice"

--- a/bundler/spec/support/artifice/compact_index_etag_match.rb
+++ b/bundler/spec/support/artifice/compact_index_etag_match.rb
@@ -9,6 +9,13 @@ class CompactIndexEtagMatch < CompactIndexAPI
     status 304
     body ""
   end
+
+  get "/info_checksums" do
+    raise "ETag header should be present" unless env["HTTP_IF_NONE_MATCH"]
+    headers "ETag" => env["HTTP_IF_NONE_MATCH"]
+    status 304
+    body ""
+  end
 end
 
 require_relative "helpers/artifice"

--- a/bundler/spec/support/artifice/compact_index_redirects.rb
+++ b/bundler/spec/support/artifice/compact_index_redirects.rb
@@ -11,6 +11,10 @@ class CompactIndexRedirect < CompactIndexAPI
     status 404
   end
 
+  get "/info_checksums" do
+    status 404
+  end
+
   get "/api/v1/dependencies" do
     status 404
   end

--- a/bundler/spec/support/artifice/helpers/compact_index.rb
+++ b/bundler/spec/support/artifice/helpers/compact_index.rb
@@ -115,6 +115,24 @@ class CompactIndexAPI < Endpoint
     end
   end
 
+  get "/info_checksums" do
+    etag_response do
+      file = tmp("versions.list")
+      FileUtils.rm_f(file)
+      # file = CompactIndex::VersionsFile.new(file.to_s, only_info_checksums: true)
+      file = CompactIndex::VersionsFile.new(file.to_s)
+      file.create(gems)
+      seen = false
+      file.contents.lines.map do |line|
+        unless seen
+          seen = line == "---\n"
+          next line
+        end
+        line.sub!(/([^ ]+) .+? ([^ ]+)/, '\1 \2') or raise("Unexpected line: #{line.inspect}")
+      end.join
+    end
+  end
+
   get "/info/:name" do
     etag_response do
       gem = gems.find {|g| g.name == params[:name] }

--- a/bundler/spec/support/artifice/helpers/compact_index_extra_api.rb
+++ b/bundler/spec/support/artifice/helpers/compact_index_extra_api.rb
@@ -19,6 +19,24 @@ class CompactIndexExtraApi < CompactIndexAPI
     end
   end
 
+  get "/extra/info_checksums" do
+    etag_response do
+      file = tmp("versions.list")
+      FileUtils.rm_f(file)
+      # file = CompactIndex::VersionsFile.new(file.to_s, only_info_checksums: true)
+      file = CompactIndex::VersionsFile.new(file.to_s)
+      file.create(gems(gem_repo4))
+      seen = false
+      file.contents.lines.map do |line|
+        unless seen
+          seen = line == "---\n"
+          next line
+        end
+        line.sub!(/([^ ]+) .+? ([^ ]+)/, '\1 \2') or raise("Unexpected line: #{line.inspect}")
+      end.join
+    end
+  end
+
   get "/extra/info/:name" do
     etag_response do
       gem = gems(gem_repo4).find {|g| g.name == params[:name] }


### PR DESCRIPTION
Since bundler/rubygems do not use the actual versions list in /versions

Signed-off-by: Samuel Giddins <segiddins@segiddins.me>

<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)