### PR TITLE
Add test for fixing mismatched versions in lockfile

### DIFF
--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -1875,6 +1875,63 @@ RSpec.describe "the lockfile format" do
     L
   end
 
+  it "automatically fixes the lockfile when it includes a gem under the correct GIT section, but also under an incorrect GEM section, with a higher version" do
+    git = build_git "foo"
+
+    gemfile <<~G
+      source "https://gem.repo1/"
+      gem "foo", "= 1.0", git: "#{lib_path("foo-1.0")}"
+    G
+
+    # If the lockfile erroneously lists platform versions of the gem
+    # that don't match the locked version of the git repo we should remove them.
+
+    lockfile <<~L
+      GIT
+        remote: #{lib_path("foo-1.0")}
+        revision: #{git.ref_for("main")}
+        specs:
+          foo (1.0)
+
+      GEM
+        remote: https://gem.repo1/
+        specs:
+          foo (1.1-x86_64-linux-gnu)
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        foo (= 1.0)!
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    bundle "install"
+
+    expect(lockfile).to eq <<~L
+      GIT
+        remote: #{lib_path("foo-1.0")}
+        revision: #{git.ref_for("main")}
+        specs:
+          foo (1.0)
+
+      GEM
+        remote: https://gem.repo1/
+        specs:
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        foo (= 1.0)!
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+  end
+
   it "automatically fixes the lockfile when it has incorrect deps, keeping the locked version" do
     build_repo4 do
       build_gem "net-smtp", "0.5.0" do |s|


### PR DESCRIPTION
This test confirms that a bug that existed in 2.6.3
was fixed by b8e55087f026ffcc5ebf135ca6726daf0ec40b5d

We had an issue where we were pointing to a git repo
and a bad rebase (or something) occurred and replaced platform specific lines of a different (higher) version.
Bundler (2.6.2 at the time) chose the platform specific gem over the git gem because of it.

Thankfully I discovered that this has been fixed, as long as the git repo locks the version, which isn't something I had previously thought to do with a git gem.

So first question: Is this test worth merging?
Second question: Is it expected/desired that if a git gem does not specify a version, that platform lines in the lock file would take precedence?  If that sounds confusing and we don't want that, this test can verify that behavior by just removing the version lock (and then it will fail).