### PR TITLE
Smoother authentication experience

### DIFF
--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -263,7 +263,10 @@ module Gem::GemcutterUtilities
       port = server.addr[1].to_s
 
       url_with_port = "#{webauthn_url}?port=#{port}"
-      say "You have enabled multi-factor authentication. Please visit #{url_with_port} to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, you can re-run the gem signin command with the `--otp [your_code]` option."
+      say "You have enabled multi-factor authentication. Please visit the following URL to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, you can re-run the gem signin command with the `--otp [your_code]` option."
+      say ""
+      say url_with_port
+      say ""
 
       threads = [WebauthnListener.listener_thread(host, server), WebauthnPoller.poll_thread(options, host, webauthn_url, credentials)]
       otp_thread = wait_for_otp_thread(*threads)

--- a/test/rubygems/test_gem_commands_owner_command.rb
+++ b/test/rubygems/test_gem_commands_owner_command.rb
@@ -386,9 +386,10 @@ EOF
       end
     end
 
-    assert_match "You have enabled multi-factor authentication. Please visit #{@stub_fetcher.webauthn_url_with_port(server.port)} " \
+    assert_match "You have enabled multi-factor authentication. Please visit the following URL " \
       "to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, " \
       "you can re-run the gem signin command with the `--otp [your_code]` option.", @stub_ui.output
+    assert_match @stub_fetcher.webauthn_url_with_port(server.port), @stub_ui.output
     assert_match "You are verified with a security device. You may close the browser window.", @stub_ui.output
     assert_equal "Uvh6T57tkWuUnWYo", @stub_fetcher.last_request["OTP"]
     assert_match response_success, @stub_ui.output
@@ -413,9 +414,10 @@ EOF
     end
 
     assert_match @stub_fetcher.last_request["Authorization"], Gem.configuration.rubygems_api_key
-    assert_match "You have enabled multi-factor authentication. Please visit #{@stub_fetcher.webauthn_url_with_port(server.port)} " \
+    assert_match "You have enabled multi-factor authentication. Please visit the following URL " \
       "to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, " \
       "you can re-run the gem signin command with the `--otp [your_code]` option.", @stub_ui.output
+    assert_match @stub_fetcher.webauthn_url_with_port(server.port), @stub_ui.output
     assert_match "ERROR:  Security device verification failed: Something went wrong", @stub_ui.error
     refute_match "You are verified with a security device. You may close the browser window.", @stub_ui.output
     refute_match response_success, @stub_ui.output
@@ -435,9 +437,10 @@ EOF
       end
     end
 
-    assert_match "You have enabled multi-factor authentication. Please visit #{@stub_fetcher.webauthn_url_with_port(server.port)} " \
+    assert_match "You have enabled multi-factor authentication. Please visit the following URL " \
       "to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, you can re-run the gem signin " \
       "command with the `--otp [your_code]` option.", @stub_ui.output
+    assert_match @stub_fetcher.webauthn_url_with_port(server.port), @stub_ui.output
     assert_match "You are verified with a security device. You may close the browser window.", @stub_ui.output
     assert_equal "Uvh6T57tkWuUnWYo", @stub_fetcher.last_request["OTP"]
     assert_match response_success, @stub_ui.output
@@ -463,9 +466,10 @@ EOF
     end
 
     assert_match @stub_fetcher.last_request["Authorization"], Gem.configuration.rubygems_api_key
-    assert_match "You have enabled multi-factor authentication. Please visit #{@stub_fetcher.webauthn_url_with_port(server.port)} " \
+    assert_match "You have enabled multi-factor authentication. Please visit the following URL " \
       "to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, you can re-run the gem signin " \
       "command with the `--otp [your_code]` option.", @stub_ui.output
+    assert_match @stub_fetcher.webauthn_url_with_port(server.port), @stub_ui.output
     assert_match "ERROR:  Security device verification failed: The token in the link you used has either expired " \
       "or been used already.", @stub_ui.error
     refute_match "You are verified with a security device. You may close the browser window.", @stub_ui.output

--- a/test/rubygems/test_gem_commands_push_command.rb
+++ b/test/rubygems/test_gem_commands_push_command.rb
@@ -477,9 +477,10 @@ class TestGemCommandsPushCommand < Gem::TestCase
       end
     end
 
-    assert_match "You have enabled multi-factor authentication. Please visit #{@fetcher.webauthn_url_with_port(server.port)} " \
+    assert_match "You have enabled multi-factor authentication. Please visit the following URL " \
       "to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, " \
       "you can re-run the gem signin command with the `--otp [your_code]` option.", @ui.output
