### PR TITLE
Prefer `FileUtils.rm_r` specs since it does not swallow errors

### DIFF
--- a/bundler/spec/cache/gems_spec.rb
+++ b/bundler/spec/cache/gems_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe "bundle cache" do
         expect(cached_gem("platform_specific-1.0-java")).to exist
       end
 
-      simulate_new_machine
+      pristine_system_gems :bundler
 
       simulate_platform "x86-darwin-100" do
         install_gemfile <<-G
@@ -312,7 +312,8 @@ RSpec.describe "bundle cache" do
         path: cached_myrack.parent,
         rubygems_version: "1.3.2"
 
-      simulate_new_machine
+      FileUtils.rm_rf default_bundle_path
+      system_gems :bundler
 
       FileUtils.rm bundled_app_lock
       bundle :install, raise_on_error: false
@@ -344,7 +345,8 @@ RSpec.describe "bundle cache" do
         c.checksum gem_repo1, "myrack", "1.0.0"
       end
 
-      simulate_new_machine
+      FileUtils.rm_rf default_bundle_path
+      system_gems :bundler
 
       lockfile <<-L
         GEM
@@ -369,7 +371,7 @@ RSpec.describe "bundle cache" do
       setup_main_repo
       cached_gem("myrack-1.0.0").rmtree
       build_gem "myrack", "1.0.0", path: bundled_app("vendor/cache")
-      simulate_new_machine
+      pristine_system_gems :bundler
 
       lockfile <<-L
         GEM

--- a/bundler/spec/cache/gems_spec.rb
+++ b/bundler/spec/cache/gems_spec.rb
@@ -312,7 +312,7 @@ RSpec.describe "bundle cache" do
         path: cached_myrack.parent,
         rubygems_version: "1.3.2"
 
-      FileUtils.rm_rf default_bundle_path
+      FileUtils.rm_r default_bundle_path
       system_gems :bundler
 
       FileUtils.rm bundled_app_lock
@@ -345,7 +345,7 @@ RSpec.describe "bundle cache" do
         c.checksum gem_repo1, "myrack", "1.0.0"
       end
 
-      FileUtils.rm_rf default_bundle_path
+      FileUtils.rm_r default_bundle_path
       system_gems :bundler
 
       lockfile <<-L

--- a/bundler/spec/cache/git_spec.rb
+++ b/bundler/spec/cache/git_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe "bundle cache with git" do
     bundle "config set path vendor/bundle"
     bundle :install
 
-    simulate_new_machine
+    pristine_system_gems :bundler
     with_path_as "" do
       bundle "config set deployment true"
       bundle "install --local"
@@ -181,10 +181,8 @@ RSpec.describe "bundle cache with git" do
     G
     bundle "config set cache_all true"
     bundle :cache, "all-platforms" => true
-    FileUtils.rm_rf Dir.glob(default_bundle_path("bundler/gems/extensions/**/foo-1.0-*")).first.to_s
-    FileUtils.rm_rf Dir.glob(default_bundle_path("bundler/gems/foo-1.0-*")).first.to_s
 
-    simulate_new_machine
+    pristine_system_gems :bundler
     bundle "config set frozen true"
     bundle "install --local --verbose"
     expect(out).to_not include("Fetching")
@@ -200,12 +198,9 @@ RSpec.describe "bundle cache with git" do
     G
     bundle "config set cache_all true"
     bundle :cache, "all-platforms" => true
-    FileUtils.rm_rf Dir.glob(default_bundle_path("bundler/gems/extensions/**/foo-1.0-*")).first.to_s
-    FileUtils.rm_rf Dir.glob(default_bundle_path("bundler/gems/foo-1.0-*")).first.to_s
 
-    simulate_new_machine
+    pristine_system_gems :bundler
     bundle "config set frozen true"
-    FileUtils.rm_rf "#{default_bundle_path}/cache/bundler/git/foo-1.0-*"
     bundle "install --local --verbose"
     expect(out).to_not include("Fetching")
     expect(the_bundle).to include_gem "foo 1.0"
@@ -220,12 +215,9 @@ RSpec.describe "bundle cache with git" do
     G
     bundle "config set cache_all true"
     bundle :cache, "all-platforms" => true
-    FileUtils.rm_rf Dir.glob(default_bundle_path("bundler/gems/extensions/**/foo-1.0-*")).first.to_s
-    FileUtils.rm_rf Dir.glob(default_bundle_path("bundler/gems/foo-1.0-*")).first.to_s
 
-    simulate_new_machine
+    pristine_system_gems :bundler
     bundle "config set frozen true"
-    FileUtils.rm_rf "#{default_bundle_path}/cache/bundler/git/foo-1.0-*"
 
     # Remove untracked files (including the empty refs dir in the cache)
     Dir.chdir(bundled_app) do
@@ -388,7 +380,7 @@ RSpec.describe "bundle cache with git" do
     bundle "config set cache_all true"
     bundle :cache, "all-platforms" => true, :install => false
 
-    simulate_new_machine
+    pristine_system_gems :bundler
     with_path_as "" do
       bundle "config set deployment true"
       bundle :install, local: true

--- a/bundler/spec/cache/git_spec.rb
+++ b/bundler/spec/cache/git_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "bundle cache with git" do
     expect(bundled_app("vendor/cache/foo-1.0-#{ref}/.git")).not_to exist
     expect(bundled_app("vendor/cache/foo-1.0-#{ref}/.bundlecache")).to be_file
 
-    FileUtils.rm_rf lib_path("foo-1.0")
+    FileUtils.rm_r lib_path("foo-1.0")
     expect(the_bundle).to include_gems "foo 1.0"
   end
 
@@ -49,7 +49,7 @@ RSpec.describe "bundle cache with git" do
     expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist
     expect(bundled_app("vendor/cache/foo-1.0-#{ref}/.git")).not_to exist
 
-    FileUtils.rm_rf lib_path("foo-1.0")
+    FileUtils.rm_r lib_path("foo-1.0")
     expect(the_bundle).to include_gems "foo 1.0"
   end
 
@@ -66,7 +66,7 @@ RSpec.describe "bundle cache with git" do
     bundle :cache
 
     expect(out).to include "Updating files in vendor/cache"
