### PR TITLE
Fix typo in Changelog for 3.6.0 / 2024-12-16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,7 +172,7 @@
 
 * Fix missing single quote in git source example. Pull request
   [#8303](https://github.com/rubygems/rubygems/pull/8303) by nobu
-* Update the `gem install` demo in REAME to use a gem that just works on
+* Update the `gem install` demo in README to use a gem that just works on
   Windows. Pull request
   [#8262](https://github.com/rubygems/rubygems/pull/8262) by soda92
 * Unify rubygems and bundler docs directory. Pull request


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Found the typo as I was updating ruby in my terminal and was reading the changelog.

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

This PR changes `REAME` → `README` in the 3.6.0 3.6.0 / 2024-12-16 "Documentation" section to better describe the effect of #8262. Proposed alongside rubygems/rubygems.github.io#226.

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] ~~Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes~~ (N/A)
- [ ] ~~Write code to solve the problem~~ (N/A)
- [x] ~~Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting)~~ (N/A) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)

---
Cheers, and thank you!
