### PR TITLE
Refine `bundle update --verbose` logs

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -337,11 +337,7 @@ module Bundler
           end
         end
       else
-        if lockfile_exists?
-          Bundler.ui.debug "Found changes from the lockfile, re-resolving dependencies because #{change_reason}"
-        else
-          Bundler.ui.debug "Resolving dependencies because there's no lockfile"
-        end
+        Bundler.ui.debug resolve_needed_reason
 
         start_resolution
       end
@@ -537,9 +533,7 @@ module Bundler
 
       return unless added.any? || deleted.any? || changed.any? || resolve_needed?
 
-      reason = resolve_needed? ? change_reason : "some dependencies were deleted from your gemfile"
-
-      msg = String.new("#{reason.capitalize.strip}, but ")
+      msg = String.new("#{change_reason.capitalize.strip}, but ")
       msg << "the lockfile " unless msg.start_with?("Your lockfile")
       msg << "can't be updated because #{update_refused_reason}"
       msg << "\n\nYou have added to the Gemfile:\n" << added.join("\n") if added.any?
@@ -796,22 +790,47 @@ module Bundler
       @most_specific_locked_platform
     end
 
-    def change_reason
-      if unlocking?
-        unlock_targets = if @gems_to_unlock.any?
-          ["gems", @gems_to_unlock]
-        elsif @sources_to_unlock.any?
-          ["sources", @sources_to_unlock]
-        end
-
-        unlock_reason = if unlock_targets
-          "#{unlock_targets.first}: (#{unlock_targets.last.join(", ")})"
+    def resolve_needed_reason
+      if lockfile_exists?
+        if unlocking?
+          "Re-resolving dependencies because #{unlocking_reason}"
         else
-          @unlocking_ruby ? "ruby" : ""
+          "Found changes from the lockfile, re-resolving dependencies because #{lockfile_changed_reason}"
         end
-
-        return "bundler is unlocking #{unlock_reason}"
+      else
+        "Resolving dependencies because there's no lockfile"
       end
+    end
+
+    def change_reason
+      if resolve_needed?
+        if unlocking?
+          unlocking_reason
+        else
+          lockfile_changed_reason
+        end
+      else
+        "some dependencies were deleted from your gemfile"
+      end
+    end
+
+    def unlocking_reason
+      unlock_targets = if @gems_to_unlock.any?
+        ["gems", @gems_to_unlock]
+      elsif @sources_to_unlock.any?
+        ["sources", @sources_to_unlock]
+      end
+
+      unlock_reason = if unlock_targets
+        "#{unlock_targets.first}: (#{unlock_targets.last.join(", ")})"
+      else
+        @unlocking_ruby ? "ruby" : ""
+      end
+
+      "bundler is unlocking #{unlock_reason}"
+    end
+
+    def lockfile_changed_reason
       [
         [@source_changes, "the list of sources changed"],
         [@dependency_changes, "the dependencies in your gemfile changed"],

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -39,6 +39,23 @@ RSpec.describe "bundle update" do
     end
   end
 
+  describe "with --verbose" do
+    before do
+      build_repo2
+
+      install_gemfile <<~G
+        source "https://gem.repo2"
+        gem "myrack"
+      G
+    end
+
+    it "logs the reason for re-resolving" do
+      bundle "update --verbose"
+      expect(out).not_to include("Found changes from the lockfile")
+      expect(out).to include("Re-resolving dependencies because bundler is unlocking")
+    end
+  end
+
   describe "with --all" do
     before do
       build_repo2


### PR DESCRIPTION



## What was the end-user or developer problem that led to this PR?

When running `bundle update --verbose`, Bundler prints:

> Found changes from the lockfile, re-resolving because Bundler is unlocking

I find it a bit confusing because Bundler did not necessarily find any changes between the Gemfile and the lockfile, it's only re-resolving because `bundle update` always re-resolves.

## What is your fix for the problem, implemented in this PR?

I changed the log message to

> Re-resolving because Bundler is unlocking

which I think it's less confusing.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
