### PR TITLE
Bump action runner images OS

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -44,13 +44,13 @@ jobs:
           - { os: { name: macOS, value: macos-14 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.3, value: 3.3.7 }, timeout: 90 }
           - { os: { name: macOS, value: macos-14 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.4, value: 3.4.2 }, timeout: 90 }
 
-          - { os: { name: Windows, value: windows-2022 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.7 }, timeout: 150 }
-          - { os: { name: Windows, value: windows-2022 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.2, value: 3.2.8 }, timeout: 150 }
-          - { os: { name: Windows, value: windows-2022 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.3, value: 3.3.7 }, timeout: 150 }
-          - { os: { name: Windows, value: windows-2022 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.4, value: 3.4.2 }, timeout: 150 }
+          - { os: { name: Windows, value: windows-2025 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.7 }, timeout: 150 }
+          - { os: { name: Windows, value: windows-2025 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.2, value: 3.2.8 }, timeout: 150 }
+          - { os: { name: Windows, value: windows-2025 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.3, value: 3.3.7 }, timeout: 150 }
+          - { os: { name: Windows, value: windows-2025 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.4, value: 3.4.2 }, timeout: 150 }
 
           - { os: { name: Ubuntu, value: ubuntu-24.04 }, bundler: { name: 2, value: '' }, ruby: { name: jruby, value: jruby-9.4.12.0 } }
-          - { os: { name: Windows, value: windows-2022 }, bundler: { name: 2, value: '' }, ruby: { name: jruby, value: jruby-9.4.12.0 } }
+          - { os: { name: Windows, value: windows-2025 }, bundler: { name: 2, value: '' }, ruby: { name: jruby, value: jruby-9.4.12.0 } }
 
     env:
       RGV: ..

--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -39,10 +39,10 @@ jobs:
           - { name: 3, value: 3.0.0 }
 
         include:
-          - { os: { name: macOS, value: macos-14 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.7 }, timeout: 90 }
-          - { os: { name: macOS, value: macos-14 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.2, value: 3.2.8 }, timeout: 90 }
-          - { os: { name: macOS, value: macos-14 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.3, value: 3.3.7 }, timeout: 90 }
-          - { os: { name: macOS, value: macos-14 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.4, value: 3.4.2 }, timeout: 90 }
+          - { os: { name: macOS, value: macos-15 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.7 }, timeout: 90 }
+          - { os: { name: macOS, value: macos-15 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.2, value: 3.2.8 }, timeout: 90 }
+          - { os: { name: macOS, value: macos-15 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.3, value: 3.3.7 }, timeout: 90 }
+          - { os: { name: macOS, value: macos-15 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.4, value: 3.4.2 }, timeout: 90 }
 
           - { os: { name: Windows, value: windows-2025 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.7 }, timeout: 150 }
           - { os: { name: Windows, value: windows-2025 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.2, value: 3.2.8 }, timeout: 150 }

--- a/.github/workflows/daily-rubygems.yml
+++ b/.github/workflows/daily-rubygems.yml
@@ -19,7 +19,7 @@ jobs:
         os: [ ubuntu-24.04 ]
         ruby: [ ruby-head, truffleruby-head ]
         include:
-          - { os: windows-2022, ruby: mswin }
+          - { os: windows-2025, ruby: mswin }
     env:
       TRUFFLERUBYOPT: "--experimental-options --testing-rubygems"
     steps:

--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -105,7 +105,7 @@ jobs:
 
   install_rubygems_windows:
     name: Install Rubygems on Windows (${{ matrix.ruby.name }})
-    runs-on: windows-2022
+    runs-on: windows-2025
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/realworld-bundler.yml
+++ b/.github/workflows/realworld-bundler.yml
@@ -35,10 +35,10 @@ jobs:
           - { name: 3, value: 3.0.0 }
 
         include:
-          - { os: { name: macOS, value: macos-14 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.7 } }
-          - { os: { name: macOS, value: macos-14 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.2, value: 3.2.8 } }
-          - { os: { name: macOS, value: macos-14 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.3, value: 3.3.7 } }
-          - { os: { name: macOS, value: macos-14 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.4, value: 3.4.2 } }
+          - { os: { name: macOS, value: macos-15 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.1, value: 3.1.7 } }
+          - { os: { name: macOS, value: macos-15 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.2, value: 3.2.8 } }
+          - { os: { name: macOS, value: macos-15 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.3, value: 3.3.7 } }
+          - { os: { name: macOS, value: macos-15 }, bundler: { name: 2, value: '' }, ruby: { name: ruby-3.4, value: 3.4.2 } }
     env:
       RGV: ..
       RUBYOPT: --disable-gems

--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os:
           - { name: Ubuntu, value: ubuntu-24.04 }
-          - { name: macOS, value: macos-14 }
+          - { name: macOS, value: macos-15 }
           - { name: Windows, value: windows-2025 }
 
         ruby:

--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -24,7 +24,7 @@ jobs:
         os:
           - { name: Ubuntu, value: ubuntu-24.04 }
           - { name: macOS, value: macos-14 }
-          - { name: Windows, value: windows-2022 }
+          - { name: Windows, value: windows-2025 }
 
         ruby:
           - { name: "3.1", value: 3.1.7 }


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

None. I just saw https://github.blog/changelog/2025-04-10-github-actions-macos-15-and-windows-2025-images-are-now-generally-available/ and thought I'd upgrade.

## What is your fix for the problem, implemented in this PR?

Use windows-2025 and macos-15 in our workflows.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
