### PR TITLE
Little tweaks to Windows CI

### DIFF
--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -173,14 +173,6 @@ RSpec.shared_examples "bundle install --standalone" do
 
       bundle "config set --local path #{bundled_app("bundle")}"
 
-      # Make sure rubyinstaller2 does not activate the etc gem in its
-      # `operating_system.rb` file, but completely disable that since it's not
-      # really needed here
-      if Gem.win_platform?
-        FileUtils.mkdir_p bundled_app("rubygems/defaults")
-        FileUtils.touch bundled_app("rubygems/defaults/operating_system.rb")
-      end
-
       bundle :install, standalone: true, dir: cwd, env: { "BUNDLER_GEM_DEFAULT_DIR" => system_gem_path.to_s }, load_path: bundled_app
 
       load_path_lines = bundled_app("bundle/bundler/setup.rb").read.split("\n").select {|line| line.start_with?("$:.unshift") }
@@ -211,14 +203,6 @@ RSpec.shared_examples "bundle install --standalone" do
         bundle "config set --local path #{bundled_app("bundle")}"
 
         bundle "lock", dir: cwd
-
-        # Make sure rubyinstaller2 does not activate the etc gem in its
-        # `operating_system.rb` file, but completely disable that since it's not
-        # really needed here
-        if Gem.win_platform?
-          FileUtils.mkdir_p bundled_app("rubygems/defaults")
-          FileUtils.touch bundled_app("rubygems/defaults/operating_system.rb")
-        end
 
         bundle :install, standalone: true, dir: cwd, env: { "BUNDLER_GEM_DEFAULT_DIR" => system_gem_path.to_s }, load_path: bundled_app
       end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

None, just noticed we can remove some Windows CI specific workarounds since they were fixed upstream a while ago.

## What is your fix for the problem, implemented in this PR?

Remove the unnecessary workaround.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
