### PR TITLE
Refuse to install and print an error in frozen mode if some entries are missing in CHECKSUMS lockfile section

### DIFF
--- a/bundler/lib/bundler/checksum.rb
+++ b/bundler/lib/bundler/checksum.rb
@@ -190,7 +190,7 @@ module Bundler
       def replace(spec, checksum)
         return unless checksum
 
-        lock_name = spec.name_tuple.lock_name
+        lock_name = spec.lock_name
         @store_mutex.synchronize do
           existing = fetch_checksum(lock_name, checksum.algo)
           if !existing || existing.same_source?(checksum)
@@ -204,7 +204,7 @@ module Bundler
       def register(spec, checksum)
         return unless checksum
 
-        register_checksum(spec.name_tuple.lock_name, checksum)
+        register_checksum(spec.lock_name, checksum)
       end
 
       def merge!(other)
@@ -216,7 +216,7 @@ module Bundler
       end
 
       def to_lock(spec)
-        lock_name = spec.name_tuple.lock_name
+        lock_name = spec.lock_name
         checksums = @store[lock_name]
         if checksums
           "#{lock_name} #{checksums.values.map(&:to_lock).sort.join(",")}"

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -911,9 +911,6 @@ module Bundler
     end
 
     def converge_path_sources_to_gemspec_sources
-      @locked_sources.map! do |source|
-        converge_path_source_to_gemspec_source(source)
-      end
       @locked_specs.each do |spec|
         spec.source &&= converge_path_source_to_gemspec_source(spec.source)
       end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -833,7 +833,7 @@ module Bundler
     end
 
     def dependencies_for_source_changed?(source, locked_source)
-      deps_for_source = @dependencies.select {|s| s.source == source }
+      deps_for_source = @dependencies.select {|dep| dep.source == source }
       locked_deps_for_source = locked_dependencies.select {|dep| dep.source == locked_source }
 
       deps_for_source.uniq.sort != locked_deps_for_source.sort

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -917,9 +917,6 @@ module Bundler
       @locked_specs.each do |spec|
         spec.source &&= converge_path_source_to_gemspec_source(spec.source)
       end
-      @locked_deps.each do |_, dep|
-        dep.source &&= converge_path_source_to_gemspec_source(dep.source)
-      end
     end
 
     def converge_sources

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -147,7 +147,6 @@ module Bundler
 
       @current_platform_missing = add_current_platform unless Bundler.frozen_bundle?
 
-      converge_path_sources_to_gemspec_sources
       @path_changes = converge_paths
       @source_changes = converge_sources
 
@@ -842,7 +841,7 @@ module Bundler
 
     def specs_for_source_changed?(source)
       locked_index = Index.new
-      locked_index.use(@locked_specs.select {|s| source.can_lock?(s) })
+      locked_index.use(@locked_specs.select {|s| s.replace_source_with!(source) })
 
       !locked_index.subset?(source.specs)
     rescue PathError, GitError => e
@@ -901,18 +900,6 @@ module Bundler
     def converge_paths
       sources.path_sources.any? do |source|
         specs_changed?(source)
-      end
-    end
-
-    def converge_path_source_to_gemspec_source(source)
-      return source unless source.instance_of?(Source::Path)
-      gemspec_source = sources.path_sources.find {|s| s == source }
-      gemspec_source || source
-    end
-
-    def converge_path_sources_to_gemspec_sources
-      @locked_specs.each do |spec|
-        spec.source &&= converge_path_source_to_gemspec_source(spec.source)
       end
     end
 

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -906,7 +906,7 @@ module Bundler
 
     def converge_path_source_to_gemspec_source(source)
       return source unless source.instance_of?(Source::Path)
-      gemspec_source = sources.path_sources.find {|s| s.is_a?(Source::Gemspec) && s.as_path_source == source }
+      gemspec_source = sources.path_sources.find {|s| s == source }
       gemspec_source || source
     end
 

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -833,7 +833,7 @@ module Bundler
       !locked || dependencies_for_source_changed?(source, locked) || specs_for_source_changed?(source)
     end
 
-    def dependencies_for_source_changed?(source, locked_source = source)
+    def dependencies_for_source_changed?(source, locked_source)
       deps_for_source = @dependencies.select {|s| s.source == source }
       locked_deps_for_source = locked_dependencies.select {|dep| dep.source == locked_source }
 

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -77,7 +77,7 @@ module Bundler
 
         @gemspecs << spec
 
-        path path, "glob" => glob, "name" => spec.name do
+        path path, "glob" => glob, "name" => spec.name, "gemspec" => spec do
           add_dependency spec.name
         end
 
