### PR TITLE
Simplify spec setup

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -76,7 +76,7 @@ jobs:
         if: matrix.bundler.value != ''
       - name: Prepare dependencies
         run: |
-          bin/rake spec:deps
+          bin/rake dev:deps
       - name: Run Test (CRuby)
         run: |
           bin/parallel_rspec

--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -76,7 +76,7 @@ jobs:
         if: matrix.bundler.value != ''
       - name: Prepare dependencies
         run: |
-          bin/rake spec:parallel_deps
+          bin/rake spec:deps
       - name: Run Test (CRuby)
         run: |
           bin/parallel_rspec

--- a/.github/workflows/daily-bundler.yml
+++ b/.github/workflows/daily-bundler.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Prepare dependencies
         run: |
           sudo apt-get install graphviz -y
-          bin/rake spec:deps
+          bin/rake dev:deps
 
       - name: Run Test
         run: |

--- a/.github/workflows/daily-bundler.yml
+++ b/.github/workflows/daily-bundler.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Prepare dependencies
         run: |
           sudo apt-get install graphviz -y
-          bin/rake spec:parallel_deps
+          bin/rake spec:deps
 
       - name: Run Test
         run: |

--- a/.github/workflows/realworld-bundler.yml
+++ b/.github/workflows/realworld-bundler.yml
@@ -53,7 +53,7 @@ jobs:
         run: BUNDLER_SPEC_SUB_VERSION=${{ matrix.bundler.value }} bin/rake override_version
         if: matrix.bundler.value != ''
       - name: Prepare dependencies
-        run: bin/rake spec:deps
+        run: bin/rake dev:deps
       - name: Run Test
         run: bin/rake spec:realworld
       - name: Upload used cassettes as artifact
@@ -107,7 +107,7 @@ jobs:
         run: BUNDLER_SPEC_SUB_VERSION=${{ matrix.bundler.value }} bin/rake override_version
         if: matrix.bundler.value != ''
       - name: Prepare dependencies
-        run: bin/rake spec:deps
+        run: bin/rake dev:deps
       - name: Run Test
         run: bin/rake spec:realworld
       - name: Upload used cassettes as artifact

--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Sync tools
         run: |
           ruby tool/sync_default_gems.rb rubygems
+          mv spec/bundler/bin/parallel_rspec spec/bin/parallel_rspec # TODO: fix `sync_default_gems.rb` script so we don't need to vendor the ruby-core binstub ourselves
         working-directory: ruby/ruby
       - name: Test RubyGems
         run: make -j2 -s test-all TESTS="rubygems --no-retry"

--- a/.github/workflows/system-rubygems-bundler.yml
+++ b/.github/workflows/system-rubygems-bundler.yml
@@ -52,7 +52,7 @@ jobs:
         if: matrix.bundler.value != ''
       - name: Prepare dependencies
         run: |
-          bin/rake spec:parallel_deps
+          bin/rake spec:deps
       - name: Run Test
         run: |
           bin/parallel_rspec

--- a/.github/workflows/system-rubygems-bundler.yml
+++ b/.github/workflows/system-rubygems-bundler.yml
@@ -52,7 +52,7 @@ jobs:
         if: matrix.bundler.value != ''
       - name: Prepare dependencies
         run: |
-          bin/rake spec:deps
+          bin/rake dev:deps
       - name: Run Test
         run: |
           bin/parallel_rspec

--- a/.github/workflows/truffleruby-bundler.yml
+++ b/.github/workflows/truffleruby-bundler.yml
@@ -32,7 +32,7 @@ jobs:
           bundler: none
       - name: Prepare dependencies
         run: |
-          bin/rake spec:parallel_deps
+          bin/rake spec:deps
       - name: Run Test
         run: |
           bin/parallel_rspec --tag truffleruby_only --tag truffleruby

--- a/.github/workflows/truffleruby-bundler.yml
+++ b/.github/workflows/truffleruby-bundler.yml
@@ -32,7 +32,7 @@ jobs:
           bundler: none
       - name: Prepare dependencies
         run: |
-          bin/rake spec:deps
+          bin/rake dev:deps
       - name: Run Test
         run: |
           bin/parallel_rspec --tag truffleruby_only --tag truffleruby

--- a/Rakefile
+++ b/Rakefile
@@ -542,16 +542,12 @@ end
 namespace :spec do
   desc "Ensure spec dependencies are installed"
   task deps: "dev:deps" do