+    assert_match @fetcher.webauthn_url_with_port(server.port), @ui.output
     assert_match "You are verified with a security device. You may close the browser window.", @ui.output
     assert_equal "Uvh6T57tkWuUnWYo", @fetcher.last_request["OTP"]
     assert_match response_success, @ui.output
@@ -505,9 +506,10 @@ class TestGemCommandsPushCommand < Gem::TestCase
     assert_equal 1, error.exit_code
 
     assert_match @fetcher.last_request["Authorization"], Gem.configuration.rubygems_api_key
-    assert_match "You have enabled multi-factor authentication. Please visit #{@fetcher.webauthn_url_with_port(server.port)} " \
+    assert_match "You have enabled multi-factor authentication. Please visit the following URL " \
       "to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, " \
       "you can re-run the gem signin command with the `--otp [your_code]` option.", @ui.output
+    assert_match @fetcher.webauthn_url_with_port(server.port), @ui.output
     assert_match "ERROR:  Security device verification failed: Something went wrong", @ui.error
     refute_match "You are verified with a security device. You may close the browser window.", @ui.output
     refute_match response_success, @ui.output
@@ -527,9 +529,10 @@ class TestGemCommandsPushCommand < Gem::TestCase
       end
     end
 
-    assert_match "You have enabled multi-factor authentication. Please visit #{@fetcher.webauthn_url_with_port(server.port)} " \
+    assert_match "You have enabled multi-factor authentication. Please visit the following URL " \
       "to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, " \
       "you can re-run the gem signin command with the `--otp [your_code]` option.", @ui.output
+    assert_match @fetcher.webauthn_url_with_port(server.port), @ui.output
     assert_match "You are verified with a security device. You may close the browser window.", @ui.output
     assert_equal "Uvh6T57tkWuUnWYo", @fetcher.last_request["OTP"]
     assert_match response_success, @ui.output
@@ -553,9 +556,10 @@ class TestGemCommandsPushCommand < Gem::TestCase
     assert_equal 1, error.exit_code
 
     assert_match @fetcher.last_request["Authorization"], Gem.configuration.rubygems_api_key
-    assert_match "You have enabled multi-factor authentication. Please visit #{@fetcher.webauthn_url_with_port(server.port)} " \
-      "to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, you can re-run the gem signin " \
-      "command with the `--otp [your_code]` option.", @ui.output
+    assert_match "You have enabled multi-factor authentication. Please visit the following URL " \
+      "to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, " \
+      "you can re-run the gem signin command with the `--otp [your_code]` option.", @ui.output
+    assert_match @fetcher.webauthn_url_with_port(server.port), @ui.output
     assert_match "ERROR:  Security device verification failed: The token in the link you used has either expired " \
       "or been used already.", @ui.error
     refute_match "You are verified with a security device. You may close the browser window.", @ui.output

