### PR TITLE
Remove MD5 digesting of compact index responses

### DIFF
--- a/bundler/lib/bundler/compact_index_client.rb
+++ b/bundler/lib/bundler/compact_index_client.rb
@@ -28,11 +28,7 @@ module Bundler
   # It may be called concurrently without global interpreter lock in some Rubies.
   # As a result, some methods may look more complex than necessary to save memory or time.
   class CompactIndexClient
-    # NOTE: MD5 is here not because we expect a server to respond with it, but
-    # because we use it to generate the etag on first request during the upgrade
-    # to the compact index client that uses opaque etags saved to files.
-    # Remove once 2.5.0 has been out for a while.
-    SUPPORTED_DIGESTS = { "sha-256" => :SHA256, "md5" => :MD5 }.freeze
+    SUPPORTED_DIGESTS = { "sha-256" => :SHA256 }.freeze
     DEBUG_MUTEX = Thread::Mutex.new
 
     # info returns an Array of INFO Arrays. Each INFO Array has the following indices:


### PR DESCRIPTION
It has been over a year since the release, so let's stop MD5ing everything

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