-    chdir("bundler") do
-      Spec::Rubygems.install_test_deps
-    end
+    Spec::Rubygems.install_test_deps
   end
 
-  desc "Ensure spec dependencies for running in parallel are installed"
-  task parallel_deps: "dev:deps" do
-    chdir("bundler") do
-      Spec::Rubygems.install_parallel_test_deps
-    end
+  desc "Ensure spec dependencies for running in parallel are installed (deprecated)"
+  task parallel_deps: "spec:deps" do
+    warn "The `spec:parallel_deps` task is deprecated because test dependency setup does not need parallelization. Use `spec:deps` task instead."
   end
 
   desc "Run all specs"

--- a/Rakefile
+++ b/Rakefile
@@ -6,60 +6,36 @@ require "rubygems"
 require "rubygems/package_task"
 require "rake/testtask"
 
-module RubyGems
-  module DevTasks
-    include FileUtils
-
-    extend self
-
-    def bundle_dev_gemfile(*args)
-      sh "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", *args, "--gemfile=tool/bundler/dev_gems.rb"
-    end
-
-    def bundle_support_gemfile(name, *args)
-      sh "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", *args, "--gemfile=tool/bundler/#{name}.rb"
-    end
-
-    def update_locked_bundler
-      require "open3"
-
-      stdout, status = Open3.capture2e("ruby", "-I", "lib", "bundler/spec/support/bundle.rb", "--version")
-      raise "Failed to find current version of Bundler" unless status.success?
-
-      version = stdout.split(" ").last
-
-      Dir.glob("tool/bundler/*_gems.rb").each do |file|
-        name = File.basename(file, ".rb")
-        bundle_support_gemfile(name, "update", "--bundler", version)
-      end
-    end
-  end
-end
+require_relative "bundler/spec/support/rubygems_ext"
 
 desc "Setup Rubygems dev environment"
-task :setup do
-  RubyGems::DevTasks.bundle_dev_gemfile "install"
+task setup: [:"dev:deps"] do
   Dir.glob("tool/bundler/*_gems.rb").each do |file|
     name = File.basename(file, ".rb")
     next if name == "dev_gems"
-    RubyGems::DevTasks.bundle_support_gemfile name, "lock"
+    Spec::Rubygems.dev_bundle "lock", gemfile: file
   end
 end
 
 desc "Update Rubygems dev environment"
 task :update do
-  RubyGems::DevTasks.bundle_dev_gemfile "update"
+  Spec::Rubygems.dev_bundle "update"
   Dir.glob("tool/bundler/*_gems.rb").each do |file|
     name = File.basename(file, ".rb")
     next if name == "dev_gems"
-    RubyGems::DevTasks.bundle_support_gemfile name, "lock", "--update"
+    Spec::Rubygems.dev_bundle "lock", "--update", gemfile: file
   end
 end
 
 namespace :version do
   desc "Update the locked bundler version in dev environment"
   task update_locked_bundler: [:"bundler:install"] do |_, _args|
-    RubyGems::DevTasks.update_locked_bundler
+    stdout = Spec::Rubygems.dev_bundle "--version"
+    version = stdout.split(" ").last
+
+    Dir.glob("tool/bundler/*_gems.rb").each do |file|
+      Spec::Rubygems.dev_bundle("update", "--bundler", version, gemfile: file)
+    end
   end
 
   desc "Check locked bundler version is up to date"
@@ -73,14 +49,14 @@ end
 
 desc "Update specific development dependencies"
 task :update_dev_dep do |_, args|
-  RubyGems::DevTasks.bundle_dev_gemfile "update", *args
+  Spec::Rubygems.dev_bundle "update", *args
 end
 
 desc "Update RSpec related gems"
 task :update_rspec_deps do |_, _args|
