### PR TITLE
Clear gem paths so release gems just installed are available immediately

### DIFF
--- a/tool/release.rb
+++ b/tool/release.rb
@@ -119,6 +119,8 @@ class Release
       "--gemfile=#{File.expand_path("bundler/release_gems.rb", __dir__)}",
       exception: true
     )
+
+    Gem.clear_paths
   end
 
   def self.for_bundler(version)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If gems like `octokit` are not installed prior to running the `prepare_release` task, the task fails. This is because even if the task installs release gems as a prerequisite, it does not make them inmediately available to the `prepare_release` task.

## What is your fix for the problem, implemented in this PR?

Fix is to clear gem paths so that installed specifications are loaded again after missing release gems are installed.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
