### PR TITLE
Remove all but one usage of MD5

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -738,8 +738,6 @@ module Bundler
       command_name = current_command.name
       return if PARSEABLE_COMMANDS.include?(command_name)
 
-      return unless SharedHelpers.md5_available?
-
       require_relative "vendored_uri"
       remote = Source::Rubygems::Remote.new(Gem::URI("https://rubygems.org"))
       cache_path = Bundler.user_cache.join("compact_index", remote.cache_slug)

--- a/bundler/lib/bundler/compact_index_client/cache.rb
+++ b/bundler/lib/bundler/compact_index_client/cache.rb
@@ -52,7 +52,7 @@ module Bundler
         name = name.to_s
         # TODO: converge this into the info_root by hashing all filenames like info_etag_path
         if /[^a-z0-9_-]/.match?(name)
-          name += "-#{SharedHelpers.digest(:MD5).hexdigest(name).downcase}"
+          name += "-#{SharedHelpers.digest(:SHA256).hexdigest(name).downcase}"
           @special_characters_info_root.join(name)
         else
           @info_root.join(name)
@@ -61,7 +61,7 @@ module Bundler
 
       def info_etag_path(name)
         name = name.to_s
-        @info_etag_root.join("#{name}-#{SharedHelpers.digest(:MD5).hexdigest(name).downcase}")
+        @info_etag_root.join("#{name}-#{SharedHelpers.digest(:SHA256).hexdigest(name).downcase}")
       end
 
       def mkdir(name)

--- a/bundler/lib/bundler/fetcher/compact_index.rb
+++ b/bundler/lib/bundler/fetcher/compact_index.rb
@@ -47,10 +47,6 @@ module Bundler
       end
 
       def available?
-        unless SharedHelpers.md5_available?
-          Bundler.ui.debug("FIPS mode is enabled, bundler can't use the CompactIndex API")
-          return nil
-        end
         # Read info file checksums out of /versions, so we can know if gems are up to date
         compact_index_client.available?
       rescue CompactIndexClient::Updater::MismatchedChecksumError => e

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -185,19 +185,6 @@ module Bundler
       msg
     end
 
-    def md5_available?
-      return @md5_available if defined?(@md5_available)
-      @md5_available = begin
-        require "openssl"
-        ::OpenSSL::Digest.digest("MD5", "")
-        true
-      rescue LoadError
-        true
-      rescue ::OpenSSL::Digest::DigestError
-        false
-      end
-    end
-
     def digest(name)
       require "digest"
       Digest(name)

--- a/bundler/lib/bundler/source/rubygems/remote.rb
+++ b/bundler/lib/bundler/source/rubygems/remote.rb
@@ -21,14 +21,12 @@ module Bundler
         #
         def cache_slug
           @cache_slug ||= begin
-            return nil unless SharedHelpers.md5_available?
-
             cache_uri = original_uri || uri
 
             host = cache_uri.to_s.start_with?("file://") ? nil : cache_uri.host
 
             uri_parts = [host, cache_uri.user, cache_uri.port, cache_uri.path]
-            uri_digest = SharedHelpers.digest(:MD5).hexdigest(uri_parts.compact.join("."))
+            uri_digest = SharedHelpers.digest(:SHA256).hexdigest(uri_parts.compact.join("."))
 
             uri_parts[-1] = uri_digest
             uri_parts.compact.join(".")

--- a/bundler/spec/bundler/fetcher/compact_index_spec.rb
+++ b/bundler/spec/bundler/fetcher/compact_index_spec.rb
@@ -39,45 +39,6 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
       it "returns true" do
         expect(compact_index).to be_available
       end
-
-      context "when OpenSSL is not available" do
-        before do
-          allow(compact_index).to receive(:require).with("openssl").and_raise(LoadError)
-        end
-
-        it "returns true" do
-          expect(compact_index).to be_available
-        end
-      end
-
-      context "when OpenSSL is FIPS-enabled" do
-        def remove_cached_md5_availability
-          return unless Bundler::SharedHelpers.instance_variable_defined?(:@md5_available)
-          Bundler::SharedHelpers.remove_instance_variable(:@md5_available)
-        end
-
-        before do
-          remove_cached_md5_availability
-          stub_const("OpenSSL::OPENSSL_FIPS", true)
-        end
-
-        after { remove_cached_md5_availability }
-
-        context "when FIPS-mode is active" do
-          before do
-            allow(OpenSSL::Digest).to receive(:digest).with("MD5", "").
-              and_raise(OpenSSL::Digest::DigestError)
-          end
-
-          it "returns false" do
-            expect(compact_index).to_not be_available
-          end
-        end
-
-        it "returns true" do
-          expect(compact_index).to be_available
-        end
-      end
     end
 
     context "logging" do

--- a/bundler/spec/bundler/source/rubygems/remote_spec.rb
+++ b/bundler/spec/bundler/source/rubygems/remote_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Bundler::Source::Rubygems::Remote do
   end
 
   before do