-  RubyGems::DevTasks.bundle_dev_gemfile "update", "rspec-core", "rspec-expectations", "rspec-mocks"
-  RubyGems::DevTasks.bundle_support_gemfile "rubocop_gems", "lock", "--update", "rspec-core", "rspec-expectations", "rspec-mocks"
-  RubyGems::DevTasks.bundle_support_gemfile "standard_gems", "lock", "--update", "rspec-core", "rspec-expectations", "rspec-mocks"
+  Spec::Rubygems.dev_bundle "update", "rspec-core", "rspec-expectations", "rspec-mocks"
+  Spec::Rubygems.dev_bundle "lock", "--update", "rspec-core", "rspec-expectations", "rspec-mocks", gemfile: "tool/bundler/rubocop_gems.rb"
+  Spec::Rubygems.dev_bundle "lock", "--update", "rspec-core", "rspec-expectations", "rspec-mocks", gemfile: "tool/bundler/standard_gems.rb"
 end
 
 desc "Setup git hooks"
@@ -515,8 +491,6 @@ task update_licenses_branch: :update_licenses do
   end
 end
 
-require_relative "bundler/spec/support/rubygems_ext"
-
 desc "Run specs"
 task :spec do
   chdir("bundler") do
@@ -527,7 +501,7 @@ end
 namespace :dev do
   desc "Ensure dev dependencies are installed"
   task :deps do
-    Spec::Rubygems.dev_setup
+    puts Spec::Rubygems.dev_bundle("install")
   end
 
   desc "Ensure dev dependencies are installed, and make sure no lockfile changes are generated"
@@ -540,14 +514,14 @@ namespace :dev do
 end
 
 namespace :spec do
-  desc "Ensure spec dependencies are installed"
+  desc "Ensure spec dependencies are installed (deprecated)"
   task deps: "dev:deps" do
-    Spec::Rubygems.install_test_deps
+    warn "The `spec:deps` task is deprecated because test dependencies are now installed by the tests themselves. Use `dev:deps` task instead."
   end
 
   desc "Ensure spec dependencies for running in parallel are installed (deprecated)"
-  task parallel_deps: "spec:deps" do
-    warn "The `spec:parallel_deps` task is deprecated because test dependency setup does not need parallelization. Use `spec:deps` task instead."
+  task parallel_deps: "dev:deps" do
+    warn "The `spec:parallel_deps` task is deprecated because test dependencies are now installed by the tests themselves and don't need parallelization. Use `dev:deps` task instead."
   end
 
   desc "Run all specs"

--- a/bin/rake
+++ b/bin/rake
@@ -3,7 +3,7 @@
 
 require_relative "../bundler/spec/support/rubygems_ext"
 
-if ["setup", "dev:deps", "dev:frozen_deps", "override_version", "spec:deps", "spec:parallel_deps"].include?(ARGV[0])
+if ["setup", "dev:deps", "dev:frozen_deps", "override_version", "spec:deps"].include?(ARGV[0])
   Spec::Rubygems.gem_load_and_possibly_install("rake", "rake")
 else
   Spec::Rubygems.gem_load("rake", "rake")

--- a/bin/rake
+++ b/bin/rake
@@ -3,7 +3,7 @@
 
 require_relative "../bundler/spec/support/rubygems_ext"
 
-if ["setup", "dev:deps", "dev:frozen_deps", "override_version", "spec:deps"].include?(ARGV[0])
+if ["setup", "dev:deps", "dev:frozen_deps", "override_version"].include?(ARGV[0])
   Spec::Rubygems.gem_load_and_possibly_install("rake", "rake")
 else
   Spec::Rubygems.gem_load("rake", "rake")

--- a/bundler/bin/rspec
+++ b/bundler/bin/rspec
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative "../spec/support/rubygems_ext"
+require_relative "../spec/support/setup"
 
 Spec::Rubygems.gem_load("rspec-core", "rspec")

--- a/bundler/spec/bin/parallel_rspec
+++ b/bundler/spec/bin/parallel_rspec
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative "../spec/support/setup"
+require_relative "../bundler/support/setup"
 
 require "turbo_tests"
 TurboTests::CLI.new(ARGV).run

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -95,8 +95,6 @@ RSpec.configure do |config|
 
     extend(Spec::Builders)
 
-    check_test_gems!
-
     build_repo1
 
     reset_paths!
@@ -118,9 +116,5 @@ RSpec.configure do |config|
     end
   ensure
     reset!
-  end
-
-  config.after :suite do
-    FileUtils.rm_r Spec::Path.pristine_system_gem_path
   end
 end

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -461,7 +461,7 @@ module Spec
           target_shipped_file = build_path + target_shipped_file
           target_shipped_dir = File.dirname(target_shipped_file)
           FileUtils.mkdir_p target_shipped_dir unless File.directory?(target_shipped_dir)
