### PR TITLE
Decouple `gem exec` output ordering from `Gem::Specification` implementation details

### DIFF
--- a/lib/rubygems/commands/exec_command.rb
+++ b/lib/rubygems/commands/exec_command.rb
@@ -216,7 +216,7 @@ to the same gem path as user-installed gems.
 
       if spec.executables.size > 1
         alert_error "Ambiguous which executable from gem `#{executable}` should be run: " \
-              "the options are #{spec.executables}, specify one via COMMAND, and use `-g` and `-v` to specify gem and version"
+              "the options are #{spec.executables.sort}, specify one via COMMAND, and use `-g` and `-v` to specify gem and version"
         terminate_interaction 1
       end
 

--- a/test/rubygems/test_gem_commands_exec_command.rb
+++ b/test/rubygems/test_gem_commands_exec_command.rb
@@ -374,7 +374,7 @@ class TestGemCommandsExecCommand < Gem::TestCase
         @cmd.invoke "a:2"
       end
       assert_equal 1, e.exit_code
-      assert_equal "ERROR:  Ambiguous which executable from gem `a` should be run: the options are [\"foo\", \"bar\"], specify one via COMMAND, and use `-g` and `-v` to specify gem and version\n", @ui.error
+      assert_equal "ERROR:  Ambiguous which executable from gem `a` should be run: the options are [\"bar\", \"foo\"], specify one via COMMAND, and use `-g` and `-v` to specify gem and version\n", @ui.error
     end
   end
 


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

Implementation details of `Gem::Specification` affect the ordering of executable names in `gem exec` output.

This is preventing #8569 from being merged.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

I added a sort in `gem exec` so that it'll always be sorted alphabetically.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
