### PR TITLE
Validate lockfile dependencies with bundle install

### DIFF
--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -66,7 +66,9 @@ module Bundler
 
       Plugin.gemfile_install(Bundler.default_gemfile) if Bundler.feature_flag.plugins?
 
-      definition = Bundler.definition
+      # For install we want to enable strict validation
+      # (rather than some optimizations we perform at app runtime).
+      definition = Bundler.definition(strict: true)
       definition.validate_runtime!
 
       installer = Installer.install(Bundler.root, definition, options)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -60,6 +60,7 @@ module Bundler
 
       if unlock == true
         @unlocking_all = true
+        strict = false
         @unlocking_bundler = false
         @unlocking = unlock
         @sources_to_unlock = []
@@ -68,6 +69,7 @@ module Bundler
         conservative = false
       else
         @unlocking_all = false
+        strict = unlock.delete(:strict)
         @unlocking_bundler = unlock.delete(:bundler)
         @unlocking = unlock.any? {|_k, v| !Array(v).empty? }
         @sources_to_unlock = unlock.delete(:sources) || []
@@ -97,7 +99,7 @@ module Bundler
 
       if lockfile_exists?
         @lockfile_contents = Bundler.read_file(lockfile)
-        @locked_gems = LockfileParser.new(@lockfile_contents)
+        @locked_gems = LockfileParser.new(@lockfile_contents, strict: strict)
         @locked_platforms = @locked_gems.platforms
         @most_specific_locked_platform = @locked_gems.most_specific_locked_platform
         @platforms = @locked_platforms.dup

--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -94,7 +94,7 @@ module Bundler
       lockfile_contents.split(BUNDLED).last.strip
     end
 
-    def initialize(lockfile)
+    def initialize(lockfile, strict: false)
       @platforms    = []
       @sources      = []
       @dependencies = {}
@@ -106,6 +106,7 @@ module Bundler
         "Gemfile.lock"
       end
       @pos = Position.new(1, 1)
+      @strict = strict
 
       if lockfile.match?(/<<<<<<<|=======|>>>>>>>|\|\|\|\|\|\|\|/)
         raise LockfileError, "Your #{@lockfile_path} contains merge conflicts.\n" \
@@ -286,7 +287,7 @@ module Bundler
 
         version = Gem::Version.new(version)
         platform = platform ? Gem::Platform.new(platform) : Gem::Platform::RUBY
-        @current_spec = LazySpecification.new(name, version, platform, @current_source)
+        @current_spec = LazySpecification.new(name, version, platform, @current_source, strict: @strict)
         @current_source.add_dependency_names(name)
 
         @specs[@current_spec.full_name] = @current_spec


### PR DESCRIPTION
It can be useful in CI to force lockfile validation
even when all gems are already installed locally
to avoid unexpected behavior when the gem cache is empty.

Right now, if the lockfile erroneously had a dependency of any gem removed
it will check/install fine if the gem is already installed (it ignores the check by design).
But then if you run the same command when that gem isn't pre-installed the command will try to edit the lockfile (which will error in deployment mode).

See [this slack thread](https://bundler.slack.com/archives/C08V1RPAP/p1745936695490739) for discussion.

Now, if the dependencies in the lockfile are not correct, running `bundle install` will abort in frozen mode (good for CI), and update the lockfile when not frozen (making it easy to commit the changes).