### PR TITLE
Remove shellwords autoload

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -511,7 +511,6 @@ lib/rubygems/security/policy.rb
 lib/rubygems/security/signer.rb
 lib/rubygems/security/trust_dir.rb
 lib/rubygems/security_option.rb
-lib/rubygems/shellwords.rb
 lib/rubygems/source.rb
 lib/rubygems/source/git.rb
 lib/rubygems/source/installed.rb

--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -7,7 +7,6 @@
 #++
 
 require_relative "../user_interaction"
-require_relative "../shellwords"
 
 class Gem::Ext::Builder
   include Gem::UserInteraction
@@ -29,7 +28,7 @@ class Gem::Ext::Builder
     target_rbconfig["configure_args"] =~ /with-make-prog\=(\w+)/
     make_program_name = ENV["MAKE"] || ENV["make"] || $1
     make_program_name ||= RUBY_PLATFORM.include?("mswin") ? "nmake" : "make"
-    make_program = Shellwords.split(make_program_name)
+    make_program = shellsplit(make_program_name)
 
     # The installation of the bundled gems is failed when DESTDIR is empty in mswin platform.
     destdir = /\bnmake/i !~ make_program_name || ENV["DESTDIR"] && ENV["DESTDIR"] != "" ? format("DESTDIR=%s", ENV["DESTDIR"]) : ""
@@ -58,7 +57,7 @@ class Gem::Ext::Builder
 
   def self.ruby
     # Gem.ruby is quoted if it contains whitespace
-    cmd = Shellwords.split(Gem.ruby)
+    cmd = shellsplit(Gem.ruby)
 
     # This load_path is only needed when running rubygems test without a proper installation.
     # Prepending it in a normal installation will cause problem with order of $LOAD_PATH.
@@ -83,7 +82,7 @@ class Gem::Ext::Builder
         p(command)
       end
       results << "current directory: #{dir}"
-      results << Shellwords.join(command)
+      results << shelljoin(command)
 
       require "open3"
       # Set $SOURCE_DATE_EPOCH for the subprocess.
@@ -125,6 +124,18 @@ class Gem::Ext::Builder
 
       raise Gem::InstallError, "#{command_name || class_name} failed#{exit_reason}"
     end
+  end
+
+  def self.shellsplit(command)
+    require "shellwords"
+
+    Shellwords.split(command)
+  end
+
+  def self.shelljoin(command)
+    require "shellwords"
+
+    Shellwords.join(command)
   end
 
   ##

--- a/lib/rubygems/ext/cargo_builder.rb
+++ b/lib/rubygems/ext/cargo_builder.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../shellwords"
-
 # This class is used by rubygems to build Rust extensions. It is a thin-wrapper
 # over the `cargo rustc` command which takes care of building Rust code in a way
 # that Ruby can use.
@@ -159,7 +157,7 @@ class Gem::Ext::CargoBuilder < Gem::Ext::Builder
   # We want to use the same linker that Ruby uses, so that the linker flags from
   # mkmf work properly.
   def linker_args
-    cc_flag = Shellwords.split(makefile_config("CC"))
+    cc_flag = self.class.shellsplit(makefile_config("CC"))
     linker = cc_flag.shift
     link_args = cc_flag.flat_map {|a| ["-C", "link-arg=#{a}"] }
 
@@ -178,7 +176,7 @@ class Gem::Ext::CargoBuilder < Gem::Ext::Builder
 
   def libruby_args(dest_dir)
     libs = makefile_config(ruby_static? ? "LIBRUBYARG_STATIC" : "LIBRUBYARG_SHARED")
-    raw_libs = Shellwords.split(libs)
+    raw_libs = self.class.shellsplit(libs)
     raw_libs.flat_map {|l| ldflag_to_link_modifier(l) }
   end
 
@@ -261,7 +259,7 @@ EOF
   end
 
   def split_flags(var)
-    Shellwords.split(RbConfig::CONFIG.fetch(var, ""))
+    self.class.shellsplit(RbConfig::CONFIG.fetch(var, ""))
   end
 
   def ldflag_to_link_modifier(arg)

--- a/lib/rubygems/ext/rake_builder.rb
+++ b/lib/rubygems/ext/rake_builder.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../shellwords"
-
 #--
 # Copyright 2006 by Chad Fowler, Rich Kilmer, Jim Weirich and others.
 # All rights reserved.
@@ -22,7 +20,7 @@ class Gem::Ext::RakeBuilder < Gem::Ext::Builder
     rake = ENV["rake"]
 
     if rake
-      rake = Shellwords.split(rake)
+      rake = shellsplit(rake)
     else
       begin
         rake = ruby << "-rrubygems" << Gem.bin_path("rake", "rake")

--- a/lib/rubygems/shellwords.rb
+++ b/lib/rubygems/shellwords.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-autoload :Shellwords, "shellwords"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We're seeing some flaky failures on truffleruby: https://github.com/rubygems/rubygems/actions/runs/14577802600/job/40887694586?pr=8642

## What is your fix for the problem, implemented in this PR?

Not sure why it started recently but issues with autoload are not that uncommon on TruffleRuby and JRuby.

I guess an `autoload` does not buy us that much, so we can maybe `require` when needed.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
