### PR TITLE
Refine all-jobs checks

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -99,6 +99,8 @@ jobs:
     timeout-minutes: ${{ matrix.timeout || 60 }}
 
   all-pass:
+    name: All bundler jobs pass
+
     if: always()
 
     needs:

--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -193,6 +193,8 @@ jobs:
     timeout-minutes: 20
 
   all-pass:
+    name: All install-rubygems jobs pass
+
     if: always()
 
     needs:

--- a/.github/workflows/read-only.yml
+++ b/.github/workflows/read-only.yml
@@ -39,6 +39,8 @@ jobs:
     timeout-minutes: 15
 
   all-pass:
+    name: All read-only jobs pass
+
     if: always()
 
     needs:

--- a/.github/workflows/realworld-bundler.yml
+++ b/.github/workflows/realworld-bundler.yml
@@ -138,6 +138,8 @@ jobs:
         run: bin/rake spec:realworld:check_unused_cassettes
 
   all-pass:
+    name: All realworld-bundler jobs pass
+
     if: always()
 
     needs:

--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -59,6 +59,8 @@ jobs:
         if: matrix.target == 'Bundler'
 
   all-pass:
+    name: All ruby-core jobs pass
+
     if: always()
 
     needs:

--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -66,6 +66,8 @@ jobs:
     timeout-minutes: 60
 
   all-pass:
+    name: All rubygems jobs pass
+
     if: always()
 
     needs:

--- a/.github/workflows/system-rubygems-bundler.yml
+++ b/.github/workflows/system-rubygems-bundler.yml
@@ -72,6 +72,8 @@ jobs:
     timeout-minutes: 60
 
   all-pass:
+    name: All system-rubygems-bundler jobs pass
+
     if: always()
 
     needs:

--- a/.github/workflows/truffleruby-bundler.yml
+++ b/.github/workflows/truffleruby-bundler.yml
@@ -40,6 +40,8 @@ jobs:
     timeout-minutes: 20
 
   all-pass:
+    name: All truffleruby-bundler jobs pass
+
     if: always()
 
     needs:

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -62,6 +62,8 @@ jobs:
     timeout-minutes: 15
 
   all-pass:
+    name: All ubuntu-lint jobs pass
+
     if: always()
 
     needs:


### PR DESCRIPTION


## What was the end-user or developer problem that led to this PR?

We need to disambiguate names and set all of them as required.

Otherwise, as long as one of them has passed, and others are not enqueued yet (because their needed jobs are still running), PR is mergeable.

## What is your fix for the problem, implemented in this PR?

Make sure jobs have unique names, so that we can require all of them to pass.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
