### PR TITLE
Default to a SOURCE_DATE_EPOCH of 315619200, to simplify reproducible builds.

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -156,6 +156,13 @@ module Gem
     specifications/default
   ].freeze
 
+  ##
+  # The default value for SOURCE_DATE_EPOCH if not specified.
+  # We want a date after 1980-01-01, to prevent issues with Zip files.
+  # This particular timestamp is for 1980-01-02 00:00:00 GMT.
+
+  DEFAULT_SOURCE_DATE_EPOCH = 315_619_200
+
   @@win_platform = nil
 
   @configuration = nil
@@ -1155,8 +1162,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
   ##
   # If the SOURCE_DATE_EPOCH environment variable is set, returns it's value.
-  # Otherwise, returns the time that +Gem.source_date_epoch_string+ was
-  # first called in the same format as SOURCE_DATE_EPOCH.
+  # Otherwise, returns DEFAULT_SOURCE_DATE_EPOCH as a string.
   #
   # NOTE(@duckinator): The implementation is a tad weird because we want to:
   #   1. Make builds reproducible by default, by having this function always
@@ -1171,15 +1177,12 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   # https://reproducible-builds.org/specs/source-date-epoch/
 
   def self.source_date_epoch_string
-    # The value used if $SOURCE_DATE_EPOCH is not set.
-    @default_source_date_epoch ||= Time.now.to_i.to_s
-
     specified_epoch = ENV["SOURCE_DATE_EPOCH"]
 
     # If it's empty or just whitespace, treat it like it wasn't set at all.
     specified_epoch = nil if !specified_epoch.nil? && specified_epoch.strip.empty?
 
-    epoch = specified_epoch || @default_source_date_epoch
+    epoch = specified_epoch || DEFAULT_SOURCE_DATE_EPOCH.to_s
 
     epoch.strip
   end

--- a/test/rubygems/test_gem_package_tar_writer.rb
+++ b/test/rubygems/test_gem_package_tar_writer.rb
@@ -33,7 +33,7 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
         f.write "a" * 10
       end
 