-    FileUtils.rm_rf lib_path("foo-1.0")
+    FileUtils.rm_r lib_path("foo-1.0")
     expect(the_bundle).to include_gems "foo 1.0"
   end
 
@@ -95,7 +95,7 @@ RSpec.describe "bundle cache with git" do
     expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist
     expect(bundled_app("vendor/cache/foo-1.0-#{old_ref}")).not_to exist
 
-    FileUtils.rm_rf lib_path("foo-1.0")
+    FileUtils.rm_r lib_path("foo-1.0")
     run "require 'foo'"
     expect(out).to eq("CACHE")
   end
@@ -124,7 +124,7 @@ RSpec.describe "bundle cache with git" do
     expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist
     expect(bundled_app("vendor/cache/foo-1.0-#{old_ref}")).not_to exist
 
-    FileUtils.rm_rf lib_path("foo-1.0")
+    FileUtils.rm_r lib_path("foo-1.0")
     run "require 'foo'"
     expect(out).to eq("CACHE")
   end
@@ -249,7 +249,7 @@ RSpec.describe "bundle cache with git" do
     # Simulate old cache by copying the real cache folder to vendor/cache
     FileUtils.mkdir_p bundled_app("vendor/cache")
     FileUtils.cp_r "#{Dir.glob(vendored_gems("cache/bundler/git/foo-1.0-*")).first}/.", cache_dir
-    FileUtils.rm_rf bundled_app("vendor/bundle")
+    FileUtils.rm_r bundled_app("vendor/bundle")
 
     bundle "install --local --verbose"
     expect(err).to include("Installing from cache in old \"bare repository\" format for compatibility")
@@ -281,7 +281,7 @@ RSpec.describe "bundle cache with git" do
     # Simulate old cache by copying the real cache folder to vendor/cache
     FileUtils.mkdir_p bundled_app("vendor/cache")
     FileUtils.cp_r "#{Dir.glob(vendored_gems("cache/bundler/git/foo-1.0-*")).first}/.", cache_dir
-    FileUtils.rm_rf bundled_app("vendor/bundle")
+    FileUtils.rm_r bundled_app("vendor/bundle")
 
     bundle "install --verbose"
     expect(out).to include("Fetching")
@@ -423,7 +423,7 @@ RSpec.describe "bundle cache with git" do
     # Simulate an old incorrect situation where vendor/cache would be the install location of git gems
     FileUtils.mkdir_p bundled_app("vendor/cache")
     FileUtils.cp_r git_path, bundled_app("vendor/cache/foo-1.0-#{path_revision}")
-    FileUtils.rm_rf bundled_app("vendor/cache/foo-1.0-#{path_revision}/.git")
+    FileUtils.rm_r bundled_app("vendor/cache/foo-1.0-#{path_revision}/.git")
 
     bundle :install, env: { "BUNDLE_DEPLOYMENT" => "true", "BUNDLE_CACHE_ALL" => "true" }
   end

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -357,7 +357,7 @@ RSpec.describe "bundle install with gem sources" do
 
       bundle :cache
       pristine_system_gems :bundler
-      FileUtils.rm_rf gem_repo2
+      FileUtils.rm_r gem_repo2
 
       bundle "install --local"
       expect(the_bundle).to include_gems "myrack 1.0.0"
@@ -372,7 +372,7 @@ RSpec.describe "bundle install with gem sources" do
 
       bundle :cache
       pristine_system_gems :bundler
-      FileUtils.rm_rf gem_repo2
+      FileUtils.rm_r gem_repo2
 
       bundle "config set --local deployment true"
       bundle "config set --local path vendor/bundle"
@@ -389,7 +389,7 @@ RSpec.describe "bundle install with gem sources" do
 
       bundle :cache
       pristine_system_gems :bundler
-      FileUtils.rm_rf gem_repo2
+      FileUtils.rm_r gem_repo2
 
       bundle "config set --local cache_all_platforms true"
       bundle "config set --local path vendor/bundle"
@@ -449,7 +449,7 @@ RSpec.describe "bundle install with gem sources" do
         empty_repo4
 
         # delete compact index cache
-        FileUtils.rm_rf home(".bundle/cache/compact_index")
+        FileUtils.rm_r home(".bundle/cache/compact_index")
 
         bundle "install", artifice: "compact_index", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
 

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -356,7 +356,7 @@ RSpec.describe "bundle install with gem sources" do
       G
 
       bundle :cache
-      simulate_new_machine
+      pristine_system_gems :bundler
       FileUtils.rm_rf gem_repo2
 
       bundle "install --local"
@@ -371,7 +371,7 @@ RSpec.describe "bundle install with gem sources" do
       G
 
       bundle :cache
-      simulate_new_machine
+      pristine_system_gems :bundler
       FileUtils.rm_rf gem_repo2
 
       bundle "config set --local deployment true"
@@ -388,7 +388,7 @@ RSpec.describe "bundle install with gem sources" do
       G
 
       bundle :cache
-      simulate_new_machine
+      pristine_system_gems :bundler
       FileUtils.rm_rf gem_repo2
 
       bundle "config set --local cache_all_platforms true"
@@ -445,9 +445,8 @@ RSpec.describe "bundle install with gem sources" do
         bundle "config set path vendor/bundle"
         bundle :cache, artifice: "compact_index", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
 
-        build_repo4 do
-          # simulate removal of all remote gems
-        end
+        # simulate removal of all remote gems
+        empty_repo4
 
         # delete compact index cache
         FileUtils.rm_rf home(".bundle/cache/compact_index")
@@ -483,7 +482,7 @@ RSpec.describe "bundle install with gem sources" do
         bundle :cache
       end
 
-      simulate_new_machine
+      pristine_system_gems :bundler
 
       bundle "config set --local force_ruby_platform true"
 

--- a/bundler/spec/commands/check_spec.rb
+++ b/bundler/spec/commands/check_spec.rb
@@ -328,7 +328,8 @@ RSpec.describe "bundle check" do
     end
 
     it "shows what is missing with the current Gemfile if it is not satisfied" do
-      simulate_new_machine
+      FileUtils.rm_rf default_bundle_path
+      system_gems :bundler
       bundle :check, raise_on_error: false
       expect(err).to match(/The following gems are missing/)
       expect(err).to include("* myrack (1.0")

