### PR TITLE
Let `bundle lock --normalize-platforms` remove invalid platforms

### DIFF
--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -29,6 +29,7 @@ module Bundler
     end
 
     def normalize_platforms!(deps, platforms)
+      remove_invalid_platforms!(deps, platforms)
       add_extra_platforms!(platforms)
 
       platforms.map! do |platform|
@@ -51,6 +52,20 @@ module Bundler
       originally_invalid_platforms.each do |originally_invalid_platform|
         platforms << originally_invalid_platform if complete_platform(originally_invalid_platform)
       end
+    end
+
+    def remove_invalid_platforms!(deps, platforms, skips: [])
+      invalid_platforms = []
+
+      platforms.reject! do |platform|
+        next false if skips.include?(platform)
+
+        invalid = incomplete_for_platform?(deps, platform)
+        invalid_platforms << platform if invalid
+        invalid
+      end
+
+      invalid_platforms
     end
 
     def add_extra_platforms!(platforms)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bundle lock --normalize-platforms` should also remove invalid platforms from the lockfile.

## What is your fix for the problem, implemented in this PR?

Add the proper logic to achieve it.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
