### PR TITLE
Bump required_ruby_version to 3.2

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -29,7 +29,6 @@ jobs:
           - { name: Ubuntu, value: ubuntu-24.04 }
 
         ruby:
-          - { name: ruby-3.1, value: 3.1.7 }
           - { name: ruby-3.2, value: 3.2.8 }
           - { name: ruby-3.3, value: 3.3.8 }
           - { name: ruby-3.4, value: 3.4.3 }
@@ -39,12 +38,10 @@ jobs:
           - { name: 3, value: 3.0.0 }
 
         include:
-          - { os: { name: macOS, value: macos-15 }, bundler: { name: 2, value: "" }, ruby: { name: ruby-3.1, value: 3.1.7 }, timeout: 90 }
           - { os: { name: macOS, value: macos-15 }, bundler: { name: 2, value: "" }, ruby: { name: ruby-3.2, value: 3.2.8 }, timeout: 90 }
           - { os: { name: macOS, value: macos-15 }, bundler: { name: 2, value: "" }, ruby: { name: ruby-3.3, value: 3.3.8 }, timeout: 90 }
           - { os: { name: macOS, value: macos-15 }, bundler: { name: 2, value: "" }, ruby: { name: ruby-3.4, value: 3.4.3 }, timeout: 90 }
 
-          - { os: { name: Windows, value: windows-2025 }, bundler: { name: 2, value: "" }, ruby: { name: ruby-3.1, value: 3.1.7 }, timeout: 150 }
           - { os: { name: Windows, value: windows-2025 }, bundler: { name: 2, value: "" }, ruby: { name: ruby-3.2, value: 3.2.8 }, timeout: 150 }
           - { os: { name: Windows, value: windows-2025 }, bundler: { name: 2, value: "" }, ruby: { name: ruby-3.3, value: 3.3.8 }, timeout: 150 }
           - { os: { name: Windows, value: windows-2025 }, bundler: { name: 2, value: "" }, ruby: { name: ruby-3.4, value: 3.4.3 }, timeout: 150 }

--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -22,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - { name: "3.1", value: 3.1.7 }
           - { name: "3.2", value: 3.2.8 }
           - { name: "3.3", value: 3.3.8 }
           - { name: "3.4", value: 3.4.3 }
@@ -110,7 +109,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - { name: "3.1", value: 3.1.7 }
           - { name: "3.2", value: 3.2.8 }
           - { name: "3.3", value: 3.3.8 }
           - { name: "3.4", value: 3.4.3 }

--- a/.github/workflows/read-only.yml
+++ b/.github/workflows/read-only.yml
@@ -26,7 +26,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - { name: ruby-3.1, value: 3.1.7 }
           - { name: ruby-3.2, value: 3.2.8 }
           - { name: ruby-3.3, value: 3.3.8 }
           - { name: ruby-3.4, value: 3.4.3 }

--- a/.github/workflows/realworld-bundler.yml
+++ b/.github/workflows/realworld-bundler.yml
@@ -11,7 +11,7 @@ concurrency:
   group: ci-${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
-permissions:  # added using https://github.com/step-security/secure-workflows
+permissions: # added using https://github.com/step-security/secure-workflows
   contents: read
 
 jobs:
@@ -25,7 +25,6 @@ jobs:
           - { name: Ubuntu, value: ubuntu-24.04 }
 
         ruby:
-          - { name: ruby-3.1, value: 3.1.7 }
           - { name: ruby-3.2, value: 3.2.8 }
           - { name: ruby-3.3, value: 3.3.8 }
           - { name: ruby-3.4, value: 3.4.3 }
@@ -35,7 +34,6 @@ jobs:
           - { name: 3, value: 3.0.0 }
 
         include:
-          - { os: { name: macOS, value: macos-15 }, bundler: { name: 2, value: null }, ruby: { name: ruby-3.1, value: 3.1.7 } }
           - { os: { name: macOS, value: macos-15 }, bundler: { name: 2, value: null }, ruby: { name: ruby-3.2, value: 3.2.8 } }
           - { os: { name: macOS, value: macos-15 }, bundler: { name: 2, value: null }, ruby: { name: ruby-3.3, value: 3.3.8 } }
           - { os: { name: macOS, value: macos-15 }, bundler: { name: 2, value: null }, ruby: { name: ruby-3.4, value: 3.4.3 } }
@@ -88,11 +86,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { bundler: { name: 2, value: null }, ruby: { name: ruby-3.1, value: 3.1.7 } }
           - { bundler: { name: 2, value: null }, ruby: { name: ruby-3.2, value: 3.2.8 } }
           - { bundler: { name: 2, value: null }, ruby: { name: ruby-3.3, value: 3.3.8 } }
           - { bundler: { name: 2, value: null }, ruby: { name: ruby-3.4, value: 3.4.3 } }
-          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.1, value: 3.1.7 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.2, value: 3.2.8 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.3, value: 3.3.8 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.4, value: 3.4.3 } }

