### PR TITLE
Fix false positive warning about insecure materialization in frozen mode

### DIFF
--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -213,7 +213,9 @@ module Bundler
       end
       if search.nil? && fallback_to_non_installable
         search = candidates.last
-      elsif search && search.full_name == full_name
+      end
+
+      if search && search.full_name == full_name
         # We don't validate locally installed dependencies but accept what's in
         # the lockfile instead for performance, since loading locally installed
         # dependencies would mean evaluating all gemspecs, which would affect
@@ -224,9 +226,9 @@ module Bundler
           if !source.is_a?(Source::Path) && search.runtime_dependencies.sort != dependencies.sort
             raise IncorrectLockfileDependencies.new(self)
           end
-
-          search.locked_platform = platform if search.instance_of?(RemoteSpecification) || search.instance_of?(EndpointSpecification)
         end
+
+        search.locked_platform = platform if search.instance_of?(RemoteSpecification) || search.instance_of?(EndpointSpecification)
       end
       search
     end

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -217,10 +217,10 @@ module Bundler
 
       if search
         if search.platform == platform
-          # We don't validate locally installed dependencies but accept what's in
-          # the lockfile instead for performance, since loading locally installed
-          # dependencies would mean evaluating all gemspecs, which would affect
-          # `bundler/setup` performance
+          # We don't validate dependencies of locally installed gems but accept
+          # what's in the lockfile instead for performance, since loading
+          # dependencies of locally installed gems would mean evaluating all
+          # gemspecs, which would affect `bundler/setup` performance
           if search.is_a?(StubSpecification)
             search.dependencies = dependencies
           else

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -215,7 +215,7 @@ module Bundler
         search = candidates.last
       end
 
-      if search && search.full_name == full_name
+      if search && search.platform == platform
         # We don't validate locally installed dependencies but accept what's in
         # the lockfile instead for performance, since loading locally installed
         # dependencies would mean evaluating all gemspecs, which would affect

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -216,23 +216,28 @@ module Bundler
       end
 
       if search
-        if search.platform == platform
-          # We don't validate dependencies of locally installed gems but accept
-          # what's in the lockfile instead for performance, since loading
-          # dependencies of locally installed gems would mean evaluating all
-          # gemspecs, which would affect `bundler/setup` performance
-          if search.is_a?(StubSpecification)
-            search.dependencies = dependencies
-          else
-            if !source.is_a?(Source::Path) && search.runtime_dependencies.sort != dependencies.sort
-              raise IncorrectLockfileDependencies.new(self)
-            end
-          end
-        end
+        validate_dependencies(search) if search.platform == platform
 
         search.locked_platform = platform if search.instance_of?(RemoteSpecification) || search.instance_of?(EndpointSpecification)
       end
       search
+    end
+
+    # Validate dependencies of this locked spec are consistent with dependencies
+    # of the actual spec that was materialized.
+    #
+    # Note that we don't validate dependencies of locally installed gems but
+    # accept what's in the lockfile instead for performance, since loading
+    # dependencies of locally installed gems would mean evaluating all gemspecs,
+    # which would affect `bundler/setup` performance.
+    def validate_dependencies(spec)
+      if spec.is_a?(StubSpecification)
+        spec.dependencies = dependencies
+      else
+        if !source.is_a?(Source::Path) && spec.runtime_dependencies.sort != dependencies.sort
+          raise IncorrectLockfileDependencies.new(self)
+        end
+      end
     end
   end
 end

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -215,16 +215,18 @@ module Bundler
         search = candidates.last
       end
 
-      if search && search.platform == platform
-        # We don't validate locally installed dependencies but accept what's in
-        # the lockfile instead for performance, since loading locally installed
-        # dependencies would mean evaluating all gemspecs, which would affect
-        # `bundler/setup` performance
-        if search.is_a?(StubSpecification)
-          search.dependencies = dependencies
-        else
-          if !source.is_a?(Source::Path) && search.runtime_dependencies.sort != dependencies.sort
-            raise IncorrectLockfileDependencies.new(self)
+      if search
+        if search.platform == platform
+          # We don't validate locally installed dependencies but accept what's in
+          # the lockfile instead for performance, since loading locally installed
+          # dependencies would mean evaluating all gemspecs, which would affect
+          # `bundler/setup` performance
+          if search.is_a?(StubSpecification)
+            search.dependencies = dependencies
+          else
+            if !source.is_a?(Source::Path) && search.runtime_dependencies.sort != dependencies.sort
+              raise IncorrectLockfileDependencies.new(self)
+            end
           end
         end
 

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -305,11 +305,10 @@ RSpec.describe "bundle install with install-time dependencies" do
 
         it "gives a meaningful error if we're in frozen mode" do
           expect do
-            bundle "install --verbose", env: { "BUNDLE_FROZEN" => "true" }, raise_on_error: false
+            bundle "install", env: { "BUNDLE_FROZEN" => "true" }, raise_on_error: false
           end.not_to change { lockfile }
 
-          expect(err).to include("parallel_tests-3.8.0 requires ruby version >= #{next_ruby_minor}")
-          expect(err).not_to include("That means the author of parallel_tests (3.8.0) has removed it.")
+          expect(err).to eq("parallel_tests-3.8.0 requires ruby version >= #{next_ruby_minor}, which is incompatible with the current version, #{Gem.ruby_version}")
         end
       end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If frozen mode is set, and a locked gem is not compatible with the current Ruby, Bundler will print, in a addition to the correct resolution error, a warning about insecure materialization.

## What is your fix for the problem, implemented in this PR?

The logic to detect insecure materialization was not running if frozen mode was set, so I refactored it to make it run regardless.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