@@ -141,8 +141,7 @@ module Bundler
     def path(path, options = {}, &blk)
       source_options = normalize_hash(options).merge(
         "path" => Pathname.new(path),
-        "root_path" => gemfile_root,
-        "gemspec" => gemspecs.find {|g| g.name == options["name"] }
+        "root_path" => gemfile_root
       )
 
       source_options["global"] = true unless block_given?

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -175,6 +175,14 @@ module Bundler
       @force_ruby_platform = true
     end
 
+    def replace_source_with!(gemfile_source)
+      return unless gemfile_source.can_lock?(self)
+
+      @source = gemfile_source
+
+      true
+    end
+
     private
 
     def use_exact_resolved_specifications?

--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -239,7 +239,6 @@ module Bundler
       spaces = $1
       return unless spaces.size == 2
       checksums = $6
-      return unless checksums
       name = $2
       version = $3
       platform = $4
@@ -249,10 +248,14 @@ module Bundler
       full_name = Gem::NameTuple.new(name, version, platform).full_name
       return unless spec = @specs[full_name]
 
-      checksums.split(",") do |lock_checksum|
-        column = line.index(lock_checksum) + 1
-        checksum = Checksum.from_lock(lock_checksum, "#{@lockfile_path}:#{@pos.line}:#{column}")
-        spec.source.checksum_store.register(spec, checksum)
+      if checksums
+        checksums.split(",") do |lock_checksum|
+          column = line.index(lock_checksum) + 1
+          checksum = Checksum.from_lock(lock_checksum, "#{@lockfile_path}:#{@pos.line}:#{column}")
+          spec.source.checksum_store.register(spec, checksum)
+        end
+      else
+        spec.source.checksum_store.register(spec, nil)
       end
     end
 

--- a/bundler/lib/bundler/plugin/installer/path.rb
+++ b/bundler/lib/bundler/plugin/installer/path.rb
@@ -8,6 +8,14 @@ module Bundler
           SharedHelpers.in_bundle? ? Bundler.root : Plugin.root
         end
 
+        def eql?(other)
+          return unless other.class == self.class
+          expanded_original_path == other.expanded_original_path &&
+            version == other.version
+        end
+
+        alias_method :==, :eql?
+
         def generate_bin(spec, disable_extensions = false)
           # Need to find a way without code duplication
           # For now, we can ignore this

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -262,6 +262,10 @@ module Gem
       !default_gem? && !File.directory?(full_gem_path)
     end
 
+    def lock_name
+      @lock_name ||= name_tuple.lock_name
+    end
+
     unless VALIDATES_FOR_RESOLUTION
       def validate_for_resolution
         SpecificationPolicy.new(self).validate_for_resolution

--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -130,11 +130,14 @@ module Bundler
 
       specs_to_cache.each do |spec|
         next if spec.name == "bundler"
-        next if spec.source.is_a?(Source::Gemspec)
-        if spec.source.respond_to?(:migrate_cache)
-          spec.source.migrate_cache(custom_path, local: local)
-        elsif spec.source.respond_to?(:cache)
-          spec.source.cache(spec, custom_path)
+
+        source = spec.source
+        next if source.is_a?(Source::Gemspec)
+
+        if source.respond_to?(:migrate_cache)
+          source.migrate_cache(custom_path, local: local)
+        elsif source.respond_to?(:cache)
+          source.cache(spec, custom_path)
         end
       end
 

--- a/bundler/lib/bundler/source/gemspec.rb
+++ b/bundler/lib/bundler/source/gemspec.rb
@@ -9,10 +9,6 @@ module Bundler
         super
         @gemspec = options["gemspec"]
       end
-
-      def as_path_source
-        Path.new(options)
-      end
     end
   end
 end

--- a/bundler/lib/bundler/source/gemspec.rb
+++ b/bundler/lib/bundler/source/gemspec.rb
@@ -4,6 +4,7 @@ module Bundler
   class Source
     class Gemspec < Path
       attr_reader :gemspec
+      attr_writer :checksum_store
 
       def initialize(options)
         super

--- a/bundler/lib/bundler/source/path.rb
+++ b/bundler/lib/bundler/source/path.rb
@@ -60,8 +60,8 @@ module Bundler
       end
 
       def eql?(other)
-        return unless other.class == self.class
-        expanded_original_path == other.expanded_original_path &&
+        [Gemspec, Path].include?(other.class) &&
+          expanded_original_path == other.expanded_original_path &&
           version == other.version
       end
 

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -183,7 +183,7 @@ module Bundler
       end
 
       path = @path_sources.map do |source|
-        replacement_sources.find {|s| s == (source.is_a?(Source::Gemspec) ? source.as_path_source : source) } || source
+        replace_source(replacement_sources, source)
       end
 
       [rubygems, path, git, plugin]

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -173,12 +173,12 @@ module Bundler
 
     def map_sources(replacement_sources)
       rubygems = @rubygems_sources.map do |source|
-        replace_rubygems_source(replacement_sources, source) || source
+        replace_rubygems_source(replacement_sources, source)
       end
 
       git, plugin = [@git_sources, @plugin_sources].map do |sources|
         sources.map do |source|
