### PR TITLE
Avoid unnecessary splat allocation

### DIFF
--- a/lib/rubygems/commands/push_command.rb
+++ b/lib/rubygems/commands/push_command.rb
@@ -92,7 +92,8 @@ The push command will use ~/.gem/credentials to authenticate to a server, but yo
   private
 
   def send_push_request(name, args)
-    rubygems_api_request(*args, scope: get_push_scope) do |request|
+    scope = get_push_scope
+    rubygems_api_request(*args, scope: scope) do |request|
       body = Gem.read_binary name
       if options[:attestations].any?
         request.set_form([


### PR DESCRIPTION
Because get_push_scope is a method call, Ruby will allocate an array for *args even though it is not necessary to do so. Using a local variable avoids the allocation.

Found by the performance warning in Ruby feature 21274.

Note that there is a similar issue in the vendored optparse.  I submitted a pull request to fix it upstream: https://github.com/ruby/optparse/pull/97

## What was the end-user or developer problem that led to this PR?

No problem, this is just a micro-optimization.

## What is your fix for the problem, implemented in this PR?

Using a local variable to avoid an unnecessary allocation.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes (not applicable as this should not affect behavior)
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)