### PR TITLE
Sync ruby/ruby changes for CGI retirement

### DIFF
--- a/bundler/lib/bundler/fetcher/dependency.rb
+++ b/bundler/lib/bundler/fetcher/dependency.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 require_relative "base"
-require "cgi/util"
+begin
+  require "cgi/escape"
+rescue LoadError
+  require "cgi/util"
+end
 
 module Bundler
   class Fetcher

--- a/bundler/lib/bundler/fetcher/dependency.rb
+++ b/bundler/lib/bundler/fetcher/dependency.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
 require_relative "base"
-begin
-  require "cgi/escape"
-rescue LoadError
-  require "cgi/util"
-end
+require "cgi/escape"
+require "cgi/util" unless defined?(CGI::EscapeExt)
 
 module Bundler
   class Fetcher

--- a/bundler/lib/bundler/friendly_errors.rb
+++ b/bundler/lib/bundler/friendly_errors.rb
@@ -102,11 +102,8 @@ module Bundler
     def issues_url(exception)
       message = exception.message.lines.first.tr(":", " ").chomp
       message = message.split("-").first if exception.is_a?(Errno)
-      begin
-        require "cgi/escape"
-      rescue LoadError
-        require "cgi/util"
-      end
+      require "cgi/escape"
+      require "cgi/util" unless defined?(CGI::EscapeExt)
       "https://github.com/rubygems/rubygems/search?q=" \
         "#{CGI.escape(message)}&type=Issues"
     end

--- a/bundler/lib/bundler/friendly_errors.rb
+++ b/bundler/lib/bundler/friendly_errors.rb
@@ -102,7 +102,11 @@ module Bundler
     def issues_url(exception)
       message = exception.message.lines.first.tr(":", " ").chomp
       message = message.split("-").first if exception.is_a?(Errno)
-      require "cgi/util"
+      begin
+        require "cgi/escape"
+      rescue LoadError
+        require "cgi/util"
+      end
       "https://github.com/rubygems/rubygems/search?q=" \
         "#{CGI.escape(message)}&type=Issues"
     end

--- a/bundler/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb
+++ b/bundler/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb
@@ -1,6 +1,11 @@
 require_relative '../../../../../vendored_net_http'
 require_relative '../../../../../vendored_uri'
-require 'cgi' # for escaping
+# for escaping
+begin
+  require 'cgi/escape'
+rescue LoadError
+  require 'cgi'
+end
 require_relative '../../../../connection_pool/lib/connection_pool'
 
 autoload :OpenSSL, 'openssl'

--- a/bundler/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb
+++ b/bundler/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb
@@ -1,10 +1,7 @@
 require_relative '../../../../../vendored_net_http'
 require_relative '../../../../../vendored_uri'
-begin
-  require 'cgi/escape'
-rescue LoadError
-  require 'cgi/util' # for escaping
-end
+require 'cgi/escape'
+require 'cgi/util' unless defined?(CGI::EscapeExt)
 require_relative '../../../../connection_pool/lib/connection_pool'
 
 autoload :OpenSSL, 'openssl'

--- a/bundler/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb
+++ b/bundler/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb
@@ -1,10 +1,9 @@
 require_relative '../../../../../vendored_net_http'
 require_relative '../../../../../vendored_uri'
-# for escaping
 begin
   require 'cgi/escape'
 rescue LoadError
-  require 'cgi'
+  require 'cgi/util' # for escaping
 end
 require_relative '../../../../connection_pool/lib/connection_pool'
 
@@ -787,7 +786,7 @@ class Gem::Net::HTTP::Persistent
       @proxy_connection_id = [nil, *@proxy_args].join ':'
 
       if @proxy_uri.query then
-        @no_proxy = CGI.parse(@proxy_uri.query)['no_proxy'].join(',').downcase.split(',').map { |x| x.strip }.reject { |x| x.empty? }
+        @no_proxy = Gem::URI.decode_www_form(@proxy_uri.query).filter_map { |k, v| v if k == 'no_proxy' }.join(',').downcase.split(',').map { |x| x.strip }.reject { |x| x.empty? }
       end
     end
 

--- a/lib/rubygems/uri_formatter.rb
+++ b/lib/rubygems/uri_formatter.rb
@@ -17,11 +17,8 @@ class Gem::UriFormatter
   # Creates a new URI formatter for +uri+.
 
   def initialize(uri)
-    begin
-      require "cgi/escape"
-    rescue LoadError
-      require "cgi/util"
-    end
+    require "cgi/escape"
+    require "cgi/util" unless defined?(CGI::EscapeExt)
 
     @uri = uri
   end

--- a/lib/rubygems/uri_formatter.rb
+++ b/lib/rubygems/uri_formatter.rb
@@ -17,7 +17,11 @@ class Gem::UriFormatter
   # Creates a new URI formatter for +uri+.
 
   def initialize(uri)
-    require "cgi/util"
+    begin
+      require "cgi/escape"
+    rescue LoadError
+      require "cgi/util"
+    end
 
     @uri = uri
   end

--- a/lib/rubygems/vendor/net-http/lib/net/http.rb
+++ b/lib/rubygems/vendor/net-http/lib/net/http.rb
@@ -1923,11 +1923,8 @@ module Gem::Net   #:nodoc:
     private
 
     def unescape(value)
-      begin
-        require "cgi/escape"
-      rescue LoadError
-        require "cgi/util"
-      end
+      require 'cgi/escape'
+      require 'cgi/util' unless defined?(CGI::EscapeExt)
       CGI.unescape(value)
     end
 

--- a/lib/rubygems/vendor/net-http/lib/net/http.rb
+++ b/lib/rubygems/vendor/net-http/lib/net/http.rb
@@ -1923,7 +1923,11 @@ module Gem::Net   #:nodoc:
     private
 
     def unescape(value)
-      require 'cgi/util'
+      begin
+        require "cgi/escape"
+      rescue LoadError
+        require "cgi/util"
+      end
       CGI.unescape(value)
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I have a plan to retire CGI library from the next stable version that is Ruby 3.5. It replaced `cgi/util` to `cgi/escape`.

## What is your fix for the problem, implemented in this PR?

I replaced `cgi/util` to `cgi/escape`. But Ruby versions < 3.5 need to require `cgi/util` for some methods like `CGI.unescape`. I added fallback condition for that.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
