### PR TITLE
Use dependency predicate methods instead of reading type directly

### DIFF
--- a/bundler/lib/bundler/index.rb
+++ b/bundler/lib/bundler/index.rb
@@ -108,7 +108,7 @@ module Bundler
       names = []
       each do |spec|
         spec.dependencies.each do |dep|
-          next if dep.type == :development
+          next if dep.development?
           names << dep.name
         end
       end
@@ -153,8 +153,8 @@ module Bundler
     end
 
     def dependencies_eql?(spec, other_spec)
-      deps       = spec.dependencies.select {|d| d.type != :development }
-      other_deps = other_spec.dependencies.select {|d| d.type != :development }
+      deps       = spec.dependencies.reject(&:development?)
+      other_deps = other_spec.dependencies.reject(&:development?)
       deps.sort == other_deps.sort
     end
 

--- a/bundler/lib/bundler/installer/parallel_installer.rb
+++ b/bundler/lib/bundler/installer/parallel_installer.rb
@@ -37,7 +37,7 @@ module Bundler
       end
 
       def ignorable_dependency?(dep)
-        dep.type == :development || dep.name == @name
+        dep.development? || dep.name == @name
       end
 
       # Checks installed dependencies against spec's dependencies to make

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -114,7 +114,7 @@ module Bundler
       out << "    #{lock_name}\n"
 
       dependencies.sort_by(&:to_s).uniq.each do |dep|
-        next if dep.type == :development
+        next if dep.development?
         out << "    #{dep.to_lock}\n"
       end
 

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -156,8 +156,8 @@ module Bundler
     end
 
     def ensure_same_dependencies(spec, old_deps, new_deps)
-      new_deps = new_deps.reject {|d| d.type == :development }
-      old_deps = old_deps.reject {|d| d.type == :development }
+      new_deps = new_deps.reject(&:development?)
+      old_deps = old_deps.reject(&:development?)
 
       without_type = proc {|d| Gem::Dependency.new(d.name, d.requirements_list.sort) }
       new_deps.map!(&without_type)

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -348,7 +348,7 @@ module Bundler
 
     def tsort_each_child(s)
       s.dependencies.sort_by(&:name).each do |d|
-        next if d.type == :development
+        next if d.development?
 
         specs_for_name = lookup[d.name]
         next unless specs_for_name

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -165,6 +165,10 @@ class Gem::Dependency
     @type == :runtime || !@type
   end
 
+  def development?
+    @type == :development
+  end
+
   def ==(other) # :nodoc:
     Gem::Dependency === other &&
       name        == other.name &&

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -404,7 +404,7 @@ class Gem::Installer
   # True if the gems in the system satisfy +dependency+.
 
   def installation_satisfies_dependency?(dependency)
-    return true if @options[:development] && dependency.type == :development
+    return true if @options[:development] && dependency.development?
     return true if installed_specs.detect {|s| dependency.matches_spec? s }
     return false if @only_install_dir
     !dependency.matching_specs.empty?
@@ -734,7 +734,7 @@ class Gem::Installer
       raise Gem::InstallError, "#{spec} has an invalid specification_version"
     end
 
-    if spec.dependencies.any? {|dep| dep.type != :runtime && dep.type != :development }
+    if spec.dependencies.any? {|dep| !Gem::Dependency::TYPES.include?(dep.type) }
       raise Gem::InstallError, "#{spec} has an invalid dependencies"
     end
 

--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -445,14 +445,14 @@ class Gem::RequestSet
 
   def tsort_each_child(node) # :nodoc:
     node.spec.dependencies.each do |dep|
-      next if dep.type == :development && !@development
+      next if dep.development? && !@development
 
       match = @requests.find do |r|
         dep.match?(r.spec.name, r.spec.version, r.spec.is_a?(Gem::Resolver::InstalledSpecification) || @prerelease)
       end
 
       unless match
-        next if dep.type == :development && @development_shallow
+        next if dep.development? && @development_shallow
         next if @soft_missing
         raise Gem::DependencyError,
               "Unresolved dependency found during sorting - #{dep} (requested by #{node.spec.full_name})"

--- a/lib/rubygems/request_set/lockfile.rb
+++ b/lib/rubygems/request_set/lockfile.rb
@@ -109,7 +109,7 @@ class Gem::RequestSet::Lockfile
         out << "    #{request.name} (#{request.version}#{platform})"
 
         request.full_spec.dependencies.sort.each do |dependency|
-          next if dependency.type == :development
+          next if dependency.development?
 
           requirement = dependency.requirement
           out << "      #{dependency.name}#{requirement.for_lockfile}"

--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -150,11 +150,9 @@ class Gem::Resolver
     s.fetch_development_dependencies if @development
 
     s.dependencies.reverse_each do |d|
-      next if d.type == :development && !@development
-      next if d.type == :development && @development_shallow &&
-              act.development?
-      next if d.type == :development && @development_shallow &&
-              act.parent
+      next if d.development? && !@development
+      next if d.development? && @development_shallow &&
+              (act.development? || act.parent)
 
       reqs << Gem::Resolver::DependencyRequest.new(d, act)
       @stats.requirement!

--- a/lib/rubygems/resolver/dependency_request.rb
+++ b/lib/rubygems/resolver/dependency_request.rb
@@ -39,7 +39,7 @@ class Gem::Resolver::DependencyRequest
   # Is this dependency a development dependency?
 
   def development?
-    @dependency.type == :development
+    @dependency.development?
   end
 
   ##

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1791,7 +1791,7 @@ class Gem::Specification < Gem::BasicSpecification
   # List of dependencies that are used for development
 
   def development_dependencies
-    dependencies.select {|d| d.type == :development }
+    dependencies.select(&:development?)
   end
 
   ##


### PR DESCRIPTION
Makes it easier to experiment with adding future types of dependencies (e.g. build-only deps) should we ever explore that direction

Signed-off-by: Samuel Giddins <segiddins@segiddins.me>

<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)