### PR TITLE
Run `bundle install` automatically after `bundle gem`

### DIFF
--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -69,6 +69,7 @@ module Bundler
         test: options[:test],
         ext: extension,
         exe: options[:exe],
+        bundle: options[:bundle],
         bundler_version: bundler_dependency_version,
         git: use_git,
         github_username: github_username.empty? ? "[USERNAME]" : github_username,
@@ -239,6 +240,13 @@ module Bundler
 
       if use_git
         IO.popen(%w[git add .], { chdir: target }, &:read)
+      end
+
+      if config[:bundle]
+        Bundler.ui.info "Running bundle install in the new gem directory."
+        Dir.chdir(target) do
+          system("bundle install")
+        end
       end
 
       # Open gemspec in editor

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "bundle gem" do
     git("config --global github.user bundleuser")
 
     global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false", "BUNDLE_GEM__LINTER" => "false",
-                  "BUNDLE_GEM__CI" => "false", "BUNDLE_GEM__CHANGELOG" => "false"
+                  "BUNDLE_GEM__CI" => "false", "BUNDLE_GEM__CHANGELOG" => "false", "BUNDLE_GEM__BUNDLE" => "false"
   end
 
   describe "git repo initialization" do
@@ -149,6 +149,26 @@ RSpec.describe "bundle gem" do
     it "generates a gem skeleton without a CHANGELOG" do
       gem_skeleton_assertions
       expect(bundled_app("#{gem_name}/CHANGELOG.md")).to_not exist
+    end
+  end
+
+  shared_examples_for "--bundle flag" do
+    before do
+      bundle "gem #{gem_name} --bundle"
+    end
+    it "generates a gem skeleton with bundle install" do
+      gem_skeleton_assertions
+      expect(Kernel).to receive(:system).with("bundle", "install").once
+    end
+  end
+
+  shared_examples_for "--no-bundle flag" do
+    before do
+      bundle "gem #{gem_name} --no-bundle"
+    end
+    it "generates a gem skeleton without bundle install" do
+      gem_skeleton_assertions
+      expect(Kernel).not_to receive(:system).with("bundle", "install")
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I organized gem workshop in last month.

https://andpad.connpass.com/event/347970/ 

I introduced how to build new gem in that workshop. The new programmer typed `bundle gem` and writing code with their idea. The whole people asked "rake release/spec is not working" to me when we publish their first gem.

It's simple problem, no one execute `bundle install` in new gem directory.

## What is your fix for the problem, implemented in this PR?

I make to run `bundle install` automatically after `bundle gem` inspired by `rails new`.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
