### PR TITLE
Fix lockfile when a gem ends up accidentally under two different sources 

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -964,11 +964,11 @@ module Bundler
         unless name == "bundler"
           locked_specs = @originally_locked_specs[name]
 
-          if locked_specs.any? && !dep.matches_spec?(locked_specs.first)
+          if locked_specs.empty?
+            @missing_lockfile_dep = name if dep_changed == false
+          elsif !dep.matches_spec?(locked_specs.first)
             @gems_to_unlock << name
             dep_changed = true
-          elsif locked_specs.empty? && dep_changed == false
-            @missing_lockfile_dep = name
           end
         end
 

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -966,9 +966,15 @@ module Bundler
 
           if locked_specs.empty?
             @missing_lockfile_dep = name if dep_changed == false
-          elsif !dep.matches_spec?(locked_specs.first)
-            @gems_to_unlock << name
-            dep_changed = true
+          else
+            if locked_specs.map(&:source).uniq.size > 1
+              @locked_specs.delete(locked_specs.select {|s| s.source != dep.source })
+            end
+
+            unless dep.matches_spec?(locked_specs.first)
+              @gems_to_unlock << name
+              dep_changed = true
+            end
           end
         end
 

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -1875,6 +1875,63 @@ RSpec.describe "the lockfile format" do
     L
   end
 
+  it "automatically fixes the lockfile when it includes a gem under the correct GIT section, but also under an incorrect GEM section, with a higher version" do
+    git = build_git "foo"
+
+    gemfile <<~G
+      source "https://gem.repo1/"
+      gem "foo", "= 1.0", git: "#{lib_path("foo-1.0")}"
+    G
+
+    # If the lockfile erroneously lists platform versions of the gem
+    # that don't match the locked version of the git repo we should remove them.
+
+    lockfile <<~L
+      GIT
+        remote: #{lib_path("foo-1.0")}
+        revision: #{git.ref_for("main")}
+        specs:
+          foo (1.0)
+
+      GEM
+        remote: https://gem.repo1/
+        specs:
+          foo (1.1-x86_64-linux-gnu)
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        foo (= 1.0)!
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    bundle "install"
+
+    expect(lockfile).to eq <<~L
+      GIT
+        remote: #{lib_path("foo-1.0")}
+        revision: #{git.ref_for("main")}
+        specs:
+          foo (1.0)
+
+      GEM
+        remote: https://gem.repo1/
+        specs:
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        foo (= 1.0)!
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+  end
+
   it "automatically fixes the lockfile when it has incorrect deps, keeping the locked version" do
     build_repo4 do
       build_gem "net-smtp", "0.5.0" do |s|

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -1875,6 +1875,63 @@ RSpec.describe "the lockfile format" do
     L
   end
 
+  it "automatically fixes the lockfile when it includes a gem under the correct GIT section, but also under an incorrect GEM section, with a higher version, and with no explicit Gemfile requirement" do
+    git = build_git "foo"
+
+    gemfile <<~G
+      source "https://gem.repo1/"
+      gem "foo", git: "#{lib_path("foo-1.0")}"
+    G
+
+    # If the lockfile erroneously lists platform versions of the gem
+    # that don't match the locked version of the git repo we should remove them.
+
+    lockfile <<~L
+      GIT
+        remote: #{lib_path("foo-1.0")}
+        revision: #{git.ref_for("main")}
+        specs:
+          foo (1.0)
+
+      GEM
+        remote: https://gem.repo1/
+        specs:
+          foo (1.1-x86_64-linux-gnu)
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        foo!
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    bundle "install"
+
+    expect(lockfile).to eq <<~L
+      GIT
+        remote: #{lib_path("foo-1.0")}
+        revision: #{git.ref_for("main")}
+        specs:
+          foo (1.0)
+
+      GEM
+        remote: https://gem.repo1/
+        specs:
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        foo!
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+  end
+
   it "automatically fixes the lockfile when it includes a gem under the correct GIT section, but also under an incorrect GEM section, with a higher version" do
     git = build_git "foo"
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If (for example) due to a bad git conflict resolution, we end up with an incorrect lockfile with the same gem in two different sources, Bundler will run into issues and (although unconfirmed) may end up choosing an incorrect version from an incorrect source.

## What is your fix for the problem, implemented in this PR?

Make sure to ignore lockfile specifications that don't match the source configured in the Gemfile, particularly in the edge case where multiple specifications are in the lockfile under different sources.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