--- a/bundler/spec/commands/check_spec.rb
+++ b/bundler/spec/commands/check_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "bundle check" do
       gem "foo", git: "#{lib_path("foo")}"
     G
 
-    FileUtils.rm_rf bundled_app("vendor/bundle")
+    FileUtils.rm_r bundled_app("vendor/bundle")
     bundle :check, raise_on_error: false
     expect(exitstatus).to eq 1
     expect(err).to include("Bundler can't satisfy your Gemfile's dependencies.")
@@ -281,7 +281,7 @@ RSpec.describe "bundle check" do
         G
         bundle "install --path vendor/bundle"
 
-        FileUtils.rm_rf(bundled_app(".bundle"))
+        FileUtils.rm_r(bundled_app(".bundle"))
       end
 
       it "returns success" do
@@ -328,7 +328,7 @@ RSpec.describe "bundle check" do
     end
 
     it "shows what is missing with the current Gemfile if it is not satisfied" do
-      FileUtils.rm_rf default_bundle_path
+      FileUtils.rm_r default_bundle_path
       system_gems :bundler
       bundle :check, raise_on_error: false
       expect(err).to match(/The following gems are missing/)

--- a/bundler/spec/commands/clean_spec.rb
+++ b/bundler/spec/commands/clean_spec.rb
@@ -352,8 +352,8 @@ RSpec.describe "bundle clean" do
     bundle "install"
 
     FileUtils.rm(vendored_gems("bin/myrackup"))
-    FileUtils.rm_rf(vendored_gems("gems/thin-1.0"))
-    FileUtils.rm_rf(vendored_gems("gems/myrack-1.0.0"))
+    FileUtils.rm_r(vendored_gems("gems/thin-1.0"))
+    FileUtils.rm_r(vendored_gems("gems/myrack-1.0.0"))
 
     bundle :clean
 

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -1262,7 +1262,7 @@ RSpec.describe "bundle exec" do
       end
 
       it "allows calling bundle install after removing gem.build_complete" do
-        FileUtils.rm_rf Dir[bundled_app(".bundle/**/gem.build_complete")]
+        FileUtils.rm_r Dir[bundled_app(".bundle/**/gem.build_complete")]
         bundle "exec #{Gem.ruby} -S bundle install"
       end
     end

--- a/bundler/spec/commands/info_spec.rb
+++ b/bundler/spec/commands/info_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "bundle info" do
     end
 
     it "warns if path does not exist on disk, but specification is there" do
-      FileUtils.rm_rf(default_bundle_path("gems", "rails-2.3.2"))
+      FileUtils.rm_r(default_bundle_path("gems", "rails-2.3.2"))
 
       bundle "info rails --path"
 

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "bundle install with gem sources" do
         gem 'myrack'
       G
 
-      FileUtils.rm_rf(default_bundle_path("gems/myrack-1.0.0"))
+      FileUtils.rm_r(default_bundle_path("gems/myrack-1.0.0"))
 
       bundle "install --verbose"
 
@@ -337,13 +337,13 @@ RSpec.describe "bundle install with gem sources" do
       it "allows running bundle install --system without deleting foo", bundler: "< 3" do
         bundle "install --path vendor"
         bundle "install --system"
-        FileUtils.rm_rf(bundled_app("vendor"))
+        FileUtils.rm_r(bundled_app("vendor"))
         expect(the_bundle).to include_gems "myrack 1.0"
       end
 
       it "allows running bundle install --system after deleting foo", bundler: "< 3" do
         bundle "install --path vendor"
-        FileUtils.rm_rf(bundled_app("vendor"))
+        FileUtils.rm_r(bundled_app("vendor"))
         bundle "install --system"
         expect(the_bundle).to include_gems "myrack 1.0"
       end

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe "bundle lock" do
     L
   end
 
-  before :each do
+  let(:gemfile_with_rails_weakling_and_foo_from_repo4) do
     build_repo4 do
       FileUtils.cp rake_path, "#{gem_repo4}/gems/"
 
@@ -143,12 +143,16 @@ RSpec.describe "bundle lock" do
   end
 
   it "prints a lockfile when there is no existing lockfile with --print" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     bundle "lock --print"
 
     expect(out).to eq(expected_lockfile.chomp)
   end
 
   it "prints a lockfile when there is an existing lockfile with --print" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     lockfile expected_lockfile
 
     bundle "lock --print"
@@ -157,6 +161,8 @@ RSpec.describe "bundle lock" do
   end
 
   it "prints a lockfile when there is an existing checksums lockfile with --print" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     lockfile expected_lockfile
 
     bundle "lock --print"
@@ -165,12 +171,16 @@ RSpec.describe "bundle lock" do
   end
 
   it "writes a lockfile when there is no existing lockfile" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     bundle "lock"
 
     expect(read_lockfile).to eq(expected_lockfile)
   end
 
   it "prints a lockfile without fetching new checksums if the existing lockfile had no checksums" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     lockfile expected_lockfile
 
     bundle "lock --print"
@@ -179,6 +189,8 @@ RSpec.describe "bundle lock" do
   end
 
   it "touches the lockfile when there is an existing lockfile that does not need changes" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     lockfile expected_lockfile
 
     expect do
@@ -187,6 +199,8 @@ RSpec.describe "bundle lock" do
   end
 
   it "does not touch lockfile with --print" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     lockfile expected_lockfile
 
     expect do
@@ -195,6 +209,8 @@ RSpec.describe "bundle lock" do
   end
 
   it "writes a lockfile when there is an outdated lockfile using --update" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     lockfile outdated_lockfile
 
     bundle "lock --update"
@@ -203,6 +219,8 @@ RSpec.describe "bundle lock" do
   end
 
   it "prints an updated lockfile when there is an outdated lockfile using --print --update" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     lockfile outdated_lockfile
 
     bundle "lock --print --update"
@@ -211,6 +229,8 @@ RSpec.describe "bundle lock" do
   end
 
   it "emits info messages to stderr when updating an outdated lockfile using --print --update" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     lockfile outdated_lockfile
 
     bundle "lock --print --update"
