### PR TITLE
bundle gem: support `--no-rbs`

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -540,6 +540,7 @@ module Bundler
     method_option :mit, type: :boolean, desc: "Generate an MIT license file. Set a default with `bundle config set --global gem.mit true`."
     method_option :rubocop, type: :boolean, desc: "Add rubocop to the generated Rakefile and gemspec. Set a default with `bundle config set --global gem.rubocop true`."
     method_option :changelog, type: :boolean, desc: "Generate changelog file. Set a default with `bundle config set --global gem.changelog true`."
+    method_option :rbs, type: :boolean, desc: "Generate RBS signatures. Set a default with `bundle config set --global gem.rbs true`."
     method_option :test, type: :string, lazy_default: Bundler.settings["gem.test"] || "", aliases: "-t", banner: "Use the specified test framework for your library", enum: %w[rspec minitest test-unit], desc: "Generate a test directory for your library, either rspec, minitest or test-unit. Set a default with `bundle config set --global gem.test (rspec|minitest|test-unit)`."
     method_option :ci, type: :string, lazy_default: Bundler.settings["gem.ci"] || "", enum: %w[github gitlab circle], desc: "Generate CI configuration, either GitHub Actions, GitLab CI or CircleCI. Set a default with `bundle config set --global gem.ci (github|gitlab|circle)`"
     method_option :linter, type: :string, lazy_default: Bundler.settings["gem.linter"] || "", enum: %w[rubocop standard], desc: "Add a linter and code formatter, either RuboCop or Standard. Set a default with `bundle config set --global gem.linter (rubocop|standard)`"

--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -83,7 +83,6 @@ module Bundler
         "Gemfile.tt" => Bundler.preferred_gemfile_name,
         "lib/newgem.rb.tt" => "lib/#{namespaced_path}.rb",
         "lib/newgem/version.rb.tt" => "lib/#{namespaced_path}/version.rb",
-        "sig/newgem.rbs.tt" => "sig/#{namespaced_path}.rbs",
         "newgem.gemspec.tt" => "#{name}.gemspec",
         "Rakefile.tt" => "Rakefile",
         "README.md.tt" => "README.md",
@@ -193,6 +192,13 @@ module Bundler
         config[:changelog] = true
         Bundler.ui.info "Changelog enabled in config"
         templates.merge!("CHANGELOG.md.tt" => "CHANGELOG.md")
+      end
+
+      if ask_and_set(:rbs, "Do you want to include RBS type signatures?",
+        "See https://github.com/ruby/rbs")
+        config[:rbs] = true
+        Bundler.ui.info "RBS signatures enabled in config"
+        templates.merge!("sig/newgem.rbs.tt" => "sig/#{namespaced_path}.rbs")
       end
 
       config[:linter] = ask_and_set_linter

--- a/bundler/lib/bundler/man/bundle-add.1
+++ b/bundler/lib/bundler/man/bundle-add.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-ADD" "1" "June 2025" ""
+.TH "BUNDLE\-ADD" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-add\fR \- Add gem to the Gemfile and run bundle install
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-binstubs.1
+++ b/bundler/lib/bundler/man/bundle-binstubs.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-BINSTUBS" "1" "June 2025" ""
+.TH "BUNDLE\-BINSTUBS" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-binstubs\fR \- Install the binstubs of the listed gems
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-cache.1
+++ b/bundler/lib/bundler/man/bundle-cache.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-CACHE" "1" "June 2025" ""
+.TH "BUNDLE\-CACHE" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-cache\fR \- Package your needed \fB\.gem\fR files into your application
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-check.1
+++ b/bundler/lib/bundler/man/bundle-check.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-CHECK" "1" "June 2025" ""
+.TH "BUNDLE\-CHECK" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-check\fR \- Verifies if dependencies are satisfied by installed gems
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-clean.1
+++ b/bundler/lib/bundler/man/bundle-clean.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-CLEAN" "1" "June 2025" ""
+.TH "BUNDLE\-CLEAN" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-clean\fR \- Cleans up unused gems in your bundler directory
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-CONFIG" "1" "June 2025" ""
+.TH "BUNDLE\-CONFIG" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-config\fR \- Set bundler configuration options
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-console.1
+++ b/bundler/lib/bundler/man/bundle-console.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-CONSOLE" "1" "June 2025" ""
+.TH "BUNDLE\-CONSOLE" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-console\fR \- Open an IRB session with the bundle pre\-loaded
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-doctor.1
+++ b/bundler/lib/bundler/man/bundle-doctor.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-DOCTOR" "1" "June 2025" ""
+.TH "BUNDLE\-DOCTOR" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-doctor\fR \- Checks the bundle for common problems
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-env.1
+++ b/bundler/lib/bundler/man/bundle-env.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-ENV" "1" "June 2025" ""
+.TH "BUNDLE\-ENV" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-env\fR \- Print information about the environment Bundler is running under
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-exec.1
+++ b/bundler/lib/bundler/man/bundle-exec.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-EXEC" "1" "June 2025" ""
+.TH "BUNDLE\-EXEC" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-exec\fR \- Execute a command in the context of the bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-fund.1
+++ b/bundler/lib/bundler/man/bundle-fund.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-FUND" "1" "June 2025" ""
+.TH "BUNDLE\-FUND" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-fund\fR \- Lists information about gems seeking funding assistance
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-gem.1
+++ b/bundler/lib/bundler/man/bundle-gem.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-GEM" "1" "June 2025" ""
+.TH "BUNDLE\-GEM" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-gem\fR \- Generate a project skeleton for creating a rubygem
 .SH "SYNOPSIS"
