### PR TITLE
Raise an error if incompatible or merge if compatible when a gemspec development dep is duplicated in Gemfile

### DIFF
--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -241,7 +241,7 @@ module Bundler
       dep = Dependency.new(name, version, options)
 
       # if there's already a dependency with this name we try to prefer one
-      if current = @dependencies.find {|d| d.name == dep.name }
+      if current = @dependencies.find {|d| d.name == name }
         if current.requirement != dep.requirement
           current_requirement_open = current.requirements_list.include?(">= 0")
 
@@ -250,7 +250,7 @@ module Bundler
             gemfile_dep = [dep, current].find(&:gemfile_dep?)
 
             if gemfile_dep && !current_requirement_open
-              Bundler.ui.warn "A gemspec development dependency (#{gemspec_dep.name}, #{gemspec_dep.requirement}) is being overridden by a Gemfile dependency (#{gemfile_dep.name}, #{gemfile_dep.requirement}).\n" \
+              Bundler.ui.warn "A gemspec development dependency (#{name}, #{gemspec_dep.requirement}) is being overridden by a Gemfile dependency (#{name}, #{gemfile_dep.requirement}).\n" \
                               "This behaviour may change in the future. Please remove either of them, or make sure they both have the same requirement\n"
             elsif gemfile_dep.nil?
               require_relative "vendor/pub_grub/lib/pub_grub/version_range"
@@ -274,14 +274,14 @@ module Bundler
               if dep.requirements_list.include?(">= 0") && !current_requirement_open
                 update_prompt = ". Gem already added"
               else
-                update_prompt = ". If you want to update the gem version, run `bundle update #{current.name}`"
+                update_prompt = ". If you want to update the gem version, run `bundle update #{name}`"
 
                 update_prompt += ". You may also need to change the version requirement specified in the Gemfile if it's too restrictive." unless current_requirement_open
               end
             end
 
             raise GemfileError, "You cannot specify the same gem twice with different version requirements.\n" \
-                           "You specified: #{current.name} (#{current.requirement}) and #{dep.name} (#{dep.requirement})" \
+                           "You specified: #{name} (#{current.requirement}) and #{name} (#{dep.requirement})" \
                            "#{update_prompt}"
           end
         end
@@ -294,10 +294,10 @@ module Bundler
             return
           elsif current.source != dep.source
             raise GemfileError, "You cannot specify the same gem twice coming from different sources.\n" \
-                            "You specified that #{dep.name} (#{dep.requirement}) should come from " \
+                            "You specified that #{name} (#{dep.requirement}) should come from " \
                             "#{current.source || "an unspecified source"} and #{dep.source}\n"
           else
-            Bundler.ui.warn "Your Gemfile lists the gem #{current.name} (#{current.requirement}) more than once.\n" \
+            Bundler.ui.warn "Your Gemfile lists the gem #{name} (#{current.requirement}) more than once.\n" \
                             "You should probably keep only one of them.\n" \
                             "Remove any duplicate entries and specify the gem only once.\n" \
                             "While it's not a problem now, it could cause errors if you change the version of one of them later."

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -474,7 +474,7 @@ RSpec.describe "bundle install with gem sources" do
       expect(the_bundle).to include_gems("my-private-gem 1.0")
     end
 
-    it "throws a warning if a gem is added once in Gemfile and also inside a gemspec as a development dependency, with different requirements" do
+    it "does not warn if a gem is added once in Gemfile and also inside a gemspec as a development dependency, with compatible requirements" do
       build_lib "my-gem", path: bundled_app do |s|
         s.add_development_dependency "rubocop", "~> 1.36.0"
       end
@@ -494,14 +494,32 @@ RSpec.describe "bundle install with gem sources" do
 
       bundle :install
 
-      expect(err).to include("A gemspec development dependency (rubocop, ~> 1.36.0) is being overridden by a Gemfile dependency (rubocop, >= 0).")
-      expect(err).to include("This behaviour may change in the future. Please remove either of them, or make sure they both have the same requirement")
+      expect(err).to be_empty
 
-      # This is not the best behavior I believe, it would be better if both
-      # requirements are considered if they are compatible, and a version
-      # satisfying both is chosen. But not sure about changing it right now, so
-      # I went with a warning for the time being.
-      expect(the_bundle).to include_gems("rubocop 1.37.1")
+      expect(the_bundle).to include_gems("rubocop 1.36.0")
+    end
+
+    it "raises an error if a gem is added once in Gemfile and also inside a gemspec as a development dependency, with incompatible requirements" do
+      build_lib "my-gem", path: bundled_app do |s|
+        s.add_development_dependency "rubocop", "~> 1.36.0"
+      end
+
+      build_repo4 do
+        build_gem "rubocop", "1.36.0"
+        build_gem "rubocop", "1.37.1"
+      end
+
+      gemfile <<~G
+        source "https://gem.repo4"
+
+        gemspec
+
+        gem "rubocop", "~> 1.37.0", group: :development
+      G
+
+      bundle :install, raise_on_error: false
+
+      expect(err).to include("The rubocop dependency has conflicting requirements in Gemfile (~> 1.37.0) and gemspec (~> 1.36.0)")
     end
 
     it "includes the gem without warning if two gemspecs add it with the same requirement" do
@@ -588,35 +606,6 @@ RSpec.describe "bundle install with gem sources" do
       bundle :install, raise_on_error: false
 
       expect(err).to include("Two gemspec development dependencies have conflicting requirements on the same gem: rubocop (~> 1.36.0) and rubocop (~> 2.0). Bundler cannot continue.")
-    end
-
-    it "warns when a Gemfile dependency is overriding a gemspec development dependency, with different requirements" do
-      build_lib "my-gem", path: bundled_app do |s|
-        s.add_development_dependency "rails", ">= 5"
-      end
-
-      build_repo4 do
-        build_gem "rails", "7.0.8"
-      end
-
-      gemfile <<~G
-        source "https://gem.repo4"
-
-        gem "rails", "~> 7.0.8"
-
-        gemspec
-      G
-
-      bundle :install
-
-      expect(err).to include("A gemspec development dependency (rails, >= 5) is being overridden by a Gemfile dependency (rails, ~> 7.0.8).")
-      expect(err).to include("This behaviour may change in the future. Please remove either of them, or make sure they both have the same requirement")
-
-      # This is not the best behavior I believe, it would be better if both
-      # requirements are considered if they are compatible, and a version
-      # satisfying both is chosen. But not sure about changing it right now, so
-      # I went with a warning for the time being.
-      expect(the_bundle).to include_gems("rails 7.0.8")
     end
 
     it "does not warn if a gem is added once in Gemfile and also inside a gemspec as a development dependency, with same requirements, and different sources" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Currently we always prefer the Gemfile dependency (even if incompatible with the gemspec dependency), and we always print a warning.

I think this is confusing for users, and not too helpful.

## What is your fix for the problem, implemented in this PR?

This PR changes the behavior to either accept the situation without a warning if requirements are compatible, or raise a proper error if not.

This PR is backwards incompatible, so I'll hold releasing it if accepted until end of year.

Fixes #8552.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