@@ -222,6 +242,8 @@ RSpec.describe "bundle lock" do
   end
 
   it "writes a lockfile when there is an outdated lockfile and bundle is frozen" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     lockfile outdated_lockfile
 
     bundle "lock --update", env: { "BUNDLE_FROZEN" => "true" }
@@ -230,12 +252,16 @@ RSpec.describe "bundle lock" do
   end
 
   it "does not fetch remote specs when using the --local option" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     bundle "lock --update --local", raise_on_error: false
 
     expect(err).to match(/locally installed gems/)
   end
 
   it "does not fetch remote checksums with --local" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     lockfile expected_lockfile
 
     bundle "lock --print --local"
@@ -244,6 +270,8 @@ RSpec.describe "bundle lock" do
   end
 
   it "works with --gemfile flag" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     gemfile "CustomGemfile", <<-G
       source "https://gem.repo4"
       gem "foo"
@@ -275,6 +303,8 @@ RSpec.describe "bundle lock" do
   end
 
   it "writes to a custom location using --lockfile" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     bundle "lock --lockfile=lock"
 
     expect(out).to match(/Writing lockfile to.+lock/)
@@ -283,6 +313,8 @@ RSpec.describe "bundle lock" do
   end
 
   it "writes to custom location using --lockfile when a default lockfile is present" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     bundle "install"
     bundle "lock --lockfile=lock"
 
@@ -338,6 +370,8 @@ RSpec.describe "bundle lock" do
   end
 
   it "update specific gems using --update" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     checksums = checksums_section_when_enabled do |c|
       c.checksum gem_repo4, "actionmailer", "2.3.1"
       c.checksum gem_repo4, "actionpack", "2.3.1"
@@ -515,6 +549,8 @@ RSpec.describe "bundle lock" do
   end
 
   it "preserves unknown checksum algorithms" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     lockfile expected_lockfile.gsub(/(sha256=[a-f0-9]+)$/, "constant=true,\\1,xyz=123")
 
     previous_lockfile = read_lockfile
@@ -525,6 +561,8 @@ RSpec.describe "bundle lock" do
   end
 
   it "does not unlock git sources when only uri shape changes" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     build_git("foo")
 
     install_gemfile <<-G
@@ -543,6 +581,8 @@ RSpec.describe "bundle lock" do
   end
 
   it "updates specific gems using --update using the locked revision of unrelated git gems for resolving" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     ref = build_git("foo").ref_for("HEAD")
 
     gemfile <<-G
@@ -581,6 +621,8 @@ RSpec.describe "bundle lock" do
   end
 
   it "errors when updating a missing specific gems using --update" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     lockfile expected_lockfile
 
     bundle "lock --update blahblah", raise_on_error: false
@@ -590,6 +632,8 @@ RSpec.describe "bundle lock" do
   end
 
   it "can lock without downloading gems" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     gemfile <<-G
       source "https://gem.repo1"
 
@@ -762,6 +806,8 @@ RSpec.describe "bundle lock" do
   end
 
   it "supports adding new platforms when there's no previous lockfile" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     bundle "lock --add-platform java x86-mingw32 --verbose"
     expect(out).to include("Resolving dependencies because there's no lockfile")
 
@@ -770,6 +816,8 @@ RSpec.describe "bundle lock" do
   end
 
   it "supports adding new platforms when a previous lockfile exists" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     bundle "lock"
     bundle "lock --add-platform java x86-mingw32 --verbose"
     expect(out).to include("Found changes from the lockfile, re-resolving dependencies because you are adding a new platform to your lockfile")
@@ -835,6 +883,8 @@ RSpec.describe "bundle lock" do
   end
 
   it "supports adding new platforms with force_ruby_platform = true" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     lockfile <<-L
       GEM
         remote: https://gem.repo1/
@@ -858,6 +908,8 @@ RSpec.describe "bundle lock" do
   end
 
   it "supports adding the `ruby` platform" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     bundle "lock --add-platform ruby"
 
     allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
@@ -865,12 +917,16 @@ RSpec.describe "bundle lock" do
   end
 
   it "fails when adding an unknown platform" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     bundle "lock --add-platform foobarbaz", raise_on_error: false
     expect(err).to include("The platform `foobarbaz` is unknown to RubyGems and can't be added to the lockfile")
     expect(last_command).to be_failure
   end
 
   it "allows removing platforms" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     bundle "lock --add-platform java x86-mingw32"
 
     allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
@@ -944,6 +1000,8 @@ RSpec.describe "bundle lock" do
   end
 
   it "errors when removing all platforms" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
     bundle "lock --remove-platform #{local_platform}", raise_on_error: false
     expect(err).to include("Removing all platforms from the bundle is not allowed")
   end
@@ -1378,6 +1436,8 @@ RSpec.describe "bundle lock" do
 
   context "when an update is available" do
     before do
+      gemfile_with_rails_weakling_and_foo_from_repo4
+
       update_repo4 do
         build_gem "foo", "2.0"
       end

--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -974,7 +974,7 @@ RSpec.describe "bundle outdated" do
         gem "terranova", '8'
       G
 
-      simulate_new_machine
+      pristine_system_gems :bundler
 
       update_git "foo", path: lib_path("foo")
       update_repo2 do

--- a/bundler/spec/commands/outdated_spec.rb
+++ b/bundler/spec/commands/outdated_spec.rb
@@ -417,7 +417,7 @@ RSpec.describe "bundle outdated" do
     end
 
     it "doesn't hit repo2" do
-      FileUtils.rm_rf(gem_repo2)
+      FileUtils.rm_r(gem_repo2)
 
       bundle "outdated --local"
       expect(out).not_to match(/Fetching (gem|version|dependency) metadata from/)

--- a/bundler/spec/commands/show_spec.rb
+++ b/bundler/spec/commands/show_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "bundle show", bundler: "< 3" do
     end
 
     it "warns if specification is installed, but path does not exist on disk" do
-      FileUtils.rm_rf(default_bundle_path("gems", "rails-2.3.2"))
+      FileUtils.rm_r(default_bundle_path("gems", "rails-2.3.2"))
 
       bundle "show rails"
 

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -653,7 +653,7 @@ RSpec.describe "bundle update" do
 
         bundle "install"
 
