### PR TITLE
Detect partial gem installs from a git source so that they are reinstalled on a successive run

### DIFF
--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -360,7 +360,11 @@ module Bundler
       end
 
       def locked_revision_checked_out?
-        locked_revision && locked_revision == revision && install_path.exist?
+        locked_revision && locked_revision == revision && installed?
+      end
+
+      def installed?
+        git_proxy.installed_to?(install_path)
       end
 
       def base_name

--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -147,6 +147,12 @@ module Bundler
           end
         end
 
+        def installed_to?(destination)
+          # if copy_to is interrupted, it may leave a partially installed directory that
+          # contains .git but no other files -- consider this not to be installed
+          Dir.exist?(destination) && (Dir.children(destination) - [".git"]).any?
+        end
+
         private
 
         def git_remote_fetch(args)

--- a/bundler/spec/bundler/source/git/git_proxy_spec.rb
+++ b/bundler/spec/bundler/source/git/git_proxy_spec.rb
@@ -211,4 +211,45 @@ RSpec.describe Bundler::Source::Git::GitProxy do
       subject.checkout
     end
   end
+
+  describe "#installed_to?" do
+    let(:destination) { "install/dir" }
+    let(:destination_dir_exists) { true }
+    let(:children) { ["gem.gemspec", "README.me", ".git", "Rakefile"] }
+
+    before do
+      allow(Dir).to receive(:exist?).with(destination).and_return(destination_dir_exists)
+      allow(Dir).to receive(:children).with(destination).and_return(children)
+    end
+
+    context "when destination dir exists with children other than just .git" do
+      it "returns true" do
+        expect(git_proxy.installed_to?(destination)).to be true
+      end
+    end
+
+    context "when destination dir does not exist" do
+      let(:destination_dir_exists) { false }
+
+      it "returns false" do
+        expect(git_proxy.installed_to?(destination)).to be false
+      end
+    end
+
+    context "when destination dir is empty" do
+      let(:children) { [] }
+
+      it "returns false" do
+        expect(git_proxy.installed_to?(destination)).to be false
+      end
+    end
+
+    context "when destination dir has only .git directory" do
+      let(:children) { [".git"] }
+
+      it "returns false" do
+        expect(git_proxy.installed_to?(destination)).to be false
+      end
+    end
+  end
 end

--- a/bundler/spec/bundler/source/git_spec.rb
+++ b/bundler/spec/bundler/source/git_spec.rb
@@ -70,4 +70,54 @@ RSpec.describe Bundler::Source::Git do
       end
     end
   end
+
+  describe "#locked_revision_checked_out?" do
+    let(:revision) { "abc" }
+    let(:git_proxy_revision) { revision }
+    let(:git_proxy_installed) { true }
+    let(:git_proxy) { subject.send(:git_proxy) }
+    let(:options) do
+      {
+        "uri" => uri,
+        "revision" => revision,
+      }
+    end
+
+    before do
+      allow(git_proxy).to receive(:revision).and_return(git_proxy_revision)
+      allow(git_proxy).to receive(:installed_to?).with(subject.install_path).and_return(git_proxy_installed)
+    end
+
+    context "when the locked revision is checked out" do
+      it "returns true" do
+        expect(subject.send(:locked_revision_checked_out?)).to be true
+      end
+    end
+
+    context "when no revision is provided" do
+      let(:options) do
+        { "uri" => uri }
+      end
+
+      it "returns falsey value" do
+        expect(subject.send(:locked_revision_checked_out?)).to be_falsey
+      end
+    end
+
+    context "when the git proxy revision is different than the git revision" do
+      let(:git_proxy_revision) { revision.next }
+
+      it "returns falsey value" do
+        expect(subject.send(:locked_revision_checked_out?)).to be_falsey
+      end
+    end
+
+    context "when the gem hasn't been installed" do
+      let(:git_proxy_installed) { false }
+
+      it "returns falsey value" do
+        expect(subject.send(:locked_revision_checked_out?)).to be_falsey
+      end
+    end
+  end
 end

--- a/bundler/spec/install/git_spec.rb
+++ b/bundler/spec/install/git_spec.rb
@@ -214,5 +214,80 @@ RSpec.describe "bundle install" do
       expect(out).to include("Using foo 1.0 from #{lib_path("foo")} (at main@#{rev[0..6]})")
       expect(the_bundle).to include_gems "foo 1.0", source: "git@#{lib_path("foo")}"
     end