-          FileUtils.cp shipped_file, target_shipped_file, preserve: true
+          FileUtils.cp File.expand_path(shipped_file, @context.source_root), target_shipped_file, preserve: true
         end
 
         @context.replace_version_file(@version, dir: build_path)

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -276,14 +276,6 @@ module Spec
       update_repo(path,**kwargs, &blk)
     end
 
-    def check_test_gems!
-      if rake_path.nil?
-        Spec::Rubygems.install_test_deps
-      end
-
-      Helpers.install_dev_bundler unless pristine_system_gem_path.exist?
-    end
-
     def update_repo(path, build_compact_index: true)
       exempted_caller = Gem.ruby_version >= Gem::Version.new("3.4.0.dev") ? "#{Module.nesting.first}#build_repo" : "build_repo"
       if path == gem_repo1 && caller_locations(1, 1).first.label != exempted_caller
@@ -453,6 +445,7 @@ module Spec
         build_path = @context.tmp + full_name
         bundler_path = build_path + "#{full_name}.gem"
 
+        require "fileutils"
         FileUtils.mkdir_p build_path
 
         @context.shipped_files.each do |shipped_file|

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -25,10 +25,6 @@ module Spec
       @relative_gemspec ||= ruby_core? ? "lib/bundler/bundler.gemspec" : "bundler.gemspec"
     end
 
-    def gemspec_dir
-      @gemspec_dir ||= gemspec.parent
-    end
-
     def loaded_gemspec
       @loaded_gemspec ||= Dir.chdir(source_root) { Gem::Specification.load(gemspec.to_s) }
     end

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -223,7 +223,7 @@ module Spec
     end
 
     def pristine_system_gem_path
-      tmp("gems/base_system")
+      tmp_root.join("gems/pristine_system")
     end
 
     def local_gem_path(*path, base: bundled_app)
@@ -277,7 +277,7 @@ module Spec
     end
 
     def rake_path
-      Dir["#{base_system_gems}/#{Bundler.ruby_scope}/**/rake*.gem"].first
+      Dir["#{base_system_gems}/*/*/**/rake*.gem"].first
     end
 
     def sinatra_dependency_paths

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -30,7 +30,7 @@ module Spec
     end
 
     def loaded_gemspec
-      @loaded_gemspec ||= Gem::Specification.load(gemspec.to_s)
+      @loaded_gemspec ||= Dir.chdir(source_root) { Gem::Specification.load(gemspec.to_s) }
     end
 
     def test_gemfile
@@ -102,11 +102,11 @@ module Spec
     end
 
     def tmp(*path)
-      tmp_root(scope).join(*path)
+      tmp_root.join("#{test_env_version}.#{scope}").join(*path)
     end
 
-    def tmp_root(scope)
-      source_root.join("tmp", "#{test_env_version}.#{scope}")
+    def tmp_root
+      source_root.join("tmp")
     end
 
     # Bump this version whenever you make a breaking change to the spec setup
@@ -180,15 +180,15 @@ module Spec
     end
 
     def base_system_gems
-      tmp("gems/base")
+      tmp_root.join("gems/base")
     end
 
     def rubocop_gems
-      tmp("gems/rubocop")
+      tmp_root.join("gems/rubocop")
     end
 
     def standard_gems
-      tmp("gems/standard")
+      tmp_root.join("gems/standard")
     end
 
     def file_uri_for(path)

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -10,10 +10,6 @@ module Spec
   module Rubygems
     extend self
 
-    def dev_setup
-      install_gems(dev_gemfile)
-    end
-
     def gem_load(gem_name, bin_container)
       require_relative "switch_rubygems"
 
@@ -57,13 +53,12 @@ module Spec
     end
 
     def install_test_deps
-      install_gems(test_gemfile, Path.base_system_gems.to_s)
-      install_gems(rubocop_gemfile, Path.rubocop_gems.to_s)
-      install_gems(standard_gemfile, Path.standard_gems.to_s)
+      dev_bundle("install", gemfile: test_gemfile, path: Path.base_system_gems.to_s)
+      dev_bundle("install", gemfile: rubocop_gemfile, path: Path.rubocop_gems.to_s)
+      dev_bundle("install", gemfile: standard_gemfile, path: Path.standard_gems.to_s)
 