-        FileUtils.rm_rf(gem_repo2)
+        FileUtils.rm_r(gem_repo2)
 
         bundle "update --local --all"
         expect(out).not_to include("Fetching source index")

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "install in deployment or frozen mode" do
 
   it "still works if you are not in the app directory and specify --gemfile" do
     bundle "install"
-    simulate_new_machine
+    pristine_system_gems :bundler
     bundle "config set --local deployment true"
     bundle "config set --local path vendor/bundle"
     bundle "install --gemfile #{tmp}/bundled_app/Gemfile", dir: tmp
@@ -547,7 +547,7 @@ RSpec.describe "install in deployment or frozen mode" do
       bundle "install --local"
       expect(out).to include("Updating files in vendor/cache")
 
-      simulate_new_machine
+      pristine_system_gems :bundler
       bundle "config set --local deployment true"
       bundle "install --verbose"
       expect(out).not_to include("but the lockfile can't be updated because frozen mode is set")

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "bundle install with git sources" do
     end
 
     it "does not write to cache on bundler/setup" do
-      FileUtils.rm_rf(default_cache_path)
+      FileUtils.rm_r(default_cache_path)
       ruby "require 'bundler/setup'"
       expect(default_cache_path).not_to exist
     end
@@ -1038,7 +1038,7 @@ RSpec.describe "bundle install with git sources" do
       gem "foo", :git => "#{lib_path("foo-1.0")}"
     G
 
-    FileUtils.rm_rf(lib_path("foo-1.0"))
+    FileUtils.rm_r(lib_path("foo-1.0"))
 
     bundle "install"
     expect(out).not_to match(/updating/i)

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -31,14 +31,13 @@ RSpec.describe "bundle install with git sources" do
     end
 
     it "does not write to cache on bundler/setup" do
-      cache_path = default_bundle_path("cache")
-      FileUtils.rm_rf(cache_path)
+      FileUtils.rm_rf(default_cache_path)
       ruby "require 'bundler/setup'"
-      expect(cache_path).not_to exist
+      expect(default_cache_path).not_to exist
     end
 
     it "caches the git repo globally and properly uses the cached repo on the next invocation" do
-      simulate_new_machine
+      pristine_system_gems :bundler
       bundle "config set global_gem_cache true"
       bundle :install
       expect(Dir["#{home}/.bundle/cache/git/foo-1.0-*"]).to have_attributes size: 1
@@ -1218,7 +1217,7 @@ RSpec.describe "bundle install with git sources" do
         gem "valim", "= 1.0", :git => "#{lib_path("valim")}"
       G
 
-      simulate_new_machine
+      pristine_system_gems :bundler
 
       bundle "config set --local deployment true"
       bundle :install
@@ -1605,7 +1604,7 @@ In Gemfile:
       G
       bundle "config set --global path vendor/bundle"
       bundle :install
-      simulate_new_machine
+      pristine_system_gems :bundler
 
       bundle "install", env: { "PATH" => "" }
       expect(out).to_not include("You need to install git to be able to use gems from git repositories.")

--- a/bundler/spec/install/gemfile/groups_spec.rb
+++ b/bundler/spec/install/gemfile/groups_spec.rb
@@ -394,7 +394,7 @@ RSpec.describe "bundle install with groups" do
     end
 
     it "does not hit the remote a second time" do
-      FileUtils.rm_rf gem_repo2
+      FileUtils.rm_r gem_repo2
       bundle "config set --local without myrack"
       bundle :install, verbose: true
       expect(last_command.stdboth).not_to match(/fetching/i)

--- a/bundler/spec/install/gemfile/platform_spec.rb
+++ b/bundler/spec/install/gemfile/platform_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe "bundle install across platforms" do
 
       expect(the_bundle).to include_gems "nokogiri 1.4.2 java", "weakling 0.0.3"
 
-      simulate_new_machine
+      pristine_system_gems :bundler
       bundle "config set --local force_ruby_platform true"
       bundle "install"
 

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -323,7 +323,7 @@ RSpec.describe "compact index api" do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
       end
-      FileUtils.rm_rf Dir[gem_repo2("gems/foo-*.gem")]
+      FileUtils.rm_r Dir[gem_repo2("gems/foo-*.gem")]
     end
 
     gemfile <<-G
@@ -341,7 +341,7 @@ RSpec.describe "compact index api" do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
       end
-      FileUtils.rm_rf Dir[gem_repo2("gems/foo-*.gem")]
+      FileUtils.rm_r Dir[gem_repo2("gems/foo-*.gem")]
     end
 
     install_gemfile <<-G, artifice: "compact_index_extra", verbose: true
@@ -406,7 +406,7 @@ RSpec.describe "compact index api" do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
       end
-      FileUtils.rm_rf Dir[gem_repo2("gems/foo-*.gem")]
+      FileUtils.rm_r Dir[gem_repo2("gems/foo-*.gem")]
     end
 
     gemfile <<-G
@@ -429,7 +429,7 @@ RSpec.describe "compact index api" do
       end
       build_gem "missing"
 
-      FileUtils.rm_rf Dir[gem_repo2("gems/foo-*.gem")]
+      FileUtils.rm_r Dir[gem_repo2("gems/foo-*.gem")]
     end
 
     install_gemfile <<-G, artifice: "compact_index_extra_missing"
@@ -449,7 +449,7 @@ RSpec.describe "compact index api" do
       end
       build_gem "missing"
 
-      FileUtils.rm_rf Dir[gem_repo4("gems/foo-*.gem")]
+      FileUtils.rm_r Dir[gem_repo4("gems/foo-*.gem")]
     end
 
     install_gemfile <<-G, artifice: "compact_index_extra_api_missing"
@@ -478,7 +478,7 @@ RSpec.describe "compact index api" do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
       end
-      FileUtils.rm_rf Dir[gem_repo2("gems/foo-*.gem")]
+      FileUtils.rm_r Dir[gem_repo2("gems/foo-*.gem")]
     end
 
     gemfile <<-G
@@ -498,7 +498,7 @@ RSpec.describe "compact index api" do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
       end
-      FileUtils.rm_rf Dir[gem_repo2("gems/foo-*.gem")]
+      FileUtils.rm_r Dir[gem_repo2("gems/foo-*.gem")]
     end
 
     gemfile <<-G

