### PR TITLE
Changelogs for RubyGems 3.6.8 and Bundler 2.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.6.8 / 2025-04-13
+
+## Enhancements:
+
+* Installs bundler 2.6.8 as a default gem.
+
 # 3.6.7 / 2025-04-03
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 2.6.8 (April 13, 2025)
+
+## Enhancements:
+
+  - Refine `bundle update --verbose` logs [#8627](https://github.com/rubygems/rubygems/pull/8627)
+  - Improve bug report instructions [#8607](https://github.com/rubygems/rubygems/pull/8607)
+
+## Bug fixes:
+
+  - Fix `bundle update` crash in an edge case [#8626](https://github.com/rubygems/rubygems/pull/8626)
+  - Fix `bundle lock --normalize-platforms` regression [#8620](https://github.com/rubygems/rubygems/pull/8620)
+
 # 2.6.7 (April 3, 2025)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.6.8 and Bundler 2.6.8 into master.