### PR TITLE
Fix `bundle lock --normalize-platforms` regression

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -465,7 +465,7 @@ module Bundler
     end
 
     def normalize_platforms
-      @platforms = resolve.normalize_platforms!(current_dependencies, platforms)
+      resolve.normalize_platforms!(current_dependencies, platforms)
 
       @resolve = SpecSet.new(resolve.for(current_dependencies, @platforms))
     end

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -29,9 +29,9 @@ module Bundler
     end
 
     def normalize_platforms!(deps, platforms)
-      complete_platforms = add_extra_platforms!(platforms)
+      add_extra_platforms!(platforms)
 
-      complete_platforms.map do |platform|
+      platforms.map! do |platform|
         next platform if platform == Gem::Platform::RUBY
 
         begin
@@ -44,7 +44,7 @@ module Bundler
         next platform if incomplete_for_platform?(deps, less_specific_platform)
 
         less_specific_platform
-      end.uniq
+      end.uniq!
     end
 
     def add_originally_invalid_platforms!(platforms, originally_invalid_platforms)
@@ -68,6 +68,7 @@ module Bundler
       return if new_platforms.empty?
 
       platforms.concat(new_platforms)
+      return if new_platforms.include?(Bundler.local_platform)
 
       less_specific_platform = new_platforms.find {|platform| platform != Gem::Platform::RUBY && Bundler.local_platform === platform && platform === Bundler.local_platform }
       platforms.delete(Bundler.local_platform) if less_specific_platform


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

For some reason I left the `--normalize-platforms` flag to `bundle lock` uncovered, and Bundler 2.6.7 made it crash.

## What is your fix for the problem, implemented in this PR?

Fix the issue and get the flag covered.

Closes #8618.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
