### PR TITLE
Fix `gem rdoc` not working with newer versions of rdoc

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -50,6 +50,10 @@ jobs:
         run: |
           ruby -Ilib -S rake install 2> errors.txt || (cat errors.txt && exit 1)
           test ! -s errors.txt || (cat errors.txt && exit 1)
+      - name: Check generating documentation with a non default rdoc
+        run: |
+          gem install rdoc
+          gem rdoc rdoc | grep -q "Parsing documentation"
       - name: Run a local rubygems command
         run: gem list bundler
         env:

--- a/lib/rubygems/rdoc.rb
+++ b/lib/rubygems/rdoc.rb
@@ -5,8 +5,6 @@ require_relative "../rubygems"
 begin
   require "rdoc/rubygems_hook"
   module Gem
-    RDoc = ::RDoc::RubygemsHook
-
     ##
     # Returns whether RDoc defines its own install hooks through a RubyGems
     # plugin. This and whatever is guarded by it can be removed once no
@@ -15,8 +13,14 @@ begin
     def self.rdoc_hooks_defined_via_plugin?
       Gem::Version.new(::RDoc::VERSION) >= Gem::Version.new("6.9.0")
     end
-  end
 
-  Gem.done_installing(&Gem::RDoc.method(:generation_hook)) unless Gem.rdoc_hooks_defined_via_plugin?
+    if rdoc_hooks_defined_via_plugin?
+      RDoc = ::RDoc::RubyGemsHook
+    else
+      RDoc = ::RDoc::RubygemsHook
+
+      Gem.done_installing(&Gem::RDoc.method(:generation_hook))
+    end
+  end
 rescue LoadError
 end

--- a/test/rubygems/test_gem_rdoc.rb
+++ b/test/rubygems/test_gem_rdoc.rb
@@ -18,19 +18,7 @@ class TestGemRDoc < Gem::TestCase
 
     install_gem @a
 
-    hook_class = if defined?(RDoc::RubyGemsHook)
-      RDoc::RubyGemsHook
-    else
-      Gem::RDoc
-    end
-
-    @hook = hook_class.new @a
-
-    begin
-      hook_class.load_rdoc
-    rescue Gem::DocumentError => e
-      pend e.message
-    end
+    @hook = Gem::RDoc.new @a
 
     Gem.configuration[:rdoc] = nil
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When the latest version of rdoc present in the system is not the default one, `gem rdoc` fails to generate documentation.
 
## What is your fix for the problem, implemented in this PR?

The problem was RubyGems was using a legacy version of the generation class that skips generating documentation when it's not a default gem:

https://github.com/ruby/rdoc/blob/c23bf636f52f603d8300b7ca73d868801817608a/lib/rdoc/rubygems_hook.rb#L289

We need to make sure to use the new class, which has the same name but different casing.

Fixes #8548.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