+
+    context "when install directory exists" do
+      let(:checkout_confirmation_log_message) { "Checking out revision" }
+      let(:using_foo_confirmation_log_message) { "Using foo 1.0 from #{lib_path("foo")} (at main@#{revision_for(lib_path("foo"))[0..6]})" }
+
+      context "and no contents besides .git directory are present" do
+        it "reinstalls gem" do
+          build_git "foo", "1.0", path: lib_path("foo")
+
+          gemfile = <<-G
+            source "https://gem.repo1"
+            gem "foo", :git => "#{lib_path("foo")}"
+          G
+
+          install_gemfile gemfile, verbose: true
+
+          expect(out).to include(checkout_confirmation_log_message)
+          expect(out).to include(using_foo_confirmation_log_message)
+          expect(the_bundle).to include_gems "foo 1.0", source: "git@#{lib_path("foo")}"
+
+          # validate that the installed directory exists and has some expected contents
+          install_directory = system_gem_path("bundler/gems/foo-#{revision_for(lib_path("foo"))[0..11]}")
+          dot_git_directory = install_directory.join(".git")
+          lib_directory = install_directory.join("lib")
+          gemspec = install_directory.join("foo.gemspec")
+          expect([install_directory, dot_git_directory, lib_directory, gemspec]).to all exist
+
+          # remove all elements in the install directory except .git directory
+          FileUtils.rm_rf(lib_directory)
+          gemspec.delete
+
+          expect(dot_git_directory).to exist
+          expect(lib_directory).not_to exist
+          expect(gemspec).not_to exist
+
+          # rerun bundle install
+          install_gemfile gemfile, verbose: true
+
+          expect(out).to include(checkout_confirmation_log_message)
+          expect(out).to include(using_foo_confirmation_log_message)
+          expect(the_bundle).to include_gems "foo 1.0", source: "git@#{lib_path("foo")}"
+
+          # validate that it reinstalls all components
+          expect([install_directory, dot_git_directory, lib_directory, gemspec]).to all exist
+        end
+      end
+
+      context "and contents besides .git directory are present" do
+        # we want to confirm that the change to try to detect partial installs and reinstall does not
+        # result in repeatedly reinstalling the gem when it is fully installed
+        it "does not reinstall gem" do
+          build_git "foo", "1.0", path: lib_path("foo")
+
+          gemfile = <<-G
+            source "https://gem.repo1"
+            gem "foo", :git => "#{lib_path("foo")}"
+          G
+
+          install_gemfile gemfile, verbose: true
+
+          expect(out).to include(checkout_confirmation_log_message)
+          expect(out).to include(using_foo_confirmation_log_message)
+          expect(the_bundle).to include_gems "foo 1.0", source: "git@#{lib_path("foo")}"
+
+          # rerun bundle install
+          install_gemfile gemfile, verbose: true
+
+          # it isn't altogether straight-forward to validate that bundle didn't do soething on the second run, however,
+          # the presence of the 2nd log message confirms install got past the point that it would have logged the above if
+          # it was going to
+          expect(out).not_to include(checkout_confirmation_log_message)
+          expect(out).to include(using_foo_confirmation_log_message)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

As described in detail in https://github.com/rubygems/rubygems/issues/8473, git-sourced gem installs can be left in a partially-installed state, for instance from a Ctrl-C at the right instant. On the next `bundle install`, that results in an error like:

```
Your bundle is locked to rails (7.2.2.1) from https://github.com/rails/rails.git (at 7-2-stable@c5c1705), but that
version can no longer be found in that source. That means the author of rails (7.2.2.1) has removed it. You'll
need to update your bundle to a version other than rails (7.2.2.1) that hasn't been removed in order to install.
```

When this happens, it generally requires manually deleting the partially-installed directory.

## What is your fix for the problem, implemented in this PR?

I changed the logic for detecting whether a locked revision is checked out. One of its checks previously just validated whether the install directory existed, but now also validates that there is something present besides just the `.git` directory in the install directory. This will result in a bundle install reinstalling the gem when only `.git` is present. Although it would be possible to be more thorough, that check covers the cases we have actually observed, and it avoids some downsides of other approaches. Further discussion can be found in [the issue](https://github.com/rubygems/rubygems/issues/8473) mentioned above.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)