### PR TITLE
Switch back to ntkme's fork for setup-ruby action

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -59,9 +59,8 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       # TODO:
       # * Go back to ruby/setup-ruby once https://github.com/ruby/setup-ruby/pull/762 is released
-      # * Figure out regression in gcc packages, my fork is pinned to https://github.com/ntkme/setup-msys2-gcc/releases/tag/v20250509.003447 because newer releases break our tests for some reason
       - name: Setup ruby
-        uses: deivid-rodriguez/setup-ruby@dev
+        uses: ntkme/setup-ruby@dev
         with:
           ruby-version: ${{ matrix.ruby.value }}
           bundler: none

--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -119,9 +119,8 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       # TODO:
       # * Go back to ruby/setup-ruby once https://github.com/ruby/setup-ruby/pull/762 is released
-      # * Figure out regression in gcc packages, my fork is pinned to https://github.com/ntkme/setup-msys2-gcc/releases/tag/v20250509.003447 because newer releases break our tests for some reason
       - name: Setup ruby
-        uses: deivid-rodriguez/setup-ruby@dev
+        uses: ntkme/setup-ruby@dev
         with:
           ruby-version: ${{ matrix.ruby.value }}
           bundler: none


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We're using a fork of a fork with some changes to pin to old packages.

## What is your fix for the problem, implemented in this PR?

Switch back to one forking level since one of the issues should be now fixed if I understood correctly.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