--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -27,7 +27,6 @@ jobs:
           - { name: Windows, value: windows-2025 }
 
         ruby:
-          - { name: "3.1", value: 3.1.7 }
           - { name: "3.2", value: 3.2.8 }
           - { name: "3.3", value: 3.3.8 }
           - { name: "3.4", value: 3.4.3 }

--- a/.github/workflows/system-rubygems-bundler.yml
+++ b/.github/workflows/system-rubygems-bundler.yml
@@ -29,11 +29,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { bundler: { name: 2, value: null }, ruby: { name: ruby-3.1, value: 3.1.0 } }
           - { bundler: { name: 2, value: null }, ruby: { name: ruby-3.2, value: 3.2.0 } }
           - { bundler: { name: 2, value: null }, ruby: { name: ruby-3.3, value: 3.3.0 } }
           - { bundler: { name: 2, value: null }, ruby: { name: ruby-3.4, value: 3.4.1 } }
-          - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.1, value: 3.1.0 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.2, value: 3.2.0 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.3, value: 3.3.0 } }
           - { bundler: { name: 3, value: 3.0.0 }, ruby: { name: ruby-3.4, value: 3.4.1 } }

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ plugins: rubocop-performance
 
 AllCops:
   DisabledByDefault: true
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
   Exclude:
     - pkg/**/*
     - tmp/**/*

--- a/bundler/bundler.gemspec
+++ b/bundler/bundler.gemspec
@@ -29,10 +29,10 @@ Gem::Specification.new do |s|
     "source_code_uri" => "https://github.com/rubygems/rubygems/tree/master/bundler",
   }
 
-  s.required_ruby_version     = ">= 3.1.0"
+  s.required_ruby_version     = ">= 3.2.0"
 
   # It should match the RubyGems version shipped with `required_ruby_version` above
-  s.required_rubygems_version = ">= 3.3.3"
+  s.required_rubygems_version = ">= 3.4.1"
 
   s.files = Dir.glob("lib/bundler{.rb,/**/*}", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }
 

--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -31,7 +31,6 @@ module Bundler
       @extension = options[:ext]
 
       validate_ext_name if @extension
-      validate_rust_builder_rubygems_version if @extension == "rust"
     end
 
     def run

--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -446,7 +446,7 @@ module Bundler
     end
 
     def required_ruby_version
-      "3.1.0"
+      "3.2.0"
     end
 
     def rubocop_version
@@ -455,13 +455,6 @@ module Bundler
 
     def standard_version
       "1.3"
-    end
-
-    def validate_rust_builder_rubygems_version
-      if Gem::Version.new(rust_builder_required_rubygems_version) > Gem.rubygems_version
-        Bundler.ui.error "Your RubyGems version (#{Gem.rubygems_version}) is too old to build Rust extension. Please update your RubyGems using `gem update --system` or any other way and try again."
-        exit 1
-      end
     end
   end
 end

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -136,23 +136,6 @@ module Gem
       full_gem_path
     end
 