-    allow(Digest(:MD5)).to receive(:hexdigest).with(duck_type(:to_s)) {|string| "MD5HEX(#{string})" }
+    allow(Digest(:SHA256)).to receive(:hexdigest).with(duck_type(:to_s)) {|string| "SHA256HEX(#{string})" }
   end
 
   let(:uri_no_auth) { Gem::URI("https://gems.example.com") }
@@ -42,12 +42,12 @@ RSpec.describe Bundler::Source::Rubygems::Remote do
 
     describe "#cache_slug" do
       it "returns the correct slug" do
-        expect(remote(uri_no_auth).cache_slug).to eq("gems.example.com.443.MD5HEX(gems.example.com.443./)")
+        expect(remote(uri_no_auth).cache_slug).to eq("gems.example.com.443.SHA256HEX(gems.example.com.443./)")
       end
 
       it "only applies the given user" do
         Bundler.settings.temporary(uri_no_auth.to_s => credentials) do
-          expect(remote(uri_no_auth).cache_slug).to eq("gems.example.com.username.443.MD5HEX(gems.example.com.username.443./)")
+          expect(remote(uri_no_auth).cache_slug).to eq("gems.example.com.username.443.SHA256HEX(gems.example.com.username.443./)")
         end
       end
     end
@@ -78,12 +78,12 @@ RSpec.describe Bundler::Source::Rubygems::Remote do
 
     describe "#cache_slug" do
       it "returns the correct slug" do
-        expect(remote(uri_with_auth).cache_slug).to eq("gems.example.com.username.443.MD5HEX(gems.example.com.username.443./)")
+        expect(remote(uri_with_auth).cache_slug).to eq("gems.example.com.username.443.SHA256HEX(gems.example.com.username.443./)")
       end
 
       it "does not apply given credentials" do
         Bundler.settings.temporary(uri_with_auth.to_s => credentials)
-        expect(remote(uri_with_auth).cache_slug).to eq("gems.example.com.username.443.MD5HEX(gems.example.com.username.443./)")
+        expect(remote(uri_with_auth).cache_slug).to eq("gems.example.com.username.443.SHA256HEX(gems.example.com.username.443./)")
       end
     end
   end
@@ -99,7 +99,7 @@ RSpec.describe Bundler::Source::Rubygems::Remote do
 
     describe "#cache_slug" do
       it "returns the correct slug" do
-        expect(remote(uri).cache_slug).to eq("gem.fury.io.SeCrEt-ToKeN.443.MD5HEX(gem.fury.io.SeCrEt-ToKeN.443./me/)")
+        expect(remote(uri).cache_slug).to eq("gem.fury.io.SeCrEt-ToKeN.443.SHA256HEX(gem.fury.io.SeCrEt-ToKeN.443./me/)")
       end
     end
   end
@@ -126,7 +126,7 @@ RSpec.describe Bundler::Source::Rubygems::Remote do
     end
 
     specify "#cache_slug returns the correct slug" do
-      expect(remote(uri).cache_slug).to eq("rubygems.org.443.MD5HEX(rubygems.org.443./)")
+      expect(remote(uri).cache_slug).to eq("rubygems.org.443.SHA256HEX(rubygems.org.443./)")
     end
   end
 
@@ -158,7 +158,7 @@ RSpec.describe Bundler::Source::Rubygems::Remote do
     end
 
     specify "#cache_slug returns the original source" do
-      expect(remote(uri).cache_slug).to eq("rubygems.org.443.MD5HEX(rubygems.org.443./)")
+      expect(remote(uri).cache_slug).to eq("rubygems.org.443.SHA256HEX(rubygems.org.443./)")
     end
   end
 

--- a/bundler/spec/install/global_cache_spec.rb
+++ b/bundler/spec/install/global_cache_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe "global gem caching" do
       G
 
       gem_binary_cache = home(".bundle", "cache", "extensions", local_platform.to_s, Bundler.ruby_scope,
-        "gem.repo1.443.#{Digest(:MD5).hexdigest("gem.repo1.443./")}", "very_simple_binary-1.0")
+        "gem.repo1.443.#{Digest(:SHA256).hexdigest("gem.repo1.443./")}", "very_simple_binary-1.0")
       git_binary_cache = home(".bundle", "cache", "extensions", local_platform.to_s, Bundler.ruby_scope,
         "very_simple_git_binary-1.0-#{revision}", "very_simple_git_binary-1.0")
 

--- a/bundler/spec/support/artifice/helpers/compact_index.rb
+++ b/bundler/spec/support/artifice/helpers/compact_index.rb
@@ -18,7 +18,7 @@ class CompactIndexAPI < Endpoint
 
     def etag_response
       response_body = yield
-      etag = Digest::MD5.hexdigest(response_body)
+      etag = Digest::SHA256.hexdigest(response_body)
       headers "ETag" => quote(etag)
       return if not_modified?(etag)
       headers "Repr-Digest" => "sha-256=:#{Digest::SHA256.base64digest(response_body)}:"


### PR DESCRIPTION
This will not yet be ready to merge, I just want to see if we can smoothly transition away from MD5 _if_ we have a non-MD5 info checksum (which will require some work both on rubygems.org, and also backwards compatibility support in Bundler)

Signed-off-by: Samuel Giddins <segiddins@segiddins.me>

<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)