### PR TITLE
Restore original branch if LoadError happens during prepare_release task

### DIFF
--- a/tool/release.rb
+++ b/tool/release.rb
@@ -206,7 +206,7 @@ class Release
           "Cherry-picking change logs from future RubyGems #{@rubygems.version} and Bundler #{@bundler.version} into master."
         )
       end
-    rescue StandardError
+    rescue StandardError, LoadError
       system("git", "checkout", initial_branch)
       raise
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I'm seeing an error if octokit is not installed prior to running this task. I want to investigate it because this task should be installing dependencies as a prerequisite, but for starters, the task should cleanup after itself when this kind of error happens.

## What is your fix for the problem, implemented in this PR?

Rescue LoadError so that the failing task leaves a better state.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
