### PR TITLE
FIX: a remote tag might have been created prior

### DIFF
--- a/bundler/lib/bundler/gem_helper.rb
+++ b/bundler/lib/bundler/gem_helper.rb
@@ -158,7 +158,7 @@ module Bundler
     end
 
     def already_tagged?
-      return false unless sh(%w[git tag]).split(/\n/).include?(version_tag)
+      return false unless sh(%w[git fetch --tags]) && sh(%w[git tag]).split(/\n/).include?(version_tag)
       Bundler.ui.confirm "Tag #{version_tag} has already been created."
       true
     end


### PR DESCRIPTION
Our release action stopped working bc the rubygems task could not push the release tag as it was already created by another step by google-release-please.

As proposed by @deivid-rodriguez I'm providing a change that should fix this problem for the workflow.

As described in this comment https://github.com/rubygems/rubygems/issues/8493#issuecomment-2663142143
