### PR TITLE
Improve wording of a few messages

### DIFF
--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1318,7 +1318,7 @@
   - Enable parallel installation on Windows by default [#4822](https://github.com/rubygems/rubygems/pull/4822)
   - More logging when compact index is not used and we fallback to other APIs [#4546](https://github.com/rubygems/rubygems/pull/4546)
   - `bundle gem` generated MiniTest file and class now start with 'test' [#3893](https://github.com/rubygems/rubygems/pull/3893)
-  - Add `Bundler::Definition.no_lock` accessor for skipping lock file creation/update [#3401](https://github.com/rubygems/rubygems/pull/3401)
+  - Add `Bundler::Definition.no_lock` accessor for skipping lockfile creation/update [#3401](https://github.com/rubygems/rubygems/pull/3401)
 
 ## Bug fixes:
 
@@ -2060,7 +2060,7 @@
   - Fix `bundle outdated --group NAME` when the group is listed second in the Gemfile ([#6116](https://github.com/rubygems/bundler/pull/6116))
   - Improve conflict resolution messages by not calling "ruby" a gem when conflict happens in the `required_ruby_version`, and by filtering out requirements that didn't contribute to the conflict ([#6647](https://github.com/rubygems/bundler/pull/6647))
   - Avoid fetching and rebuilding git gems whenever any gem is changed in the Gemfile ([#6711](https://github.com/rubygems/bundler/pull/6711))
-  - Include the exact bundler version in the lock file in the suggested command when bundler warns about version mismatches of itself [#6971](https://github.com/rubygems/bundler/pull/6971)
+  - Include the exact bundler version in the lockfile in the suggested command when bundler warns about version mismatches of itself [#6971](https://github.com/rubygems/bundler/pull/6971)
   - Fix plugins being installed every time a command is run #[#6978](https://github.com/rubygems/bundler/pull/6978)
   - Fallback to sequentially fetching specs on 429s [#6728](https://github.com/rubygems/bundler/pull/6728)
   - Make `bundle clean` also clean native extensions for gems with a git source [#7058](https://github.com/rubygems/bundler/pull/7058)
@@ -3525,7 +3525,7 @@ Changes
 
 ## Bug fixes:
 
-  - Revert gem source sorting in lock files (@indirect)
+  - Revert gem source sorting in lockfiles (@indirect)
 
 # 1.7.1 (August 20, 2014)
 
@@ -3625,7 +3625,7 @@ Changes
   - redirects across hosts now work on rubies without OpenSSL ([#2686](https://github.com/rubygems/bundler/issues/2686), @grddev)
   - gemspecs now handle filenames with newlines ([#2634](https://github.com/rubygems/bundler/issues/2634), @jasonmp85)
   - support escaped characters in usernames and passwords (@punkie)
-  - no more exception on `update GEM` without lock file (@simi)
+  - no more exception on `update GEM` without lockfile (@simi)
   - allow long config values ([#2823](https://github.com/rubygems/bundler/issues/2823), @kgrz)
   - cache successfully even locked to gems shipped with Ruby ([#2869](https://github.com/rubygems/bundler/issues/2869), @aughr)
   - respect NO_PROXY even if a proxy is configured ([#2878](https://github.com/rubygems/bundler/issues/2878), @stlay)
@@ -3773,7 +3773,7 @@ Changes
 
 ## Bug fixes:
 
-  - make gemspec path option preserve relative paths in lock file (@bwillis)
+  - make gemspec path option preserve relative paths in lockfile (@bwillis)
   - use umask when creating binstubs ([#1618](https://github.com/rubygems/bundler/issues/1618), @v-yarotsky)
   - warn if graphviz is not installed ([#2435](https://github.com/rubygems/bundler/issues/2435), @Agis-)
   - show git errors while loading gemspecs
@@ -4662,7 +4662,7 @@ Changes
   - Skeleton gemspec now works with older versions of git
   - Fix shell quoting and ref fetching in GemHelper
   - Disable colored output in --deployment
-  - Preserve line endings in lock file
+  - Preserve line endings in lockfile
 
 ## Features:
 

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -539,8 +539,9 @@ module Bundler
 
       reason = resolve_needed? ? change_reason : "some dependencies were deleted from your gemfile"
 
-      msg = String.new
-      msg << "#{reason.capitalize.strip}, but the lockfile can't be updated because #{update_refused_reason}"
+      msg = String.new("#{reason.capitalize.strip}, but ")
+      msg << "the lockfile " unless msg.start_with?("Your lockfile")
+      msg << "can't be updated because #{update_refused_reason}"
       msg << "\n\nYou have added to the Gemfile:\n" << added.join("\n") if added.any?
       msg << "\n\nYou have deleted from the Gemfile:\n" << deleted.join("\n") if deleted.any?
       msg << "\n\nYou have changed in the Gemfile:\n" << changed.join("\n") if changed.any?

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -544,7 +544,7 @@ module Bundler
       msg << "\n\nYou have added to the Gemfile:\n" << added.join("\n") if added.any?
       msg << "\n\nYou have deleted from the Gemfile:\n" << deleted.join("\n") if deleted.any?
       msg << "\n\nYou have changed in the Gemfile:\n" << changed.join("\n") if changed.any?
-      msg << "\n\nRun `bundle install` elsewhere and add the updated #{SharedHelpers.relative_gemfile_path} to version control.\n" unless unlocking?
+      msg << "\n\nRun `bundle install` elsewhere and add the updated #{SharedHelpers.relative_lockfile_path} to version control.\n" unless unlocking?
       msg
     end
 

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -813,9 +813,9 @@ module Bundler
         [@new_platforms.any?, "you are adding a new platform to your lockfile"],
         [@path_changes, "the gemspecs for path gems changed"],
         [@local_changes, "the gemspecs for git local gems changed"],
-        [@missing_lockfile_dep, "your lock file is missing \"#{@missing_lockfile_dep}\""],
+        [@missing_lockfile_dep, "your lockfile is missing \"#{@missing_lockfile_dep}\""],
         [@unlocking_bundler, "an update to the version of Bundler itself was requested"],
-        [@locked_spec_with_missing_deps, "your lock file includes \"#{@locked_spec_with_missing_deps}\" but not some of its dependencies"],
+        [@locked_spec_with_missing_deps, "your lockfile includes \"#{@locked_spec_with_missing_deps}\" but not some of its dependencies"],
         [@locked_spec_with_invalid_deps, "your lockfile does not satisfy dependencies of \"#{@locked_spec_with_invalid_deps}\""],
       ].select(&:first).map(&:last).join(", ")
     end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -810,7 +810,7 @@ module Bundler
       [
         [@source_changes, "the list of sources changed"],
         [@dependency_changes, "the dependencies in your gemfile changed"],
-        [@current_platform_missing, "your lockfile does not include the current platform"],
+        [@current_platform_missing, "your lockfile is missing the current platform"],
         [@new_platforms.any?, "you are adding a new platform to your lockfile"],
         [@path_changes, "the gemspecs for path gems changed"],
         [@local_changes, "the gemspecs for git local gems changed"],

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -196,7 +196,7 @@ module Bundler
 
     # If in frozen mode, we fallback to a non-installable candidate because by
     # doing this we avoid re-resolving and potentially end up changing the
-    # lock file, which is not allowed. In that case, we will give a proper error
+    # lockfile, which is not allowed. In that case, we will give a proper error
     # about the mismatch higher up the stack, right before trying to install the
     # bad gem.
     def choose_compatible(candidates, fallback_to_non_installable: Bundler.frozen_bundle?)

--- a/bundler/lib/bundler/plugin.rb
+++ b/bundler/lib/bundler/plugin.rb
@@ -195,7 +195,7 @@ module Bundler
       @sources[name]
     end
 
-    # @param [Hash] The options that are present in the lock file
+    # @param [Hash] The options that are present in the lockfile
     # @return [API::Source] the instance of the class that handles the source
     #                       type passed in locked_opts
     def from_lock(locked_opts)

--- a/bundler/lib/bundler/plugin/api/source.rb
+++ b/bundler/lib/bundler/plugin/api/source.rb
@@ -67,7 +67,7 @@ module Bundler
         # to check out same version of gem later.
         #
         # There options are passed when the source plugin is created from the
-        # lock file.
+        # lockfile.
         #
         # @return [Hash]
         def options_to_lock

--- a/bundler/lib/bundler/resolver/candidate.rb
+++ b/bundler/lib/bundler/resolver/candidate.rb
@@ -17,7 +17,7 @@ module Bundler
     # Some candidates may also keep some information explicitly about the
     # package they refer to. These candidates are referred to as "canonical" and
     # are used when materializing resolution results back into RubyGems
-    # specifications that can be installed, written to lock files, and so on.
+    # specifications that can be installed, written to lockfiles, and so on.
     #
     class Candidate
       include Comparable

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Bundler::Definition do
       before { Bundler::Definition.no_lock = true }
       after { Bundler::Definition.no_lock = false }
 
-      it "does not create a lock file" do
+      it "does not create a lockfile" do
         subject.lock
         expect(bundled_app_lock).not_to be_file
       end

--- a/bundler/spec/bundler/shared_helpers_spec.rb
+++ b/bundler/spec/bundler/shared_helpers_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Bundler::SharedHelpers do
 
       before { allow(subject).to receive(:default_gemfile).and_return(gemfile_path) }
 
-      it "returns the lock file path" do
+      it "returns the lockfile path" do
         expect(subject.default_lockfile).to eq(expected_lockfile_path)
       end
     end

--- a/bundler/spec/commands/check_spec.rb
+++ b/bundler/spec/commands/check_spec.rb
@@ -258,7 +258,7 @@ RSpec.describe "bundle check" do
     expect(err).not_to include("Unfortunately, a fatal error has occurred. ")
   end
 
-  it "fails when there's no lock file and frozen is set" do
+  it "fails when there's no lockfile and frozen is set" do
     install_gemfile <<-G
       source "https://gem.repo1"
       gem "foo"

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -1368,7 +1368,7 @@ RSpec.describe "bundle install with gem sources" do
     it "adds the current platform to the lockfile" do
       bundle "install --verbose"
 
-      expect(out).to include("re-resolving dependencies because your lockfile does not include the current platform")
+      expect(out).to include("re-resolving dependencies because your lockfile is missing the current platform")
       expect(out).not_to include("you are adding a new platform to your lockfile")
 
       expect(lockfile).to eq <<~L

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "bundle install with gem sources" do
       expect(bundled_app(".bundle")).not_to exist
     end
 
-    it "creates lock files based on the Gemfile name" do
+    it "creates lockfiles based on the Gemfile name" do
       gemfile bundled_app("OmgFile"), <<-G
         source "https://gem.repo1"
         gem "myrack", "1.0"

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "bundle update" do
   end
 
   describe "with --gemfile" do
-    it "creates lock files based on the Gemfile name" do
+    it "creates lockfiles based on the Gemfile name" do
       gemfile bundled_app("OmgFile"), <<-G
         source "https://gem.repo1"
         gem "myrack", "1.0"

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -321,7 +321,7 @@ RSpec.describe "install in deployment or frozen mode" do
       L
 
       bundle :install, env: { "BUNDLE_FROZEN" => "true" }, raise_on_error: false, artifice: "compact_index"
-      expect(err).to include("Your lock file is missing \"bar\", but the lockfile can't be updated because frozen mode is set")
+      expect(err).to include("Your lockfile is missing \"bar\", but the lockfile can't be updated because frozen mode is set")
     end
 
     it "explodes if a path gem is missing" do

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -321,7 +321,7 @@ RSpec.describe "install in deployment or frozen mode" do
       L
 
       bundle :install, env: { "BUNDLE_FROZEN" => "true" }, raise_on_error: false, artifice: "compact_index"
-      expect(err).to include("Your lockfile is missing \"bar\", but the lockfile can't be updated because frozen mode is set")
+      expect(err).to include("Your lockfile is missing \"bar\", but can't be updated because frozen mode is set")
     end
 
     it "explodes if a path gem is missing" do
@@ -550,7 +550,7 @@ RSpec.describe "install in deployment or frozen mode" do
       pristine_system_gems :bundler
       bundle "config set --local deployment true"
       bundle "install --verbose"
-      expect(out).not_to include("but the lockfile can't be updated because frozen mode is set")
+      expect(out).not_to include("can't be updated because frozen mode is set")
       expect(out).not_to include("You have added to the Gemfile")
       expect(out).not_to include("You have deleted from the Gemfile")
       expect(out).to include("vendor/cache/foo")

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -273,7 +273,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           expect(the_bundle).to include_gems("depends_on_myrack 1.0.1", "myrack 1.0.0", source: "remote3")
 
           # In https://github.com/bundler/bundler/issues/3585 this failed
-          # when there is already a lock file, and the gems are missing, so try again
+          # when there is already a lockfile, and the gems are missing, so try again
           system_gems []
           bundle :install, artifice: "compact_index"
 
@@ -482,7 +482,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
           expect(the_bundle).to include_gems("depends_on_myrack 1.0.1", "myrack 1.0.0")
 
           # In https://github.com/rubygems/bundler/issues/3585 this failed
-          # when there is already a lock file, and the gems are missing, so try again
+          # when there is already a lockfile, and the gems are missing, so try again
           system_gems []
           bundle :install, artifice: "compact_index"
 

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe "bundle install with specific platforms" do
            #{Bundler::VERSION}
       L
 
-      # force strict usage of the lock file by setting frozen mode
+      # force strict usage of the lockfile by setting frozen mode
       bundle "config set --local frozen true"
 
       # make sure the platform that got actually installed with the old bundler is used

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -394,7 +394,7 @@ RSpec.describe "bundle install with install-time dependencies" do
         end
       end
 
-      context "with a Gemfile and lock file that don't resolve under the current platform" do
+      context "with a Gemfile and lockfile that don't resolve under the current platform" do
         before do
           build_repo4 do
             build_gem "sorbet", "0.5.10554" do |s|

--- a/bundler/spec/install/process_lock_spec.rb
+++ b/bundler/spec/install/process_lock_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "process lock spec" do
     context "when creating a lock raises Errno::ENOTSUP" do
       before { allow(File).to receive(:open).and_raise(Errno::ENOTSUP) }
 
-      it "skips creating the lock file and yields" do
+      it "skips creating the lockfile and yields" do
         processed = false
         Bundler::ProcessLock.lock(default_bundle_path) { processed = true }
 
@@ -35,7 +35,7 @@ RSpec.describe "process lock spec" do
     context "when creating a lock raises Errno::EPERM" do
       before { allow(File).to receive(:open).and_raise(Errno::EPERM) }
 
-      it "skips creating the lock file and yields" do
+      it "skips creating the lockfile and yields" do
         processed = false
         Bundler::ProcessLock.lock(default_bundle_path) { processed = true }
 
@@ -46,7 +46,7 @@ RSpec.describe "process lock spec" do
     context "when creating a lock raises Errno::EROFS" do
       before { allow(File).to receive(:open).and_raise(Errno::EROFS) }
 
-      it "skips creating the lock file and yields" do
+      it "skips creating the lockfile and yields" do
         processed = false
         Bundler::ProcessLock.lock(default_bundle_path) { processed = true }
 

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -2030,7 +2030,7 @@ RSpec.describe "the lockfile format" do
     L
 
     bundle "install --verbose"
-    expect(out).to include("re-resolving dependencies because your lock file includes \"minitest-bisect\" but not some of its dependencies")
+    expect(out).to include("re-resolving dependencies because your lockfile includes \"minitest-bisect\" but not some of its dependencies")
 
     expect(lockfile).to eq <<~L
       GEM

--- a/bundler/spec/plugins/source/example_spec.rb
+++ b/bundler/spec/plugins/source/example_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "real source plugins" do
       expect(the_bundle).to include_gems("a-path-gem 1.0")
     end
 
-    it "writes to lock file" do
+    it "writes to lockfile" do
       bundle "install"
 
       checksums = checksums_section_when_enabled do |c|
@@ -336,7 +336,7 @@ RSpec.describe "real source plugins" do
       expect(the_bundle).to include_gems("ma-gitp-gem 1.0")
     end
 
-    it "writes to lock file" do
+    it "writes to lockfile" do
       revision = revision_for(lib_path("ma-gitp-gem-1.0"))
       bundle "install"
 

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1683,7 +1683,7 @@ end
         RUBY
       end
 
-      expect(err).to include("Your lockfile does not include the current platform, but the lockfile can't be updated because file system is read-only")
+      expect(err).to include("Your lockfile does not include the current platform, but can't be updated because file system is read-only")
     end
   end
 end

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1683,7 +1683,7 @@ end
         RUBY
       end
 
-      expect(err).to include("Your lockfile does not include the current platform, but can't be updated because file system is read-only")
+      expect(err).to include("Your lockfile is missing the current platform, but can't be updated because file system is read-only")
     end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I found some messages could use improvements while working on #8563, so I extracted those improvements to a separate PR.

## What is your fix for the problem, implemented in this PR?

* Use "lockfile" over "lock file" consistently.
* Fix frozen error message to mention the lockfile instead of the Gemfile:
    > Run `bundle install` elsewhere and add the updated Gemfile.lock to version control
  
  rather than
    > Run `bundle install` elsewhere and add the updated Gemfile to version control
* Don't redundantly mention "lockfile" in some log messages
    > Your lockfile is missing \"bar\", but can't be updated because frozen mode is set

  rather than
    > Your lockfile is missing \"bar\", but the lockfile can't be updated because frozen mode is set
* Improve missing platform message:
    > Your lockfile is missing the current platform

  rather than
    > Your lockfile does not include the current platform

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