-      # For some reason, doing this here crashes on JRuby + Windows. So defer to
-      # when the test suite is running in that case.
-      Helpers.install_dev_bundler unless Gem.win_platform? && RUBY_ENGINE == "jruby"
+      require_relative "helpers"
+      Helpers.install_dev_bundler
     end
 
     def check_source_control_changes(success_message:, error_message:)
@@ -84,6 +79,36 @@ module Spec
 
         exit(1)
       end
+    end
+
+    def dev_bundle(*args, gemfile: dev_gemfile, path: nil)
+      old_gemfile = ENV["BUNDLE_GEMFILE"]
+      old_orig_gemfile = ENV["BUNDLER_ORIG_BUNDLE_GEMFILE"]
+      ENV["BUNDLE_GEMFILE"] = gemfile.to_s
+      ENV["BUNDLER_ORIG_BUNDLE_GEMFILE"] = nil
+
+      if path
+        old_path = ENV["BUNDLE_PATH"]
+        ENV["BUNDLE_PATH"] = path
+      else
+        old_path__system = ENV["BUNDLE_PATH__SYSTEM"]
+        ENV["BUNDLE_PATH__SYSTEM"] = "true"
+      end
+
+      require "shellwords"
+      # We don't use `Open3` here because it does not work on JRuby + Windows
+      output = `ruby #{File.expand_path("support/bundle.rb", Path.spec_dir)} #{args.shelljoin}`
+      raise output unless $?.success?
+      output
+    ensure
+      if path
+        ENV["BUNDLE_PATH"] = old_path
+      else
+        ENV["BUNDLE_PATH__SYSTEM"] = old_path__system
+      end
+
+      ENV["BUNDLER_ORIG_BUNDLE_GEMFILE"] = old_orig_gemfile
+      ENV["BUNDLE_GEMFILE"] = old_gemfile
     end
 
     private
@@ -112,34 +137,6 @@ module Spec
       require "bundler"
       gem_requirement = Bundler::LockfileParser.new(File.read(dev_lockfile)).specs.find {|spec| spec.name == gem_name }.version
       gem gem_name, gem_requirement
-    end
-
-    def install_gems(gemfile, path = nil)
-      old_gemfile = ENV["BUNDLE_GEMFILE"]
-      old_orig_gemfile = ENV["BUNDLER_ORIG_BUNDLE_GEMFILE"]
-      ENV["BUNDLE_GEMFILE"] = gemfile.to_s
-      ENV["BUNDLER_ORIG_BUNDLE_GEMFILE"] = nil
-
-      if path
-        old_path = ENV["BUNDLE_PATH"]
-        ENV["BUNDLE_PATH"] = path
-      else
-        old_path__system = ENV["BUNDLE_PATH__SYSTEM"]
-        ENV["BUNDLE_PATH__SYSTEM"] = "true"
-      end
-
-      # We don't use `Open3` here because it does not work on JRuby + Windows
-      output = `#{Gem.ruby} #{File.expand_path("support/bundle.rb", Path.spec_dir)} install`
-      raise output unless $?.success?
-    ensure
-      if path
-        ENV["BUNDLE_PATH"] = old_path
-      else
-        ENV["BUNDLE_PATH__SYSTEM"] = old_path__system
-      end
-
-      ENV["BUNDLER_ORIG_BUNDLE_GEMFILE"] = old_orig_gemfile
-      ENV["BUNDLE_GEMFILE"] = old_gemfile
     end
 
     def test_gemfile

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -67,10 +67,7 @@ module Spec
     end
 
     def setup_test_paths
-      Gem.clear_paths
-
       ENV["BUNDLE_PATH"] = nil
-      ENV["GEM_HOME"] = ENV["GEM_PATH"] = Path.base_system_gem_path.to_s
       ENV["PATH"] = [Path.system_gem_path("bin"), ENV["PATH"]].join(File::PATH_SEPARATOR)
       ENV["PATH"] = [Path.bindir, ENV["PATH"]].join(File::PATH_SEPARATOR) if Path.ruby_core?
     end

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -50,22 +50,6 @@ module Spec
       Gem::DefaultUserInteraction.ui = Gem::SilentUI.new
     end
 
