### PR TITLE
Fix `bundle update` crash in an edge case

### DIFF
--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -213,7 +213,7 @@ module Bundler
     def load_plugins
       Gem.load_plugins
 
-      requested_path_gems = @definition.requested_specs.select {|s| s.source.is_a?(Source::Path) }
+      requested_path_gems = @definition.specs.select {|s| s.source.is_a?(Source::Path) }
       path_plugin_files = requested_path_gems.flat_map do |spec|
         spec.matches_for_glob("rubygems_plugin#{Bundler.rubygems.suffix_pattern}")
       rescue TypeError

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -181,7 +181,7 @@ module Bundler
     end
 
     def version_for(name)
-      self[name].first&.version
+      exemplary_spec(name)&.version
     end
 
     def what_required(spec)
@@ -286,8 +286,13 @@ module Bundler
     end
 
     def additional_variants_from(other)
-      other.select do |spec|
-        version_for(spec.name) == spec.version && valid_dependencies?(spec)
+      other.select do |other_spec|
+        spec = exemplary_spec(other_spec.name)
+        next unless spec
+
+        selected = spec.version == other_spec.version && valid_dependencies?(other_spec)
+        other_spec.source = spec.source if selected
+        selected
       end
     end
 
@@ -363,6 +368,10 @@ module Bundler
     def index_spec(hash, key, value)
       hash[key] ||= []
       hash[key] << value
+    end
+
+    def exemplary_spec(name)
+      self[name].first
     end
   end
 end

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -540,9 +540,18 @@ RSpec.describe "bundle install with install-time dependencies" do
           lockfile original_lockfile
         end
 
-        it "keeps both variants in the lockfile, and uses the generic one since it's compatible" do
+        it "keeps both variants in the lockfile when installing, and uses the generic one since it's compatible" do
           simulate_platform "x86_64-linux" do
             bundle "install --verbose"
+
+            expect(lockfile).to eq(original_lockfile)
+            expect(the_bundle).to include_gems("nokogiri 1.16.3")
+          end
+        end
+
+        it "keeps both variants in the lockfile when updating, and uses the generic one since it's compatible" do
+          simulate_platform "x86_64-linux" do
+            bundle "update --verbose"
 
             expect(lockfile).to eq(original_lockfile)
             expect(the_bundle).to include_gems("nokogiri 1.16.3")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If both a native and a generic version are locked, but the native version is incompatible with the running Ruby, Bundler will still keep the native version in the lockfile, since it could be potentially useful when using other rubies.
    
However, when `bundle update` is run, this was not the case because the locked native gems were not using the right source when materializing. They were using the lockfile source instead of the Gemfile source, and that meant they could not be found when materializing, because the lockfile source always uses local mode so does not see them.
    
The effect of this was normally that they were incorrectly removed from the lockfile and a strange "this spec has been possibly yanked" was printed in verbose mode. However, in certain situations (i.e., when the generic gem would bring extra dependencies), it could also make `bundle update` crash.

## What is your fix for the problem, implemented in this PR?

The solution is, when adding this extra locked specs to the result after resolving, maybe sure they inherit the source from the resolved specs, so they can be found when materializing.
    
`bundle install` did not have the issue because it passes locked specs to the resolver, and assigns the right source to them in `Definition#converge_locked_specs`.

Fixes #8585.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
