### PR TITLE
Sync ruby core changes related CGI retirement

### DIFF
--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -2,7 +2,6 @@
 
 require_relative "vendored_persistent"
 require_relative "vendored_timeout"
-require "cgi"
 require_relative "vendored_securerandom"
 require "zlib"
 

--- a/bundler/lib/bundler/fetcher/dependency.rb
+++ b/bundler/lib/bundler/fetcher/dependency.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "base"
-require "cgi"
+require "cgi/util"
 
 module Bundler
   class Fetcher

--- a/bundler/lib/bundler/friendly_errors.rb
+++ b/bundler/lib/bundler/friendly_errors.rb
@@ -102,7 +102,7 @@ module Bundler
     def issues_url(exception)
       message = exception.message.lines.first.tr(":", " ").chomp
       message = message.split("-").first if exception.is_a?(Errno)
-      require "cgi"
+      require "cgi/util"
       "https://github.com/rubygems/rubygems/search?q=" \
         "#{CGI.escape(message)}&type=Issues"
     end

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -473,7 +473,7 @@ RSpec.describe "bundle gem" do
     end
   end
 
-  it "generates a valid gemspec", :ruby_repo do
+  it "generates a valid gemspec" do
     bundle "gem newgem --bin"
 
     prepare_gemspec(bundled_app("newgem", "newgem.gemspec"))

--- a/bundler/spec/commands/ssl_spec.rb
+++ b/bundler/spec/commands/ssl_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "bundle doctor ssl" do
       expect { subject.run }.to output("").to_stdout.and output(expected_err).to_stderr
     end
 
-    it "fails due to certificate verification" do
+    it "fails due to certificate verification", :ruby_repo do
       net_http = Class.new(Artifice::Net::HTTP) do
         def connect
           raise OpenSSL::SSL::SSLError, "certificate verify failed"

--- a/lib/rubygems/gemcutter_utilities/webauthn_listener.rb
+++ b/lib/rubygems/gemcutter_utilities/webauthn_listener.rb
@@ -85,10 +85,17 @@ module Gem::GemcutterUtilities
     end
 
     def parse_otp_from_uri(uri)
-      require "cgi"
+      query = uri.query
+      return unless query && !query.empty?
 
-      return if uri.query.nil?
-      CGI.parse(uri.query).dig("code", 0)
+      query.split('&') do |param|
+        key, value = param.split('=', 2)
+        if value && Gem::URI.decode_www_form_component(key) == "code"
+          return Gem::URI.decode_www_form_component(value)
+        end
+      end
+
+      nil
     end
 
     class SocketResponder

--- a/lib/rubygems/gemcutter_utilities/webauthn_listener.rb
+++ b/lib/rubygems/gemcutter_utilities/webauthn_listener.rb
@@ -88,8 +88,8 @@ module Gem::GemcutterUtilities
       query = uri.query
       return unless query && !query.empty?
 
-      query.split('&') do |param|
-        key, value = param.split('=', 2)
+      query.split("&") do |param|
+        key, value = param.split("=", 2)
         if value && Gem::URI.decode_www_form_component(key) == "code"
           return Gem::URI.decode_www_form_component(value)
         end

--- a/lib/rubygems/uri_formatter.rb
+++ b/lib/rubygems/uri_formatter.rb
@@ -17,7 +17,7 @@ class Gem::UriFormatter
   # Creates a new URI formatter for +uri+.
 
   def initialize(uri)
-    require "cgi"
+    require "cgi/util"
 
     @uri = uri
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I added the following changes to rubygems and bundler at ruby/ruby repository.

* Preparation of retirement of CGI: https://bugs.ruby-lang.org/issues/21258
* Update enabled/disabled examples

## What is your fix for the problem, implemented in this PR?

If `cgi` is retired in the future, RubyGems and Bundler are breaking with that version of Ruby.

RubyGems/Bundler should use `cgi/util` instead of `cgi` if we need only call like `CGI.escape`. and we can use `URI.decode_www_from_component` and built-in ruby feature instead of `CGI.parse`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
