### PR TITLE
Changelogs for RubyGems 3.6.9 and Bundler 2.6.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+# 3.6.9 / 2025-05-13
+
+## Enhancements:
+
+* Add mtime to Gem::Package::TarWriter#add_file argument. Pull request
+  [#8673](https://github.com/rubygems/rubygems/pull/8673) by unasuke
+* Print webauthn authentication link as a separate line to make it easier
+  to visit. Pull request
+  [#8663](https://github.com/rubygems/rubygems/pull/8663) by mperham
+* Remove shellwords autoload. Pull request
+  [#8644](https://github.com/rubygems/rubygems/pull/8644) by
+  deivid-rodriguez
+* Installs bundler 2.6.9 as a default gem.
+
+## Performance:
+
+* Avoid unnecessary splat allocation. Pull request
+  [#8640](https://github.com/rubygems/rubygems/pull/8640) by jeremyevans
+
+## Documentation:
+
+* Fix typo in Changelog for 3.6.0 / 2024-12-16. Pull request
+  [#8638](https://github.com/rubygems/rubygems/pull/8638) by thatrobotdev
+
 # 3.6.8 / 2025-04-13
 
 ## Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 2.6.9 (May 13, 2025)
+
+## Enhancements:
+
+  - Fix doctor command parsing of otool output [#8665](https://github.com/rubygems/rubygems/pull/8665)
+  - Add SSL troubleshooting to `bundle doctor` [#8624](https://github.com/rubygems/rubygems/pull/8624)
+  - Let `bundle lock --normalize-platforms` remove invalid platforms [#8631](https://github.com/rubygems/rubygems/pull/8631)
+
+## Bug fixes:
+
+  - Fix `bundle lock` sometimes allowing invalid platforms into the lockfile [#8630](https://github.com/rubygems/rubygems/pull/8630)
+  - Fix false positive warning about insecure materialization in frozen mode [#8629](https://github.com/rubygems/rubygems/pull/8629)
+
 # 2.6.8 (April 13, 2025)
 
 ## Enhancements:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 3.6.9 and Bundler 2.6.9 into master.