-    unless const_defined?(:LATEST_RUBY_WITHOUT_PATCH_VERSIONS)
-      LATEST_RUBY_WITHOUT_PATCH_VERSIONS = Gem::Version.new("2.1")
-
-      alias_method :rg_required_ruby_version=, :required_ruby_version=
-      def required_ruby_version=(req)
-        self.rg_required_ruby_version = req
-
-        @required_ruby_version.requirements.map! do |op, v|
-          if v >= LATEST_RUBY_WITHOUT_PATCH_VERSIONS && v.release.segments.size == 4
-            [op == "~>" ? "=" : op, Gem::Version.new(v.segments.tap {|s| s.delete_at(3) }.join("."))]
-          else
-            [op, v]
-          end
-        end
-      end
-    end
-
     def insecurely_materialized?
       false
     end

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -13,15 +13,6 @@ require "rubygems" unless defined?(Gem)
 # `Gem::Source` from the redefined `Gem::Specification#source`.
 require "rubygems/source"
 
-# Cherry-pick fixes to `Gem.ruby_version` to be useful for modern Bundler
-# versions and ignore patchlevels
-# (https://github.com/rubygems/rubygems/pull/5472,
-# https://github.com/rubygems/rubygems/pull/5486). May be removed once RubyGems
-# 3.3.12 support is dropped.
-unless Gem.ruby_version.to_s == RUBY_VERSION || RUBY_PATCHLEVEL == -1
-  Gem.instance_variable_set(:@ruby_version, Gem::Version.new(RUBY_VERSION))
-end
-
 module Gem
   # Can be removed once RubyGems 3.5.11 support is dropped
   unless Gem.respond_to?(:freebsd_platform?)
@@ -92,20 +83,9 @@ module Gem
           # version
           (
             (@os != "linux" && (@version.nil? || other.version.nil?)) ||
-            (@os == "linux" && (normalized_linux_version_ext == other.normalized_linux_version_ext || ["musl#{@version}", "musleabi#{@version}", "musleabihf#{@version}"].include?(other.version))) ||
+            (@os == "linux" && (normalized_linux_version == other.normalized_linux_version || ["musl#{@version}", "musleabi#{@version}", "musleabihf#{@version}"].include?(other.version))) ||
             @version == other.version
           )
-      end
-
-      # This is a copy of RubyGems 3.3.23 or higher `normalized_linux_method`.
-      # Once only 3.3.23 is supported, we can use the method in RubyGems.
-      def normalized_linux_version_ext
-        return nil unless @version
-
-        without_gnu_nor_abi_modifiers = @version.sub(/\Agnu/, "").sub(/eabi(hf)?\Z/, "")
-        return nil if without_gnu_nor_abi_modifiers.empty?
-
-        without_gnu_nor_abi_modifiers
       end
     end
   end
@@ -143,9 +123,6 @@ module Gem
 
   # Can be removed once RubyGems 3.5.14 support is dropped
   VALIDATES_FOR_RESOLUTION = Specification.new.respond_to?(:validate_for_resolution).freeze
-
-  # Can be removed once RubyGems 3.3.15 support is dropped
-  FLATTENS_REQUIRED_PATHS = Specification.new.respond_to?(:flatten_require_paths).freeze
 
   class Specification
     # Can be removed once RubyGems 3.5.15 support is dropped
@@ -269,27 +246,6 @@ module Gem
     unless VALIDATES_FOR_RESOLUTION
       def validate_for_resolution
         SpecificationPolicy.new(self).validate_for_resolution
-      end
-    end
-
-    unless FLATTENS_REQUIRED_PATHS
-      def flatten_require_paths
-        return unless raw_require_paths.first.is_a?(Array)
-
-        warn "#{name} #{version} includes a gemspec with `require_paths` set to an array of arrays. Newer versions of this gem might've already fixed this"
-        raw_require_paths.flatten!
-      end
-
-      class << self
-        module RequirePathFlattener
-          def from_yaml(input)
-            spec = super(input)
-            spec.flatten_require_paths
-            spec
-          end
-        end
-
-        prepend RequirePathFlattener
       end
     end
 
@@ -470,16 +426,5 @@ module Gem
     end
 
     Package::TarReader::Entry.prepend(FixFullNameEncoding)
-  end
-
-  require "rubygems/uri"
-
-  # Can be removed once RubyGems 3.3.15 support is dropped
-  unless Gem::Uri.respond_to?(:redact)
-    class Uri
-      def self.redact(uri)
-        new(uri).redacted
-      end
-    end
   end
 end

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -62,61 +62,6 @@ module Gem
     WINDOWS = [MSWIN, MSWIN64, UNIVERSAL_MINGW].flatten.freeze
     X64_LINUX = Gem::Platform.new("x86_64-linux")
     X64_LINUX_MUSL = Gem::Platform.new("x86_64-linux-musl")