@@ -13,6 +13,8 @@ Run \fBrake \-T\fR in the resulting project for a list of Rake tasks that can be
 The generated project skeleton can be customized with OPTIONS, as explained below\. Note that these options can also be specified via Bundler's global configuration file using the following names:
 .IP "\(bu" 4
 \fBgem\.coc\fR
+.IP "\(bu" 4
+\fBgem\.rbs\fR
 .IP "\(bu" 4
 \fBgem\.mit\fR
 .IP "\(bu" 4
@@ -37,6 +39,12 @@ Add a \fBCHANGELOG\.md\fR file to the root of the generated project\. If this op
 .TP
 \fB\-\-no\-changelog\fR
 Do not create a \fBCHANGELOG\.md\fR (overrides \fB\-\-changelog\fR specified in the global config)\.
+.TP
+\fB\-\-rbs\fR
+Add a RBS signatures file in \fBsig/GEM_NAME\.rbs\fR\. If this option is unspecified, an interactive prompt will be displayed and the answer will be saved in Bundler's global config for future \fBbundle gem\fR use\.
+.TP
+\fB\-\-no\-rbs\fR
+Do not create \fBsig/GEM_NAME\.rbs\fR (overrides \fB\-\-rbs\fR specified in the global config)\.
 .TP
 \fB\-\-ext=c\fR, \fB\-\-ext=rust\fR
 Add boilerplate for C or Rust (currently magnus \fIhttps://docs\.rs/magnus\fR based) extension code to the generated project\. This behavior is disabled by default\.

--- a/bundler/lib/bundler/man/bundle-gem.1.ronn
+++ b/bundler/lib/bundler/man/bundle-gem.1.ronn
@@ -19,6 +19,7 @@ below. Note that these options can also be specified via Bundler's global
 configuration file using the following names:
 
 * `gem.coc`
+* `gem.rbs`
 * `gem.mit`
 * `gem.test`
 
@@ -50,6 +51,15 @@ configuration file using the following names:
 * `--no-changelog`:
   Do not create a `CHANGELOG.md` (overrides `--changelog` specified in the
   global config).
+
+* `--rbs`:
+  Add a RBS signatures file in `sig/GEM_NAME.rbs`. If this option is
+  unspecified, an interactive prompt will be displayed and the answer will be
+  saved in Bundler's global config for future `bundle gem` use.
+
+* `--no-rbs`:
+  Do not create `sig/GEM_NAME.rbs` (overrides `--rbs` specified in the global
+  config).
 
 * `--ext=c`, `--ext=rust`:
   Add boilerplate for C or Rust (currently [magnus](https://docs.rs/magnus) based) extension code to the generated project. This behavior

--- a/bundler/lib/bundler/man/bundle-help.1
+++ b/bundler/lib/bundler/man/bundle-help.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-HELP" "1" "June 2025" ""
+.TH "BUNDLE\-HELP" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-help\fR \- Displays detailed help for each subcommand
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-info.1
+++ b/bundler/lib/bundler/man/bundle-info.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-INFO" "1" "June 2025" ""
+.TH "BUNDLE\-INFO" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-info\fR \- Show information for the given gem in your bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-init.1
+++ b/bundler/lib/bundler/man/bundle-init.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-INIT" "1" "June 2025" ""
+.TH "BUNDLE\-INIT" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-init\fR \- Generates a Gemfile into the current working directory
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-inject.1
+++ b/bundler/lib/bundler/man/bundle-inject.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-INJECT" "1" "June 2025" ""
+.TH "BUNDLE\-INJECT" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-inject\fR \- Add named gem(s) with version requirements to Gemfile
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-install.1
+++ b/bundler/lib/bundler/man/bundle-install.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-INSTALL" "1" "June 2025" ""
+.TH "BUNDLE\-INSTALL" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-install\fR \- Install the dependencies specified in your Gemfile
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-issue.1
+++ b/bundler/lib/bundler/man/bundle-issue.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-ISSUE" "1" "June 2025" ""
+.TH "BUNDLE\-ISSUE" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-issue\fR \- Get help reporting Bundler issues
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-licenses.1
+++ b/bundler/lib/bundler/man/bundle-licenses.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-LICENSES" "1" "June 2025" ""
+.TH "BUNDLE\-LICENSES" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-licenses\fR \- Print the license of all gems in the bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-list.1
+++ b/bundler/lib/bundler/man/bundle-list.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-LIST" "1" "June 2025" ""
+.TH "BUNDLE\-LIST" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-list\fR \- List all the gems in the bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-lock.1
+++ b/bundler/lib/bundler/man/bundle-lock.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-LOCK" "1" "June 2025" ""
+.TH "BUNDLE\-LOCK" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-lock\fR \- Creates / Updates a lockfile without installing
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-open.1
+++ b/bundler/lib/bundler/man/bundle-open.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-OPEN" "1" "June 2025" ""
+.TH "BUNDLE\-OPEN" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-open\fR \- Opens the source directory for a gem in your bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-outdated.1
+++ b/bundler/lib/bundler/man/bundle-outdated.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-OUTDATED" "1" "June 2025" ""
+.TH "BUNDLE\-OUTDATED" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-outdated\fR \- List installed gems with newer versions available
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-platform.1
+++ b/bundler/lib/bundler/man/bundle-platform.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-PLATFORM" "1" "June 2025" ""
+.TH "BUNDLE\-PLATFORM" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-platform\fR \- Displays platform compatibility information
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-plugin.1
+++ b/bundler/lib/bundler/man/bundle-plugin.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-PLUGIN" "1" "June 2025" ""
+.TH "BUNDLE\-PLUGIN" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-plugin\fR \- Manage Bundler plugins
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-pristine.1
+++ b/bundler/lib/bundler/man/bundle-pristine.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-PRISTINE" "1" "June 2025" ""
+.TH "BUNDLE\-PRISTINE" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-pristine\fR \- Restores installed gems to their pristine condition
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-remove.1
+++ b/bundler/lib/bundler/man/bundle-remove.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-REMOVE" "1" "June 2025" ""
+.TH "BUNDLE\-REMOVE" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-remove\fR \- Removes gems from the Gemfile
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-show.1
+++ b/bundler/lib/bundler/man/bundle-show.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-SHOW" "1" "June 2025" ""
+.TH "BUNDLE\-SHOW" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-show\fR \- Shows all the gems in your bundle, or the path to a gem
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-update.1
+++ b/bundler/lib/bundler/man/bundle-update.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-UPDATE" "1" "June 2025" ""
+.TH "BUNDLE\-UPDATE" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-update\fR \- Update your gems to the latest available versions
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-version.1
+++ b/bundler/lib/bundler/man/bundle-version.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-VERSION" "1" "June 2025" ""
+.TH "BUNDLE\-VERSION" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-version\fR \- Prints Bundler version information
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-viz.1
+++ b/bundler/lib/bundler/man/bundle-viz.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-VIZ" "1" "June 2025" ""
+.TH "BUNDLE\-VIZ" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\-viz\fR \- Generates a visual dependency graph for your Gemfile
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle.1
+++ b/bundler/lib/bundler/man/bundle.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE" "1" "June 2025" ""
+.TH "BUNDLE" "1" "July 2025" ""
 .SH "NAME"
 \fBbundle\fR \- Ruby Dependency Management
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/gemfile.5
+++ b/bundler/lib/bundler/man/gemfile.5
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "GEMFILE" "5" "June 2025" ""
+.TH "GEMFILE" "5" "July 2025" ""
 .SH "NAME"
 \fBGemfile\fR \- A format for describing gem dependencies for Ruby programs
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -25,6 +25,7 @@ module Bundler
       forget_cli_options
       frozen
       gem.changelog
+      gem.rbs
       gem.coc
       gem.mit
       gem.bundle

--- a/bundler/spec/quality_spec.rb
+++ b/bundler/spec/quality_spec.rb
@@ -140,6 +140,7 @@ RSpec.describe "The library itself" do
     exemptions = %w[
       forget_cli_options
       gem.changelog
+      gem.rbs
       gem.ci
       gem.coc
       gem.linter


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

I don't use RBS, so it's an extra step to have to `rm -rf sig/` when creating a new gem.

We should support a `--no-rbs` option, similar to our other options (e.g, `--no-changelog`).

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Add support for a `--no-rbs` option to `bundle gem`, which will skip creating the RBS directory/file.

Fixes https://github.com/rubygems/rubygems/issues/8531

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
