### PR TITLE
Bump up minimum required version for CMake 4

### DIFF
--- a/test/rubygems/test_gem_ext_cmake_builder.rb
+++ b/test/rubygems/test_gem_ext_cmake_builder.rb
@@ -29,7 +29,7 @@ class TestGemExtCmakeBuilder < Gem::TestCase
   def test_self_build
     File.open File.join(@ext, "CMakeLists.txt"), "w" do |cmakelists|
       cmakelists.write <<-EO_CMAKE
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 project(self_build NONE)
 install (FILES test.txt DESTINATION bin)
       EO_CMAKE


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`TestGemExtCmakeBuilder#test_self_build` is failed with CMake 4.

```
  1) Error:
  TestGemExtCmakeBuilder#test_self_build:
  Test::Unit::ProxyError: cmake failed, exit code 1
      /home/runner/work/ruby/ruby/src/lib/rubygems/ext/builder.rb:126:in 'Gem::Ext::Builder.run'
      /home/runner/work/ruby/ruby/src/lib/rubygems/ext/cmake_builder.rb:14:in 'Gem::Ext::CmakeBuilder.build'
      /home/runner/work/ruby/ruby/src/test/rubygems/test_gem_ext_cmake_builder.rb:42:in 'TestGemExtCmakeBuilder#test_self_build'
```

## What is your fix for the problem, implemented in this PR?

I'm debugging that failure, cmake shows the following:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

I bump up to minimum cmake version to 3.5 from 2.6.


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