--- a/bundler/spec/install/gems/dependency_api_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe "gemcutter's dependency API" do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
       end
-      FileUtils.rm_rf Dir[gem_repo2("gems/foo-*.gem")]
+      FileUtils.rm_r Dir[gem_repo2("gems/foo-*.gem")]
     end
 
     gemfile <<-G
@@ -278,7 +278,7 @@ RSpec.describe "gemcutter's dependency API" do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
       end
-      FileUtils.rm_rf Dir[gem_repo2("gems/foo-*.gem")]
+      FileUtils.rm_r Dir[gem_repo2("gems/foo-*.gem")]
     end
 
     gemfile <<-G
@@ -343,7 +343,7 @@ RSpec.describe "gemcutter's dependency API" do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
       end
-      FileUtils.rm_rf Dir[gem_repo2("gems/foo-*.gem")]
+      FileUtils.rm_r Dir[gem_repo2("gems/foo-*.gem")]
     end
 
     gemfile <<-G
@@ -366,7 +366,7 @@ RSpec.describe "gemcutter's dependency API" do
       end
       build_gem "missing"
 
-      FileUtils.rm_rf Dir[gem_repo2("gems/foo-*.gem")]
+      FileUtils.rm_r Dir[gem_repo2("gems/foo-*.gem")]
     end
 
     install_gemfile <<-G, artifice: "endpoint_extra_missing"
@@ -385,7 +385,7 @@ RSpec.describe "gemcutter's dependency API" do
       end
       build_gem "missing"
 
-      FileUtils.rm_rf Dir[gem_repo2("gems/foo-*.gem")]
+      FileUtils.rm_r Dir[gem_repo2("gems/foo-*.gem")]
     end
 
     install_gemfile <<-G, artifice: "endpoint_extra_missing"
@@ -403,7 +403,7 @@ RSpec.describe "gemcutter's dependency API" do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
       end
-      FileUtils.rm_rf Dir[gem_repo2("gems/foo-*.gem")]
+      FileUtils.rm_r Dir[gem_repo2("gems/foo-*.gem")]
     end
 
     gemfile <<-G
@@ -423,7 +423,7 @@ RSpec.describe "gemcutter's dependency API" do
       build_gem "back_deps" do |s|
         s.add_dependency "foo"
       end
-      FileUtils.rm_rf Dir[gem_repo2("gems/foo-*.gem")]
+      FileUtils.rm_r Dir[gem_repo2("gems/foo-*.gem")]
     end
 
     gemfile <<-G

--- a/bundler/spec/install/git_spec.rb
+++ b/bundler/spec/install/git_spec.rb
@@ -242,7 +242,7 @@ RSpec.describe "bundle install" do
           expect([install_directory, dot_git_directory, lib_directory, gemspec]).to all exist
 
           # remove all elements in the install directory except .git directory
-          FileUtils.rm_rf(lib_directory)
+          FileUtils.rm_r(lib_directory)
           gemspec.delete
 
           expect(dot_git_directory).to exist

--- a/bundler/spec/install/global_cache_spec.rb
+++ b/bundler/spec/install/global_cache_spec.rb
@@ -51,12 +51,14 @@ RSpec.describe "global gem caching" do
 
     describe "when the same gem from different sources is installed" do
       it "should use the appropriate one from the global cache" do
+        bundle "config path.system true"
+
         install_gemfile <<-G, artifice: "compact_index"
           source "#{source}"
           gem "myrack"
         G
 
-        simulate_new_machine
+        pristine_system_gems :bundler
         expect(the_bundle).not_to include_gems "myrack 1.0.0"
         expect(source_global_cache("myrack-1.0.0.gem")).to exist
         # myrack 1.0.0 is not installed and it is in the global cache
@@ -66,7 +68,7 @@ RSpec.describe "global gem caching" do
           gem "myrack", "0.9.1"
         G
 
-        simulate_new_machine
+        pristine_system_gems :bundler
         expect(the_bundle).not_to include_gems "myrack 0.9.1"
         expect(source2_global_cache("myrack-0.9.1.gem")).to exist
         # myrack 0.9.1 is not installed and it is in the global cache
@@ -80,7 +82,7 @@ RSpec.describe "global gem caching" do
         # myrack 1.0.0 is installed and myrack 0.9.1 is not
         expect(the_bundle).to include_gems "myrack 1.0.0"
         expect(the_bundle).not_to include_gems "myrack 0.9.1"
-        simulate_new_machine
+        pristine_system_gems :bundler
 
         gemfile <<-G
           source "#{source2}"
@@ -94,13 +96,15 @@ RSpec.describe "global gem caching" do
       end
 
       it "should not install if the wrong source is provided" do
+        bundle "config path.system true"
+
         gemfile <<-G
           source "#{source}"
           gem "myrack"
         G
 
         bundle :install, artifice: "compact_index"
-        simulate_new_machine
+        pristine_system_gems :bundler
         expect(the_bundle).not_to include_gems "myrack 1.0.0"
         expect(source_global_cache("myrack-1.0.0.gem")).to exist
         # myrack 1.0.0 is not installed and it is in the global cache
@@ -111,7 +115,7 @@ RSpec.describe "global gem caching" do
         G
 
         bundle :install, artifice: "compact_index"
-        simulate_new_machine
+        pristine_system_gems :bundler
         expect(the_bundle).not_to include_gems "myrack 0.9.1"
         expect(source2_global_cache("myrack-0.9.1.gem")).to exist
         # myrack 0.9.1 is not installed and it is in the global cache
@@ -150,6 +154,8 @@ RSpec.describe "global gem caching" do
 
     describe "when installing gems from a different directory" do
       it "uses the global cache as a source" do
+        bundle "config path.system true"
+
         install_gemfile <<-G, artifice: "compact_index"
           source "#{source}"
           gem "myrack"
@@ -161,7 +167,7 @@ RSpec.describe "global gem caching" do
         expect(the_bundle).to include_gems "activesupport 2.3.5"
         expect(source_global_cache("myrack-1.0.0.gem")).to exist
         expect(source_global_cache("activesupport-2.3.5.gem")).to exist
