### PR TITLE
Fix `bundle add` sometimes generating invalid lockfiles

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -95,6 +95,7 @@ module Bundler
       @locked_ruby_version = nil
       @new_platforms = []
       @removed_platforms = []
+      @originally_invalid_platforms = []
 
       if lockfile_exists?
         @lockfile_contents = Bundler.read_file(lockfile)
@@ -760,7 +761,11 @@ module Bundler
         end
       end
 
-      result.add_extra_platforms!(platforms) if should_add_extra_platforms?
+      if should_add_extra_platforms?
+        result.add_extra_platforms!(platforms)
+      elsif @originally_invalid_platforms.any?
+        result.add_originally_invalid_platforms!(platforms, @originally_invalid_platforms)
+      end
 
       SpecSet.new(result.for(dependencies, @platforms | [Gem::Platform::RUBY]))
     end
@@ -1137,17 +1142,15 @@ module Bundler
     def remove_invalid_platforms!
       return if Bundler.frozen_bundle?
 
-      invalid_platforms = platforms.select do |platform|
+      @originally_invalid_platforms = platforms.select do |platform|
         next if local_platform == platform ||
                 @new_platforms.include?(platform) ||
-                @path_changes ||
-                @dependency_changes ||
-                @locked_spec_with_invalid_deps
+                @dependency_changes
 
         spec_set_incomplete_for_platform?(@originally_locked_specs, platform)
       end
 
-      @platforms -= invalid_platforms
+      @platforms -= @originally_invalid_platforms
     end
 
     def spec_set_incomplete_for_platform?(spec_set, platform)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -1137,16 +1137,17 @@ module Bundler
     def remove_invalid_platforms!
       return if Bundler.frozen_bundle?
 
-      platforms.reverse_each do |platform|
+      invalid_platforms = platforms.select do |platform|
         next if local_platform == platform ||
                 @new_platforms.include?(platform) ||
                 @path_changes ||
                 @dependency_changes ||
-                @locked_spec_with_invalid_deps ||
-                !spec_set_incomplete_for_platform?(@originally_locked_specs, platform)
+                @locked_spec_with_invalid_deps
 
-        remove_platform(platform)
+        spec_set_incomplete_for_platform?(@originally_locked_specs, platform)
       end
+
+      @platforms -= invalid_platforms
     end
 
     def spec_set_incomplete_for_platform?(spec_set, platform)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -1144,8 +1144,14 @@ module Bundler
 
       @originally_invalid_platforms = platforms.select do |platform|
         next if local_platform == platform ||
-                @new_platforms.include?(platform) ||
-                @dependency_changes
+                @new_platforms.include?(platform)
+
+        # We should probably avoid removing non-ruby platforms, since that means
+        # lockfile will no longer install on those platforms, so a error to give
+        # heads up to the user may be better. However, we have tests expecting
+        # non ruby platform autoremoval to work, so leaving that in place for
+        # now.
+        next if @dependency_changes && platform != Gem::Platform::RUBY
 
         spec_set_incomplete_for_platform?(@originally_locked_specs, platform)
       end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -760,7 +760,7 @@ module Bundler
         end
       end
 
-      @platforms = result.add_extra_platforms!(platforms) if should_add_extra_platforms?
+      result.add_extra_platforms!(platforms) if should_add_extra_platforms?
 
       SpecSet.new(result.for(dependencies, @platforms | [Gem::Platform::RUBY]))
     end

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -48,7 +48,10 @@ module Bundler
     end
 
     def add_extra_platforms!(platforms)
-      return platforms.concat([Gem::Platform::RUBY]).uniq if @specs.empty?
+      if @specs.empty?
+        platforms.concat([Gem::Platform::RUBY]).uniq
+        return
+      end
 
       new_platforms = all_platforms.select do |platform|
         next if platforms.include?(platform)
@@ -56,14 +59,12 @@ module Bundler
 
         complete_platform(platform)
       end
