### PR TITLE
Fix "FrozenError: can't modify frozen Array" error

### DIFF
--- a/bundler/lib/bundler/endpoint_specification.rb
+++ b/bundler/lib/bundler/endpoint_specification.rb
@@ -34,7 +34,7 @@ module Bundler
     end
 
     def dependencies
-      @dependencies ||= @unbuilt_dependencies.map! {|dep, reqs| build_dependency(dep, reqs) }
+      @dependencies ||= @unbuilt_dependencies.map {|dep, reqs| build_dependency(dep, reqs) }
     end
     alias_method :runtime_dependencies, :dependencies
 

--- a/bundler/spec/bundler/endpoint_specification_spec.rb
+++ b/bundler/spec/bundler/endpoint_specification_spec.rb
@@ -80,4 +80,22 @@ RSpec.describe Bundler::EndpointSpecification do
     expect(spec).to eql(spec)
     expect(spec).to_not eql(other_spec)
   end
+
+  describe '#dependencies' do
+    let(:name)         { "foo" }
+    let(:requirement)  { "~> 1.1" }
+    let(:dependencies) { [[name, requirement]] }
+
+    it "should return an array of Gem::Dependency objects" do
+      expect(subject.dependencies). to eq([Gem::Dependency.new(name, requirement)])
+    end
+
+    context 'when dependencies parameter is a frozen array' do
+      let(:dependencies) { [[name, requirement]].freeze }
+
+      it "should return an array of Gem::Dependency objects" do
+        expect(subject.dependencies). to eq([Gem::Dependency.new(name, requirement)])
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The `FrozenError: can't modify frozen Array` exception is raised when trying to bundle install gems that have no dependencies.
Start of the stack trace:
```
FrozenError: can't modify frozen Array: []
/Users/dan/projects/rubygems/bundler/lib/bundler/endpoint_specification.rb:37:in 'Array#map!'
/Users/dan/projects/rubygems/bundler/lib/bundler/endpoint_specification.rb:37:in 'Bundler::EndpointSpecification#dependencies'
/Users/dan/projects/rubygems/bundler/lib/bundler/lazy_specification.rb:224:in 'Bundler::LazySpecification#choose_compatible'
/Users/dan/projects/rubygems/bundler/lib/bundler/lazy_specification.rb:149:in 'block in Bundler::LazySpecification#materialize_for_installation'
/Users/dan/projects/rubygems/bundler/lib/bundler/lazy_specification.rb:202:in 'Bundler::LazySpecification#materialize'
/Users/dan/projects/rubygems/bundler/lib/bundler/lazy_specification.rb:144:in 'Bundler::LazySpecification#materialize_for_installation'
/Users/dan/projects/rubygems/bundler/lib/bundler/lazy_specification.rb:131:in 'Bundler::LazySpecification#materialized_for_installation'
/Users/dan/projects/rubygems/bundler/lib/bundler/gem_helpers.rb:67:in 'Array#each'
/Users/dan/projects/rubygems/bundler/lib/bundler/gem_helpers.rb:67:in 'Enumerable#filter_map'
/Users/dan/projects/rubygems/bundler/lib/bundler/gem_helpers.rb:67:in 'Bundler::GemHelpers.select_best_local_platform_match'
/Users/dan/projects/rubygems/bundler/lib/bundler/materialization.rb:27:in 'Bundler::Materialization#specs'
/Users/dan/projects/rubygems/bundler/lib/bundler/materialization.rb:18:in 'Bundler::Materialization#complete?'
/Users/dan/projects/rubygems/bundler/lib/bundler/spec_set.rb:239:in 'block in Bundler::SpecSet#materialize_dependencies'
```

## What is your fix for the problem, implemented in this PR?

Two independent changes led to the problem.

The first one was freezing the empty arrays returned as dependencies from the parser of the `CompactIndexClient`:
https://github.com/rubygems/rubygems/commit/c68b41b0e52ec0140ab23fbcc138de1299219e70#diff-6ab9e9b457602e5d6c76d1ef57a39d69a6f88936280e79c0cb10fc2c84a9e0a0

Another one was lazy initialization of dependencies in `EndpointSpecification`:
https://github.com/rubygems/rubygems/commit/61eee39d815378c7448f15dd653d83c48e1f3749#diff-18aa0703355522e1391f4c87fb16813a9e49fc13b51c68725214b9070751dfc6

In some circumstances, the `map!` method is applied to frozen arrays, which causes the error.

The fix simply changes `map!` to `map`, so that initial array itself is not changed. `map!` is not needed here anyway.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
