### PR TITLE
Improve bug report instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bundler-related-issue.md
+++ b/.github/ISSUE_TEMPLATE/bundler-related-issue.md
@@ -59,9 +59,11 @@ Ideally, we recommend you set up the list of steps as a Dockerfile. A Dockerfile
 
 <!-- Replace this with the results you expected before running the command. -->
 
-### What actually happened?
+### What happened instead?
 
-<!-- Replace this with the actual result you got. Paste the output of your command here. -->
+````
+Replace this with the actual result you got. Paste the output of your command here.
+````
 
 ### If not included with the output of your command, run `bundle env` and paste the output below
 

--- a/bundler/lib/bundler/friendly_errors.rb
+++ b/bundler/lib/bundler/friendly_errors.rb
@@ -80,7 +80,7 @@ module Bundler
         First, try this link to see if there are any existing issue reports for this error:
         #{issues_url(e)}
 
-        If there aren't any reports for this error yet, please fill in the new issue form located at #{new_issue_url}, and copy and paste the report template above in there.
+        If there aren't any reports for this error yet, please fill in the new issue form located at #{new_issue_url}. Make sure to copy and paste the full output of this command under the "What happened instead?" section.
       EOS
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes users only copy the BUG REPORT TEMPLATE part of errors into issue reports. However, the full output of the failed command is better.

## What is your fix for the problem, implemented in this PR?

* Explicitly recommend copying full command output and not just the bug report template part.
* Include quadruple quotes in the "What actually happened section" and tell users to copy full command output inside. Hopefully quadruple quotes will make the error report information (which includes triple quotes itself) render fine by default.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