-        simulate_new_machine
+        pristine_system_gems :bundler
         # Both gems are now only in the global cache
         expect(the_bundle).not_to include_gems "myrack 1.0.0"
         expect(the_bundle).not_to include_gems "activesupport 2.3.5"

--- a/bundler/spec/install/global_cache_spec.rb
+++ b/bundler/spec/install/global_cache_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe "global gem caching" do
       R
       expect(out).to eq "VERY_SIMPLE_BINARY_IN_C\nVERY_SIMPLE_GIT_BINARY_IN_C"
 
-      FileUtils.rm_rf Dir[home(".bundle", "cache", "extensions", "**", "*binary_c*")]
+      FileUtils.rm_r Dir[home(".bundle", "cache", "extensions", "**", "*binary_c*")]
 
       gem_binary_cache.join("very_simple_binary_c.rb").open("w") {|f| f << "puts File.basename(__FILE__)" }
       git_binary_cache.join("very_simple_git_binary_c.rb").open("w") {|f| f << "puts File.basename(__FILE__)" }

--- a/bundler/spec/install/path_spec.rb
+++ b/bundler/spec/install/path_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "bundle install" do
 
     it "remembers to disable system gems after the first time with bundle --path vendor/bundle", bundler: "< 3" do
       bundle "install --path vendor/bundle"
-      FileUtils.rm_rf bundled_app("vendor")
+      FileUtils.rm_r bundled_app("vendor")
       bundle "install"
 
       expect(vendored_gems("gems/myrack-1.0.0")).to be_directory

--- a/bundler/spec/install/prereleases_spec.rb
+++ b/bundler/spec/install/prereleases_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "bundle install" do
       build_repo3 do
         build_gem "myrack"
       end
-      FileUtils.rm_rf Dir[gem_repo3("prerelease*")]
+      FileUtils.rm_r Dir[gem_repo3("prerelease*")]
 
       install_gemfile <<-G
         source "https://gem.repo3"

--- a/bundler/spec/install/yanked_spec.rb
+++ b/bundler/spec/install/yanked_spec.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.context "when installing a bundle that includes yanked gems" do
-  before(:each) do
+  it "throws an error when the original gem version is yanked" do
     build_repo4 do
       build_gem "foo", "9.0.0"
     end
-  end
 
-  it "throws an error when the original gem version is yanked" do
     lockfile <<-L
        GEM
          remote: https://gem.repo4
@@ -116,6 +114,10 @@ RSpec.context "when installing a bundle that includes yanked gems" do
   end
 
   it "throws the original error when only the Gemfile specifies a gem version that doesn't exist" do
+    build_repo4 do
+      build_gem "foo", "9.0.0"
+    end
+
     bundle "config set force_ruby_platform true"
 
     install_gemfile <<-G, raise_on_error: false

--- a/bundler/spec/lock/git_spec.rb
+++ b/bundler/spec/lock/git_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "bundle lock with git gems" do
   it "doesn't print errors even if running lock after removing the cache" do
     install_gemfile_with_foo_as_a_git_dependency
 
-    FileUtils.rm_rf(Dir[default_cache_path("git/foo-1.0-*")].first)
+    FileUtils.rm_r(Dir[default_cache_path("git/foo-1.0-*")].first)
 
     bundle "lock --verbose"
 

--- a/bundler/spec/plugins/source/example_spec.rb
+++ b/bundler/spec/plugins/source/example_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe "real source plugins" do
         expect(bundled_app("vendor/cache/a-path-gem-1.0-#{uri_hash}/.git")).not_to exist
         expect(bundled_app("vendor/cache/a-path-gem-1.0-#{uri_hash}/.bundlecache")).to be_file
 
-        FileUtils.rm_rf lib_path("a-path-gem-1.0")
+        FileUtils.rm_r lib_path("a-path-gem-1.0")
         expect(the_bundle).to include_gems("a-path-gem 1.0")
       end
 
@@ -143,7 +143,7 @@ RSpec.describe "real source plugins" do
 
         expect(bundled_app("vendor/cache/a-path-gem-1.0-#{uri_hash}")).to exist
 
-        FileUtils.rm_rf lib_path("a-path-gem-1.0")
+        FileUtils.rm_r lib_path("a-path-gem-1.0")
         expect(the_bundle).to include_gems("a-path-gem 1.0")
       end
 
@@ -155,7 +155,7 @@ RSpec.describe "real source plugins" do
 
         expect(bundled_app("vendor/cache/a-path-gem-1.0-#{uri_hash}")).to exist
 
-        FileUtils.rm_rf lib_path("a-path-gem-1.0")
+        FileUtils.rm_r lib_path("a-path-gem-1.0")
         expect(the_bundle).to include_gems("a-path-gem 1.0")
       end
     end
@@ -452,7 +452,7 @@ RSpec.describe "real source plugins" do
         expect(bundled_app("vendor/cache/foo-1.0-#{ref}/.git")).not_to exist
         expect(bundled_app("vendor/cache/foo-1.0-#{ref}/.bundlecache")).to be_file
 
-        FileUtils.rm_rf lib_path("foo-1.0")
+        FileUtils.rm_r lib_path("foo-1.0")
         expect(the_bundle).to include_gems "foo 1.0"
       end
     end

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -459,7 +459,7 @@ RSpec.describe "Bundler.setup" do
 
     it "works even when the cache directory has been deleted" do
       bundle :install
-      FileUtils.rm_rf default_cache_path
+      FileUtils.rm_r default_cache_path
       expect(the_bundle).to include_gems "myrack 1.0.0"
     end
 