-      return platforms if new_platforms.empty?
+      return if new_platforms.empty?
 
       platforms.concat(new_platforms)
 
       less_specific_platform = new_platforms.find {|platform| platform != Gem::Platform::RUBY && Bundler.local_platform === platform && platform === Bundler.local_platform }
       platforms.delete(Bundler.local_platform) if less_specific_platform
-
-      platforms
     end
 
     def validate_deps(s)

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -47,6 +47,12 @@ module Bundler
       end.uniq
     end
 
+    def add_originally_invalid_platforms!(platforms, originally_invalid_platforms)
+      originally_invalid_platforms.each do |originally_invalid_platform|
+        platforms << originally_invalid_platform if complete_platform(originally_invalid_platform)
+      end
+    end
+
     def add_extra_platforms!(platforms)
       if @specs.empty?
         platforms.concat([Gem::Platform::RUBY]).uniq

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -640,7 +640,7 @@ RSpec.describe "bundle update" do
                 myrack
 
           PLATFORMS
-            #{local_platform}
+            x86-darwin-100
 
           DEPENDENCIES
             activesupport

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -752,6 +752,80 @@ RSpec.describe "bundle install with specific platforms" do
     L
   end
 
+  it "automatically fixes the lockfile when adding a gem that introduces dependencies with no ruby platform variants transitively" do
+    simulate_platform "x86_64-linux" do
+      build_repo4 do
+        build_gem "nokogiri", "1.18.2"
+
+        build_gem "nokogiri", "1.18.2" do |s|
+          s.platform = "x86_64-linux"
+        end
+
+        build_gem("sorbet", "0.5.11835") do |s|
+          s.add_dependency "sorbet-static", "= 0.5.11835"
+        end
+
+        build_gem "sorbet-static", "0.5.11835" do |s|
+          s.platform = "x86_64-linux"
+        end
+      end
+
+      gemfile <<~G
+        source "https://gem.repo4"
+
+        gem "nokogiri"
+        gem "sorbet"
+      G
+
+      lockfile <<~L
+        GEM
+          remote: https://gem.repo4/
+          specs:
+            nokogiri (1.18.2)
+            nokogiri (1.18.2-x86_64-linux)
+
+        PLATFORMS
+          ruby
+          x86_64-linux
+
+        DEPENDENCIES
+          nokogiri
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "lock"
+
+      checksums = checksums_section_when_enabled do |c|
+        c.checksum gem_repo4, "nokogiri", "1.18.2", "x86_64-linux"
+        c.checksum gem_repo4, "sorbet", "0.5.11835"
+        c.checksum gem_repo4, "sorbet-static", "0.5.11835", "x86_64-linux"
+      end
+
+      expect(lockfile).to eq <<~L
+        GEM
+          remote: https://gem.repo4/
+          specs:
+            nokogiri (1.18.2)
+            nokogiri (1.18.2-x86_64-linux)
+            sorbet (0.5.11835)
+              sorbet-static (= 0.5.11835)
+            sorbet-static (0.5.11835-x86_64-linux)
+
+        PLATFORMS
+          x86_64-linux
+
+        DEPENDENCIES
+          nokogiri
+          sorbet
+        #{checksums}
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+    end
+  end
+
   it "automatically fixes the lockfile if multiple platforms locked, but no valid versions of direct dependencies for all of them" do
     simulate_platform "x86_64-linux" do
       build_repo4 do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes, when adding gems that don't have generic variants but only platforms specific variants, Bundler will automatically remove the RUBY platform from the lockfile, to allow resolution to succeed.

However, sometimes (when running `bundle add`), it was not able to detect the situation and would either raise a resolution error, or generating an invalid lockfile (locked to "ruby" platform, but including gems without "ruby" variants).

## What is your fix for the problem, implemented in this PR?

Our previous approach was not able to reliably detect invalid platform situations in cases where dependencies from the Gemfile are out of date with the lockfile (for example, during `bundle add`), so the ruby platform was not getting removed.

I changed the approach to remove the "ruby" platform more liberally for resolution, and then add it back after resolving if the result happens to be compatible.

Fixes #8560.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
