### PR TITLE
Ensure that Gem::Platform parses strings to a fix point

### DIFF
--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -126,7 +126,7 @@ class Gem::Platform
                       when /solaris-?(\d+\.\d+)?/ then       ["solaris",   $1]
                       when /wasi/ then                       ["wasi",      nil]
                       # test
-                      when /^(\w+_platform)(\d+)?/ then      [$1,          $2]
+                      when /^(\w+_platform)-?(\d+)?/ then    [$1,          $2]
                       else ["unknown", nil]
       end
     when Gem::Platform then

--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -97,16 +97,15 @@ class Gem::Platform
       end
 
       cpu = arch.shift
-      if cpu.nil? || "" == cpu
+      if cpu.nil? || cpu == ""
         raise ArgumentError, "empty cpu in platform #{arch_str.inspect}"
       end
 
-
       @cpu = if cpu.match?(/i\d86/)
-                "x86"
-              else
-                cpu
-              end
+        "x86"
+      else
+        cpu
+      end
 
       if arch.length == 2 && arch.last.match?(/^\d+(\.\d+)?$/) # for command-line
         @os, @version = arch
@@ -127,10 +126,10 @@ class Gem::Platform
                       when /^macruby$/ then             ["macruby",   nil]
                       when /freebsd(\d+)?/ then         ["freebsd",   $1]
                       when /^java$/, /^jruby$/ then     ["java",      nil]
-                      when /^java(\d+(?:\.\d+)*)?/ then   ["java",      $1]
+                      when /^java(\d+(?:\.\d+)*)?/ then ["java", $1]
                       when /^dalvik(\d+)?$/ then        ["dalvik",    $1]
                       when /^dotnet$/ then              ["dotnet",    nil]
-                      when /^dotnet(\d+(?:\.\d+)*)?/ then ["dotnet",    $1]
+                      when /^dotnet(\d+(?:\.\d+)*)?/ then ["dotnet", $1]
                       when /linux-?(\w+)?/ then         ["linux",     $1]
                       when /mingw32/ then               ["mingw32",   nil]
                       when /mingw-?(\w+)?/ then         ["mingw",     $1]

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -158,6 +158,10 @@ class TestGemPlatform < Gem::TestCase
       "darwin0---" => [nil, "darwin", "0"],
       "x86-linux-x8611.0l" => ["x86", "linux", "x8611"],
       "0-x86linuxx86---" => ["0", "linux", "x86"],
+      "x86_64-macruby-x86" => ["x86_64", "macruby", nil],
+      "x86_64-dotnetx86" => ["x86_64", "dotnet", nil],
+      "x86_64-dalvik0" => ["x86_64", "dalvik", "0"],
+      "x86_64-dotnet1." => ["x86_64", "dotnet", "1"],
     }
 
     test_cases.each do |arch, expected|

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -148,12 +148,23 @@ class TestGemPlatform < Gem::TestCase
       "wasm32-wasi" => ["wasm32", "wasi", nil],
       "wasm32-wasip1" => ["wasm32", "wasi", nil],
       "wasm32-wasip2" => ["wasm32", "wasi", nil],
+
+      "darwin-java-java" => ["darwin", "java", nil],
+      "linux-linux-linux" => ["linux", "linux", "linux"],
+      "linux-linux-linux1.0" => ["linux", "linux", "linux1"],
+      "x86x86-1x86x86x86x861linuxx86x86" => ["x86x86", "linux", "x86x86"],
+      "freebsd0" => [nil, "freebsd", "0"],
+      "darwin0" => [nil, "darwin", "0"],
+      "darwin0---" => [nil, "darwin", "0"],
+      "x86-linux-x8611.0l" => ["x86", "linux", "x8611"],
+      "0-x86linuxx86---" => ["0", "linux", "x86"],
     }
 
     test_cases.each do |arch, expected|
       platform = Gem::Platform.new arch
       assert_equal expected, platform.to_a, arch.inspect
-      assert_equal expected, Gem::Platform.new(platform.to_s).to_a, arch.inspect
+      platform2 = Gem::Platform.new platform.to_s
+      assert_equal expected, platform2.to_a, "#{arch.inspect} => #{platform2.inspect}"
     end
   end
 


### PR DESCRIPTION
The issue was that the property that

```ruby
platform = Gem::Platform.new $string
platform == Gem::Platform.new(platform.to_s)
```

was not always true.

This property (of acchieving a fix point) is important,
since `Gem::Platform` gets serialized to a string and
then deserialized back to a `Gem::Platform` object.
If it doesn't deserialize to the same object, then
different platforms are used for the initial serialization
than subsequent runs.

I used https://github.com/segiddins/Scratch/blob/main/2025/03/rubygems-platform.rb
to find the failing cases and then fixed them.
With this patch, the prop check test now passes.

<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)