@@ -496,7 +496,7 @@ RSpec.describe "Bundler.setup" do
       bundle %(config set local.myrack #{lib_path("local-myrack")})
       bundle :install
 
-      FileUtils.rm_rf(lib_path("local-myrack"))
+      FileUtils.rm_r(lib_path("local-myrack"))
       run "require 'myrack'", raise_on_error: false
       expect(err).to match(/Cannot use local override for myrack-0.8 because #{Regexp.escape(lib_path("local-myrack").to_s)} does not exist/)
     end
@@ -611,7 +611,7 @@ RSpec.describe "Bundler.setup" do
         gem 'foo', :path => 'vendor/foo', :group => :development
       G
 
-      FileUtils.rm_rf(path)
+      FileUtils.rm_r(path)
 
       ruby "require 'bundler'; Bundler.setup", env: { "DEBUG" => "1" }
       expect(out).to include("Assuming that source at `vendor/foo` has not changed since fetching its specs errored")

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -458,9 +458,8 @@ RSpec.describe "Bundler.setup" do
     end
 
     it "works even when the cache directory has been deleted" do
-      bundle "config set --local path vendor/bundle"
       bundle :install
-      FileUtils.rm_rf vendored_gems("cache")
+      FileUtils.rm_rf default_cache_path
       expect(the_bundle).to include_gems "myrack 1.0.0"
     end
 

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -121,6 +121,6 @@ RSpec.configure do |config|
   end
 
   config.after :suite do
-    FileUtils.rm_rf Spec::Path.pristine_system_gem_path
+    FileUtils.rm_r Spec::Path.pristine_system_gem_path
   end
 end

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -187,30 +187,35 @@ module Spec
     end
 
     def build_repo2(**kwargs, &blk)
-      FileUtils.rm_rf gem_repo2
-      FileUtils.cp_r gem_repo1, gem_repo2
+      FileUtils.cp_r gem_repo1, gem_repo2, remove_destination: true
       update_repo2(**kwargs, &blk) if block_given?
     end
 
     # A repo that has no pre-installed gems included. (The caller completely
     # determines the contents with the block.)
     def build_repo3(**kwargs, &blk)
-      build_empty_repo gem_repo3, **kwargs, &blk
+      raise "gem_repo3 already exists -- use update_repo3 instead" if File.exist?(gem_repo3)
+      build_repo gem_repo3, **kwargs, &blk
     end
 
     # Like build_repo3, this is a repo that has no pre-installed gems included.
     # We have two different methods for situations where two different empty
     # sources are needed.
     def build_repo4(**kwargs, &blk)
-      build_empty_repo gem_repo4, **kwargs, &blk
-    end
-
-    def update_repo4(&blk)
-      update_repo(gem_repo4, &blk)
+      raise "gem_repo4 already exists -- use update_repo4 instead" if File.exist?(gem_repo4)
+      build_repo gem_repo4, **kwargs, &blk
     end
 
     def update_repo2(**kwargs, &blk)
       update_repo(gem_repo2, **kwargs, &blk)
+    end
+
+    def update_repo3(&blk)
+      update_repo(gem_repo3, &blk)
+    end
+
+    def update_repo4(&blk)
+      update_repo(gem_repo4, &blk)
     end
 
     def build_security_repo
@@ -273,7 +278,6 @@ module Spec
 
     def check_test_gems!
       if rake_path.nil?
-        FileUtils.rm_rf(base_system_gems)
         Spec::Rubygems.install_test_deps
       end
 
@@ -351,11 +355,6 @@ module Spec
     end
 
     private
-
-    def build_empty_repo(gem_repo, **kwargs, &blk)
-      FileUtils.rm_rf gem_repo
-      build_repo(gem_repo, **kwargs, &blk)
-    end
 
     def build_with(builder, name, args, &blk)
       @_build_path ||= nil

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -414,7 +414,6 @@ module Spec
     def cache_gems(*gems, gem_repo: gem_repo1)
       gems = gems.flatten
 
-      FileUtils.rm_rf("#{bundled_app}/vendor/cache")
       FileUtils.mkdir_p("#{bundled_app}/vendor/cache")
 
       gems.each do |g|
@@ -547,6 +546,12 @@ module Spec
     def exit_status_for_signal(signal_number)
       # For details see: https://en.wikipedia.org/wiki/Exit_status#Shell_and_scripts
       128 + signal_number
+    end
+
+    def empty_repo4
+      FileUtils.rm_r gem_repo4
+
+      build_repo4 {}
     end
 
     private

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -20,7 +20,7 @@ module Spec
     def reset!
       Dir.glob("#{tmp}/{gems/*,*}", File::FNM_DOTMATCH).each do |dir|
         next if %w[base base_system remote1 rubocop standard gems rubygems . ..].include?(File.basename(dir))
-        FileUtils.rm_rf(dir)
+        FileUtils.rm_r(dir)
       end
       FileUtils.mkdir_p(home)
       FileUtils.mkdir_p(tmpdir)
@@ -396,7 +396,7 @@ module Spec
     end
 
     def pristine_system_gems(*gems)
-      FileUtils.rm_rf(system_gem_path)
+      FileUtils.rm_r(system_gem_path)
 
       system_gems(*gems)
     end
@@ -424,7 +424,7 @@ module Spec
     end
 
     def simulate_new_machine
-      FileUtils.rm_rf bundled_app(".bundle")
+      FileUtils.rm_r bundled_app(".bundle")
       pristine_system_gems :bundler
     end
 

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -62,8 +62,7 @@ module Spec
         source = Path.tmp_root("1")
         destination = Path.tmp_root(n.to_s)
 
-        FileUtils.rm_rf destination
-        FileUtils.cp_r source, destination
+        FileUtils.cp_r source, destination, remove_destination: true
       end
     end
 

--- a/bundler/spec/update/git_spec.rb
+++ b/bundler/spec/update/git_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "bundle update" do
         gem "foo", "1.0", :git => "#{lib_path("foo_one")}"
       G
 
-      FileUtils.rm_rf lib_path("foo_one")
+      FileUtils.rm_r lib_path("foo_one")
 
       install_gemfile <<-G
         source "https://gem.repo1"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Debugging #5578 was very difficult, because the main issue affecting tests on Windows was failing to cleanup after the new test that PR is adding.

Because that test was leaving test files around in tmp, those test files could be randomly affecting any spec run after that. Currently implementation of `FileUtils.rm_rf` swallows all errors happening during removal, and does not give a hint that the files failed to be removed.

## What is your fix for the problem, implemented in this PR?

This is not the first time I encounter this issue. I tried to fix it in fileutils in https://github.com/ruby/fileutils/pull/58, but the change was rejected because of compatibility concerns.

I may try again to change `FileUtils`, but for now I changed our specs to use a more strict version of `rm_rf` that raises if any error happens during removal, and thus files are left around.

This should make the actual problem in #5578 easier to understand.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