-      assert_headers_equal(tar_file_header("x", "", 0o644, 10, Time.now),
+      assert_headers_equal(tar_file_header("x", "", 0o644, 10, Time.at(Gem::DEFAULT_SOURCE_DATE_EPOCH).utc),
                          @io.string[0, 512])
     end
     assert_equal "aaaaaaaaaa#{"\0" * 502}", @io.string[512, 512]
@@ -54,7 +54,7 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
     Time.stub :now, Time.at(1_458_518_157) do
       @tar_writer.add_symlink "x", "y", 0o644
 
-      assert_headers_equal(tar_symlink_header("x", "", 0o644, Time.now, "y"),
+      assert_headers_equal(tar_symlink_header("x", "", 0o644, Time.at(Gem::DEFAULT_SOURCE_DATE_EPOCH).utc, "y"),
                          @io.string[0, 512])
     end
     assert_equal 512, @io.pos
@@ -86,7 +86,7 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
                    "e1cf14b0",
                    digests["SHA512"].hexdigest
 
-      assert_headers_equal(tar_file_header("x", "", 0o644, 10, Time.now),
+      assert_headers_equal(tar_file_header("x", "", 0o644, 10, Time.at(Gem::DEFAULT_SOURCE_DATE_EPOCH).utc),
                          @io.string[0, 512])
     end
     assert_equal "aaaaaaaaaa#{"\0" * 502}", @io.string[512, 512]
@@ -109,7 +109,7 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
                    "e1cf14b0",
                    digests["SHA512"].hexdigest
 
-      assert_headers_equal(tar_file_header("x", "", 0o644, 10, Time.now),
+      assert_headers_equal(tar_file_header("x", "", 0o644, 10, Time.at(Gem::DEFAULT_SOURCE_DATE_EPOCH).utc),
                            @io.string[0, 512])
     end
     assert_equal "aaaaaaaaaa#{"\0" * 502}", @io.string[512, 512]
@@ -126,7 +126,7 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
         io.write "a" * 10
       end
 
-      assert_headers_equal(tar_file_header("x", "", 0o644, 10, Time.now),
+      assert_headers_equal(tar_file_header("x", "", 0o644, 10, Time.at(Gem::DEFAULT_SOURCE_DATE_EPOCH).utc),
                            @io.string[0, 512])
 
       assert_equal "aaaaaaaaaa#{"\0" * 502}", @io.string[512, 512]
@@ -137,7 +137,7 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
       signature = signer.sign digest.digest
 
       assert_headers_equal(tar_file_header("x.sig", "", 0o444, signature.length,
-                                           Time.now),
+                                           Time.at(Gem::DEFAULT_SOURCE_DATE_EPOCH).utc),
                            @io.string[1024, 512])
       assert_equal "#{signature}#{"\0" * (512 - signature.length)}",
                    @io.string[1536, 512]
@@ -154,7 +154,7 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
         io.write "a" * 10
       end
 
-      assert_headers_equal(tar_file_header("x", "", 0o644, 10, Time.now),
+      assert_headers_equal(tar_file_header("x", "", 0o644, 10, Time.at(Gem::DEFAULT_SOURCE_DATE_EPOCH).utc),
                            @io.string[0, 512])
     end
     assert_equal "aaaaaaaaaa#{"\0" * 502}", @io.string[512, 512]
@@ -168,7 +168,7 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
         io.write "a" * 10
       end
 
-      assert_headers_equal(tar_file_header("x", "", 0o644, 10, Time.now),
+      assert_headers_equal(tar_file_header("x", "", 0o644, 10, Time.at(Gem::DEFAULT_SOURCE_DATE_EPOCH).utc),
                            @io.string[0, 512])
 
       assert_equal "aaaaaaaaaa#{"\0" * 502}", @io.string[512, 512]
@@ -192,7 +192,7 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
     Time.stub :now, Time.at(1_458_518_157) do
       @tar_writer.add_file_simple "x", 0, 100
 
-      assert_headers_equal tar_file_header("x", "", 0, 100, Time.now),
+      assert_headers_equal tar_file_header("x", "", 0, 100, Time.at(Gem::DEFAULT_SOURCE_DATE_EPOCH).utc),
         @io.string[0, 512]
     end
 
@@ -250,7 +250,7 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
     Time.stub :now, Time.at(1_458_518_157) do
       @tar_writer.mkdir "foo", 0o644
 
-      assert_headers_equal tar_dir_header("foo", "", 0o644, Time.now),
+      assert_headers_equal tar_dir_header("foo", "", 0o644, Time.at(Gem::DEFAULT_SOURCE_DATE_EPOCH).utc),
                            @io.string[0, 512]
 
       assert_equal 512, @io.pos

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -16,7 +16,7 @@ rubygems_version: "1.0"
 name: keyedlist
 version: !ruby/object:Gem::Version
   version: 0.4.0
-date: 2004-03-28 15:37:49.828000 +02:00
+date: 1980-01-02 00:00:00 UTC
 platform:
 summary: A Hash which automatically computes keys.
 require_paths:
@@ -75,7 +75,7 @@ end
   def assert_date(date)
     assert_kind_of Time, date
     assert_equal [0, 0, 0], [date.hour, date.min, date.sec]
-    assert_operator (Gem::Specification::TODAY..Time.now), :cover?, date
+    assert_equal Time.at(Gem::DEFAULT_SOURCE_DATE_EPOCH).utc, date
   end
 
   def setup


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

We were contacted by some folks researching reproducible builds, and they pointed out that tools like [`reprotest`](https://salsa.debian.org/reproducible-builds/reprotest) don't compare against an existing build artifact. (Which is what `gem rebuild` does.)

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Instead of having `Gem.source_date_epoch` default to the current time the first time it's run, it defaults to 315619200.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes (tests already exist)
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
