### PR TITLE
Use a working setup-ruby action on Windows to get CI green

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -57,8 +57,11 @@ jobs:
       RUBYOPT: --disable-gems
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      # TODO:
+      # * Go back to ruby/setup-ruby once https://github.com/ruby/setup-ruby/pull/762 is released
+      # * Figure out regression in gcc packages, my fork is pinned to https://github.com/ntkme/setup-msys2-gcc/releases/tag/v20250509.003447 because newer releases break our tests for some reason
       - name: Setup ruby
-        uses: ruby/setup-ruby@eaecf785f6a34567a6d97f686bbb7bccc1ac1e5c # v1.237.0
+        uses: deivid-rodriguez/setup-ruby@dev
         with:
           ruby-version: ${{ matrix.ruby.value }}
           bundler: none

--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -117,8 +117,11 @@ jobs:
           - { name: jruby, value: jruby-9.4.12.0, rails-args: "--skip-webpack-install" }
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      # TODO:
+      # * Go back to ruby/setup-ruby once https://github.com/ruby/setup-ruby/pull/762 is released
+      # * Figure out regression in gcc packages, my fork is pinned to https://github.com/ntkme/setup-msys2-gcc/releases/tag/v20250509.003447 because newer releases break our tests for some reason
       - name: Setup ruby
-        uses: ruby/setup-ruby@eaecf785f6a34567a6d97f686bbb7bccc1ac1e5c # v1.237.0
+        uses: deivid-rodriguez/setup-ruby@dev
         with:
           ruby-version: ${{ matrix.ruby.value }}
           bundler: none


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Some CI jobs on Windows broke some hours ago.

## What is your fix for the problem, implemented in this PR?

New packages with ucrt64 gcc chain were uploaded to https://github.com/ruby/setup-msys2-gcc/releases/tag/msys2-gcc-pkgs very recently and they seem to have broken extension compilation when Ruby 3.2 and Ruby 3.3 are run on Windows. 

~Apparently recent GCC issues have led to a rewrite of the ruby/setup-ruby action on Windows, and the rewrite does not have any issues and it's also dramatically faster.~

EDIT: The same issues showed up in the fork in the last few days, however, it's easier to go back to working GCC packages in the fork, so I'm still using it. And it's still much faster.

So switch to that for now to get our CI back to green.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