-          replacement_sources.find {|s| s == source } || source
+          replace_source(replacement_sources, source)
         end
       end
 
@@ -190,19 +190,24 @@ module Bundler
     end
 
     def global_replacement_source(replacement_sources)
-      replacement_source = replace_rubygems_source(replacement_sources, global_rubygems_source)
-      return global_rubygems_source unless replacement_source
-
-      replacement_source.local!
-      replacement_source
+      replace_rubygems_source(replacement_sources, global_rubygems_source, &:local!)
     end
 
     def replace_rubygems_source(replacement_sources, gemfile_source)
-      replacement_source = replacement_sources.find {|s| s == gemfile_source }
-      return unless replacement_source
+      replace_source(replacement_sources, gemfile_source) do |replacement_source|
+        # locked sources never include credentials so always prefer remotes from the gemfile
+        replacement_source.remotes = gemfile_source.remotes
 
-      # locked sources never include credentials so always prefer remotes from the gemfile
-      replacement_source.remotes = gemfile_source.remotes
+        yield replacement_source if block_given?
+      end
+    end
+
+    def replace_source(replacement_sources, gemfile_source)
+      replacement_source = replacement_sources.find {|s| s == gemfile_source }
+      return gemfile_source unless replacement_source
+
+      yield replacement_source if block_given?
+
       replacement_source
     end
 

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -183,6 +183,8 @@ module Bundler
       end
 
       path = @path_sources.map do |source|
+        next source if source.is_a?(Source::Gemspec)
+
         replace_source(replacement_sources, source)
       end
 

--- a/bundler/spec/bundler/lockfile_parser_spec.rb
+++ b/bundler/spec/bundler/lockfile_parser_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Bundler::LockfileParser do
         expect(subject.ruby_version).to eq ruby_version
         rake_spec = specs.last
         checksums = subject.sources.last.checksum_store.to_lock(specs.last)
-        expect(checksums).to eq("#{rake_spec.name_tuple.lock_name} #{rake_checksums.map(&:to_lock).sort.join(",")}")
+        expect(checksums).to eq("#{rake_spec.lock_name} #{rake_checksums.map(&:to_lock).sort.join(",")}")
       end
     end
 

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -1221,7 +1221,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
 
           DEPENDENCIES
             myrack!
-          #{checksums_section}
+
           BUNDLED WITH
              #{Bundler::VERSION}
         L

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -96,7 +96,6 @@ RSpec.describe "compact index api" do
     bundle :install, artifice: "compact_index"
 
     bundle "config set --local deployment true"
-    bundle "config set --local path vendor/bundle"
     bundle :install, artifice: "compact_index"
     expect(out).to include("Fetching gem metadata from #{source_uri}")
     expect(the_bundle).to include_gems "myrack 1.0.0"

--- a/bundler/spec/install/gems/dependency_api_spec.rb
+++ b/bundler/spec/install/gems/dependency_api_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe "gemcutter's dependency API" do
     bundle :install, artifice: "endpoint"
 
     bundle "config set --local deployment true"
-    bundle "config set --local path vendor/bundle"
     bundle :install, artifice: "endpoint"
     expect(out).to include("Fetching gem metadata from #{source_uri}")
     expect(the_bundle).to include_gems "myrack 1.0.0"

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -1613,6 +1613,39 @@ RSpec.describe "the lockfile format" do
     expect(the_bundle).not_to include_gems "myrack_middleware 1.0"
   end
 
+  it "raises a clear error when frozen mode is set and lockfile is missing entries in CHECKSUMS section, and does not install any gems" do
+    lockfile <<-L
+      GEM
+        remote: https://gem.repo2/
+        specs:
+          myrack_middleware (1.0)
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        myrack_middleware
+
+      CHECKSUMS
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    install_gemfile <<-G, env: { "BUNDLE_FROZEN" => "true" }, raise_on_error: false
+      source "https://gem.repo2"
+      gem "myrack_middleware"
+    G
+
+    expect(err).to eq <<~L.strip
+      Your lockfile is missing a checksums entry for \"myrack_middleware\", but can't be updated because frozen mode is set
+
+      Run `bundle install` elsewhere and add the updated Gemfile.lock to version control.
+    L
+
+    expect(the_bundle).not_to include_gems "myrack_middleware 1.0"
+  end
+
   it "automatically fixes the lockfile when it's missing deps, they conflict with other locked deps, but conflicts are fixable" do
     build_repo4 do
       build_gem "other_dep", "0.9"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If the CHECKSUMS section is present in the lockfile, but some entries are missing, Bundler will still happily install gems, even in `frozen` mode.

## What is your fix for the problem, implemented in this PR?

My fix is to instead print an error explaining the situation and refuse to install.

Fixes #8561.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