-    def install_parallel_test_deps
-      Gem.clear_paths
-
-      require "parallel"
-      require "fileutils"
-
-      install_test_deps
-
-      (2..Parallel.processor_count).each do |n|
-        source = Path.tmp_root("1")
-        destination = Path.tmp_root(n.to_s)
-
-        FileUtils.cp_r source, destination, remove_destination: true
-      end
-    end
-
     def setup_test_paths
       ENV["BUNDLE_PATH"] = nil
       ENV["PATH"] = [Path.system_gem_path("bin"), ENV["PATH"]].join(File::PATH_SEPARATOR)
@@ -73,8 +57,6 @@ module Spec
     end
 
     def install_test_deps
-      Gem.clear_paths
-
       install_gems(test_gemfile, Path.base_system_gems.to_s)
       install_gems(rubocop_gemfile, Path.rubocop_gems.to_s)
       install_gems(standard_gemfile, Path.standard_gems.to_s)

--- a/bundler/spec/support/setup.rb
+++ b/bundler/spec/support/setup.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require_relative "switch_rubygems"
+
+require_relative "rubygems_ext"
+Spec::Rubygems.install_test_deps
+
+require_relative "path"
+$LOAD_PATH.unshift(File.expand_path("../../lib", __dir__)) if Spec::Path.ruby_core?

--- a/doc/bundler/development/SETUP.md
+++ b/doc/bundler/development/SETUP.md
@@ -12,9 +12,9 @@ To work on Bundler, you'll probably want to do a couple of things:
 
         brew install graphviz
 
-* Install development dependencies and Bundler's test dependencies from the rubygems root directory:
+* Install development dependencies from the rubygems root directory:
 
-        bin/rake setup spec:deps
+        bin/rake setup
 
 * Change into the bundler directory:
 

--- a/doc/bundler/development/SETUP.md
+++ b/doc/bundler/development/SETUP.md
@@ -14,7 +14,7 @@ To work on Bundler, you'll probably want to do a couple of things:
 
 * Install development dependencies and Bundler's test dependencies from the rubygems root directory:
 
-        bin/rake setup spec:parallel_deps
+        bin/rake setup spec:deps
 
 * Change into the bundler directory:
 

--- a/doc/bundler/documentation/WRITING.md
+++ b/doc/bundler/documentation/WRITING.md
@@ -39,7 +39,7 @@ If you're not sure if the formatting looks right, that's ok! Make a pull request
 To preview your changes as they will print out for Bundler users, you'll need to run a series of commands:
 
 ```
-$ bin/rake spec:deps
+$ bin/rake dev:deps
 $ bin/rake man:build
 $ man ./lib/bundler/man/bundle-cookies.1
 ```

--- a/doc/rubygems/CONTRIBUTING.md
+++ b/doc/rubygems/CONTRIBUTING.md
@@ -70,10 +70,6 @@ And to run an individual test method named `test_default` within a test file, yo
 
 ### Running bundler tests
 
-To setup bundler tests:
-
-    bin/rake spec:deps
-
 To run the entire bundler test suite in parallel (it takes a while), run the following from the `bundler/` subfolder:
 
     bin/parallel_rspec

--- a/doc/rubygems/CONTRIBUTING.md
+++ b/doc/rubygems/CONTRIBUTING.md
@@ -72,7 +72,7 @@ And to run an individual test method named `test_default` within a test file, yo
 
 To setup bundler tests:
 
-    bin/rake spec:parallel_deps
+    bin/rake spec:deps
 
 To run the entire bundler test suite in parallel (it takes a while), run the following from the `bundler/` subfolder:
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

* Sometimes there are issues that affect specs, but only when run from `ruby/ruby`. This makes ruby-core maintainers patch Bundler directly in `ruby/ruby` to workaround issues. Then changes need to be ported back to our repo in the "reverse" way. It's also hard for us to understand issues when they are specific to `ruby/ruby`. See https://github.com/rubygems/rubygems/pull/8277 for an example.

* Bundler specs use a lot of redundant disk space and setup because they duplicate test gems like `sinatra`, `rake`, and others for each test process.

## What is your fix for the problem, implemented in this PR?

For the first issue, I refactored setup so that both test suites run more similarly: test dependencies like `sinatra` or `rake` are now installed automatically when tests are run, without the need for a specific setup task, like ruby-core does already. I'd expect this to reduce ruby-core specific issues, at least we would've noticed the issues in #8277 earlier.

For the second issue, I moved setting up these gems to a location that's common to all test workers, and which happens before test workers are launched.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
