### PR TITLE
Removed Solaris conditions from test file

### DIFF
--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -82,7 +82,7 @@ class TestGemBundlerVersionFinder < Gem::TestCase
 
   def test_deleted_directory
     pend "Cannot perform this test on windows" if Gem.win_platform?
-    pend "Cannot perform this test on Solaris" if RUBY_PLATFORM.include?("solaris")
+
     require "tmpdir"
 
     orig_dir = Dir.pwd


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

From https://github.com/ruby/ruby/pull/13037

We no longer test with Solaris platforms.

## What is your fix for the problem, implemented in this PR?

Removed that condition.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
