### PR TITLE
Add all-pass jobs to PR workflows

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -97,3 +97,17 @@ jobs:
         if: matrix.ruby.name == 'jruby' && matrix.os.name == 'Ubuntu'
 
     timeout-minutes: ${{ matrix.timeout || 60 }}
+
+  all-pass:
+    if: always()
+
+    needs:
+      - bundler
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: check dependent jobs
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -191,3 +191,19 @@ jobs:
           GEM_PATH: bar
 
     timeout-minutes: 20
+
+  all-pass:
+    if: always()
+
+    needs:
+      - install_rubygems_ubuntu
+      - install_rubygems_windows
+      - shared_gem_home
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: check dependent jobs
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/read-only.yml
+++ b/.github/workflows/read-only.yml
@@ -37,3 +37,17 @@ jobs:
         run: docker run --mount type=bind,source=.,target=/rubygems --rm --read-only ruby:${{ matrix.ruby.value }} ruby -I/rubygems/bundler/lib -r'bundler/inline' -e 'gemfile {}; puts :ok'
 
     timeout-minutes: 15
+
+  all-pass:
+    if: always()
+
+    needs:
+      - read-only
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: check dependent jobs
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/realworld-bundler.yml
+++ b/.github/workflows/realworld-bundler.yml
@@ -136,3 +136,20 @@ jobs:
           path: ./bundler/spec/support/artifice/used_vcr_cassettes
       - name: Check unused cassettes
         run: bin/rake spec:realworld:check_unused_cassettes
+
+  all-pass:
+    if: always()
+
+    needs:
+      - bundler
+      - tapioca
+      - system_rubygems_bundler
+      - check_unused_cassettes
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: check dependent jobs
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -57,3 +57,17 @@ jobs:
           make test-bundler-parallel
         working-directory: ruby/ruby
         if: matrix.target == 'Bundler'
+
+  all-pass:
+    if: always()
+
+    needs:
+      - ruby_core
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: check dependent jobs
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -64,3 +64,17 @@ jobs:
         if: matrix.ruby.name == 'truffleruby'
 
     timeout-minutes: 60
+
+  all-pass:
+    if: always()
+
+    needs:
+      - rubygems
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: check dependent jobs
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/system-rubygems-bundler.yml
+++ b/.github/workflows/system-rubygems-bundler.yml
@@ -70,3 +70,17 @@ jobs:
           ruby -I../../lib:lib:test test/rubygems/test_gem_requirement.rb
         working-directory: ./bundler/tmp/rubygems
     timeout-minutes: 60
+
+  all-pass:
+    if: always()
+
+    needs:
+      - system_rubygems_bundler
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: check dependent jobs
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/truffleruby-bundler.yml
+++ b/.github/workflows/truffleruby-bundler.yml
@@ -38,3 +38,17 @@ jobs:
           bin/parallel_rspec --tag truffleruby_only --tag truffleruby
         working-directory: ./bundler
     timeout-minutes: 20
+
+  all-pass:
+    if: always()
+
+    needs:
+      - truffleruby_bundler
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: check dependent jobs
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -47,3 +47,17 @@ jobs:
         run: bin/rake check_rvm_integration man:check vendor:check version:check check_rubygems_integration
         if: matrix.ruby.name != 'jruby'
     timeout-minutes: 15
+
+  all-pass:
+    if: always()
+
+    needs:
+      - ubuntu_lint
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: check dependent jobs
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
This way, we can require the all-pass jobs in branch protection and dont need to list out every matrix entry

Signed-off-by: Samuel Giddins <segiddins@segiddins.me>

<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)