### PR TITLE
Restore to use rm_rf for failing example

### DIFF
--- a/bundler/spec/install/global_cache_spec.rb
+++ b/bundler/spec/install/global_cache_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe "global gem caching" do
       R
       expect(out).to eq "VERY_SIMPLE_BINARY_IN_C\nVERY_SIMPLE_GIT_BINARY_IN_C"
 
-      FileUtils.rm_r Dir[home(".bundle", "cache", "extensions", "**", "*binary_c*")]
+      FileUtils.rm_rf Dir[home(".bundle", "cache", "extensions", "**", "*binary_c*")]
 
       gem_binary_cache.join("very_simple_binary_c.rb").open("w") {|f| f << "puts File.basename(__FILE__)" }
       git_binary_cache.join("very_simple_git_binary_c.rb").open("w") {|f| f << "puts File.basename(__FILE__)" }


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`spec/bundler/install/global_cache_spec.rb` with `rm_r` is failing now in ruby/ruby CI

https://github.com/ruby/ruby/actions/runs/13804651931/job/38616664529?pr=12911

```
  1) global gem caching extension caching works
     Failure/Error: File.unlink path

     Errno::ENOENT:
```

## What is your fix for the problem, implemented in this PR?

I restore `rm_rf` for this example.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