-
-    if X64_LINUX === X64_LINUX_MUSL
-      remove_method :===
-
-      def ===(other)
-        return nil unless Gem::Platform === other
-
-        # universal-mingw32 matches x64-mingw-ucrt
-        return true if (@cpu == "universal" || other.cpu == "universal") &&
-                       @os.start_with?("mingw") && other.os.start_with?("mingw")
-
-        # cpu
-        ([nil,"universal"].include?(@cpu) || [nil, "universal"].include?(other.cpu) || @cpu == other.cpu ||
-        (@cpu == "arm" && other.cpu.start_with?("armv"))) &&
-
-          # os
-          @os == other.os &&
-
-          # version
-          (
-            (@os != "linux" && (@version.nil? || other.version.nil?)) ||
-            (@os == "linux" && (normalized_linux_version == other.normalized_linux_version || ["musl#{@version}", "musleabi#{@version}", "musleabihf#{@version}"].include?(other.version))) ||
-            @version == other.version
-          )
-      end
-    end
-  end
-
-  Platform.singleton_class.module_eval do
-    unless Platform.singleton_methods.include?(:match_spec?)
-      def match_spec?(spec)
-        match_gem?(spec.platform, spec.name)
-      end
-
-      def match_gem?(platform, gem_name)
-        match_platforms?(platform, Gem.platforms)
-      end
-    end
-
-    match_platforms_defined = Gem::Platform.respond_to?(:match_platforms?, true)
-
-    if !match_platforms_defined || Gem::Platform.send(:match_platforms?, Gem::Platform::X64_LINUX_MUSL, [Gem::Platform::X64_LINUX])
-
-      private
-
-      remove_method :match_platforms? if match_platforms_defined
-
-      def match_platforms?(platform, platforms)
-        platforms.any? do |local_platform|
-          platform.nil? ||
-            local_platform == platform ||
-            (local_platform != Gem::Platform::RUBY && platform =~ local_platform)
-        end
-      end
-    end
   end
 
   require "rubygems/specification"

--- a/bundler/spec/bundler/specifications/foo.gemspec
+++ b/bundler/spec/bundler/specifications/foo.gemspec
@@ -8,6 +8,6 @@ Gem::Specification.new do |s|
   s.version = "1.0.0"
   s.loaded_from = __FILE__
   s.extensions = "ext/foo"
-  s.required_ruby_version = ">= 3.1.0"
+  s.required_ruby_version = ">= 3.2.0"
 end
 # rubocop:enable Style/FrozenStringLiteralComment

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-abort "RubyGems only supports Ruby 3.1 or higher" if RUBY_VERSION < "3.1.0"
+abort "RubyGems only supports Ruby 3.2 or higher" if RUBY_VERSION < "3.2.0"
 
 require_relative "path"
 

--- a/rubygems-update.gemspec
+++ b/rubygems-update.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
     "hide_lib_for_update/note.txt", *Dir["bundler/lib/bundler/man/*.1", base: __dir__]
   ]
 
-  s.required_ruby_version = Gem::Requirement.new(">= 3.1.0")
+  s.required_ruby_version = Gem::Requirement.new(">= 3.2.0")
   s.required_rubygems_version = Gem::Requirement.new(">= 0")
 
   s.specification_version = 4

--- a/setup.rb
+++ b/setup.rb
@@ -7,7 +7,7 @@
 # See LICENSE.txt for permissions.
 #++
 
-abort "RubyGems only supports Ruby 3.1 or higher" if RUBY_VERSION < "3.1.0"
+abort "RubyGems only supports Ruby 3.2 or higher" if RUBY_VERSION < "3.2.0"
 
 # Make sure rubygems isn't already loaded.
 if ENV["RUBYOPT"] || defined? Gem


### PR DESCRIPTION
Ruby 3.1 was EOL March 2025

Depends on https://github.com/rubygems/rubygems/pull/8688 to pass the jruby specs

<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
