### PR TITLE
Changelogs for RubyGems 3.6.6 and Bundler 2.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 3.6.6 / 2025-03-13
+
+## Enhancements:
+
+* Update vendored uri to 1.0.3. Pull request
+  [#8534](https://github.com/rubygems/rubygems/pull/8534) by hsbt
+* Installs bundler 2.6.6 as a default gem.
+
+## Bug fixes:
+
+* Fix `gem rdoc` not working with newer versions of rdoc when not
+  installed as default gems. Pull request
+  [#8549](https://github.com/rubygems/rubygems/pull/8549) by
+  deivid-rodriguez
+
 # 3.6.5 / 2025-02-20
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,30 @@
+# 2.6.6 (March 13, 2025)
+
+## Enhancements:
+
+  - Fix `ENAMETOOLONG` error when creating compact index cache [#5578](https://github.com/rubygems/rubygems/pull/5578)
+  - Use shorthand hash syntax for bundle add [#8547](https://github.com/rubygems/rubygems/pull/8547)
+  - Update vendored uri to 1.0.3 [#8534](https://github.com/rubygems/rubygems/pull/8534)
+  - Retry gracefully on blank partial response in compact index [#8524](https://github.com/rubygems/rubygems/pull/8524)
+  - Give a better error when trying to write the lock file on a read-only filesystem [#5920](https://github.com/rubygems/rubygems/pull/5920)
+  - Improve log messages when lockfile platforms are added [#8523](https://github.com/rubygems/rubygems/pull/8523)
+  - Allow noop `bundle install` to work on read-only or protected folders [#8519](https://github.com/rubygems/rubygems/pull/8519)
+
+## Bug fixes:
+
+  - Detect partial gem installs from a git source so that they are reinstalled on a successive run [#8539](https://github.com/rubygems/rubygems/pull/8539)
+  - Modify `bundle doctor` to not report issue when files aren't writable [#8520](https://github.com/rubygems/rubygems/pull/8520)
+
+## Performance:
+
+  - Optimize resolution by removing an array allocation from `Candidate#<=>` [#8559](https://github.com/rubygems/rubygems/pull/8559)
+
+## Documentation:
+
+  - Update docs for with/without consistency [#8555](https://github.com/rubygems/rubygems/pull/8555)
+  - Recommend non-deprecated methods in `bundle exec` documentation [#8537](https://github.com/rubygems/rubygems/pull/8537)
+  - Hint about default group when using `only` configuration option [#8536](https://github.com/rubygems/rubygems/pull/8536)
+
 # 2.6.5 (February 20, 2025)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.6.6 and Bundler 2.6.6 into master.