### PR TITLE
Reenable skipped specs in truffleruby since they should be fixed

### DIFF
--- a/test/rubygems/test_gem_safe_marshal.rb
+++ b/test/rubygems/test_gem_safe_marshal.rb
@@ -234,8 +234,6 @@ class TestGemSafeMarshal < Gem::TestCase
   end
 
   def test_link_after_float
-    pend "Marshal.load of links and floats is broken on truffleruby, see https://github.com/oracle/truffleruby/issues/3747" if RUBY_ENGINE == "truffleruby"
-
     a = []
     a << a
     assert_safe_load_as [0.0, a, 1.0, a]

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3664,8 +3664,6 @@ Did you mean 'Ruby'?
   end
 
   def test__load_fixes_Date_objects
-    pend "Marshal.load of links and floats is broken on truffleruby, see https://github.com/oracle/truffleruby/issues/3747" if RUBY_ENGINE == "truffleruby"
-
     spec = util_spec "a", 1
     spec.instance_variable_set :@date, Date.today
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Just found some skipped specs in TruffleRuby that I believe should be now passing.

## What is your fix for the problem, implemented in this PR?

Reenable the specs.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
