### PR TITLE
Cleanup no longer necessary workaround

### DIFF
--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           repository: ruby/ruby
           path: ruby/ruby
-          ref: v3_4_4
+          ref: 2cce628721728409a26c2d4732f63419785c7fd8 # TODO: Point to v3_4_5 once released
           persist-credentials: false
       - name: Install libraries
         run: |
@@ -47,7 +47,6 @@ jobs:
       - name: Sync tools
         run: |
           ruby tool/sync_default_gems.rb rubygems
-          mv spec/bundler/bin/parallel_rspec spec/bin/parallel_rspec # TODO: fix `sync_default_gems.rb` script so we don't need to vendor the ruby-core binstub ourselves
         working-directory: ruby/ruby
       - name: Test RubyGems
         run: make -j2 -s test-all TESTS="rubygems --no-retry"

--- a/bundler/spec/bin/parallel_rspec
+++ b/bundler/spec/bin/parallel_rspec
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-# frozen_string_literal: true
-
-require_relative "../bundler/support/setup"
-
-require "turbo_tests"
-TurboTests::CLI.new(ARGV).run


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

None, just want to remove unnecessary code.

## What is your fix for the problem, implemented in this PR?

I only added this to get the ruby-core job green before patches to sync_default_gems.rb script in ruby-core was patched. Now this script is patched by https://github.com/ruby/ruby/pull/13083, so this is no longer necessary.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
