### PR TITLE
Remove array allocation from Candidate#<=>

### DIFF
--- a/bundler/lib/bundler/resolver/candidate.rb
+++ b/bundler/lib/bundler/resolver/candidate.rb
@@ -48,35 +48,38 @@ module Bundler
         @version.segments
       end
 
-      def sort_obj
-        [@version, @priority]
-      end
-
       def <=>(other)
         return unless other.is_a?(self.class)
 
-        sort_obj <=> other.sort_obj
+        version_comparison = version <=> other.version
+        return version_comparison unless version_comparison.zero?
+
+        priority <=> other.priority
       end
 
       def ==(other)
         return unless other.is_a?(self.class)
 
-        sort_obj == other.sort_obj
+        version == other.version && priority == other.priority
       end
 
       def eql?(other)
         return unless other.is_a?(self.class)
 
-        sort_obj.eql?(other.sort_obj)
+        version.eql?(other.version) && priority.eql?(other.priority)
       end
 
       def hash
-        sort_obj.hash
+        [@version, @priority].hash
       end
 
       def to_s
         @version.to_s
       end
+
+      protected
+
+      attr_reader :priority
     end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In a large application I profiled allocations while running `bundle update` and found that this method was ~60% of allocations while resolving (and Candidate#<=> is almost half of the total runtime).

## What is your fix for the problem, implemented in this PR?

This commit removes the array allocation in Candidate#<=> (and similar methods since the implementations are so simple). The array is always the same two elements so they can just be compared directly.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
