### PR TITLE
Fix `--prerelease` flag to `gem install` sometimes not respected

### DIFF
--- a/lib/rubygems/resolver/best_set.rb
+++ b/lib/rubygems/resolver/best_set.rb
@@ -21,7 +21,7 @@ class Gem::Resolver::BestSet < Gem::Resolver::ComposedSet
 
   def pick_sets # :nodoc:
     @sources.each_source do |source|
-      @sets << source.dependency_resolver_set
+      @sets << source.dependency_resolver_set(@prerelease)
     end
   end
 

--- a/lib/rubygems/resolver/source_set.rb
+++ b/lib/rubygems/resolver/source_set.rb
@@ -42,6 +42,6 @@ class Gem::Resolver::SourceSet < Gem::Resolver::Set
 
   def get_set(name)
     link = @links[name]
-    @sets[link] ||= Gem::Source.new(link).dependency_resolver_set if link
+    @sets[link] ||= Gem::Source.new(link).dependency_resolver_set(@prerelease) if link
   end
 end

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -1214,6 +1214,30 @@ ERROR:  Possible alternatives: non_existent_with_hint
     assert_match "Installing a (2)", @ui.output
   end
 
+  def test_execute_installs_from_a_gemdeps_with_prerelease
+    spec_fetcher do |fetcher|
+      fetcher.download "a", 1
+      fetcher.download "a", "2.a"
+    end
+
+    File.open @gemdeps, "w" do |f|
+      f << "gem 'a'"
+    end
+
+    @cmd.handle_options %w[--prerelease]
+    @cmd.options[:gemdeps] = @gemdeps
+
+    use_ui @ui do
+      assert_raise Gem::MockGemUi::SystemExitException, @ui.error do
+        @cmd.execute
+      end
+    end
+
+    assert_equal %w[a-2.a], @cmd.installed_specs.map(&:full_name)
+
+    assert_match "Installing a (2.a)", @ui.output
+  end
+
   def test_execute_installs_deps_a_gemdeps
     spec_fetcher do |fetcher|
       fetcher.download "q", "1.0"

--- a/test/rubygems/test_gem_resolver_best_set.rb
+++ b/test/rubygems/test_gem_resolver_best_set.rb
@@ -31,6 +31,20 @@ class TestGemResolverBestSet < Gem::TestCase
     assert_equal %w[a-1], found.map(&:full_name)
   end
 
+  def test_pick_sets_prerelease
+    set = Gem::Resolver::BestSet.new
+    set.prerelease = true
+
+    set.pick_sets
+
+    sets = set.sets
+
+    assert_equal 1, sets.count
+
+    source_set = sets.first
+    assert_equal true, source_set.prerelease
+  end
+
   def test_find_all_local
     spec_fetcher do |fetcher|
       fetcher.spec "a", 1


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I wasn't able to install prerelease gems from a [Geminabox](https://github.com/geminabox/geminabox) server I was running locally. It appeared that the `--prerelease` argument to `gem install` was being ignored. 

## What is your fix for the problem, implemented in this PR?

Internally, I discovered that Rubygems uses something called `BestSet` to resolve dependencies. `BestSet` has a method, `pick_sets`, which builds up a list of sets for each gem source. However, it doesn't propagate the value of the `@prerelease` attribute to those sets, which causes the `--prerelease` argument to be ignored. 

I've been able to get prerelease gem installation working locally on my laptop through the change in this pull request. I'm not sure it's correct, or how to test it outside of my usage scenario, or whether there are other attributes besides `@prelelease` that should also be transferred. I'm very unfamiliar with the Rubygems codebase, unfortunately.

## Make sure the following tasks are checked

Unfortunately, I can't get the test suite to run. I think I'm supposed to invoke it via `bin/rake`, but I'm getting an error:

```
> bin/rake
/opt/homebrew/Cellar/ruby/3.4.3/lib/ruby/gems/3.4.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:3:in 'Kernel#require': cannot load such file -- rake/file_list (LoadError)
        from /opt/homebrew/Cellar/ruby/3.4.3/lib/ruby/gems/3.4.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:3:in '<main>'
rake aborted!
Command failed with status (1)
/Users/ntl/Projects/Personal/rubygems/bundler/spec/support/rubygems_ext.rb:118:in 'Kernel#load'
/Users/ntl/Projects/Personal/rubygems/bundler/spec/support/rubygems_ext.rb:118:in 'Spec::Rubygems#gem_load_and_activate'
/Users/ntl/Projects/Personal/rubygems/bundler/spec/support/rubygems_ext.rb:16:in 'Spec::Rubygems#gem_load'
Tasks: TOP => default => test
(See full trace by running task with --trace)
```
