### PR TITLE
Sorting files in metadata for reproducibility

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -2144,11 +2144,11 @@ class Gem::Specification < Gem::BasicSpecification
       @files.concat(@extra_rdoc_files)
     end
 
-    @files            = @files.uniq if @files
-    @extensions       = @extensions.uniq if @extensions
-    @test_files       = @test_files.uniq if @test_files
-    @executables      = @executables.uniq if @executables
-    @extra_rdoc_files = @extra_rdoc_files.uniq if @extra_rdoc_files
+    @files            = @files.uniq.sort if @files
+    @extensions       = @extensions.uniq.sort if @extensions
+    @test_files       = @test_files.uniq.sort if @test_files
+    @executables      = @executables.uniq.sort if @executables
+    @extra_rdoc_files = @extra_rdoc_files.uniq.sort if @extra_rdoc_files
   end
 
   ##

--- a/test/rubygems/test_gem_commands_exec_command.rb
+++ b/test/rubygems/test_gem_commands_exec_command.rb
@@ -374,7 +374,7 @@ class TestGemCommandsExecCommand < Gem::TestCase
         @cmd.invoke "a:2"
       end
       assert_equal 1, e.exit_code
-      assert_equal "ERROR:  Ambiguous which executable from gem `a` should be run: the options are [\"foo\", \"bar\"], specify one via COMMAND, and use `-g` and `-v` to specify gem and version\n", @ui.error
+      assert_equal "ERROR:  Ambiguous which executable from gem `a` should be run: the options are [\"bar\", \"foo\"], specify one via COMMAND, and use `-g` and `-v` to specify gem and version\n", @ui.error
     end
   end
 


### PR DESCRIPTION
This is just #8569 with an additional commit to fix the test.

<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

Files sorting is system-dependent making a build not reproducible. This behavior can be seen using `reprotest` to manipulate the file ordering during a build.



## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Adding a `sort` while reading files listed in metadata fixes this issue.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