--- a/test/rubygems/test_gem_commands_yank_command.rb
+++ b/test/rubygems/test_gem_commands_yank_command.rb
@@ -131,9 +131,10 @@ class TestGemCommandsYankCommand < Gem::TestCase
     end
 
     assert_match %r{Yanking gem from http://example}, @ui.output
-    assert_match "You have enabled multi-factor authentication. Please visit #{@fetcher.webauthn_url_with_port(server.port)} " \
+    assert_match "You have enabled multi-factor authentication. Please visit the following URL " \
       "to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, " \
       "you can re-run the gem signin command with the `--otp [your_code]` option.", @ui.output
+    assert_match @fetcher.webauthn_url_with_port(server.port), @ui.output
     assert_match "You are verified with a security device. You may close the browser window.", @ui.output
     assert_equal "Uvh6T57tkWuUnWYo", @fetcher.last_request["OTP"]
     assert_match "Successfully yanked", @ui.output
@@ -163,9 +164,10 @@ class TestGemCommandsYankCommand < Gem::TestCase
 
     assert_match @fetcher.last_request["Authorization"], Gem.configuration.rubygems_api_key
     assert_match %r{Yanking gem from http://example}, @ui.output
-    assert_match "You have enabled multi-factor authentication. Please visit #{@fetcher.webauthn_url_with_port(server.port)} " \
+    assert_match "You have enabled multi-factor authentication. Please visit the following URL " \
       "to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, " \
       "you can re-run the gem signin command with the `--otp [your_code]` option.", @ui.output
+    assert_match @fetcher.webauthn_url_with_port(server.port), @ui.output
     assert_match "ERROR:  Security device verification failed: Something went wrong", @ui.error
     refute_match "You are verified with a security device. You may close the browser window.", @ui.output
     refute_match "Successfully yanked", @ui.output
@@ -189,9 +191,10 @@ class TestGemCommandsYankCommand < Gem::TestCase
     end
 
     assert_match %r{Yanking gem from http://example}, @ui.output
-    assert_match "You have enabled multi-factor authentication. Please visit #{@fetcher.webauthn_url_with_port(server.port)} " \
+    assert_match "You have enabled multi-factor authentication. Please visit the following URL " \
       "to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, " \
       "you can re-run the gem signin command with the `--otp [your_code]` option.", @ui.output
+    assert_match @fetcher.webauthn_url_with_port(server.port), @ui.output
     assert_match "You are verified with a security device. You may close the browser window.", @ui.output
     assert_equal "Uvh6T57tkWuUnWYo", @fetcher.last_request["OTP"]
     assert_match "Successfully yanked", @ui.output
@@ -219,9 +222,10 @@ class TestGemCommandsYankCommand < Gem::TestCase
 
     assert_match @fetcher.last_request["Authorization"], Gem.configuration.rubygems_api_key
     assert_match %r{Yanking gem from http://example}, @ui.output
-    assert_match "You have enabled multi-factor authentication. Please visit #{@fetcher.webauthn_url_with_port(server.port)} " \
+    assert_match "You have enabled multi-factor authentication. Please visit the following URL " \
       "to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, " \
       "you can re-run the gem signin command with the `--otp [your_code]` option.", @ui.output
+    assert_match @fetcher.webauthn_url_with_port(server.port), @ui.output
     assert_match "ERROR:  Security device verification failed: The token in the link you used has either expired " \
       "or been used already.", @ui.error
     refute_match "You are verified with a security device. You may close the browser window.", @ui.output

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -233,9 +233,10 @@ class TestGemGemcutterUtilities < Gem::TestCase
       end
     end
 
-    assert_match "You have enabled multi-factor authentication. Please visit #{@fetcher.webauthn_url_with_port(server.port)} " \
+    assert_match "You have enabled multi-factor authentication. Please visit the following URL " \
       "to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, " \
       "you can re-run the gem signin command with the `--otp [your_code]` option.", @sign_in_ui.output
+    assert_match @fetcher.webauthn_url_with_port(server.port), @sign_in_ui.output
     assert_match "You are verified with a security device. You may close the browser window.", @sign_in_ui.output
     assert_equal "Uvh6T57tkWuUnWYo", @fetcher.last_request["OTP"]
   end
@@ -255,9 +256,10 @@ class TestGemGemcutterUtilities < Gem::TestCase
     end
     assert_equal 1, error.exit_code
 
-    assert_match "You have enabled multi-factor authentication. Please visit #{@fetcher.webauthn_url_with_port(server.port)} " \
+    assert_match "You have enabled multi-factor authentication. Please visit the following URL " \
       "to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, " \
       "you can re-run the gem signin command with the `--otp [your_code]` option.", @sign_in_ui.output
+    assert_match @fetcher.webauthn_url_with_port(server.port), @sign_in_ui.output
     assert_match "ERROR:  Security device verification failed: Something went wrong", @sign_in_ui.error
     refute_match "You are verified with a security device. You may close the browser window.", @sign_in_ui.output
     refute_match "Signed in with API key:", @sign_in_ui.output
@@ -273,9 +275,10 @@ class TestGemGemcutterUtilities < Gem::TestCase
       util_sign_in
     end
 
-    assert_match "You have enabled multi-factor authentication. Please visit #{@fetcher.webauthn_url_with_port(server.port)} " \
+    assert_match "You have enabled multi-factor authentication. Please visit the following URL " \
       "to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, " \
       "you can re-run the gem signin command with the `--otp [your_code]` option.", @sign_in_ui.output
+    assert_match @fetcher.webauthn_url_with_port(server.port), @sign_in_ui.output
     assert_match "You are verified with a security device. You may close the browser window.", @sign_in_ui.output
     assert_equal "Uvh6T57tkWuUnWYo", @fetcher.last_request["OTP"]
   end
@@ -292,9 +295,10 @@ class TestGemGemcutterUtilities < Gem::TestCase
       end
     end
 
-    assert_match "You have enabled multi-factor authentication. Please visit #{@fetcher.webauthn_url_with_port(server.port)} " \
+    assert_match "You have enabled multi-factor authentication. Please visit the following URL " \
       "to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, " \
       "you can re-run the gem signin command with the `--otp [your_code]` option.", @sign_in_ui.output
+    assert_match @fetcher.webauthn_url_with_port(server.port), @sign_in_ui.output
     assert_match "ERROR:  Security device verification failed: " \
       "The token in the link you used has either expired or been used already.", @sign_in_ui.error
   end


### PR DESCRIPTION
Copying the URL is painful here because the URL is embedded within a paragraph of text. I presume we don't want to automatically open the browser.

Instead, move the URL to its own line so that "triple click" will automatically select the whole thing.
