### PR TITLE
Skip fiddle assertions if fiddle is not available

### DIFF
--- a/test/rubygems/test_gem_ext_cargo_builder.rb
+++ b/test/rubygems/test_gem_ext_cargo_builder.rb
@@ -3,7 +3,10 @@
 require_relative "helper"
 require "rubygems/ext"
 require "open3"
-require "fiddle"
+begin
+  require "fiddle"
+rescue LoadError
+end
 
 class TestGemExtCargoBuilder < Gem::TestCase
   def setup
@@ -150,6 +153,8 @@ class TestGemExtCargoBuilder < Gem::TestCase
   end
 
   def assert_ffi_handle(bundle, name)
+    return unless defined?(Fiddle)
+
     dylib_handle = Fiddle.dlopen bundle
     assert_nothing_raised { dylib_handle[name] }
   ensure
@@ -157,6 +162,8 @@ class TestGemExtCargoBuilder < Gem::TestCase
   end
 
   def refute_ffi_handle(bundle, name)
+    return unless defined?(Fiddle)
+
     dylib_handle = Fiddle.dlopen bundle
     assert_raise { dylib_handle[name] }
   ensure


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

fixup #8522

The top level of `fiddle` couldn't load in ruby core repository. We need to avoid that with `LoadError`.

## What is your fix for the problem, implemented in this PR?

omit the assertions with `fiddle` if it's not available.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
