### PR TITLE
don't create tmp home dir when checking if unrelated string equality

### DIFF
--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -39,7 +39,7 @@ module Bundler
 
       bundle_dir = Pathname.new(bundle_dir)
 
-      global_bundle_dir = Bundler.user_home.join(".bundle")
+      global_bundle_dir = File.join(Bundler.rubygems.user_home, ".bundle")
       return nil if bundle_dir == global_bundle_dir
 
       bundle_dir


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
