### PR TITLE
Add mtime to Gem::Package::TarWriter#add_file argument

### DIFF
--- a/lib/rubygems/package/tar_writer.rb
+++ b/lib/rubygems/package/tar_writer.rb
@@ -95,10 +95,11 @@ class Gem::Package::TarWriter
   end
 
   ##
-  # Adds file +name+ with permissions +mode+, and yields an IO for writing the
-  # file to
+  # Adds file +name+ with permissions +mode+ and mtime +mtime+ (sets
+  # Gem.source_date_epoch if not specified), and yields an IO for
+  # writing the file to
 
-  def add_file(name, mode) # :yields: io
+  def add_file(name, mode, mtime=nil) # :yields: io
     check_closed
 
     name, prefix = split_name name
@@ -118,7 +119,7 @@ class Gem::Package::TarWriter
 
     header = Gem::Package::TarHeader.new name: name, mode: mode,
                                          size: size, prefix: prefix,
-                                         mtime: Gem.source_date_epoch
+                                         mtime: mtime || Gem.source_date_epoch
 
     @io.write header
     @io.pos = final_pos

--- a/test/rubygems/test_gem_package_tar_writer.rb
+++ b/test/rubygems/test_gem_package_tar_writer.rb
@@ -52,11 +52,13 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
 
   def test_add_file_with_mtime
     Time.stub :now, Time.at(1_458_518_157) do
-      @tar_writer.add_file "x", 0o644, Time.now do |f|
+      mtime = Time.now
+
+      @tar_writer.add_file "x", 0o644, mtime do |f|
         f.write "a" * 10
       end
 
-      assert_headers_equal(tar_file_header("x", "", 0o644, 10, Time.now),
+      assert_headers_equal(tar_file_header("x", "", 0o644, 10, mtime),
                          @io.string[0, 512])
     end
   end

--- a/test/rubygems/test_gem_package_tar_writer.rb
+++ b/test/rubygems/test_gem_package_tar_writer.rb
@@ -50,6 +50,17 @@ class TestGemPackageTarWriter < Gem::Package::TarTestCase
     end
   end
 
+  def test_add_file_with_mtime
+    Time.stub :now, Time.at(1_458_518_157) do
+      @tar_writer.add_file "x", 0o644, Time.now do |f|
+        f.write "a" * 10
+      end
+
+      assert_headers_equal(tar_file_header("x", "", 0o644, 10, Time.now),
+                         @io.string[0, 512])
+    end
+  end
+
   def test_add_symlink
     Time.stub :now, Time.at(1_458_518_157) do
       @tar_writer.add_symlink "x", "y", 0o644


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

* https://github.com/itamae-kitchen/itamae/issues/377
* https://github.com/upserve/docker-api/blob/7e19faf75b886660afc43d21b1ad137642ee1d6f/lib/docker/util.rb#L128
* #8568 

From #8568, changing the behavior of the `Gem::Package::TarWriter#add_file` changes the docker-api gems (that use TarWriter) behavior, failing the itamae gems test suite, which checks the mtime value.


## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Since 9e21dd9, `Gem::Package::TarWriter#add_file` adds the file to the tar with `Gem.source_date_epoch` for its mtime.
This behavior breaks the code depending on the previous add_file behavior.
Therefore, `add_file` accepts mtime as an argument, and uses `Gem.source_date_epoch` if not specified.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
