### PR TITLE
Forward-port from ruby/ruby

### DIFF
--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1247,7 +1247,7 @@ end
     end
 
     assert_raise(Gem::Ext::BuildError) do
-      installer.install
+      build_rake_in {installer.install}
     end
 
     assert_path_not_exist(File.join(installer.bin_dir, "executable.lock"))


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In `macos-15` runner, I sometimes got the following failure.

```
   1) Failure:
  TestGemConfigFile#test_handle_arguments_traceback [D:/a/ruby/ruby/src/test/rubygems/helper.rb:479]:
  Expected path 'D:/a/_temp/rubytest.lnlwhh/test_rubygems_20250413-4772-18u9ey' to not exist.
```

## What is your fix for the problem, implemented in this PR?

@nobu did investigate that. `macos-15` runner can't invoke properly `rake` command. we should use it with `build_rake_in`.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
