### PR TITLE
Fix heading ranks in documentation

### DIFF
--- a/.changelog.yml
+++ b/.changelog.yml
@@ -1,6 +1,6 @@
 ---
 
-header_template: "# %new_version / %release_date"
+header_template: "## %new_version / %release_date"
 
 entry_template: "* %title. Pull request [#%pull_request_number](%pull_request_url) by %pull_request_author"
 
@@ -13,14 +13,14 @@ release_date_format: "%Y-%m-%d"
 entry_wrapping: 74
 
 changelog_label_mapping:
-  "rubygems: security": "## Security:"
-  "rubygems: breaking change": "## Breaking changes:"
-  "rubygems: deprecation": "## Deprecations:"
-  "rubygems: feature": "## Features:"
-  "rubygems: performance": "## Performance:"
-  "rubygems: enhancement": "## Enhancements:"
-  "rubygems: bug fix": "## Bug fixes:"
-  "rubygems: documentation": "## Documentation:"
+  "rubygems: security": "### Security:"
+  "rubygems: breaking change": "### Breaking changes:"
+  "rubygems: deprecation": "### Deprecations:"
+  "rubygems: feature": "### Features:"
+  "rubygems: performance": "### Performance:"
+  "rubygems: enhancement": "### Enhancements:"
+  "rubygems: bug fix": "### Bug fixes:"
+  "rubygems: documentation": "### Documentation:"
   "rubygems: skip changelog": null
 
 patch_level_labels:

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -80,8 +80,11 @@ jobs:
           bundler: none
       - name: Install Dependencies
         run: bin/rake setup
-      - name: Run Lint
+      - name: Run Ruby Lint
         run: bin/rake rubocop
+      - name: Run Markdown Lint
+        run: bin/mdl -g . -r MD001,MD025
+        if: matrix.ruby.name == 'ruby'
       - name: Generate docs
         run: bin/rake docs
         if: matrix.ruby.name != 'jruby'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-# 3.6.9 / 2025-05-13
+# Changelog
 
-## Enhancements:
+## 3.6.9 / 2025-05-13
+
+### Enhancements:
 
 * Add mtime to Gem::Package::TarWriter#add_file argument. Pull request
   [#8673](https://github.com/rubygems/rubygems/pull/8673) by unasuke
@@ -12,25 +14,25 @@
   deivid-rodriguez
 * Installs bundler 2.6.9 as a default gem.
 
-## Performance:
+### Performance:
 
 * Avoid unnecessary splat allocation. Pull request
   [#8640](https://github.com/rubygems/rubygems/pull/8640) by jeremyevans
 
-## Documentation:
+### Documentation:
 
 * Fix typo in Changelog for 3.6.0 / 2024-12-16. Pull request
   [#8638](https://github.com/rubygems/rubygems/pull/8638) by thatrobotdev
 
-# 3.6.8 / 2025-04-13
+## 3.6.8 / 2025-04-13
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.6.8 as a default gem.
 
-# 3.6.7 / 2025-04-03
+## 3.6.7 / 2025-04-03
 
-## Enhancements:
+### Enhancements:
 
 * Sorting files in metadata for build reproducibility. Pull request
   [#8569](https://github.com/rubygems/rubygems/pull/8569) by
@@ -43,54 +45,54 @@
   deivid-rodriguez
 * Installs bundler 2.6.7 as a default gem.
 
-## Performance:
+### Performance:
 
 * Speed up Version#<=> ~20-50% when lengths differ. Pull request
   [#8565](https://github.com/rubygems/rubygems/pull/8565) by skipkayhil
 
-# 3.6.6 / 2025-03-13
+## 3.6.6 / 2025-03-13
 
-## Enhancements:
+### Enhancements:
 
 * Update vendored uri to 1.0.3. Pull request
   [#8534](https://github.com/rubygems/rubygems/pull/8534) by hsbt
 * Installs bundler 2.6.6 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix `gem rdoc` not working with newer versions of rdoc when not
   installed as default gems. Pull request
   [#8549](https://github.com/rubygems/rubygems/pull/8549) by
   deivid-rodriguez
 
-# 3.6.5 / 2025-02-20
+## 3.6.5 / 2025-02-20
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.6.5 as a default gem.
 
-## Documentation:
+### Documentation:
 
 * Removed `gem server` from `gem help`. Pull request
   [#8507](https://github.com/rubygems/rubygems/pull/8507) by hsbt
 
-# 3.6.4 / 2025-02-17
+## 3.6.4 / 2025-02-17
 
-## Enhancements:
+### Enhancements:
 
 * Raise a simpler error when RubyGems fails to activate a dependency. Pull
   request [#8449](https://github.com/rubygems/rubygems/pull/8449) by
   deivid-rodriguez
 * Installs bundler 2.6.4 as a default gem.
 
-## Performance:
+### Performance:
 
 * Allocate strings from Requirement match only once. Pull request
   [#8245](https://github.com/rubygems/rubygems/pull/8245) by segiddins
 
-# 3.6.3 / 2025-01-16
+## 3.6.3 / 2025-01-16
 
-## Enhancements:
+### Enhancements:
 
 * Add credentials file path to `gem env`. Pull request
   [#8375](https://github.com/rubygems/rubygems/pull/8375) by duckinator
@@ -99,14 +101,14 @@
   github-actions[bot]
 * Installs bundler 2.6.3 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix `@licenses` array unmarshalling. Pull request
   [#8411](https://github.com/rubygems/rubygems/pull/8411) by rykov
 
-# 3.6.2 / 2024-12-23
+## 3.6.2 / 2024-12-23
 
-## Security:
+### Security:
 
 * Fix Gem::SafeMarshal buffer overrun when given lengths larger than fit
   into a byte. Pull request
@@ -114,55 +116,55 @@
 * Improve type checking in marshal_load methods. Pull request
   [#8306](https://github.com/rubygems/rubygems/pull/8306) by segiddins
 
-## Enhancements:
+### Enhancements:
 
 * Skip rdoc hooks and their tests on newer rdoc versions. Pull request
   [#8340](https://github.com/rubygems/rubygems/pull/8340) by
   deivid-rodriguez
 * Installs bundler 2.6.2 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix serialized metadata including an empty `@original_platform`
   attribute. Pull request
   [#8355](https://github.com/rubygems/rubygems/pull/8355) by
   deivid-rodriguez
 
-# 3.6.1 / 2024-12-17
+## 3.6.1 / 2024-12-17
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.6.1 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix `gem info` tagging some non default gems as default. Pull request
   [#8321](https://github.com/rubygems/rubygems/pull/8321) by
   deivid-rodriguez
 
-## Documentation:
+### Documentation:
 
 * Fix broken links. Pull request
   [#8327](https://github.com/rubygems/rubygems/pull/8327) by st0012
 
-# 3.6.0 / 2024-12-16
+## 3.6.0 / 2024-12-16
 
-## Security:
+### Security:
 
 * Stop storing executable names in ivars. Pull request
   [#8307](https://github.com/rubygems/rubygems/pull/8307) by segiddins
 
-## Breaking changes:
+### Breaking changes:
 
 * Drop ruby 3.0 support. Pull request
   [#8091](https://github.com/rubygems/rubygems/pull/8091) by segiddins
 
-## Features:
+### Features:
 
 * Add --attestation option to gem push. Pull request
   [#8239](https://github.com/rubygems/rubygems/pull/8239) by segiddins
 
-## Enhancements:
+### Enhancements:
 
 * Skip unresolved deps warning on `Gem::Specification.reset` on benign
   cases. Pull request
@@ -184,7 +186,7 @@
   [#6463](https://github.com/rubygems/rubygems/pull/6463) by hsbt
 * Installs bundler 2.6.0 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Set $0 to exe when running `gem exec` to fix name in CLI output. Pull
   request [#8267](https://github.com/rubygems/rubygems/pull/8267) by adam12
@@ -192,7 +194,7 @@
   request [#8202](https://github.com/rubygems/rubygems/pull/8202) by
   deivid-rodriguez
 
-## Documentation:
+### Documentation:
 
 * Fix missing single quote in git source example. Pull request
   [#8303](https://github.com/rubygems/rubygems/pull/8303) by nobu
@@ -202,9 +204,9 @@
 * Unify rubygems and bundler docs directory. Pull request
   [#8159](https://github.com/rubygems/rubygems/pull/8159) by hsbt
 
-# 3.5.23 / 2024-11-05
+## 3.5.23 / 2024-11-05
 
-## Enhancements:
+### Enhancements:
 
 * Validate user input encoding of `gem` CLI arguments. Pull request
   [#6471](https://github.com/rubygems/rubygems/pull/6471) by
@@ -215,7 +217,7 @@
   deivid-rodriguez
 * Installs bundler 2.5.23 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix commands with 2 MFA requests when webauthn is enabled. Pull request
   [#8174](https://github.com/rubygems/rubygems/pull/8174) by
@@ -225,20 +227,20 @@
   [#7872](https://github.com/rubygems/rubygems/pull/7872) by
   deivid-rodriguez
 
-## Performance:
+### Performance:
 
 * Speed up `gem install <nonexistent-gem>` by finding alternative name
   suggestions faster. Pull request
   [#8084](https://github.com/rubygems/rubygems/pull/8084) by duckinator
 
-## Documentation:
+### Documentation:
 
 * Add missing comma in documentation. Pull request
   [#8152](https://github.com/rubygems/rubygems/pull/8152) by leoarnold
 
-# 3.5.22 / 2024-10-16
+## 3.5.22 / 2024-10-16
 
-## Enhancements:
+### Enhancements:
 
 * Prevent `._*` files in packages generated from macOS. Pull request
   [#8150](https://github.com/rubygems/rubygems/pull/8150) by
@@ -253,7 +255,7 @@
   [#8112](https://github.com/rubygems/rubygems/pull/8112) by segiddins
 * Installs bundler 2.5.22 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix `gem contents` for default gems. Pull request
   [#8132](https://github.com/rubygems/rubygems/pull/8132) by
@@ -271,9 +273,9 @@
   [#8121](https://github.com/rubygems/rubygems/pull/8121) by
   deivid-rodriguez
 
-# 3.5.21 / 2024-10-03
+## 3.5.21 / 2024-10-03
 
-## Enhancements:
+### Enhancements:
 
 * Fix `Gem::MissingSpecVersionError#to_s` not showing exception message.
   Pull request [#8074](https://github.com/rubygems/rubygems/pull/8074) by
@@ -287,7 +289,7 @@
   deivid-rodriguez
 * Installs bundler 2.5.21 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix error in one source when fetching dependency APIs clearing results
   from all sources. Pull request
@@ -297,15 +299,15 @@
   request [#8072](https://github.com/rubygems/rubygems/pull/8072) by
   deivid-rodriguez
 
-# 3.5.20 / 2024-09-24
+## 3.5.20 / 2024-09-24
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.5.20 as a default gem.
 
-# 3.5.19 / 2024-09-18
+## 3.5.19 / 2024-09-18
 
-## Enhancements:
+### Enhancements:
 
 * Standardize pretty-print output for `Gem::Source` and subclasses. Pull
   request [#7994](https://github.com/rubygems/rubygems/pull/7994) by
@@ -315,7 +317,7 @@
   hsbt
 * Installs bundler 2.5.19 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix `bundle exec rake install` failing when local gem has extensions.
   Pull request [#7977](https://github.com/rubygems/rubygems/pull/7977) by
@@ -337,33 +339,33 @@
   unmarshalled. Pull request
   [#7975](https://github.com/rubygems/rubygems/pull/7975) by djberube
 
-## Performance:
+### Performance:
 
 * Fix `gem install does-not-exist` being super slow. Pull request
   [#8006](https://github.com/rubygems/rubygems/pull/8006) by
   deivid-rodriguez
 
-# 3.5.18 / 2024-08-26
+## 3.5.18 / 2024-08-26
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.5.18 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix `gem uninstall <name>:<version>` failing on shadowed default gems.
   Pull request [#7949](https://github.com/rubygems/rubygems/pull/7949) by
   deivid-rodriguez
 
-# 3.5.17 / 2024-08-01
+## 3.5.17 / 2024-08-01
 
-## Enhancements:
+### Enhancements:
 
 * Explicitly encode `Gem::Dependency` to yaml. Pull request
   [#7867](https://github.com/rubygems/rubygems/pull/7867) by segiddins
 * Installs bundler 2.5.17 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix `gem list` regression when a regular gem shadows a default one. Pull
   request [#7892](https://github.com/rubygems/rubygems/pull/7892) by
@@ -374,13 +376,13 @@
 * Fix line comment issue for hash when loading gemrc. Pull request
   [#7857](https://github.com/rubygems/rubygems/pull/7857) by leetking
 
-# 3.5.16 / 2024-07-18
+## 3.5.16 / 2024-07-18
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.5.16 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix gemspec `require_paths` validation. Pull request
   [#7866](https://github.com/rubygems/rubygems/pull/7866) by
@@ -389,18 +391,18 @@
   Pull request [#7851](https://github.com/rubygems/rubygems/pull/7851) by
   moofkit
 
-## Performance:
+### Performance:
 
 * Use `caller_locations` instead of splitting `caller`. Pull request
   [#7708](https://github.com/rubygems/rubygems/pull/7708) by nobu
 
-# 3.5.15 / 2024-07-09
+## 3.5.15 / 2024-07-09
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.5.15 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Restrict generic `arm` to only match 32-bit arm. Pull request
   [#7830](https://github.com/rubygems/rubygems/pull/7830) by ntkme
@@ -408,42 +410,42 @@
   [#7806](https://github.com/rubygems/rubygems/pull/7806) by
   deivid-rodriguez
 
-## Documentation:
+### Documentation:
 
 * Make it clearer that `add_dependency` is the main way to add
   non-development dependencies. Pull request
   [#7800](https://github.com/rubygems/rubygems/pull/7800) by jeromedalbert
 
-# 3.5.14 / 2024-06-21
+## 3.5.14 / 2024-06-21
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.5.14 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Make "bundler? update --bundler" behave identically. Pull request
   [#7778](https://github.com/rubygems/rubygems/pull/7778) by x-yuri
 
-# 3.5.13 / 2024-06-14
+## 3.5.13 / 2024-06-14
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.5.13 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Never remove executables that may belong to a default gem. Pull request
   [#7747](https://github.com/rubygems/rubygems/pull/7747) by
   deivid-rodriguez
 
-# 3.5.12 / 2024-06-13
+## 3.5.12 / 2024-06-13
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.5.12 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix `gem uninstall` unresolved specifications warning. Pull request
   [#7667](https://github.com/rubygems/rubygems/pull/7667) by
@@ -452,9 +454,9 @@
   Pull request [#7664](https://github.com/rubygems/rubygems/pull/7664) by
   deivid-rodriguez
 
-# 3.5.11 / 2024-05-28
+## 3.5.11 / 2024-05-28
 
-## Enhancements:
+### Enhancements:
 
 * Update SPDX license list as of 2024-05-22. Pull request
   [#7689](https://github.com/rubygems/rubygems/pull/7689) by
@@ -469,7 +471,7 @@
   deivid-rodriguez
 * Installs bundler 2.5.11 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix binstubs sometimes not getting regenerated when `--destdir` is
   given. Pull request
@@ -485,26 +487,26 @@
 * Fix plugins uninstallation for user installed gems. Pull request
   [#6456](https://github.com/rubygems/rubygems/pull/6456) by voxik
 
-## Performance:
+### Performance:
 
 * Use a constant empty tar header to avoid extra allocations. Pull request
   [#7484](https://github.com/rubygems/rubygems/pull/7484) by segiddins
 
-## Documentation:
+### Documentation:
 
 * Recommend `bin/rake` over `rake` in contributing docs. Pull request
   [#7648](https://github.com/rubygems/rubygems/pull/7648) by
   deivid-rodriguez
 
-# 3.5.10 / 2024-05-03
+## 3.5.10 / 2024-05-03
 
-## Security:
+### Security:
 
 * Add a limit to the size of the metadata and checksums files in a gem
   package. Pull request
   [#7568](https://github.com/rubygems/rubygems/pull/7568) by segiddins
 
-## Enhancements:
+### Enhancements:
 
 * Don't fully require `rubygems` from `rubygems/package` to prevent some
   circular require warnings when using Bundler. Pull request
@@ -512,26 +514,26 @@
   deivid-rodriguez
 * Installs bundler 2.5.10 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Rename credential email to identifier in WebAuthn poller. Pull request
   [#7623](https://github.com/rubygems/rubygems/pull/7623) by jenshenny
 
-# 3.5.9 / 2024-04-12
+## 3.5.9 / 2024-04-12
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.5.9 as a default gem.
 
-# 3.5.8 / 2024-04-11
+## 3.5.8 / 2024-04-11
 
-## Security:
+### Security:
 
 * Respect global umask when writing regular files. Pull request
   [#7518](https://github.com/rubygems/rubygems/pull/7518) by
   deivid-rodriguez
 
-## Enhancements:
+### Enhancements:
 
 * Allow string keys with gemrc. Pull request
   [#7543](https://github.com/rubygems/rubygems/pull/7543) by hsbt
@@ -539,7 +541,7 @@
   [#4913](https://github.com/rubygems/rubygems/pull/4913) by duckinator
 * Installs bundler 2.5.8 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix NoMethodError crash when building errors about corrupt package
   files. Pull request
@@ -549,9 +551,9 @@
   [#7537](https://github.com/rubygems/rubygems/pull/7537) by
   deivid-rodriguez
 
-# 3.5.7 / 2024-03-22
+## 3.5.7 / 2024-03-22
 
-## Enhancements:
+### Enhancements:
 
 * Warn on empty or open required_ruby_version specification attribute.
   Pull request [#5010](https://github.com/rubygems/rubygems/pull/5010) by
@@ -564,22 +566,22 @@
   github-actions[bot]
 * Installs bundler 2.5.7 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Allow prerelease activation (even if requirement is not explicit about
   it) when it's the only possibility. Pull request
   [#7428](https://github.com/rubygems/rubygems/pull/7428) by kimesf
 
-## Documentation:
+### Documentation:
 
 * Fix a typo. Pull request
   [#7505](https://github.com/rubygems/rubygems/pull/7505) by hsbt
 * Use https instead of http in documentation links. Pull request
   [#7481](https://github.com/rubygems/rubygems/pull/7481) by hsbt
 
-# 3.5.6 / 2024-02-06
+## 3.5.6 / 2024-02-06
 
-## Enhancements:
+### Enhancements:
 
 * Deep copy requirements in `Gem::Specification` and `Gem::Requirement`.
   Pull request [#7439](https://github.com/rubygems/rubygems/pull/7439) by
@@ -596,20 +598,20 @@
   deivid-rodriguez
 * Installs bundler 2.5.6 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Skip to load commented out words. Pull request
   [#7413](https://github.com/rubygems/rubygems/pull/7413) by hsbt
 * Fix rake runtime dependency warning for rake based extension. Pull
   request [#7395](https://github.com/rubygems/rubygems/pull/7395) by ntkme
 
-# 3.5.5 / 2024-01-18
+## 3.5.5 / 2024-01-18
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.5.5 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix `require` activation conflicts when requiring default gems under
   some situations. Pull request
@@ -618,63 +620,63 @@
 * Use cache_home instead of data_home in default_spec_cache_dir. Pull
   request [#7331](https://github.com/rubygems/rubygems/pull/7331) by mrkn
 
-## Documentation:
+### Documentation:
 
 * Use squiggly heredocs in `Gem::Specification#description` documentation,
   so it doesn't add leading whitespace. Pull request
   [#7373](https://github.com/rubygems/rubygems/pull/7373) by bravehager
 
-# 3.5.4 / 2024-01-04
+## 3.5.4 / 2024-01-04
 
-## Enhancements:
+### Enhancements:
 
 * Always avoid "Updating rubygems-update" message. Pull request
   [#7335](https://github.com/rubygems/rubygems/pull/7335) by
   deivid-rodriguez
 * Installs bundler 2.5.4 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Make `gem update --system` respect ruby version constraints. Pull
   request [#7334](https://github.com/rubygems/rubygems/pull/7334) by
   deivid-rodriguez
 
-# 3.5.3 / 2023-12-22
+## 3.5.3 / 2023-12-22
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.5.3 as a default gem.
 
-# 3.5.2 / 2023-12-21
+## 3.5.2 / 2023-12-21
 
-## Enhancements:
+### Enhancements:
 
 * Support dynamic library loading with extension .so or .o. Pull request
   [#7241](https://github.com/rubygems/rubygems/pull/7241) by hogelog
 * Installs bundler 2.5.2 as a default gem.
 
-## Performance:
+### Performance:
 
 * Replace `object_id` comparison with identity Hash. Pull request
   [#7303](https://github.com/rubygems/rubygems/pull/7303) by amomchilov
 * Use IO.copy_stream when reading, writing. Pull request
   [#6958](https://github.com/rubygems/rubygems/pull/6958) by martinemde
 
-# 3.5.1 / 2023-12-15
+## 3.5.1 / 2023-12-15
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.5.1 as a default gem.
 
-# 3.5.0 / 2023-12-15
+## 3.5.0 / 2023-12-15
 
-## Security:
+### Security:
 
 * Replace `Marshal.load` with a fully-checked safe gemspec loader. Pull
   request [#6896](https://github.com/rubygems/rubygems/pull/6896) by
   segiddins
 
-## Breaking changes:
+### Breaking changes:
 
 * Drop ruby 2.6 and 2.7 support. Pull request
   [#7116](https://github.com/rubygems/rubygems/pull/7116) by
@@ -686,14 +688,14 @@
 * Deprecated `Gem.datadir` has been removed. Pull request
   [#6469](https://github.com/rubygems/rubygems/pull/6469) by hsbt
 
-## Deprecations:
+### Deprecations:
 
 * Deprecate `Gem::Platform.match?`. Pull request
   [#6783](https://github.com/rubygems/rubygems/pull/6783) by hsbt
 * Deprecate `Gem::List`. Pull request
   [#6311](https://github.com/rubygems/rubygems/pull/6311) by segiddins
 
-## Features:
+### Features:
 
 * The `generate_index` command can now generate compact index files and
   lives as an external `rubygems-generate_index` gem. Pull request
@@ -705,7 +707,7 @@
   that will be turned into bundled gems in the future. Pull request
   [#6840](https://github.com/rubygems/rubygems/pull/6840) by hsbt
 
-## Performance:
+### Performance:
 
 * Use match? when regexp match data is unused. Pull request
   [#7263](https://github.com/rubygems/rubygems/pull/7263) by segiddins
@@ -714,7 +716,7 @@
 * Optimize allocations in `Gem::Version`. Pull request
   [#6970](https://github.com/rubygems/rubygems/pull/6970) by segiddins
 
-## Enhancements:
+### Enhancements:
 
 * Warn for duplicate meta data links when building gems. Pull request
   [#7213](https://github.com/rubygems/rubygems/pull/7213) by etherbob
@@ -750,22 +752,22 @@
   [#6436](https://github.com/rubygems/rubygems/pull/6436) by hsbt
 * Installs bundler 2.5.0 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix installing from source with same default bundler version already
   installed. Pull request
   [#7244](https://github.com/rubygems/rubygems/pull/7244) by
   deivid-rodriguez
 
-## Documentation:
+### Documentation:
 
 * Improve comment explaining the necessity of `write_default_spec` method.
   Pull request [#6563](https://github.com/rubygems/rubygems/pull/6563) by
   voxik
 
-# 3.4.22 / 2023-11-09
+## 3.4.22 / 2023-11-09
 
-## Enhancements:
+### Enhancements:
 
 * Update SPDX license list as of 2023-10-05. Pull request
   [#7040](https://github.com/rubygems/rubygems/pull/7040) by
@@ -775,7 +777,7 @@
   deivid-rodriguez
 * Installs bundler 2.4.22 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Handle empty array at built-in YAML serializer. Pull request
   [#7099](https://github.com/rubygems/rubygems/pull/7099) by hsbt
@@ -785,20 +787,20 @@
   request [#7063](https://github.com/rubygems/rubygems/pull/7063) by
   kstevens715
 
-## Performance:
+### Performance:
 
 * Avoid regexp match on every call to `Gem::Platform.local`. Pull request
   [#7104](https://github.com/rubygems/rubygems/pull/7104) by segiddins
 
-## Documentation:
+### Documentation:
 
 * Get `Gem::Specification#extensions_dir` documented. Pull request
   [#6218](https://github.com/rubygems/rubygems/pull/6218) by
   deivid-rodriguez
 
-# 3.4.21 / 2023-10-17
+## 3.4.21 / 2023-10-17
 
-## Enhancements:
+### Enhancements:
 
 * Abort `setup.rb` if Ruby is too old. Pull request
   [#7011](https://github.com/rubygems/rubygems/pull/7011) by
@@ -811,16 +813,16 @@
   request [#6615](https://github.com/rubygems/rubygems/pull/6615) by hsbt
 * Installs bundler 2.4.21 as a default gem.
 
-## Documentation:
+### Documentation:
 
 * Update suggested variable for bindir. Pull request
   [#7028](https://github.com/rubygems/rubygems/pull/7028) by hsbt
 * Fix invalid links in documentation. Pull request
   [#7008](https://github.com/rubygems/rubygems/pull/7008) by simi
 
-# 3.4.20 / 2023-09-27
+## 3.4.20 / 2023-09-27
 
-## Enhancements:
+### Enhancements:
 
 * Raise `Gem::Package::FormatError` when gem encounters corrupt EOF.
   Pull request [#6882](https://github.com/rubygems/rubygems/pull/6882)
@@ -837,7 +839,7 @@
   [#6310](https://github.com/rubygems/rubygems/pull/6310) by segiddins
 * Installs bundler 2.4.20 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fixed false positive SymlinkError in symbolic link directory. Pull
   request [#6947](https://github.com/rubygems/rubygems/pull/6947) by
@@ -849,26 +851,26 @@
   Pull request [#6901](https://github.com/rubygems/rubygems/pull/6901) by
   amatsuda
 
-## Performance:
+### Performance:
 
 * Reduce allocations for stub specifications. Pull request
   [#6972](https://github.com/rubygems/rubygems/pull/6972) by segiddins
 
-# 3.4.19 / 2023-08-17
+## 3.4.19 / 2023-08-17
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.4.19 as a default gem.
 
-## Performance:
+### Performance:
 
 * Speedup building docs when updating rubygems. Pull request
   [#6864](https://github.com/rubygems/rubygems/pull/6864) by
   deivid-rodriguez
 
-# 3.4.18 / 2023-08-02
+## 3.4.18 / 2023-08-02
 
-## Enhancements:
+### Enhancements:
 
 * Add poller to fetch WebAuthn OTP. Pull request
   [#6774](https://github.com/rubygems/rubygems/pull/6774) by jenshenny
@@ -878,83 +880,83 @@
   [#6704](https://github.com/rubygems/rubygems/pull/6704) by hsbt
 * Installs bundler 2.4.18 as a default gem.
 
-# 3.4.17 / 2023-07-14
+## 3.4.17 / 2023-07-14
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.4.17 as a default gem.
 
-## Performance:
+### Performance:
 
 * Avoid unnecessary work for private local gem installation. Pull request
   [#6810](https://github.com/rubygems/rubygems/pull/6810) by
   deivid-rodriguez
 
-# 3.4.16 / 2023-07-10
+## 3.4.16 / 2023-07-10
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.4.16 as a default gem.
 
-# 3.4.15 / 2023-06-29
+## 3.4.15 / 2023-06-29
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.4.15 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Autoload shellwords when it's needed. Pull request
   [#6734](https://github.com/rubygems/rubygems/pull/6734) by ioquatix
 
-## Documentation:
+### Documentation:
 
 * Update command to test local gem command changes. Pull request
   [#6761](https://github.com/rubygems/rubygems/pull/6761) by jenshenny
 
-# 3.4.14 / 2023-06-12
+## 3.4.14 / 2023-06-12
 
-## Enhancements:
+### Enhancements:
 
 * Load plugin immediately. Pull request
   [#6673](https://github.com/rubygems/rubygems/pull/6673) by kou
 * Installs bundler 2.4.14 as a default gem.
 
-## Documentation:
+### Documentation:
 
 * Clarify what the `rubygems-update` gem is for, and link to source code
   and guides. Pull request
   [#6710](https://github.com/rubygems/rubygems/pull/6710) by davetron5000
 
-# 3.4.13 / 2023-05-09
+## 3.4.13 / 2023-05-09
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.4.13 as a default gem.
 
-# 3.4.12 / 2023-04-11
+## 3.4.12 / 2023-04-11
 
-## Enhancements:
+### Enhancements:
 
 * [Experimental] Add WebAuthn Support to the CLI. Pull request
   [#6560](https://github.com/rubygems/rubygems/pull/6560) by jenshenny
 * Installs bundler 2.4.12 as a default gem.
 
-# 3.4.11 / 2023-04-10
+## 3.4.11 / 2023-04-10
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.4.11 as a default gem.
 
-# 3.4.10 / 2023-03-27
+## 3.4.10 / 2023-03-27
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.4.10 as a default gem.
 
-# 3.4.9 / 2023-03-20
+## 3.4.9 / 2023-03-20
 
-## Enhancements:
+### Enhancements:
 
 * Improve `TarHeader#calculate_checksum` speed and readability. Pull
   request [#6476](https://github.com/rubygems/rubygems/pull/6476) by
@@ -963,7 +965,7 @@
   [#6446](https://github.com/rubygems/rubygems/pull/6446) by hsbt
 * Installs bundler 2.4.9 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix `$LOAD_PATH` in rake and ext_conf builder. Pull request
   [#6490](https://github.com/rubygems/rubygems/pull/6490) by ntkme
@@ -971,15 +973,15 @@
   [#6481](https://github.com/rubygems/rubygems/pull/6481) by
   deivid-rodriguez
 
-## Documentation:
+### Documentation:
 
 * Document our current release policy. Pull request
   [#6450](https://github.com/rubygems/rubygems/pull/6450) by
   deivid-rodriguez
 
-# 3.4.8 / 2023-03-08
+## 3.4.8 / 2023-03-08
 
-## Enhancements:
+### Enhancements:
 
 * Add TarReader::Entry#seek to seek within the tar file entry. Pull
   request [#6390](https://github.com/rubygems/rubygems/pull/6390) by
@@ -994,7 +996,7 @@
   [#6309](https://github.com/rubygems/rubygems/pull/6309) by segiddins
 * Installs bundler 2.4.8 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix installation error of same version of default gems with local
   installation. Pull request
@@ -1002,101 +1004,101 @@
 * Use proper memoized var name for Gem.state_home. Pull request
   [#6420](https://github.com/rubygems/rubygems/pull/6420) by simi
 
-## Documentation:
+### Documentation:
 
 * Switch supporting explanations to all Ruby Central. Pull request
   [#6419](https://github.com/rubygems/rubygems/pull/6419) by indirect
 * Update the link to OpenSource.org. Pull request
   [#6392](https://github.com/rubygems/rubygems/pull/6392) by nobu
 
-# 3.4.7 / 2023-02-15
+## 3.4.7 / 2023-02-15
 
-## Enhancements:
+### Enhancements:
 
 * Warn on self referencing gemspec dependency. Pull request
   [#6335](https://github.com/rubygems/rubygems/pull/6335) by simi
 * Installs bundler 2.4.7 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix inconsistent behavior of zero byte files in archive. Pull request
   [#6329](https://github.com/rubygems/rubygems/pull/6329) by martinemde
 
-# 3.4.6 / 2023-01-31
+## 3.4.6 / 2023-01-31
 
-## Enhancements:
+### Enhancements:
 
 * Allow `require` decorations be disabled. Pull request
   [#6319](https://github.com/rubygems/rubygems/pull/6319) by
   deivid-rodriguez
 * Installs bundler 2.4.6 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Include directory in CargoBuilder install path. Pull request
   [#6298](https://github.com/rubygems/rubygems/pull/6298) by matsadler
 
-## Documentation:
+### Documentation:
 
 * Include links to pull requests in changelog. Pull request
   [#6316](https://github.com/rubygems/rubygems/pull/6316) by
   deivid-rodriguez
 
-# 3.4.5 / 2023-01-21
+## 3.4.5 / 2023-01-21
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.4.5 as a default gem.
 
-# 3.4.4 / 2023-01-16
+## 3.4.4 / 2023-01-16
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.4.4 as a default gem.
 
-## Documentation:
+### Documentation:
 
 * Improve documentation about `Kernel` monkeypatches. Pull request [#6217](https://github.com/rubygems/rubygems/pull/6217)
   by nobu
 
-# 3.4.3 / 2023-01-06
+## 3.4.3 / 2023-01-06
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.4.3 as a default gem.
 
-## Documentation:
+### Documentation:
 
 * Fix several typos. Pull request [#6224](https://github.com/rubygems/rubygems/pull/6224) by jdufresne
 
-# 3.4.2 / 2023-01-01
+## 3.4.2 / 2023-01-01
 
-## Enhancements:
+### Enhancements:
 
 * Add global flag (`-C`) to change execution directory. Pull request [#6180](https://github.com/rubygems/rubygems/pull/6180)
   by gustavothecoder
 * Installs bundler 2.4.2 as a default gem.
 
-# 3.4.1 / 2022-12-24
+## 3.4.1 / 2022-12-24
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.4.1 as a default gem.
 
-# 3.4.0 / 2022-12-24
+## 3.4.0 / 2022-12-24
 
-## Breaking changes:
+### Breaking changes:
 
 * Drop support for Ruby 2.3, 2.4, 2.5 and RubyGems 2.5, 2.6, 2.7. Pull
   request [#6107](https://github.com/rubygems/rubygems/pull/6107) by deivid-rodriguez
 * Remove support for deprecated OS. Pull request [#6041](https://github.com/rubygems/rubygems/pull/6041) by peterzhu2118
 
-## Features:
+### Features:
 
 * Add 'call for update' to RubyGems install command. Pull request [#5922](https://github.com/rubygems/rubygems/pull/5922) by
   simi
 
-## Enhancements:
+### Enhancements:
 
 * Add `mswin` support for cargo builder. Pull request [#6167](https://github.com/rubygems/rubygems/pull/6167) by ianks
 * Validate Cargo.lock is present for Rust based extensions. Pull request
@@ -1105,23 +1107,23 @@
   deivid-rodriguez
 * Installs bundler 2.4.0 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix crash due to `BundlerVersionFinder` not defined. Pull request [#6152](https://github.com/rubygems/rubygems/pull/6152)
   by deivid-rodriguez
 * Don't leave corrupted partial package download around when running out
   of disk space. Pull request [#5681](https://github.com/rubygems/rubygems/pull/5681) by duckinator
 
-# 3.3.26 / 2022-11-16
+## 3.3.26 / 2022-11-16
 
-## Enhancements:
+### Enhancements:
 
 * Upgrade rb-sys to 0.9.37. Pull request [#6047](https://github.com/rubygems/rubygems/pull/6047) by ianks
 * Installs bundler 2.3.26 as a default gem.
 
-# 3.3.25 / 2022-11-02
+## 3.3.25 / 2022-11-02
 
-## Enhancements:
+### Enhancements:
 
 * Github source should default to secure protocol. Pull request [#6026](https://github.com/rubygems/rubygems/pull/6026) by
   jasonkarns
@@ -1129,21 +1131,21 @@
   by enebo
 * Installs bundler 2.3.25 as a default gem.
 
-# 3.3.24 / 2022-10-17
+## 3.3.24 / 2022-10-17
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.3.24 as a default gem.
 
-# 3.3.23 / 2022-10-05
+## 3.3.23 / 2022-10-05
 
-## Enhancements:
+### Enhancements:
 
 * Add better error handling for permanent redirect responses. Pull request
   [#5931](https://github.com/rubygems/rubygems/pull/5931) by jenshenny
 * Installs bundler 2.3.23 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix generic arm platform matching against runtime arm platforms with
   eabi modifiers. Pull request [#5957](https://github.com/rubygems/rubygems/pull/5957) by deivid-rodriguez
@@ -1154,30 +1156,30 @@
 * Mask the file mode when extracting files. Pull request [#5906](https://github.com/rubygems/rubygems/pull/5906) by
   kddnewton
 
-# 3.3.22 / 2022-09-07
+## 3.3.22 / 2022-09-07
 
-## Enhancements:
+### Enhancements:
 
 * Support non gnu libc arm-linux-eabi platforms. Pull request [#5889](https://github.com/rubygems/rubygems/pull/5889) by
   ntkme
 * Installs bundler 2.3.22 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix `gem info` with explicit `--version`. Pull request [#5884](https://github.com/rubygems/rubygems/pull/5884) by
   tonyaraujop
 
-# 3.3.21 / 2022-08-24
+## 3.3.21 / 2022-08-24
 
-## Enhancements:
+### Enhancements:
 
 * Support non gnu libc linux platforms. Pull request [#5852](https://github.com/rubygems/rubygems/pull/5852) by
   deivid-rodriguez
 * Installs bundler 2.3.21 as a default gem.
 
-# 3.3.20 / 2022-08-10
+## 3.3.20 / 2022-08-10
 
-## Enhancements:
+### Enhancements:
 
 * Include backtrace with crashes by default. Pull request [#5811](https://github.com/rubygems/rubygems/pull/5811) by
   deivid-rodriguez
@@ -1187,7 +1189,7 @@
   request [#5794](https://github.com/rubygems/rubygems/pull/5794) by deivid-rodriguez
 * Installs bundler 2.3.20 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Always consider installed specs for resolution, even if prereleases.
   Pull request [#5821](https://github.com/rubygems/rubygems/pull/5821) by deivid-rodriguez
@@ -1195,9 +1197,9 @@
   correctly. Pull request [#5820](https://github.com/rubygems/rubygems/pull/5820) by deivid-rodriguez
 * Fix platform matching for index specs. Pull request [#5795](https://github.com/rubygems/rubygems/pull/5795) by Ilushkanama
 
-# 3.3.19 / 2022-07-27
+## 3.3.19 / 2022-07-27
 
-## Enhancements:
+### Enhancements:
 
 * Display mfa warnings on `gem signin`. Pull request [#5590](https://github.com/rubygems/rubygems/pull/5590) by aellispierce
 * Require fileutils more lazily when installing gems. Pull request [#5738](https://github.com/rubygems/rubygems/pull/5738)
@@ -1209,19 +1211,19 @@
 * Unify loading `Gem::Requirement`. Pull request [#5596](https://github.com/rubygems/rubygems/pull/5596) by deivid-rodriguez
 * Installs bundler 2.3.19 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix `ruby setup.rb` with `--destdir` writing outside of `--destdir`.
   Pull request [#5737](https://github.com/rubygems/rubygems/pull/5737) by deivid-rodriguez
 
-## Documentation:
+### Documentation:
 
 * Fix wrong information about default RubyGems source. Pull request [#5723](https://github.com/rubygems/rubygems/pull/5723)
   by tnir
 
-# 3.3.18 / 2022-07-14
+## 3.3.18 / 2022-07-14
 
-## Enhancements:
+### Enhancements:
 
 * Make platform `universal-mingw32` match "x64-mingw-ucrt". Pull request
   [#5655](https://github.com/rubygems/rubygems/pull/5655) by johnnyshields
@@ -1229,14 +1231,14 @@
   gems. Pull request [#5676](https://github.com/rubygems/rubygems/pull/5676) by brianleshopify
 * Installs bundler 2.3.18 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Make sure RubyGems prints no warnings when loading plugins. Pull request
   [#5607](https://github.com/rubygems/rubygems/pull/5607) by deivid-rodriguez
 
-# 3.3.17 / 2022-06-29
+## 3.3.17 / 2022-06-29
 
-## Enhancements:
+### Enhancements:
 
 * Document `gem env` argument aliases and add `gem env user_gemhome` and
   `gem env user_gemdir`. Pull request [#5644](https://github.com/rubygems/rubygems/pull/5644) by deivid-rodriguez
@@ -1247,66 +1249,66 @@
 * Simplify extension builder. Pull request [#5626](https://github.com/rubygems/rubygems/pull/5626) by deivid-rodriguez
 * Installs bundler 2.3.17 as a default gem.
 
-## Documentation:
+### Documentation:
 
 * Modify RubyGems issue template to be like the one for Bundler. Pull
   request [#5643](https://github.com/rubygems/rubygems/pull/5643) by deivid-rodriguez
 
-# 3.3.16 / 2022-06-15
+## 3.3.16 / 2022-06-15
 
-## Enhancements:
+### Enhancements:
 
 * Auto-fix and warn gem packages including a gemspec with `require_paths`
   as an array of arrays. Pull request [#5615](https://github.com/rubygems/rubygems/pull/5615) by deivid-rodriguez
 * Misc cargo builder improvements. Pull request [#5459](https://github.com/rubygems/rubygems/pull/5459) by ianks
 * Installs bundler 2.3.16 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix incorrect password redaction when there's an error in `gem source
   -a`. Pull request [#5623](https://github.com/rubygems/rubygems/pull/5623) by deivid-rodriguez
 * Fix another regression when loading old marshaled specs. Pull request
   [#5610](https://github.com/rubygems/rubygems/pull/5610) by deivid-rodriguez
 
-# 3.3.15 / 2022-06-01
+## 3.3.15 / 2022-06-01
 
-## Enhancements:
+### Enhancements:
 
 * Support the change of did_you_mean about `Exception#detailed_message`.
   Pull request [#5560](https://github.com/rubygems/rubygems/pull/5560) by mame
 * Installs bundler 2.3.15 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix loading old marshaled specs including `YAML::PrivateType` constant.
   Pull request [#5415](https://github.com/rubygems/rubygems/pull/5415) by deivid-rodriguez
 * Fix rubygems update when non default `--install-dir` is configured. Pull
   request [#5566](https://github.com/rubygems/rubygems/pull/5566) by deivid-rodriguez
 
-# 3.3.14 / 2022-05-18
+## 3.3.14 / 2022-05-18
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.3.14 as a default gem.
 
-# 3.3.13 / 2022-05-04
+## 3.3.13 / 2022-05-04
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.3.13 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix regression when resolving ruby constraints. Pull request [#5486](https://github.com/rubygems/rubygems/pull/5486) by
   deivid-rodriguez
 
-## Documentation:
+### Documentation:
 
 * Clarify description of owner-flags. Pull request [#5497](https://github.com/rubygems/rubygems/pull/5497) by kronn
 
-# 3.3.12 / 2022-04-20
+## 3.3.12 / 2022-04-20
 
-## Enhancements:
+### Enhancements:
 
 * Less error swallowing when installing gems. Pull request [#5475](https://github.com/rubygems/rubygems/pull/5475) by
   deivid-rodriguez
@@ -1316,14 +1318,14 @@
   deivid-rodriguez
 * Installs bundler 2.3.12 as a default gem.
 
-## Documentation:
+### Documentation:
 
 * Fix formatting in docs. Pull request [#5470](https://github.com/rubygems/rubygems/pull/5470) by peterzhu2118
 * Fix a typo. Pull request [#5401](https://github.com/rubygems/rubygems/pull/5401) by znz
 
-# 3.3.11 / 2022-04-07
+## 3.3.11 / 2022-04-07
 
-## Enhancements:
+### Enhancements:
 
 * Enable mfa on specific keys during gem signin. Pull request [#5305](https://github.com/rubygems/rubygems/pull/5305) by
   aellispierce
@@ -1331,48 +1333,48 @@
 * Add cargo builder for rust extensions. Pull request [#5175](https://github.com/rubygems/rubygems/pull/5175) by ianks
 * Installs bundler 2.3.11 as a default gem.
 
-## Documentation:
+### Documentation:
 
 * Improve RDoc setup. Pull request [#5398](https://github.com/rubygems/rubygems/pull/5398) by deivid-rodriguez
 
-# 3.3.10 / 2022-03-23
+## 3.3.10 / 2022-03-23
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.3.10 as a default gem.
 
-## Documentation:
+### Documentation:
 
 * Enable `Gem::Package` example in RDoc documentation. Pull request [#5399](https://github.com/rubygems/rubygems/pull/5399)
   by nobu
 * Unhide RDoc documentation from top level `Gem` module. Pull request
   [#5396](https://github.com/rubygems/rubygems/pull/5396) by nobu
 
-# 3.3.9 / 2022-03-09
+## 3.3.9 / 2022-03-09
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.3.9 as a default gem.
 
-# 3.3.8 / 2022-02-23
+## 3.3.8 / 2022-02-23
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.3.8 as a default gem.
 
-# 3.3.7 / 2022-02-09
+## 3.3.7 / 2022-02-09
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.3.7 as a default gem.
 
-## Documentation:
+### Documentation:
 
 * Fix missing rdoc for `Gem::Version`. Pull request [#5299](https://github.com/rubygems/rubygems/pull/5299) by nevans
 
-# 3.3.6 / 2022-01-26
+## 3.3.6 / 2022-01-26
 
-## Enhancements:
+### Enhancements:
 
 * Forbid downgrading past the originally shipped version on Ruby 3.1. Pull
   request [#5301](https://github.com/rubygems/rubygems/pull/5301) by deivid-rodriguez
@@ -1381,16 +1383,16 @@
 * Let `Version#<=>` accept a String. Pull request [#5275](https://github.com/rubygems/rubygems/pull/5275) by amatsuda
 * Installs bundler 2.3.6 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Avoid `flock` on non Windows systems, since it causing issues on NFS
   file systems. Pull request [#5278](https://github.com/rubygems/rubygems/pull/5278) by deivid-rodriguez
 * Fix `gem update --system`  for already installed version of
   `rubygems-update`. Pull request [#5285](https://github.com/rubygems/rubygems/pull/5285) by loadkpi
 
-# 3.3.5 / 2022-01-12
+## 3.3.5 / 2022-01-12
 
-## Enhancements:
+### Enhancements:
 
 * Don't activate `yaml` gem from RubyGems. Pull request [#5266](https://github.com/rubygems/rubygems/pull/5266) by
   deivid-rodriguez
@@ -1398,89 +1400,89 @@
   `--[no-]suggestions` flag. Pull request [#5242](https://github.com/rubygems/rubygems/pull/5242) by ximenasandoval
 * Installs bundler 2.3.5 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix `gem install <non-existent-gem> --force` crash. Pull request [#5262](https://github.com/rubygems/rubygems/pull/5262)
   by deivid-rodriguez
 * Fix longstanding `gem install` failure on JRuby. Pull request [#5228](https://github.com/rubygems/rubygems/pull/5228) by
   deivid-rodriguez
 
-## Documentation:
+### Documentation:
 
 * Markup `Gem::Specification` documentation with RDoc notations. Pull
   request [#5268](https://github.com/rubygems/rubygems/pull/5268) by nobu
 
-# 3.3.4 / 2021-12-29
+## 3.3.4 / 2021-12-29
 
-## Enhancements:
+### Enhancements:
 
 * Don't redownload `rubygems-update` package if already there. Pull
   request [#5230](https://github.com/rubygems/rubygems/pull/5230) by deivid-rodriguez
 * Installs bundler 2.3.4 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix `gem update --system` crashing when latest version not supported.
   Pull request [#5191](https://github.com/rubygems/rubygems/pull/5191) by deivid-rodriguez
 
-## Performance:
+### Performance:
 
 * Make SpecificationPolicy autoload constant. Pull request [#5222](https://github.com/rubygems/rubygems/pull/5222) by pocke
 
-# 3.3.3 / 2021-12-24
+## 3.3.3 / 2021-12-24
 
-## Enhancements:
+### Enhancements:
 
 * Installs bundler 2.3.3 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix gem installation failing in Solaris due to bad `IO#flock` usage.
   Pull request [#5216](https://github.com/rubygems/rubygems/pull/5216) by mame
 
-# 3.3.2 / 2021-12-23
+## 3.3.2 / 2021-12-23
 
-## Enhancements:
+### Enhancements:
 
 * Fix deprecations when activating DidYouMean for misspelled command
   suggestions. Pull request [#5211](https://github.com/rubygems/rubygems/pull/5211) by yuki24
 * Installs bundler 2.3.2 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix gemspec truncation. Pull request [#5208](https://github.com/rubygems/rubygems/pull/5208) by deivid-rodriguez
 
-# 3.3.1 / 2021-12-22
+## 3.3.1 / 2021-12-22
 
-## Enhancements:
+### Enhancements:
 
 * Fix compatibility with OpenSSL 3.0. Pull request [#5196](https://github.com/rubygems/rubygems/pull/5196) by rhenium
 * Remove hard errors when matching major bundler not found. Pull request
   [#5181](https://github.com/rubygems/rubygems/pull/5181) by deivid-rodriguez
 * Installs bundler 2.3.1 as a default gem.
 
-# 3.3.0 / 2021-12-21
+## 3.3.0 / 2021-12-21
 
-## Breaking changes:
+### Breaking changes:
 
 * Removed deprecated `gem server` command. Pull request [#5034](https://github.com/rubygems/rubygems/pull/5034) by hsbt
 * Remove macOS specific gem layout. Pull request [#4833](https://github.com/rubygems/rubygems/pull/4833) by deivid-rodriguez
 * Default `gem update` documentation format is now only `ri`. Pull request
   [#3888](https://github.com/rubygems/rubygems/pull/3888) by hsbt
 
-## Features:
+### Features:
 
 * Give command misspelled suggestions via `did_you_mean` gem. Pull request
   [#3904](https://github.com/rubygems/rubygems/pull/3904) by hsbt
 
-## Performance:
+### Performance:
 
 * Avoid some unnecessary stat calls. Pull request [#3887](https://github.com/rubygems/rubygems/pull/3887) by kares
 * Improve spell checking suggestion performance by
   vendoring`DidYouMean::Levenshtein.distance` from `did_you_mean-1.4.0`.
   Pull request [#3856](https://github.com/rubygems/rubygems/pull/3856) by austinpray
 
-## Enhancements:
+### Enhancements:
 
 * Set `BUNDLER_VERSION` when `bundle _<version>_` is passed. Pull request
   [#5180](https://github.com/rubygems/rubygems/pull/5180) by deivid-rodriguez
@@ -1489,7 +1491,7 @@
   information on errors. Pull request [#4189](https://github.com/rubygems/rubygems/pull/4189) by deivid-rodriguez
 * Installs bundler 2.3.0 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix encoding mismatch issues when writing gem packages. Pull request
   [#5162](https://github.com/rubygems/rubygems/pull/5162) by deivid-rodriguez
@@ -1500,13 +1502,13 @@
 * Fix upgrade crashing when multiple versions of `fileutils` installed.
   Pull request [#5140](https://github.com/rubygems/rubygems/pull/5140) by deivid-rodriguez
 
-# 3.2.33 / 2021-12-07
+## 3.2.33 / 2021-12-07
 
-## Deprecations:
+### Deprecations:
 
 * Deprecate typo name. Pull request [#5109](https://github.com/rubygems/rubygems/pull/5109) by nobu
 
-## Enhancements:
+### Enhancements:
 
 * Add login & logout alias for the signin & signout commands. Pull request
   [#5133](https://github.com/rubygems/rubygems/pull/5133) by colby-swandale
@@ -1514,21 +1516,21 @@
   request [#4408](https://github.com/rubygems/rubygems/pull/4408) by deivid-rodriguez
 * Installs bundler 2.2.33 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix `ruby setup.rb` trying to write outside of `--destdir`. Pull request
   [#5053](https://github.com/rubygems/rubygems/pull/5053) by deivid-rodriguez
 
-## Documentation:
+### Documentation:
 
 * Move required_ruby_version gemspec attribute to recommended section.
   Pull request [#5130](https://github.com/rubygems/rubygems/pull/5130) by simi
 * Ignore to generate the documentation from vendored libraries. Pull
   request [#5118](https://github.com/rubygems/rubygems/pull/5118) by hsbt
 
-# 3.2.32 / 2021-11-23
+## 3.2.32 / 2021-11-23
 
-## Enhancements:
+### Enhancements:
 
 * Refactor installer thread safety protections. Pull request [#5050](https://github.com/rubygems/rubygems/pull/5050) by
   deivid-rodriguez
@@ -1536,9 +1538,9 @@
   deivid-rodriguez
 * Installs bundler 2.2.32 as a default gem.
 
-# 3.2.31 / 2021-11-08
+## 3.2.31 / 2021-11-08
 
-## Enhancements:
+### Enhancements:
 
 * Don't pass empty `DESTDIR` to `nmake` since it works differently from
   standard `make`. Pull request [#5057](https://github.com/rubygems/rubygems/pull/5057) by hsbt
@@ -1550,16 +1552,16 @@
   deivid-rodriguez
 * Install bundler 2.2.31 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix `ruby setup.rb` when `--prefix` is passed. Pull request [#5051](https://github.com/rubygems/rubygems/pull/5051) by
   deivid-rodriguez
 * Don't apply `--destdir` twice when running `setup.rb`. Pull request
   [#2768](https://github.com/rubygems/rubygems/pull/2768) by alyssais
 
-# 3.2.30 / 2021-10-26
+## 3.2.30 / 2021-10-26
 
-## Enhancements:
+### Enhancements:
 
 * Add support to build and sign certificates with multiple key algorithms.
   Pull request [#4991](https://github.com/rubygems/rubygems/pull/4991) by doodzik
@@ -1571,32 +1573,32 @@
   `Gem::Request.verify_certificate_message`. Pull request [#4975](https://github.com/rubygems/rubygems/pull/4975) by nobu
 * Install bundler 2.2.30 as a default gem.
 
-## Performance:
+### Performance:
 
 * Speed up `gem install`, specially under Windows. Pull request [#4960](https://github.com/rubygems/rubygems/pull/4960) by
   deivid-rodriguez
 
-# 3.2.29 / 2021-10-08
+## 3.2.29 / 2021-10-08
 
-## Enhancements:
+### Enhancements:
 
 * Only disallow FIXME/TODO for first word of gemspec description. Pull
   request [#4937](https://github.com/rubygems/rubygems/pull/4937) by duckinator
 * Install bundler 2.2.29 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix `wordy` method in `SourceFetchProblem` changing the password of
   source. Pull request [#4910](https://github.com/rubygems/rubygems/pull/4910) by Huangxiaodui
 
-## Performance:
+### Performance:
 
 * Improve `require` performance, particularly on systems with a lot of
   gems installed. Pull request [#4951](https://github.com/rubygems/rubygems/pull/4951) by pocke
 
-# 3.2.28 / 2021-09-23
+## 3.2.28 / 2021-09-23
 
-## Enhancements:
+### Enhancements:
 
 * Support MINGW-UCRT. Pull request [#4925](https://github.com/rubygems/rubygems/pull/4925) by hsbt
 * Only check if descriptions *start with* FIXME/TODO. Pull request [#4841](https://github.com/rubygems/rubygems/pull/4841)
@@ -1605,14 +1607,14 @@
   [#4897](https://github.com/rubygems/rubygems/pull/4897) by deivid-rodriguez
 * Install bundler 2.2.28 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix redacted credentials being sent to gemserver. Pull request [#4919](https://github.com/rubygems/rubygems/pull/4919) by
   jdliss
 
-# 3.2.27 / 2021-09-03
+## 3.2.27 / 2021-09-03
 
-## Enhancements:
+### Enhancements:
 
 * Redact credentials when printing URI. Pull request [#4868](https://github.com/rubygems/rubygems/pull/4868) by intuxicated
 * Prefer `require_relative` to `require` for internal requires. Pull
@@ -1621,9 +1623,9 @@
   fetching once we find a valid candidate. Pull request [#4843](https://github.com/rubygems/rubygems/pull/4843) by intuxicated
 * Install bundler 2.2.27 as a default gem.
 
-# 3.2.26 / 2021-08-17
+## 3.2.26 / 2021-08-17
 
-## Enhancements:
+### Enhancements:
 
 * Enhance the error handling for loading the
   `rubygems/defaults/operating_system` file. Pull request [#4824](https://github.com/rubygems/rubygems/pull/4824) by
@@ -1632,14 +1634,14 @@
   deivid-rodriguez
 * Install bundler 2.2.26 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Also load user installed rubygems plugins. Pull request [#4829](https://github.com/rubygems/rubygems/pull/4829) by
   deivid-rodriguez
 
-# 3.2.25 / 2021-07-30
+## 3.2.25 / 2021-07-30
 
-## Enhancements:
+### Enhancements:
 
 * Don't load the `base64` library since it's not used. Pull request [#4785](https://github.com/rubygems/rubygems/pull/4785)
   by deivid-rodriguez
@@ -1650,38 +1652,38 @@
   request [#4651](https://github.com/rubygems/rubygems/pull/4651) by nobu
 * Install bundler 2.2.25 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Add missing `require 'fileutils'` in `Gem::ConfigFile`. Pull request
   [#4768](https://github.com/rubygems/rubygems/pull/4768) by ybiquitous
 
-# 3.2.24 / 2021-07-15
+## 3.2.24 / 2021-07-15
 
-## Enhancements:
+### Enhancements:
 
 * Install bundler 2.2.24 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix contradictory message about deletion of default gem. Pull request
   [#4739](https://github.com/rubygems/rubygems/pull/4739) by jaredbeck
 
-## Documentation:
+### Documentation:
 
 * Add a description about `GEM_HOST_OTP_CODE` to help text. Pull request
   [#4742](https://github.com/rubygems/rubygems/pull/4742) by ybiquitous
 
-# 3.2.23 / 2021-07-09
+## 3.2.23 / 2021-07-09
 
-## Enhancements:
+### Enhancements:
 
 * Rewind IO source to allow working with contents in memory. Pull request
   [#4729](https://github.com/rubygems/rubygems/pull/4729) by drcapulet
 * Install bundler 2.2.23 as a default gem.
 
-# 3.2.22 / 2021-07-06
+## 3.2.22 / 2021-07-06
 
-## Enhancements:
+### Enhancements:
 
 * Allow setting `--otp` via `GEM_HOST_OTP_CODE`. Pull request [#4697](https://github.com/rubygems/rubygems/pull/4697) by
   CGA1123
@@ -1689,9 +1691,9 @@
   [#4695](https://github.com/rubygems/rubygems/pull/4695) by rhenium
 * Install bundler 2.2.22 as a default gem.
 
-# 3.2.21 / 2021-06-23
+## 3.2.21 / 2021-06-23
 
-## Enhancements:
+### Enhancements:
 
 * Fix typo in OpenSSL detection. Pull request [#4679](https://github.com/rubygems/rubygems/pull/4679) by osyoyu
 * Add the most recent licenses from spdx.org. Pull request [#4662](https://github.com/rubygems/rubygems/pull/4662) by nobu
@@ -1699,42 +1701,42 @@
   truffleruby 21.0 and 21.1. Pull request [#4624](https://github.com/rubygems/rubygems/pull/4624) by deivid-rodriguez
 * Install bundler 2.2.21 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Create credentials folder when setting API keys if not there yet. Pull
   request [#4665](https://github.com/rubygems/rubygems/pull/4665) by deivid-rodriguez
 
-# 3.2.20 / 2021-06-11
+## 3.2.20 / 2021-06-11
 
-## Security fixes:
+### Security fixes:
 
 * Verify platform before installing to avoid potential remote code
   execution. Pull request [#4667](https://github.com/rubygems/rubygems/pull/4667) by sonalkr132
 
-## Enhancements:
+### Enhancements:
 
 * Add better specification policy error description. Pull request [#4658](https://github.com/rubygems/rubygems/pull/4658) by
   ceritium
 * Install bundler 2.2.20 as a default gem.
 
-# 3.2.19 / 2021-05-31
+## 3.2.19 / 2021-05-31
 
-## Enhancements:
+### Enhancements:
 
 * Fix `gem help build` output format. Pull request [#4613](https://github.com/rubygems/rubygems/pull/4613) by tnir
 * Install bundler 2.2.19 as a default gem.
 
-# 3.2.18 / 2021-05-25
+## 3.2.18 / 2021-05-25
 
-## Enhancements:
+### Enhancements:
 
 * Don't leave temporary directory around when building extensions to
   improve build reproducibility. Pull request [#4610](https://github.com/rubygems/rubygems/pull/4610) by baloo
 * Install bundler 2.2.18 as a default gem.
 
-# 3.2.17 / 2021-05-05
+## 3.2.17 / 2021-05-05
 
-## Enhancements:
+### Enhancements:
 
 * Only print month & year in deprecation messages. Pull request [#3085](https://github.com/rubygems/rubygems/pull/3085) by
   Schwad
@@ -1744,94 +1746,94 @@
 * Prefer File.open instead of Kernel#open. Pull request [#4529](https://github.com/rubygems/rubygems/pull/4529) by mame
 * Install bundler 2.2.17 as a default gem.
 
-## Documentation:
+### Documentation:
 
 * Fix usage messages to reflect the current POSIX-compatible behaviour.
   Pull request [#4551](https://github.com/rubygems/rubygems/pull/4551) by graywolf-at-work
 
-# 3.2.16 / 2021-04-08
+## 3.2.16 / 2021-04-08
 
-## Enhancements:
+### Enhancements:
 
 * Install bundler 2.2.16 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Correctly handle symlinks. Pull request [#2836](https://github.com/rubygems/rubygems/pull/2836) by voxik
 
-# 3.2.15 / 2021-03-19
+## 3.2.15 / 2021-03-19
 
-## Enhancements:
+### Enhancements:
 
 * Prevent downgrades to untested rubygems versions. Pull request [#4460](https://github.com/rubygems/rubygems/pull/4460) by
   deivid-rodriguez
 * Install bundler 2.2.15 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix missing require breaking `gem cert`. Pull request [#4464](https://github.com/rubygems/rubygems/pull/4464) by lukehinds
 
-# 3.2.14 / 2021-03-08
+## 3.2.14 / 2021-03-08
 
-## Enhancements:
+### Enhancements:
 
 * Less wrapping of network errors. Pull request [#4064](https://github.com/rubygems/rubygems/pull/4064) by deivid-rodriguez
 * Install bundler 2.2.14 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Revert addition of support for `musl` variants to restore graceful
   fallback on Alpine. Pull request [#4434](https://github.com/rubygems/rubygems/pull/4434) by deivid-rodriguez
 
-# 3.2.13 / 2021-03-03
+## 3.2.13 / 2021-03-03
 
-## Enhancements:
+### Enhancements:
 
 * Install bundler 2.2.13 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Support non-gnu libc linux platforms. Pull request [#4082](https://github.com/rubygems/rubygems/pull/4082) by lloeki
 
-# 3.2.12 / 2021-03-01
+## 3.2.12 / 2021-03-01
 
-## Enhancements:
+### Enhancements:
 
 * Install bundler 2.2.12 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Restore the ability to manually install extension gems. Pull request
   [#4384](https://github.com/rubygems/rubygems/pull/4384) by cfis
 
-# 3.2.11 / 2021-02-17
+## 3.2.11 / 2021-02-17
 
-## Enhancements:
+### Enhancements:
 
 * Optionally fallback to IPv4 when IPv6 is unreachable. Pull request [#2662](https://github.com/rubygems/rubygems/pull/2662)
   by sonalkr132
 * Install bundler 2.2.11 as a default gem.
 
-# 3.2.10 / 2021-02-15
+## 3.2.10 / 2021-02-15
 
-## Enhancements:
+### Enhancements:
 
 * Install bundler 2.2.10 as a default gem.
 
-## Documentation:
+### Documentation:
 
 * Add a `gem push` example to `gem help`. Pull request [#4373](https://github.com/rubygems/rubygems/pull/4373) by
   deivid-rodriguez
 * Improve documentation for `required_ruby_version`. Pull request [#4343](https://github.com/rubygems/rubygems/pull/4343) by
   AlexWayfer
 
-# 3.2.9 / 2021-02-08
+## 3.2.9 / 2021-02-08
 
-## Enhancements:
+### Enhancements:
 
 * Install bundler 2.2.9 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix error message when underscore selection can't find bundler. Pull
   request [#4363](https://github.com/rubygems/rubygems/pull/4363) by deivid-rodriguez
@@ -1842,59 +1844,59 @@
 * Fix `gem outdated` incorrectly handling platform specific gems. Pull
   request [#4248](https://github.com/rubygems/rubygems/pull/4248) by deivid-rodriguez
 
-# 3.2.8 / 2021-02-02
+## 3.2.8 / 2021-02-02
 
-## Enhancements:
+### Enhancements:
 
 * Install bundler 2.2.8 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix `gem install` crashing on gemspec with nil required_ruby_version.
   Pull request [#4334](https://github.com/rubygems/rubygems/pull/4334) by pbernays
 
-# 3.2.7 / 2021-01-26
+## 3.2.7 / 2021-01-26
 
-## Enhancements:
+### Enhancements:
 
 * Install bundler 2.2.7 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Generate plugin wrappers with relative requires. Pull request [#4317](https://github.com/rubygems/rubygems/pull/4317) by
   deivid-rodriguez
 
-# 3.2.6 / 2021-01-18
+## 3.2.6 / 2021-01-18
 
-## Enhancements:
+### Enhancements:
 
 * Fix `Gem::Platform#inspect` showing duplicate information. Pull request
   [#4276](https://github.com/rubygems/rubygems/pull/4276) by deivid-rodriguez
 * Install bundler 2.2.6 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Swallow any system call error in `ensure_gem_subdirs` to support jruby
   embedded paths. Pull request [#4291](https://github.com/rubygems/rubygems/pull/4291) by kares
 * Restore accepting custom make command with extra options as the `make`
   env variable. Pull request [#4271](https://github.com/rubygems/rubygems/pull/4271) by terceiro
 
-# 3.2.5 / 2021-01-11
+## 3.2.5 / 2021-01-11
 
-## Enhancements:
+### Enhancements:
 
 * Install bundler 2.2.5 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Don't load more specs after the whole set of specs has been setup. Pull
   request [#4262](https://github.com/rubygems/rubygems/pull/4262) by deivid-rodriguez
 * Fix broken `bundler` executable after `gem update --system`. Pull
   request [#4221](https://github.com/rubygems/rubygems/pull/4221) by deivid-rodriguez
 
-# 3.2.4 / 2020-12-31
+## 3.2.4 / 2020-12-31
 
-## Enhancements:
+### Enhancements:
 
 * Use a CHANGELOG in markdown for rubygems. Pull request [#4168](https://github.com/rubygems/rubygems/pull/4168) by
   deivid-rodriguez
@@ -1902,33 +1904,33 @@
   deivid-rodriguez
 * Install bundler 2.2.4 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix fallback to the old index and installation from it not working. Pull
   request [#4213](https://github.com/rubygems/rubygems/pull/4213) by deivid-rodriguez
 * Fix installing from source on truffleruby. Pull request [#4201](https://github.com/rubygems/rubygems/pull/4201) by
   deivid-rodriguez
 
-# 3.2.3 / 2020-12-22
+## 3.2.3 / 2020-12-22
 
-## Enhancements:
+### Enhancements:
 
 * Fix misspellings in default API key name. Pull request [#4177](https://github.com/rubygems/rubygems/pull/4177) by hsbt
 * Install bundler 2.2.3 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Respect `required_ruby_version` and `required_rubygems_version`
   constraints when looking for `gem install` candidates. Pull request [#4110](https://github.com/rubygems/rubygems/pull/4110)
   by deivid-rodriguez
 
-# 3.2.2 / 2020-12-17
+## 3.2.2 / 2020-12-17
 
-## Enhancements:
+### Enhancements:
 
 * Install bundler 2.2.2 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix issue where CLI commands making more than one request to
   rubygems.org needing an OTP code would crash or ask for the code twice.
@@ -1938,24 +1940,24 @@
 * Fix `gem update --system` displaying too many changelog entries. Pull
   request [#4145](https://github.com/rubygems/rubygems/pull/4145) by deivid-rodriguez
 
-# 3.2.1 / 2020-12-14
+## 3.2.1 / 2020-12-14
 
-## Enhancements:
+### Enhancements:
 
 * Added help message for gem i webrick in gem server command. Pull request
   [#4117](https://github.com/rubygems/rubygems/pull/4117) by hsbt
 * Install bundler 2.2.1 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Added the missing loading of fileutils same as load_specs. Pull request
   [#4124](https://github.com/rubygems/rubygems/pull/4124) by hsbt
 * Fix Resolver::APISet to always include prereleases when necessary. Pull
   request [#4113](https://github.com/rubygems/rubygems/pull/4113) by deivid-rodriguez
 
-# 3.2.0 / 2020-12-07
+## 3.2.0 / 2020-12-07
 
-## Enhancements:
+### Enhancements:
 
 * Do not override Kernel#warn when there is no need. Pull request [#4075](https://github.com/rubygems/rubygems/pull/4075) by
   eregon
@@ -1975,7 +1977,7 @@
   eregon
 * Install bundler 2.2.0 as a default gem.
 
-## Bug fixes:
+### Bug fixes:
 
 * Use better owner & group for files in rubygems package. Pull request
   [#4065](https://github.com/rubygems/rubygems/pull/4065) by deivid-rodriguez
@@ -2001,18 +2003,18 @@
 * Make `--default` and `--install-dir` options to `gem install` play nice
   together. Pull request [#3906](https://github.com/rubygems/rubygems/pull/3906) by deivid-rodriguez
 
-## Deprecations:
+### Deprecations:
 
 * Deprecate server command. Pull request [#3868](https://github.com/rubygems/rubygems/pull/3868) by bronzdoc
 
-## Performance:
+### Performance:
 
 * Don't change ruby process CWD when building extensions. Pull request
   [#3498](https://github.com/rubygems/rubygems/pull/3498) by deivid-rodriguez
 
-# 3.2.0.rc.2 / 2020-10-08
+## 3.2.0.rc.2 / 2020-10-08
 
-## Enhancements:
+### Enhancements:
 
 * Make --dry-run flag consistent across rubygems commands. Pull request
   [#3867](https://github.com/rubygems/rubygems/pull/3867) by bronzdoc
@@ -2029,7 +2031,7 @@
 * Ignore internal frames in RubyGems' Kernel#warn. Pull request [#3810](https://github.com/rubygems/rubygems/pull/3810) by
   eregon
 
-## Bug fixes:
+### Bug fixes:
 
 * Add missing fileutils require. Pull request [#3911](https://github.com/rubygems/rubygems/pull/3911) by deivid-rodriguez
 * Fix false positive warning on Windows when PATH has
@@ -2041,7 +2043,7 @@
 * `gem install --user` fails with `Gem::FilePermissionError` on the system
   plugins directory. Pull request [#3804](https://github.com/rubygems/rubygems/pull/3804) by nobu
 
-## Performance:
+### Performance:
 
 * Avoid duplicated generation of APISpecification objects. Pull request
   [#3940](https://github.com/rubygems/rubygems/pull/3940) by mame
@@ -2051,9 +2053,9 @@
   casperisfine
 * Optimize Gem.already_loaded?. Pull request [#3793](https://github.com/rubygems/rubygems/pull/3793) by casperisfine
 
-# 3.2.0.rc.1 / 2020-07-04
+## 3.2.0.rc.1 / 2020-07-04
 
-## Enhancements:
+### Enhancements:
 
 * Test TruffleRuby in CI. Pull request [#2797](https://github.com/rubygems/rubygems/pull/2797) by Benoit Daloze.
 * Rework plugins system and speed up rubygems. Pull request [#3108](https://github.com/rubygems/rubygems/pull/3108) by David
@@ -2100,7 +2102,7 @@
 * Only rescue the errors we actually want to rescue. Pull request [#3156](https://github.com/rubygems/rubygems/pull/3156) by
   David Rodríguez.
 
-## Bug fixes:
+### Bug fixes:
 
 * Accept not only /usr/bin/env but also /bin/env in some tests. Pull
   request [#3422](https://github.com/rubygems/rubygems/pull/3422) by Yusuke Endoh.
@@ -2122,12 +2124,12 @@
 * Fix `ruby setup.rb` for new plugins layout. Pull request [#3144](https://github.com/rubygems/rubygems/pull/3144) by David
   Rodríguez.
 
-## Deprecations:
+### Deprecations:
 
 * Set deprecation warning on query command. Pull request [#2967](https://github.com/rubygems/rubygems/pull/2967) by Luis
   Sagastume.
 
-## Breaking changes:
+### Breaking changes:
 
 * Remove ruby 1.8 leftovers. Pull request [#3442](https://github.com/rubygems/rubygems/pull/3442) by David Rodríguez.
 * Minitest cleanup. Pull request [#3445](https://github.com/rubygems/rubygems/pull/3445) by David Rodríguez.
@@ -2154,9 +2156,9 @@
 * Requiring rubygems/source_specific_file is deprecated, remove it. Pull
   request [#3114](https://github.com/rubygems/rubygems/pull/3114) by Luis Sagastume.
 
-# 3.1.4 / 2020-06-03
+## 3.1.4 / 2020-06-03
 
-## Enhancements:
+### Enhancements:
 
 * Deprecate rubyforge_project attribute only during build
   time. Pull request [#3609](https://github.com/rubygems/rubygems/pull/3609) by Josef Šimánek.
@@ -2165,9 +2167,9 @@
 * Remove failing ubuntu-rvm CI flow. Pull request [#3611](https://github.com/rubygems/rubygems/pull/3611) by
   Josef Šimánek.
 
-# 3.1.3 / 2020-05-05
+## 3.1.3 / 2020-05-05
 
-## Enhancements:
+### Enhancements:
 
 * Resolver: require NameTuple before use. Pull request [#3171](https://github.com/rubygems/rubygems/pull/3171) by Olle
   Jonsson.
@@ -2178,7 +2180,7 @@
 * Add tests to check if Gem.ruby_version works with ruby git master.
   Pull request [#3049](https://github.com/rubygems/rubygems/pull/3049) by Yusuke Endoh.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix platform comparison check in #contains_requirable_file?. Pull
   request [#3495](https://github.com/rubygems/rubygems/pull/3495) by Benoit Daloze.
@@ -2190,9 +2192,9 @@
 * Fix gem install from a gemdeps file with complex dependencies.
   Pull request [#3054](https://github.com/rubygems/rubygems/pull/3054) by Luis Sagastume.
 
-# 3.1.2 / 2019-12-20
+## 3.1.2 / 2019-12-20
 
-## Enhancements:
+### Enhancements:
 
 * Restore non prompting `gem update --system` behavior. Pull request [#3040](https://github.com/rubygems/rubygems/pull/3040)
   by David Rodríguez.
@@ -2202,24 +2204,24 @@
   Pull request [#3042](https://github.com/rubygems/rubygems/pull/3042) by David Rodríguez.
 * Use Bundler 2.1.2. Pull request [#3043](https://github.com/rubygems/rubygems/pull/3043) by SHIBATA Hiroshi.
 
-## Bug fixes:
+### Bug fixes:
 
 * Require `uri` in source.rb. Pull request [#3034](https://github.com/rubygems/rubygems/pull/3034) by mihaibuzgau.
 * Fix `gem update --system --force`. Pull request [#3035](https://github.com/rubygems/rubygems/pull/3035) by David
   Rodríguez.
 * Move `require uri` to source_list. Pull request [#3038](https://github.com/rubygems/rubygems/pull/3038) by mihaibuzgau.
 
-# 3.1.1 / 2019-12-16
+## 3.1.1 / 2019-12-16
 
-## Bug fixes:
+### Bug fixes:
 
 * Vendor Bundler 2.1.0 again. The version of Bundler with
   RubyGems 3.1.0 was Bundler 2.1.0.pre.3. Pull request [#3029](https://github.com/rubygems/rubygems/pull/3029) by
   SHIBATA Hiroshi.
 
-# 3.1.0 / 2019-12-16
+## 3.1.0 / 2019-12-16
 
-## Enhancements:
+### Enhancements:
 
 * Vendor bundler 2.1. Pull request [#3028](https://github.com/rubygems/rubygems/pull/3028) by David Rodríguez.
 * Check for rubygems.org typo squatting sources. Pull request [#2999](https://github.com/rubygems/rubygems/pull/2999) by
@@ -2233,25 +2235,25 @@
 * Use bundler to manage development dependencies. Pull request [#3012](https://github.com/rubygems/rubygems/pull/3012) by
   David Rodríguez.
 
-## Bug fixes:
+### Bug fixes:
 
 * Remove unnecessary executable flags. Pull request [#2982](https://github.com/rubygems/rubygems/pull/2982) by David
   Rodríguez.
 * Remove configuration that contained a typo. Pull request [#2989](https://github.com/rubygems/rubygems/pull/2989) by David
   Rodríguez.
 
-## Deprecations:
+### Deprecations:
 
 * Deprecate `gem generate_index --modern` and `gem generate_index
   --no-modern`. Pull request [#2992](https://github.com/rubygems/rubygems/pull/2992) by David Rodríguez.
 
-## Breaking changes:
+### Breaking changes:
 
 * Remove 1.8.7 leftovers. Pull request [#2972](https://github.com/rubygems/rubygems/pull/2972) by David Rodríguez.
 
-# 3.1.0.pre3 / 2019-11-11
+## 3.1.0.pre3 / 2019-11-11
 
-## Enhancements:
+### Enhancements:
 
 * Fix gem pristine not accounting for user installed gems. Pull request
   [#2914](https://github.com/rubygems/rubygems/pull/2914) by Luis Sagastume.
@@ -2270,18 +2272,18 @@
 * Fix Gem::LOADED_SPECS_MUTEX handling for recursive locking. Pull request
   [#2985](https://github.com/rubygems/rubygems/pull/2985) by MSP-Greg.
 
-# 3.1.0.pre2 / 2019-10-15
+## 3.1.0.pre2 / 2019-10-15
 
-## Enhancements:
+### Enhancements:
 
 * Optimize Gem::Package::TarReader#each. Pull request [#2941](https://github.com/rubygems/rubygems/pull/2941) by Jean byroot
   Boussier.
 * Time comparison around date boundary. Pull request [#2944](https://github.com/rubygems/rubygems/pull/2944) by Nobuyoshi
   Nakada.
 
-# 3.1.0.pre1 / 2019-10-08
+## 3.1.0.pre1 / 2019-10-08
 
-## Enhancements:
+### Enhancements:
 
 * Try to use bundler-2.1.0.pre.2. Pull request [#2923](https://github.com/rubygems/rubygems/pull/2923) by SHIBATA Hiroshi.
 * [Require] Ensure -I beats a default gem. Pull request [#1868](https://github.com/rubygems/rubygems/pull/1868) by Samuel
@@ -2411,7 +2413,7 @@
   Berger.
 * Remove useless TODO comment. Pull request [#2818](https://github.com/rubygems/rubygems/pull/2818) by Luis Sagastume.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix typos in History.txt. Pull request [#2565](https://github.com/rubygems/rubygems/pull/2565) by Igor Zubkov.
 * Remove unused empty sources array. Pull request [#2598](https://github.com/rubygems/rubygems/pull/2598) by Aaron
@@ -2444,7 +2446,7 @@
 * Fix cryptic error on local and ignore-dependencies combination. Pull
   request [#2650](https://github.com/rubygems/rubygems/pull/2650) by David Rodríguez.
 
-## Deprecations:
+### Deprecations:
 
 * Make deprecate Gem::RubyGemsVersion and Gem::ConfigMap. Pull request
   [#2857](https://github.com/rubygems/rubygems/pull/2857) by SHIBATA Hiroshi.
@@ -2458,7 +2460,7 @@
 * Add deprecation warnings for cli options. Pull request [#2607](https://github.com/rubygems/rubygems/pull/2607) by Luis
   Sagastume.
 
-## Breaking changes:
+### Breaking changes:
 
 * Suppress keywords warning. Pull request [#2934](https://github.com/rubygems/rubygems/pull/2934) by Nobuyoshi Nakada.
 * Suppress Ruby 2.7's real kwargs warning. Pull request [#2912](https://github.com/rubygems/rubygems/pull/2912) by Koichi
@@ -2481,16 +2483,16 @@
   [#2685](https://github.com/rubygems/rubygems/pull/2685) by SHIBATA Hiroshi.
 * Removing yaml require. Pull request [#2538](https://github.com/rubygems/rubygems/pull/2538) by Luciano Sousa.
 
-# 3.0.8 / 2020-02-19
+## 3.0.8 / 2020-02-19
 
-## Bug fixes:
+### Bug fixes:
 
 * Gem::Specification#to_ruby needs OpenSSL. Pull request [#2937](https://github.com/rubygems/rubygems/pull/2937) by
   Nobuyoshi Nakada.
 
-# 3.0.7 / 2020-02-18
+## 3.0.7 / 2020-02-18
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix underscore version selection for bundler #2908 by David Rodríguez.
 * Add missing wrapper. Pull request [#2690](https://github.com/rubygems/rubygems/pull/2690) by David Rodríguez.
@@ -2500,15 +2502,15 @@
 * Use IAM role to extract security-credentials for EC2 instance. Pull
   request [#2894](https://github.com/rubygems/rubygems/pull/2894) by Alexander Pakulov.
 
-# 3.0.6 / 2019-08-17
+## 3.0.6 / 2019-08-17
 
-## Bug fixes:
+### Bug fixes:
 
 * Revert #2813. It broke the compatibility with 3.0.x versions.
 
-# 3.0.5 / 2019-08-16
+## 3.0.5 / 2019-08-16
 
-## Enhancements:
+### Enhancements:
 
 * Use env var to configure api key on push. Pull request [#2559](https://github.com/rubygems/rubygems/pull/2559) by Luis
   Sagastume.
@@ -2543,7 +2545,7 @@
   by Alexander Pakulov.
 * Fixup #2844. Pull request [#2878](https://github.com/rubygems/rubygems/pull/2878) by SHIBATA Hiroshi.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix intermittent test error on Appveyor & Travis. Pull request [#2568](https://github.com/rubygems/rubygems/pull/2568) by
   MSP-Greg.
@@ -2559,9 +2561,9 @@
 * Ignore GEMRC variable for test suite. Pull request [#2837](https://github.com/rubygems/rubygems/pull/2837) by SHIBATA
   Hiroshi.
 
-# 3.0.4 / 2019-06-14
+## 3.0.4 / 2019-06-14
 
-## Enhancements:
+### Enhancements:
 
 * Add support for TruffleRuby #2612 by Benoit Daloze
 * Serve a more descriptive error when --no-ri or --no-rdoc are used #2572
@@ -2598,7 +2600,7 @@
   request [#2777](https://github.com/rubygems/rubygems/pull/2777) by Yusuke Endoh.
 * Backport ruby core changes. Pull request [#2778](https://github.com/rubygems/rubygems/pull/2778) by SHIBATA Hiroshi.
 
-## Bug fixes:
+### Bug fixes:
 
 * Test_gem.rb - intermittent failure fix. Pull request [#2613](https://github.com/rubygems/rubygems/pull/2613) by MSP-Greg.
 * Fix sporadic CI failures. Pull request [#2617](https://github.com/rubygems/rubygems/pull/2617) by David Rodríguez.
@@ -2614,7 +2616,7 @@
   [#2732](https://github.com/rubygems/rubygems/pull/2732) by Alex Junger.
 * Fix TODOs. Pull request [#2748](https://github.com/rubygems/rubygems/pull/2748) by David Rodríguez.
 
-# 3.0.3 / 2019-03-05
+## 3.0.3 / 2019-03-05
 
 Security fixes:
 
@@ -2625,14 +2627,14 @@ Security fixes:
   * CVE-2019-8324: Installing a malicious gem may lead to arbitrary code execution
   * CVE-2019-8325: Escape sequence injection vulnerability in errors
 
-# 3.0.2 / 2019-01-01
+## 3.0.2 / 2019-01-01
 
-## Enhancements:
+### Enhancements:
 
 * Use Bundler-1.17.3. Pull request [#2556](https://github.com/rubygems/rubygems/pull/2556) by SHIBATA Hiroshi.
 * Fix document flag description. Pull request [#2555](https://github.com/rubygems/rubygems/pull/2555) by Luis Sagastume.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix tests when ruby --program-suffix is used without rubygems
   --format-executable. Pull request [#2549](https://github.com/rubygems/rubygems/pull/2549) by Jeremy Evans.
@@ -2642,9 +2644,9 @@ Security fixes:
   Fukumori.
 * Restore SOURCE_DATE_EPOCH. Pull request [#2560](https://github.com/rubygems/rubygems/pull/2560) by SHIBATA Hiroshi.
 
-# 3.0.1 / 2018-12-23
+## 3.0.1 / 2018-12-23
 
-## Bug fixes:
+### Bug fixes:
 
 * Ensure globbed files paths are expanded. Pull request [#2536](https://github.com/rubygems/rubygems/pull/2536) by Tony Ta.
 * Dup the Dir.home string before passing it on. Pull request [#2545](https://github.com/rubygems/rubygems/pull/2545) by
@@ -2653,9 +2655,9 @@ Security fixes:
   by SHIBATA Hiroshi.
 * Restore release task without hoe. Pull request [#2547](https://github.com/rubygems/rubygems/pull/2547) by SHIBATA Hiroshi.
 
-# 3.0.0 / 2018-12-19
+## 3.0.0 / 2018-12-19
 
-## Enhancements:
+### Enhancements:
 
 * S3 source. Pull request [#1690](https://github.com/rubygems/rubygems/pull/1690) by Aditya Prakash.
 * Download gems with threads. Pull request [#1898](https://github.com/rubygems/rubygems/pull/1898) by André Arko.
@@ -2820,7 +2822,7 @@ Security fixes:
 * Support the environment without OpenSSL. Pull request [#2528](https://github.com/rubygems/rubygems/pull/2528) by SHIBATA
   Hiroshi.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix undefined method error when printing alert. Pull request [#1884](https://github.com/rubygems/rubygems/pull/1884) by
   Robert Ross.
@@ -2873,7 +2875,7 @@ Security fixes:
 * Fix tests when --program-suffix and similar ruby configure options are
   used. Pull request [#2529](https://github.com/rubygems/rubygems/pull/2529) by Jeremy Evans.
 
-## Breaking changes:
+### Breaking changes:
 
 * IO.binread is not provided at Ruby 1.8. Pull request [#2093](https://github.com/rubygems/rubygems/pull/2093) by SHIBATA
   Hiroshi.
@@ -2926,9 +2928,9 @@ Security fixes:
 * [BudlerVersionFinder] set .filter! and .compatible? to match only on
   major versions. Pull request [#2515](https://github.com/rubygems/rubygems/pull/2515) by Colby Swandale.
 
-# 2.7.10 / 2019-06-14
+## 2.7.10 / 2019-06-14
 
-## Enhancements:
+### Enhancements:
 
 * Fix bundler rubygems binstub not properly looking for bundler. Pull request [#2426](https://github.com/rubygems/rubygems/pull/2426)
   by David Rodríguez.
@@ -2936,7 +2938,7 @@ Security fixes:
   Pull request [#2515](https://github.com/rubygems/rubygems/pull/2515) by Colby Swandale.
 + Update for compatibility with new minitest. Pull request [#2118](https://github.com/rubygems/rubygems/pull/2118) by MSP-Greg.
 
-# 2.7.9 / 2019-03-05
+## 2.7.9 / 2019-03-05
 
 Security fixes:
 
@@ -2947,9 +2949,9 @@ Security fixes:
   * CVE-2019-8324: Installing a malicious gem may lead to arbitrary code execution
   * CVE-2019-8325: Escape sequence injection vulnerability in errors
 
-# 2.7.8 / 2018-11-02
+## 2.7.8 / 2018-11-02
 
-## Enhancements:
+### Enhancements:
 
 * [Requirement] Treat requirements with == versions as equal. Pull
   request [#2230](https://github.com/rubygems/rubygems/pull/2230) by Samuel Giddins.
@@ -2968,7 +2970,7 @@ Security fixes:
 * Improve bindir flag description. Pull request [#2383](https://github.com/rubygems/rubygems/pull/2383) by Luis Sagastume.
 * Update bundler-1.16.6. Pull request [#2423](https://github.com/rubygems/rubygems/pull/2423) by SHIBATA Hiroshi.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix #1470: generate documentation when --install-dir is present. Pull
   request [#2229](https://github.com/rubygems/rubygems/pull/2229) by Elias Hernandis.
@@ -2981,9 +2983,9 @@ Security fixes:
 * Gem::Version should handle nil like it used to before. Pull request
   [#2363](https://github.com/rubygems/rubygems/pull/2363) by Luis Sagastume.
 
-# 2.7.7 / 2018-05-08
+## 2.7.7 / 2018-05-08
 
-## Enhancements:
+### Enhancements:
 
 * [RequestSet] Only suggest a gem version with an installable platform.
   Pull request [#2175](https://github.com/rubygems/rubygems/pull/2175) by Samuel Giddins.
@@ -2998,7 +3000,7 @@ Security fixes:
   Sagastume.
 * Backport ruby core commits. Pull request [#2264](https://github.com/rubygems/rubygems/pull/2264) by SHIBATA Hiroshi.
 
-## Bug fixes:
+### Bug fixes:
 
 * Frozen string fix - lib/rubygems/bundler_version_finder.rb. Pull request
   [#2115](https://github.com/rubygems/rubygems/pull/2115) by MSP-Greg.
@@ -3011,7 +3013,7 @@ Security fixes:
 * Fix path checks for case insensitive filesystem. Pull request [#2211](https://github.com/rubygems/rubygems/pull/2211) by
   Lars Kanis.
 
-## Deprecations:
+### Deprecations:
 
 * Deprecate unused code before removing them at #1524. Pull request [#2197](https://github.com/rubygems/rubygems/pull/2197)
   by SHIBATA Hiroshi.
@@ -3019,11 +3021,11 @@ Security fixes:
 * Mark deprecation to `ubygems.rb` for RubyGems 4. Pull request [#2269](https://github.com/rubygems/rubygems/pull/2269) by
   SHIBATA Hiroshi.
 
-## Breaking changes:
+### Breaking changes:
 
 * Update bundler-1.16.2. Pull request [#2291](https://github.com/rubygems/rubygems/pull/2291) by SHIBATA Hiroshi.
 
-# 2.7.6 / 2018-02-16
+## 2.7.6 / 2018-02-16
 
 Security fixes:
 
@@ -3042,9 +3044,9 @@ Security fixes:
 * Prevent Path Traversal issue during gem installation.
   Discovered by nmalkin.
 
-# 2.7.5
+## 2.7.5
 
-## Bug fixes:
+### Bug fixes:
 
 * To use bundler-1.16.1 #2121 by SHIBATA Hiroshi.
 * Fixed leaked FDs. Pull request [#2127](https://github.com/rubygems/rubygems/pull/2127) by Nobuyoshi Nakada.
@@ -3056,9 +3058,9 @@ Security fixes:
 * Set whether bundler is used for gemdeps with an environmental variable #2126 by SHIBATA Hiroshi.
 * Fix undefined method error when printing alert #1884 by Robert Ross.
 
-# 2.7.4
+## 2.7.4
 
-## Bug fixes:
+### Bug fixes:
 
 * Fixed leaked FDs. Pull request [#2127](https://github.com/rubygems/rubygems/pull/2127) by Nobuyoshi Nakada.
 * Avoid to warnings about gemspec loadings in rubygems tests. Pull request
@@ -3067,9 +3069,9 @@ Security fixes:
 * Handle environment that does not have `flock` system call. Pull request
   [#2107](https://github.com/rubygems/rubygems/pull/2107) by SHIBATA Hiroshi.
 
-# 2.7.3
+## 2.7.3
 
-## Enhancements:
+### Enhancements:
 
 * Removed needless version lock. Pull request [#2074](https://github.com/rubygems/rubygems/pull/2074) by SHIBATA Hiroshi.
 * Add --[no-]check-development option to cleanup command. Pull request
@@ -3082,7 +3084,7 @@ Security fixes:
 * Remove multi load warning from plugins documentation. Pull request [#2103](https://github.com/rubygems/rubygems/pull/2103)
   by Thibault Jouan.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix test failure on Alpine Linux. Pull request [#2079](https://github.com/rubygems/rubygems/pull/2079) by Ellen Marie
   Dash.
@@ -3101,25 +3103,25 @@ Security fixes:
 * Use setup command --regenerate-binstubs option flag. Pull request [#2099](https://github.com/rubygems/rubygems/pull/2099)
   by Thibault Jouan.
 
-# 2.7.2
+## 2.7.2
 
-## Bug fixes:
+### Bug fixes:
 
 * Added template files to vendoerd bundler. Pull request [#2065](https://github.com/rubygems/rubygems/pull/2065) by SHIBATA
   Hiroshi.
 * Added workaround for non-git environment. Pull request [#2066](https://github.com/rubygems/rubygems/pull/2066) by SHIBATA
   Hiroshi.
 
-# 2.7.1 (2017-11-03)
+## 2.7.1 (2017-11-03)
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix `gem update --system` with RubyGems 2.7+. Pull request [#2054](https://github.com/rubygems/rubygems/pull/2054) by
   Samuel Giddins.
 
-# 2.7.0 (2017-11-02)
+## 2.7.0 (2017-11-02)
 
-## Enhancements:
+### Enhancements:
 
 * Update vendored bundler-1.16.0. Pull request [#2051](https://github.com/rubygems/rubygems/pull/2051) by Samuel Giddins.
 * Use Bundler for Gem.use_gemdeps. Pull request [#1674](https://github.com/rubygems/rubygems/pull/1674) by Samuel Giddins.
@@ -3210,7 +3212,7 @@ Security fixes:
 * Warn when requiring deprecated files. Pull request [#1939](https://github.com/rubygems/rubygems/pull/1939) by Ellen Marie
   Dash.
 
-## Deprecations:
+### Deprecations:
 
 * Deprecate Gem::InstallerTestCase#util_gem_bindir and
   Gem::InstallerTestCase#util_gem_dir. Pull request [#1729](https://github.com/rubygems/rubygems/pull/1729) by Jon Moss.
@@ -3220,7 +3222,7 @@ Security fixes:
 * Add deprecation warning for Gem::DependencyInstaller#gems_to_install.
   Pull request [#1731](https://github.com/rubygems/rubygems/pull/1731) by Jon Moss.
 
-## Breaking changes:
+### Breaking changes:
 
 * Use `-rrubygems` instead of `-rubygems.rb`. Because ubygems.rb is
   unavailable on Ruby 2.5. Pull request [#2028](https://github.com/rubygems/rubygems/pull/2028) #2027 #2029
@@ -3228,7 +3230,7 @@ Security fixes:
 * Update Code of Conduct to Contributor Covenant v1.4.0. Pull request
   [#1796](https://github.com/rubygems/rubygems/pull/1796) by Matej.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix issue for MinGW / MSYS2 builds and testing. Pull request [#1876](https://github.com/rubygems/rubygems/pull/1876) by
   MSP-Greg.
@@ -3281,7 +3283,7 @@ Security fixes:
 * [StubSpecification] Don’t iterate through all loaded specs in #to_spec.
   Pull request [#1738](https://github.com/rubygems/rubygems/pull/1738) by Samuel Giddins.
 
-# 2.6.14 / 2017-10-09
+## 2.6.14 / 2017-10-09
 
 Security fixes:
 
@@ -3289,7 +3291,7 @@ Security fixes:
   See CVE-2017-0903 for full details.
   Fix by Aaron Patterson.
 
-# 2.6.13 / 2017-08-27
+## 2.6.13 / 2017-08-27
 
 Security fixes:
 
@@ -3303,9 +3305,9 @@ Security fixes:
   to overwrite arbitrary files. (CVE-2017-0901)
   Discovered by Yusuke Endoh, fix by Samuel Giddins.
 
-# 2.6.12 / 2017-04-30
+## 2.6.12 / 2017-04-30
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix test_self_find_files_with_gemfile to sort expected files. Pull
   request [#1880](https://github.com/rubygems/rubygems/pull/1880) by Kazuaki Matsuo.
@@ -3326,9 +3328,9 @@ Security fixes:
 * Allow Gem.finish_resolve to respect already-activated specs. Pull
   request [#1910](https://github.com/rubygems/rubygems/pull/1910) by Samuel Giddins.
 
-# 2.6.11 / 2017-03-16
+## 2.6.11 / 2017-03-16
 
-## Bug fixes:
+### Bug fixes:
 
 * Fixed broken tests on ruby-head. Pull request [#1841](https://github.com/rubygems/rubygems/pull/1841) by
   SHIBATA Hiroshi.
@@ -3339,16 +3341,16 @@ Security fixes:
 * Use improved resolver sorting algorithm. Pull request [#1856](https://github.com/rubygems/rubygems/pull/1856) by
   Samuel Giddins.
 
-# 2.6.10 / 2017-01-23
+## 2.6.10 / 2017-01-23
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix `require` calling the wrong `gem` method when it is overridden.
   Pull request [#1822](https://github.com/rubygems/rubygems/pull/1822) by Samuel Giddins.
 
-# 2.6.9 / 2017-01-20
+## 2.6.9 / 2017-01-20
 
-## Bug fixes:
+### Bug fixes:
 
 * Allow initializing versions with empty strings. Pull request [#1767](https://github.com/rubygems/rubygems/pull/1767) by
   Luis Sagastume.
@@ -3362,9 +3364,9 @@ Security fixes:
 * RakeBuilder: avoid frozen string issue. Pull request [#1819](https://github.com/rubygems/rubygems/pull/1819) by Olle
   Jonsson.
 
-# 2.6.8 / 2016-10-29
+## 2.6.8 / 2016-10-29
 
-## Bug fixes:
+### Bug fixes:
 
 * Improve SSL verification failure message. Pull request [#1751](https://github.com/rubygems/rubygems/pull/1751)
   by Eric Hodel.
@@ -3373,9 +3375,9 @@ Security fixes:
 * Update vendored Molinillo to 0.5.3. Pull request [#1763](https://github.com/rubygems/rubygems/pull/1763) by
   Samuel Giddins.
 
-# 2.6.7 / 2016-09-26
+## 2.6.7 / 2016-09-26
 
-## Bug fixes:
+### Bug fixes:
 
 * Install native extensions in the correct location when using the
   `--user-install` flag. Pull request [#1683](https://github.com/rubygems/rubygems/pull/1683) by Noah Kantrowitz.
@@ -3387,24 +3389,24 @@ Security fixes:
 * Update vendored Molinillo to 0.5.1. Pull request [#1714](https://github.com/rubygems/rubygems/pull/1714) by
   Samuel Giddins.
 
-# 2.6.6 / 2016-06-22
+## 2.6.6 / 2016-06-22
 
-## Bug fixes:
+### Bug fixes:
 
 * Sort installed versions to make sure we install the latest version when
   running `gem update --system`. As a one-time fix, run
   `gem update --system=2.6.6`. Pull request [#1601](https://github.com/rubygems/rubygems/pull/1601) by David Radcliffe.
 
-# 2.6.5 / 2016-06-21
+## 2.6.5 / 2016-06-21
 
-## Enhancements:
+### Enhancements:
 
 * Support for unified Integer in Ruby 2.4. Pull request [#1618](https://github.com/rubygems/rubygems/pull/1618)
   by SHIBATA Hiroshi.
 * Update vendored Molinillo to 0.5.0 for performance improvements.
   Pull request [#1638](https://github.com/rubygems/rubygems/pull/1638) by Samuel Giddins.
 
-## Bug fixes:
+### Bug fixes:
 
 * Raise an explicit error if Signer#sign is called with no certs. Pull
   request [#1605](https://github.com/rubygems/rubygems/pull/1605) by Daniel Berger.
@@ -3424,16 +3426,16 @@ Security fixes:
   Pull request [#1644](https://github.com/rubygems/rubygems/pull/1644) by Charles Oliver Nutter.
 * Run Bundler tests on TravisCI. Pull request [#1650](https://github.com/rubygems/rubygems/pull/1650) by Samuel Giddins.
 
-# 2.6.4 / 2016-04-26
+## 2.6.4 / 2016-04-26
 
-## Enhancements:
+### Enhancements:
 
 * Use Gem::Util::NULL_DEVICE instead of hard coded strings. Pull request [#1588](https://github.com/rubygems/rubygems/pull/1588)
   by Chris Charabaruk.
 * Use File.symlink on MS Windows if supported. Pull request [#1418](https://github.com/rubygems/rubygems/pull/1418)
   by Nobuyoshi Nakada.
 
-## Bug fixes:
+### Bug fixes:
 
 * Redact uri password from error output when gem fetch fails. Pull request
   [#1565](https://github.com/rubygems/rubygems/pull/1565) by Brian Fletcher.
@@ -3441,9 +3443,9 @@ Security fixes:
 * Escape user-supplied content served on web pages by `gem server` to avoid
   potential XSS vulnerabilities. Samuel Giddins.
 
-# 2.6.3 / 2016-04-05
+## 2.6.3 / 2016-04-05
 
-## Enhancements:
+### Enhancements:
 
 * Lazily calculate Gem::LoadError exception messages. Pull request [#1550](https://github.com/rubygems/rubygems/pull/1550)
   by Aaron Patterson.
@@ -3454,7 +3456,7 @@ Security fixes:
 * Show default gems when using "gem list". Pull request [#1570](https://github.com/rubygems/rubygems/pull/1570) by Luis
   Sagastume.
 
-## Bug fixes:
+### Bug fixes:
 
 * Stub ordering should be consistent regardless of how cache is populated.
   Pull request [#1552](https://github.com/rubygems/rubygems/pull/1552) by Aaron Patterson.
@@ -3470,9 +3472,9 @@ Security fixes:
   Giddins.
 * Allow two digit version numbers in the tests. Pull request [#1575](https://github.com/rubygems/rubygems/pull/1575) by unak.
 
-# 2.6.2 / 2016-03-12
+## 2.6.2 / 2016-03-12
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix wrong version of gem activation for bin stub. Pull request [#1527](https://github.com/rubygems/rubygems/pull/1527) by
   Aaron Patterson.
@@ -3483,9 +3485,9 @@ Security fixes:
   [#1538](https://github.com/rubygems/rubygems/pull/1538) by Charles Oliver Nutter.
 
 
-# 2.6.1 / 2016-02-28
+## 2.6.1 / 2016-02-28
 
-## Bug fixes:
+### Bug fixes:
 
 * Ensure `default_path` and `home` are set for paths. Pull request [#1513](https://github.com/rubygems/rubygems/pull/1513)
   by Aaron Patterson.
@@ -3494,9 +3496,9 @@ Security fixes:
 * Fix invalid gem file preventing gem install from working. Pull request
   [#1499](https://github.com/rubygems/rubygems/pull/1499) by Luis Sagastume.
 
-# 2.6.0 / 2016-02-26
+## 2.6.0 / 2016-02-26
 
-## Enhancements:
+### Enhancements:
 
 * RubyGems now defaults the `gem push` to the gem's "allowed_push_host"
   metadata setting.  Pull request [#1486](https://github.com/rubygems/rubygems/pull/1486) by Josh Lane.
@@ -3507,7 +3509,7 @@ Security fixes:
 * Allow specifying gem requirements via env variables. Pull request [#1472](https://github.com/rubygems/rubygems/pull/1472)
   by Samuel E. Giddins.
 
-## Bug fixes:
+### Bug fixes:
 
 * RubyGems now stores `gem push` credentials under the host you signed-in for.
   Pull request [#1485](https://github.com/rubygems/rubygems/pull/1485) by Josh Lane.
@@ -3533,9 +3535,9 @@ Security fixes:
 * Find_files only from loaded_gems when using gemdeps. Pull request [#1277](https://github.com/rubygems/rubygems/pull/1277)
   by Michal Papis.
 
-# 2.5.2 / 2016-01-31
+## 2.5.2 / 2016-01-31
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix memoization of Gem::Version#prerelease? Pull request [#1125](https://github.com/rubygems/rubygems/pull/1125) by Matijs van
   Zuijlen.
@@ -3551,7 +3553,7 @@ Security fixes:
 * Handle symlinks containing ".." correctly. Pull request [#1457](https://github.com/rubygems/rubygems/pull/1457) by Samuel E.
   Giddins.
 
-## Enhancements:
+### Enhancements:
 
 * Add `--no-rc` flag, which skips loading `.gemrc`. Pull request [#1329](https://github.com/rubygems/rubygems/pull/1329) by Luis
   Sagastume.
@@ -3576,9 +3578,9 @@ Security fixes:
 * Function correctly when string literals are frozen on Ruby 2.3. Pull request
   [#1408](https://github.com/rubygems/rubygems/pull/1408) by Samuel E. Giddins.
 
-# 2.5.1 / 2015-12-10
+## 2.5.1 / 2015-12-10
 
-## Bug fixes:
+### Bug fixes:
 
 * Ensure platform sorting only uses strings. Affected binary installs on Windows.
   Issue #1369 reported by Ryan Atball (among others).
@@ -3607,9 +3609,9 @@ Security fixes:
   Kudo.
 * Fixed double word typo.  Pull request [#1411](https://github.com/rubygems/rubygems/pull/1411) by Jake Worth.
 
-# 2.5.0 / 2015-11-03
+## 2.5.0 / 2015-11-03
 
-## Enhancements:
+### Enhancements:
 
 * Added the Gem::Licenses class which provides a set of standard license
   identifiers as set by spdx.org. This is now used by the
@@ -3679,7 +3681,7 @@ Security fixes:
 * Gem::RemoteFetcher allows users to set HTTP headers.  Pull request [#1363](https://github.com/rubygems/rubygems/pull/1363) by
   Agis Anastasopoulos.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fixed Rake homepage url in example for Gem::Specification#homepage.
   Pull request [#1171](https://github.com/rubygems/rubygems/pull/1171) by Arthur Nogueira Neves
@@ -3736,22 +3738,22 @@ Security fixes:
 * RubyGems handles invalid config files better.  Pull request [#1367](https://github.com/rubygems/rubygems/pull/1367) by Agis
   Anastasopoulos.
 
-# 2.4.8 / 2015-06-08
+## 2.4.8 / 2015-06-08
 
-## Bug fixes:
+### Bug fixes:
 
 * Tightened API endpoint checks for CVE-2015-3900
 
-# 2.4.7 / 2015-05-14
+## 2.4.7 / 2015-05-14
 
-## Bug fixes:
+### Bug fixes:
 
 * Limit API endpoint to original security domain for CVE-2015-3900.
   Fix by claudijd
 
-# 2.4.6 / 2015-02-05
+## 2.4.6 / 2015-02-05
 
-## Bug fixes:
+### Bug fixes:
 
 * Fixed resolving gems with both upper and lower requirement boundaries.
   Issue #1141 by Jakub Jirutka.
@@ -3776,9 +3778,9 @@ Security fixes:
   Ondruch.
 * Relaxed Psych dependency.  Pull request [#1128](https://github.com/rubygems/rubygems/pull/1128) by Vít Ondruch.
 
-# 2.4.5 / 2014-12-03
+## 2.4.5 / 2014-12-03
 
-## Bug fixes:
+### Bug fixes:
 
 * Improved speed of requiring gems.  (Around 25% for a 60 gem test).  Pull
   request [#1060](https://github.com/rubygems/rubygems/pull/1060) by unak.
@@ -3818,27 +3820,27 @@ Security fixes:
 * Fixed grouped expression warning.  Pull request [#1081](https://github.com/rubygems/rubygems/pull/1081) by André Arko.
 * Fixed handling of platforms when writing lockfiles.
 
-# 2.4.4 / 2014-11-12
+## 2.4.4 / 2014-11-12
 
-## Bug fixes:
+### Bug fixes:
 
 * Add alternate Root CA for upcoming certificate change. Fixes #1050 by
   Protosac
 
-# 2.4.3 / 2014-11-10
+## 2.4.3 / 2014-11-10
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix redefine MirrorCommand issue. Pull request [#1044](https://github.com/rubygems/rubygems/pull/1044) by @akr.
 * Fix typo in platform= docs.  Pull request [#1048](https://github.com/rubygems/rubygems/pull/1048) by @jasonrclark
 * Add root SSL certificates for upcoming certificate change.  Fixes #1050 by
   Protosac
 
-# 2.4.2 / 2014-10-01
+## 2.4.2 / 2014-10-01
 
 This release was sponsored by Ruby Central.
 
-## Bug fixes:
+### Bug fixes:
 
 * RubyGems now correctly matches wildcard no_proxy hosts.  Issue #997 by
   voelzemo.
@@ -3872,16 +3874,16 @@ This release was sponsored by Ruby Central.
 * RubyGems now fails immediately when a git reference cannot be found instead
   of spewing git errors.  Issue #1031 by Michal Papis
 
-# 2.4.1 / 2014-07-17
+## 2.4.1 / 2014-07-17
 
-## Bug fixes:
+### Bug fixes:
 
 * RubyGems can now be updated on Ruby implementations that do not support
   vendordir in RbConfig::CONFIG.  Issue #974 by net1957.
 
-# 2.4.0 / 2014-07-16
+## 2.4.0 / 2014-07-16
 
-## Enhancements:
+### Enhancements:
 
 * The contents command now supports a --show-install-dir option that shows
   only the directory the gem is installed in.  Feature request [#966](https://github.com/rubygems/rubygems/pull/966) by Akinori
@@ -3892,7 +3894,7 @@ This release was sponsored by Ruby Central.
   in Gem.vendor_dir with the --vendor option to gem install.  Issue #943 by
   Marcus Rückert.
 
-## Bug fixes:
+### Bug fixes:
 
 * Kernel#gem now respects the prerelease flag when activating gems.
   Previously this behavior was undefined which could lead to bugs when a
@@ -3942,9 +3944,9 @@ This release was sponsored by Ruby Central.
   during gem resolution.
 
 
-# 2.3.0 / 2014-06-10
+## 2.3.0 / 2014-06-10
 
-## Enhancements:
+### Enhancements:
 
 * Added the `open` command which allows you to inspect the source of a gem
   using your editor.
@@ -3985,7 +3987,7 @@ This release was sponsored by Ruby Central.
 * RubyGems recommends SPDX IDs for licenses now.  Pull request [#917](https://github.com/rubygems/rubygems/pull/917) by
   Benjamin Fleischer.
 
-## Bug fixes:
+### Bug fixes:
 
 * RubyGems now only fetches the latest specs to find misspellings which speeds
   up gem suggestions.  Pull request [#808](https://github.com/rubygems/rubygems/pull/808) by Aaron Patterson.
@@ -4065,29 +4067,29 @@ This release was sponsored by Ruby Central.
 * Gem::BasicSpecification#require_paths respects default_ext_dir_for now.  Bug
   #852 by Vít Ondruch.
 
-# 2.2.5 / 2015-06-08
+## 2.2.5 / 2015-06-08
 
-## Bug fixes:
+### Bug fixes:
 
 * Tightened API endpoint checks for CVE-2015-3900
 
-# 2.2.4 / 2015-05-14
+## 2.2.4 / 2015-05-14
 
-## Bug fixes:
+### Bug fixes:
 
 * Backport: Limit API endpoint to original security domain for CVE-2015-3900.
   Fix by claudijd
 
-# 2.2.3 / 2014-12-21
+## 2.2.3 / 2014-12-21
 
-## Bug fixes:
+### Bug fixes:
 
 * Backport: Add alternate Root CA for upcoming certificate change.
   Fixes #1050 by Protosac
 
-# 2.2.2 / 2014-02-05
+## 2.2.2 / 2014-02-05
 
-## Bug fixes:
+### Bug fixes:
 
 * Fixed ruby tests when BASERUBY is not set.  Patch for #778 by Nobuyoshi
   Nakada.
@@ -4112,9 +4114,9 @@ This release was sponsored by Ruby Central.
 * Restored behavior of Gem::Version::new when subclassed.  Issue #805 by
   Sergio Rubio.
 
-# 2.2.1 / 2014-01-06
+## 2.2.1 / 2014-01-06
 
-## Bug fixes:
+### Bug fixes:
 
 * Platforms in the Gemfile.lock GEM section are now handled correctly.  Bug
   #767 by Diego Viola.
@@ -4140,12 +4142,12 @@ This release was sponsored by Ruby Central.
 * Fixed specification file sorting for Ruby 1.8.7 compatibility.  Pull
   request [#763](https://github.com/rubygems/rubygems/pull/763) by James Mead
 
-# 2.2.0 / 2013-12-26
+## 2.2.0 / 2013-12-26
 
 Special thanks to Vít Ondruch and Michal Papis for testing and finding bugs in
 RubyGems as it was prepared for the 2.2.0 release.
 
-## Enhancements:
+### Enhancements:
 
 * RubyGems can check for gem dependencies files (gem.deps.rb or Gemfile) when
   rubygems executables are started and uses the found dependencies.  This
@@ -4213,7 +4215,7 @@ RubyGems as it was prepared for the 2.2.0 release.
 * Relaxed Gem.ruby tests for platforms that override where ruby lives.  Pull
   Request #755 by strzibny.
 
-## Bug fixes:
+### Bug fixes:
 
 * RubyGems now returns an error status when any file given to `gem which`
   cannot be found.  Ruby bug #9004 by Eugene Vilensky.
@@ -4230,9 +4232,9 @@ RubyGems as it was prepared for the 2.2.0 release.
 * Improved speed of `gem install --ignore-dependencies`.  Patch by Terence
   Lee.
 
-# 2.1.11 / 2013-11-12
+## 2.1.11 / 2013-11-12
 
-## Bug fixes:
+### Bug fixes:
 
 * Gem::Specification::remove_spec no longer checks for existence of the spec
   to be removed.  Issue #698 by Tiago Macedo.
@@ -4242,9 +4244,9 @@ RubyGems as it was prepared for the 2.2.0 release.
 * The Gem::RemoteFetcher tests now choose the test server port more reliably.
   Pull Request #706 by akr.
 
-# 2.1.10 / 2013-10-24
+## 2.1.10 / 2013-10-24
 
-## Bug fixes:
+### Bug fixes:
 
 * Use class check instead of :version method check when creating Gem::Version
   objects.  Fixes #674 by jkanywhere.
@@ -4263,18 +4265,18 @@ RubyGems as it was prepared for the 2.2.0 release.
 * The --ignore-dependencies option for gem installation works again.  Issue
   #695
 
-# 2.1.9 / 2013-10-14
+## 2.1.9 / 2013-10-14
 
-## Bug fixes:
+### Bug fixes:
 
 * Reduce sorting when fetching specifications.  This speeds up the update and
   outdated commands, and others.  Issue #657 by windwiny.
 * Proxy usernames and passwords are now escaped properly.  Ruby Bug #8979 by
   Masahiro Tomita, Issue #668 by Kouhei Sutou.
 
-# 2.1.8 / 2013-10-10
+## 2.1.8 / 2013-10-10
 
-## Bug fixes:
+### Bug fixes:
 
 * Fixed local installation of platform gem files.  Issue #664 by Ryan Melton.
 * Files starting with "." in the root directory are installed again.  Issue
@@ -4282,9 +4284,9 @@ RubyGems as it was prepared for the 2.2.0 release.
 * The index generator no longer indexes default gems.  Issue #661 by
   Jeremy Hinegardner.
 
-# 2.1.7 / 2013-10-09
+## 2.1.7 / 2013-10-09
 
-## Bug fixes:
+### Bug fixes:
 
 * `gem sources --list` now displays a list of sources.  Pull request [#672](https://github.com/rubygems/rubygems/pull/672) by
   Nathan Marley.
@@ -4297,9 +4299,9 @@ RubyGems as it was prepared for the 2.2.0 release.
 * Expand unpack destination directory.  This fixes problems when File.realpath
   is missing and $GEM_HOME contains "..".  Issue #679 by Charles Nutter.
 
-# 2.1.6 / 2013-10-08
+## 2.1.6 / 2013-10-08
 
-## Bug fixes:
+### Bug fixes:
 
 * Added certificates to follow the s3.amazonaws.com certificate change.  Fixes
   #665 by emeyekayee.  Fixes #671 by jonforums.
@@ -4314,7 +4316,7 @@ RubyGems as it was prepared for the 2.2.0 release.
   version.)  Issue #676 by Michal Papis.  Issue wayneeseguin/rvm#2262 by
   Thomas Sänger.
 
-# 2.1.5 / 2013-09-24
+## 2.1.5 / 2013-09-24
 
 Security fixes:
 
@@ -4323,25 +4325,25 @@ Security fixes:
   including vulnerable APIs.  Fixed versions include 2.1.5, 2.0.10, 1.8.27 and
   1.8.23.2 (for Ruby 1.9.3).
 
-# 2.1.4 / 2013-09-17
+## 2.1.4 / 2013-09-17
 
-## Bug fixes:
+### Bug fixes:
 
 * `gem uninstall foo --all` now force-uninstalls all versions of foo.  Issue
   #650 by Kyle (remkade).
 * Fixed uninstalling gems installed in the home directory (as in
   `--user-install`).  Issue #653 by Lin Jen-Shin.
 
-# 2.1.3 / 2013-09-12
+## 2.1.3 / 2013-09-12
 
-## Bug fixes:
+### Bug fixes:
 
 * Gems with files entries starting with "./" no longer install 0 files.  Issue
   #644 by Darragh Curran, #645 by Brandon Turner, #646 by Alex Tambellini
 
-# 2.1.2 / 2013-09-11
+## 2.1.2 / 2013-09-11
 
-## Bug fixes:
+### Bug fixes:
 
 * Restore concurrent requires following the fix for ruby bug #8374.  Pull
   request [#637](https://github.com/rubygems/rubygems/pull/637) and issue #640 by Charles Nutter.
@@ -4350,14 +4352,14 @@ Security fixes:
 * Gem fetch now fetches the newest (not oldest) gem when --version is given.
   Issue #643 by Brian Shirai.
 
-# 2.1.1 / 2013-09-10
+## 2.1.1 / 2013-09-10
 
-## Bug fixes:
+### Bug fixes:
 
 * Only matching gems matching your local platform are considered for
   installation.  Issue #638 by José M. Prieto, issue #639 by sawanoboly.
 
-# 2.1.0 / 2013-09-09
+## 2.1.0 / 2013-09-09
 
 Security fixes:
 
@@ -4366,7 +4368,7 @@ Security fixes:
   including vulnerable APIs.  Fixed versions include 2.0.8, 1.8.26 and
   1.8.23.1 (for Ruby 1.9.3).  Issue #626 by Damir Sharipov.
 
-## Enhancements:
+### Enhancements:
 
 * RubyGems uses a new dependency resolver for gem installation which works
   similar to the bundler resolver.  The new resolver can resolve conflicts the
@@ -4442,7 +4444,7 @@ Security fixes:
   still slow, but I see a near 50% improvement for 250 gems on a fast
   connection).  See also Gem::Specification::outdated_and_latest_version
 
-## Bug fixes:
+### Bug fixes:
 
 * rubygems_plugin.rb files are now only loaded from the latest installed gem.
 * Fixed Gem.clear_paths when Security is defined at top-level.  Pull request
@@ -4450,29 +4452,29 @@ Security fixes:
 * Fixed credential creation for `gem push` when `--host` is not given.  Pull
   request [#622](https://github.com/rubygems/rubygems/pull/622) by Arthur Nogueira Neves
 
-# 2.0.17 / 2015-06-08
+## 2.0.17 / 2015-06-08
 
-## Bug fixes:
+### Bug fixes:
 
 * Tightened API endpoint checks for CVE-2015-3900
 
-# 2.0.16 / 2015-05-14
+## 2.0.16 / 2015-05-14
 
-## Bug fixes:
+### Bug fixes:
 
 * Backport: Limit API endpoint to original security domain for CVE-2015-3900.
   Fix by claudijd
 
-# 2.0.15 / 2014-12-21
+## 2.0.15 / 2014-12-21
 
-## Bug fixes:
+### Bug fixes:
 
 * Backport: Add alternate Root CA for upcoming certificate change.
   Fixes #1050 by Protosac
 
-# 2.0.14 / 2013-11-12
+## 2.0.14 / 2013-11-12
 
-## Bug fixes:
+### Bug fixes:
 
 * Gem::Specification::remove_spec no longer checks for existence of the spec
   to be removed.  Issue #698 by Tiago Macedo.
@@ -4482,9 +4484,9 @@ Security fixes:
 * The Gem::RemoteFetcher tests now choose the test server port more reliably.
   Pull Request #706 by akr.
 
-# 2.0.13 / 2013-10-24
+## 2.0.13 / 2013-10-24
 
-## Bug fixes:
+### Bug fixes:
 
 * Use class check instead of :version method check when creating Gem::Version
   objects.  Fixes #674 by jkanywhere.
@@ -4493,16 +4495,16 @@ Security fixes:
 * Fix updating gems which have multiple platforms.  Issue #693 by Ookami
   Kenrou.
 
-# 2.0.12 / 2013-10-14
+## 2.0.12 / 2013-10-14
 
-## Bug fixes:
+### Bug fixes:
 
 * Proxy usernames and passwords are now escaped properly.  Ruby Bug #8979 by
   Masahiro Tomita, Issue #668 by Kouhei Sutou.
 
-# 2.0.11 / 2013-10-08
+## 2.0.11 / 2013-10-08
 
-## Bug fixes:
+### Bug fixes:
 
 * Added certificates to follow the s3.amazonaws.com certificate change.  Fixes
   #665 by emeyekayee.  Fixes #671 by jonforums.
@@ -4517,7 +4519,7 @@ Security fixes:
   version.)  Issue #676 by Michal Papis.  Issue wayneeseguin/rvm#2262 by
   Thomas Sänger.
 
-# 2.0.10 / 2013-09-24
+## 2.0.10 / 2013-09-24
 
 Security fixes:
 
@@ -4526,16 +4528,16 @@ Security fixes:
   including vulnerable APIs.  Fixed versions include 2.1.5, 2.0.10, 1.8.27 and
   1.8.23.2 (for Ruby 1.9.3).
 
-# 2.0.9 / 2013-09-13
+## 2.0.9 / 2013-09-13
 
-## Bug fixes:
+### Bug fixes:
 
 * Gem fetch now fetches the newest (not oldest) gem when --version is given.
   Issue #643 by Brian Shirai.
 * Fixed credential creation for `gem push` when `--host` is not given.  Pull
   request [#622](https://github.com/rubygems/rubygems/pull/622) by Arthur Nogueira Neves
 
-# 2.0.8 / 2013-09-09
+## 2.0.8 / 2013-09-09
 
 Security fixes:
 
@@ -4544,14 +4546,14 @@ Security fixes:
   including vulnerable APIs.  Fixed versions include 2.0.8, 1.8.26 and
   1.8.23.1 (for Ruby 1.9.3).  Issue #626 by Damir Sharipov.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fixed Gem.clear_paths when Security is defined at top-level.  Pull request
   [#625](https://github.com/rubygems/rubygems/pull/625) by elarkin
 
-# 2.0.7 / 2013-08-15
+## 2.0.7 / 2013-08-15
 
-## Bug fixes:
+### Bug fixes:
 
 * Extensions may now be built in parallel (therefore gems may be installed in
   parallel).  Bug #607 by Hemant Kumar.
@@ -4561,9 +4563,9 @@ Security fixes:
   Patches by Yui Naruse and Koichi Sasada.
 * Fixed documentation for Kernel#require.
 
-# 2.0.6 / 2013-07-24
+## 2.0.6 / 2013-07-24
 
-## Bug fixes:
+### Bug fixes:
 
 * Fixed the `--no-install` and `-I` options to `gem list` and friends.  Bug
   #593 by Blargel.
@@ -4575,14 +4577,14 @@ Security fixes:
   Bug #599 by Chris Riesbeck
 * Restored default of remote search to `gem search`.
 
-# 2.0.5 / 2013-07-11
+## 2.0.5 / 2013-07-11
 
 * Fixed building of extensions that run ruby in their makefiles.  Bug #589 by
   Zachary Salzbank.
 
-# 2.0.4 / 2013-07-09
+## 2.0.4 / 2013-07-09
 
-## Bug fixes:
+### Bug fixes:
 
 * Fixed error caused by gem install not finding the right platform for your
   platform. Bug #576 by John Anderson
@@ -4621,9 +4623,9 @@ Security fixes:
 * Fix deprecation warnings when converting gemspecs to yaml.  Ruby commit
   r41148 by Yui Naruse
 
-# 2.0.3 / 2013-03-11
+## 2.0.3 / 2013-03-11
 
-## Bug fixes:
+### Bug fixes:
   * Reverted automatic upgrade to HTTPS as it breaks RubyGems APIs.  Fixes
     #506 by André Arko
   * Use File.realpath to remove extra / while checking if files are
@@ -4638,17 +4640,17 @@ Security fixes:
   * Fixed default gem key and cert locations.  Pull request [#511](https://github.com/rubygems/rubygems/pull/511) by Samuel
     Cochran.
 
-# 2.0.2 / 2013-03-06
+## 2.0.2 / 2013-03-06
 
-## Bug fixes:
+### Bug fixes:
   * HTTPS URLs are preferred over HTTP URLs.  RubyGems will now attempt to
     upgrade any HTTP source to HTTPS.  Credit to Alex Gaynor.
   * SSL Certificates are now installed properly.  Fixes #491 by hemanth.hm
   * Fixed HTTP to HTTPS upgrade for rubygems.org.
 
-# 2.0.1 / 2013-03-05
+## 2.0.1 / 2013-03-05
 
-## Bug fixes:
+### Bug fixes:
   * Lazily load RubyGems.org API credentials to avoid failure during
     RubyGems installation.  Bug #465 by Isaac Sanders.
   * RubyGems now picks the latest prerelease to install.  Fixes bug #468 by
@@ -4670,7 +4672,7 @@ Security fixes:
     Ruby bug #7713 by nobu
   * Fix tests when an 'a.rb' exists.  Ruby bug #7749 by nobu.
 
-# 2.0.0 / 2013-02-24
+## 2.0.0 / 2013-02-24
 
 RubyGems 2.0 includes several new features and many breaking changes.  Some of
 these changes will cause existing software to break.  These changes are a
@@ -4682,7 +4684,7 @@ newer.  Older versions of bundler will not work with RubyGems 2.0.
 
 Changes since RubyGems 1.8.25 (including past pre-releases):
 
-## Breaking changes:
+### Breaking changes:
 
   * Deprecated Gem.unresolved_deps in favor of
     Gem::Specification.unresolved_deps
@@ -4704,7 +4706,7 @@ Changes since RubyGems 1.8.25 (including past pre-releases):
   * Removed support for Ruby 1.9.1
   * Removed many deprecated methods
 
-## Enhancements:
+### Enhancements:
 
   * Improved support for default gems shipping with ruby 2.0.0+
   * A gem can have arbitrary metadata through Gem::Specification#metadata
@@ -4764,7 +4766,7 @@ Changes since RubyGems 1.8.25 (including past pre-releases):
     GEM_HOME
   * When building gems with non-world-readable files a warning is shown.
 
-## Bug fixes:
+### Bug fixes:
   * Gem.refresh now maintains the active gem list.  Clearing the list would
     cause double-loads which would cause other bugs.  Pull Request #427 by
     Jeremy Evans
@@ -4821,7 +4823,7 @@ Changes since RubyGems 1.8.25 (including past pre-releases):
 
 Changes since RubyGems 2.0.0.rc.2:
 
-## Bug fixes:
+### Bug fixes:
   * Gem.gzip and Gem.gunzip now return strings with BINARY encoding.  Issue
     #450 by Jeremy Kemper
   * Fixed placement of executables with --user-install.  Ruby bug #7779 by Jon
@@ -4834,48 +4836,48 @@ Changes since RubyGems 2.0.0.rc.2:
   * Fixed verification of gems at LowSecurity due to missing signature.
     Thanks to André Arko.
 
-# 2.0.0.rc.2 / 2013-02-08
+## 2.0.0.rc.2 / 2013-02-08
 
-## Bug fixes:
+### Bug fixes:
   * Fixed signature verification of gems which was broken only on master.
     Thanks to Brian Buchanan.
   * Proper exceptions are raised when verifying an unsigned gem.  Thanks to
     André Arko.
 
-# 2.0.0.rc.1 / 2013-01-08
+## 2.0.0.rc.1 / 2013-01-08
 
-## Enhancements:
+### Enhancements:
   * This release of RubyGems can push gems to rubygems.org.  Ordinarily
     prerelease versions of RubyGems cannot push gems.
   * Added `gem check --doctor` to clean up after failed uninstallation.  Bug
     #419 by Erik Hollensbe
 
-## Bug fixes:
+### Bug fixes:
   * Fixed exception raised when attempting to push gems to rubygems.org.  Bug
     #418 by André Arko
   * Gem installation will fail if RubyGems cannot load the specification from
     the gem.  Bug #419 by Erik Hollensbe
 
-# 2.0.0.preview2.2 / 2012-12-14
+## 2.0.0.preview2.2 / 2012-12-14
 
-## Enhancements:
+### Enhancements:
   * Added a cmake builder.  Pull request [#265](https://github.com/rubygems/rubygems/pull/265) by Allan Espinosa.
   * Removed rubyforge page from gem list output
 
-## Bug fixes:
+### Bug fixes:
   * Restored RubyGems 1.8 packaging behavior of omitting directories.  Bug
     #413 by Jeremy Kemper.
 
-# 2.0.0.preview2.1 / 2012-12-08
+## 2.0.0.preview2.1 / 2012-12-08
 
-## Enhancements:
+### Enhancements:
   * Gem::DependencyInstaller now passes build_args down to the installer.
     Pull Request #412 by Sam Rawlins.
   * RubyGems no longer defaults to uninstalling gems if a dependency would be
     broken.  Now you must manually say "yes".  Pull Request #406 by Shannon
     Skipper.
 
-## Bug fixes:
+### Bug fixes:
   * RubyGems tests now run in FIPS mode.  Issue #365 by Vít Ondruch
   * Fixed Gem::Specification#base_dir for default gems.  Ruby Bug #7469
   * Only update the spec cache when we have permission.  Ruby Bug #7509
@@ -4887,13 +4889,13 @@ Changes since RubyGems 2.0.0.rc.2:
   * gem install now ignores directories that match the gem to install.  Bug
     #407 by Santiago Pastorino.
 
-# 2.0.0.preview2 / 2012-12-01
+## 2.0.0.preview2 / 2012-12-01
 
 This release contains two commits not present in Ruby 2.0.0.preview2.  One
 commit is for ruby 1.8.7 support, the second allows RubyGems to work under
 $SAFE=1.  There is no functional difference compared to Ruby 2.0.0.preview2
 
-## Breaking changes:
+### Breaking changes:
 
   * Deprecated Gem.unresolved_deps in favor of
     Gem::Specification.unresolved_deps
@@ -4915,7 +4917,7 @@ $SAFE=1.  There is no functional difference compared to Ruby 2.0.0.preview2
   * Removed support for Ruby 1.9.1
   * Removed many deprecated methods
 
-## Enhancements:
+### Enhancements:
 
   * Improved support for default gems shipping with ruby 2.0.0+
   * A gem can have arbitrary metadata through Gem::Specification#metadata
@@ -4966,7 +4968,7 @@ $SAFE=1.  There is no functional difference compared to Ruby 2.0.0.preview2
     GEM_HOME
   * When building gems with non-world-readable files a warning is shown.
 
-## Bug fixes:
+### Bug fixes:
 
   * Added PID to setup bin_file while installing RubyGems to protect against
     errors. Fixes #328 by ConradIrwin
@@ -5007,17 +5009,17 @@ $SAFE=1.  There is no functional difference compared to Ruby 2.0.0.preview2
   * URI scheme matching is no longer case-sensitive.  Fixes #322
   * ext/builder now checks $MAKE as well as $make (okkez)
 
-# 1.8.29 / 2013-11-23
+## 1.8.29 / 2013-11-23
 
-## Bug fixes:
+### Bug fixes:
 
 * Fixed installation when the LANG environment variable is empty.
 * Added DigiCert High Assurance EV Root CA to the default SSL certificates for
   cloudfront.
 
-# 1.8.28 / 2013-10-08
+## 1.8.28 / 2013-10-08
 
-## Bug fixes:
+### Bug fixes:
 
 * Added the Verisign Class 3 Public Primary Certification Authority G5
   certificate and its intermediary to follow the s3.amazonaws.com certificate
@@ -5027,7 +5029,7 @@ $SAFE=1.  There is no functional difference compared to Ruby 2.0.0.preview2
 * Added test for missing certificates for https://s3.amazonaws.com or
   https://rubygems.org.  Pull request [#673](https://github.com/rubygems/rubygems/pull/673) by Hannes Georg.
 
-# 1.8.27 / 2013-09-24
+## 1.8.27 / 2013-09-24
 
 Security fixes:
 
@@ -5036,7 +5038,7 @@ Security fixes:
   including vulnerable APIs.  Fixed versions include 2.1.5, 2.0.10, 1.8.27 and
   1.8.23.2 (for Ruby 1.9.3).
 
-# 1.8.26 / 2013-09-09
+## 1.8.26 / 2013-09-09
 
 Security fixes:
 
@@ -5045,13 +5047,13 @@ Security fixes:
   including vulnerable APIs.  Fixed versions include 2.0.8, 1.8.26 and
   1.8.23.1 (for Ruby 1.9.3).  Issue #626 by Damir Sharipov.
 
-## Bug fixes:
+### Bug fixes:
 
 * Fixed editing of a Makefile with 8-bit characters.  Fixes #181
 
-# 1.8.25 / 2013-01-24
+## 1.8.25 / 2013-01-24
 
-## Bug fixes:
+### Bug fixes:
   * Added 11627 to setup bin_file location to protect against errors. Fixes
     #328 by ConradIrwin
   * Specification#ruby_code didn't handle Requirement with multiple
@@ -5060,14 +5062,14 @@ Security fixes:
   * Fix missing load_yaml in YAML-related requirement.rb code.
   * Manually backport encoding-aware YAML gemspec
 
-# 1.8.24 / 2012-04-27
+## 1.8.24 / 2012-04-27
 
-## Bug fixes:
+### Bug fixes:
 
   * Install the .pem files properly. Fixes #320
   * Remove OpenSSL dependency from the http code path
 
-# 1.8.23.2 / 2013-09-24
+## 1.8.23.2 / 2013-09-24
 
 Security fixes:
 
@@ -5076,7 +5078,7 @@ Security fixes:
   including vulnerable APIs.  Fixed versions include 2.1.5, 2.0.10, 1.8.27 and
   1.8.23.2 (for Ruby 1.9.3).
 
-# 1.8.23.1 / 2013-09-09
+## 1.8.23.1 / 2013-09-09
 
 Security fixes:
 
@@ -5085,7 +5087,7 @@ Security fixes:
   including vulnerable APIs.  Fixed versions include 2.0.8, 1.8.26 and
   1.8.23.1 (for Ruby 1.9.3).  Issue #626 by Damir Sharipov.
 
-# 1.8.23 / 2012-04-19
+## 1.8.23 / 2012-04-19
 
 This release increases the security used when RubyGems is talking to
 an https server. If you use a custom RubyGems server over SSL, this
@@ -5105,49 +5107,49 @@ Security fixes:
   * Disallow redirects from https to http
   * Turn on verification of server SSL certs
 
-## Enhancements:
+### Enhancements:
   * Add --clear-sources to fetch
 
-## Bug fixes:
+### Bug fixes:
   * Use File.identical? to check if two files are the same.
   * Fixed init_with warning when using psych
 
-# 1.8.22 / 2012-04-13
+## 1.8.22 / 2012-04-13
 
-## Bug fixes:
+### Bug fixes:
 
   * Workaround for psych/syck YAML date parsing issue
   * Don't trust the encoding of ARGV. Fixes #307
   * Quiet default warnings about missing spec variables
   * Read a binary file properly (windows fix)
 
-# 1.8.21 / 2012-03-22
+## 1.8.21 / 2012-03-22
 
-## Bug fixes:
+### Bug fixes:
 
   * Add workaround for buggy yaml output from 1.9.2
   * Force 1.9.1 to remove it's prelude code. Fixes #305
 
-# 1.8.20 / 2012-03-21
+## 1.8.20 / 2012-03-21
 
-## Bug fixes:
+### Bug fixes:
 
   * Add --force to `gem build` to skip validation. Fixes #297
   * Gracefully deal with YAML::PrivateType objects in Marshal'd gemspecs
   * Treat the source as a proper url base. Fixes #304
   * Warn when updating the specs cache fails. Fixes #300
 
-# 1.8.19 / 2012-03-14
+## 1.8.19 / 2012-03-14
 
-## Bug fixes:
+### Bug fixes:
 
   * Handle loading psych vs syck properly. Fixes #298
   * Make sure Date objects don't leak in via Marshal
   * Perform Date => Time coercion on yaml loading. Fixes #266
 
-# 1.8.18 / 2012-03-11
+## 1.8.18 / 2012-03-11
 
-## Bug fixes:
+### Bug fixes:
 
   * Use Psych API to emit more compatible YAML
   * Download and write inside `gem fetch` directly. Fixes #289
@@ -5155,14 +5157,14 @@ Security fixes:
   * Search everywhere for a spec for `gem spec`. Fixes #288
   * Fix Gem.all_load_path. Fixes #171
 
-# 1.8.17 / 2012-02-17
+## 1.8.17 / 2012-02-17
 
-## Enhancements:
+### Enhancements:
 
   * Add MacRuby to the list of special cases for platforms (ferrous26)
   * Add a default for where to install rubygems itself
 
-## Bug fixes:
+### Bug fixes:
 
   * Fixed gem loading issue caused by dependencies not resolving.
   * Fixed umask error when stdlib is required and unresolved dependencies exist.
@@ -5170,59 +5172,59 @@ Security fixes:
   * Define SUCKAGE better, ie only MRI 1.9.2
   * Propagate env-shebang to the pristine command if set for install.
 
-# 1.8.16 / 2012-02-12
+## 1.8.16 / 2012-02-12
 
-## Bug fixes:
+### Bug fixes:
 
   * Fix gem specification loading when encoding is not UTF-8. #146
   * Allow group writable if umask allows it already.
   * Uniquify the spec list based on directory order priority
 
-# 1.8.15 / 2012-01-06
+## 1.8.15 / 2012-01-06
 
-## Bug fixes:
+### Bug fixes:
 
   * Don't eager load yaml, it creates a bad loop. Fixes #256
 
-# 1.8.14 / 2012-01-05
+## 1.8.14 / 2012-01-05
 
-## Bug fixes:
+### Bug fixes:
 
   * Ignore old/bad cache data in Version
   * Make sure our YAML workarounds are loaded properly. Fixes #250.
 
-# 1.8.13 / 2011-12-21
+## 1.8.13 / 2011-12-21
 
-## Bug fixes:
+### Bug fixes:
 
   * Check loaded_specs properly when trying to satisfy a dep
 
-## Enhancements:
+### Enhancements:
 
   * Remove using #loaded_path? for performance
   * Remove Zlib workaround for Windows build.
 
-# 1.8.12 / 2011-12-02
+## 1.8.12 / 2011-12-02
 
-## Bug fixes:
+### Bug fixes:
 
   * Handle more cases where Syck's DefaultKey showed up in requirements
     and wasn't cleaned out.
 
-# 1.8.11 / 2011-10-03
+## 1.8.11 / 2011-10-03
 
-## Bug fixes:
+### Bug fixes:
 
   * Deprecate was moved to Gem::Deprecate to stop polluting the top-level
     namespace.
 
-# 1.8.10 / 2011-08-25
+## 1.8.10 / 2011-08-25
 
 RubyGems 1.8.10 contains a security fix that prevents malicious gems from
 executing code when their specification is loaded.  See
 https://github.com/rubygems/rubygems/pull/165 for details.
 
-## Bug fixes:
+### Bug fixes:
 
   * RubyGems escapes strings in ruby-format specs using #dump instead of #to_s
     and %q to prevent code injection.  Issue #165 by Postmodern
@@ -5233,21 +5235,21 @@ https://github.com/rubygems/rubygems/pull/165 for details.
   * Fixed Syck DefaultKey infecting ruby-format specifications.
   * `gem uninstall a b` no longer stops if gem "a" is not installed.
 
-# 1.8.9 / 2011-08-23
+## 1.8.9 / 2011-08-23
 
-## Bug fixes:
+### Bug fixes:
 
   * Fixed uninstalling multiple gems using `gem uninstall`
   * Gem.use_paths splatted to take multiple paths!  Issue #148
 
-# 1.8.8 / 2011-08-11
+## 1.8.8 / 2011-08-11
 
-## Bug fixes:
+### Bug fixes:
   * The encoding of a gem's YAML spec is now UTF-8.  Issue #149
 
-# 1.8.7 / 2011-08-04
+## 1.8.7 / 2011-08-04
 
-## Bug fixes:
+### Bug fixes:
   * Added missing require for `gem uninstall --format-executable`
   * The correct name of the executable being uninstalled is now displayed with
     --format-executable
@@ -5259,14 +5261,14 @@ https://github.com/rubygems/rubygems/pull/165 for details.
   * Gem repository directories are no longer created world-writable.  Patch by
     Sakuro OZAWA.  Ruby Bug #4930
 
-# 1.8.6 / 2011-07-25
+## 1.8.6 / 2011-07-25
 
-## Enhancements:
+### Enhancements:
 
   * Add autorequires and delay startup of RubyGems until require is called.
     See Ruby bug #4962
 
-## Bug fixes:
+### Bug fixes:
 
   * Restore behavior of Gem::Specification#loaded?  Ruby Bug #5032
   * Clean up SourceIndex.add_specs to not be so damn noisy. (tadman)
@@ -5278,27 +5280,27 @@ https://github.com/rubygems/rubygems/pull/165 for details.
   * Handle the Syck DefaultKey problem once and for all.
   * Fix SystemStackError occurring with "gem list -r -a" on 1.9.
 
-# 1.8.5 / 2011-05-31
+## 1.8.5 / 2011-05-31
 
-## Enhancements:
+### Enhancements:
 
   * The -u option to 'update local source cache' is official deprecated.
   * Remove has_rdoc deprecations from Specification.
 
-## Bug fixes:
+### Bug fixes:
 
   * Handle bad specs more gracefully.
   * Reset any Gem paths changed in the installer.
 
-# 1.8.4 / 2011-05-25
+## 1.8.4 / 2011-05-25
 
-## Enhancements:
+### Enhancements:
 
   * Removed default_executable deprecations from Specification.
 
-# 1.8.3 / 2011-05-19
+## 1.8.3 / 2011-05-19
 
-## Bug fixes:
+### Bug fixes:
 
   * Fix independent testing of test_gem_package_tar_output.  Ruby Bug #4686 by
     Shota Fukumori
@@ -5307,33 +5309,33 @@ https://github.com/rubygems/rubygems/pull/165 for details.
   * Fixed some bad calls left behind after rolling out some refactorings.
   * Syck has a parse error on (good) times output from Psych. (dazuma, et al)
 
-# 1.8.2 / 2011-05-11
+## 1.8.2 / 2011-05-11
 
-## Enhancements:
+### Enhancements:
 
   * Moved #outdated from OutdatedCommand to Specification (for Isolate).
   * Print out a warning about missing executables.
 
-## Bug fixes:
+### Bug fixes:
 
   * Added missing requires to fix various upgrade issues.
   * `gem pristine` respects multiple gem repositories.
   * setup.rb now execs with --disable-gems when possible
 
-# 1.8.1 / 2011-05-05
+## 1.8.1 / 2011-05-05
 
-## Enhancements:
+### Enhancements:
 
   * Added Gem::Requirement#specific? and Gem::Dependency#specific?
 
-## Bug fixes:
+### Bug fixes:
 
   * Typo on Indexer rendered it useless on Windows
   * gem dep can fetch remote dependencies for non-latest gems again.
   * gem uninstall with multiple versions no longer crashes with ArgumentError
   * Always use binary mode for File.open to keep Windows happy
 
-# 1.8.0 / 2011-04-34
+## 1.8.0 / 2011-04-34
 
 This release focused on properly encapsulating functionality.  Most of this
 work focused on moving functionality out of Gem::SourceIndex and
@@ -5348,7 +5350,7 @@ extensions.  You will need to run `gem pristine gem_with_extension --
 --build-arg` to regenerate a gem with an extension where it requires special
 build arguments.
 
-## Deprecations:
+### Deprecations:
 
   * DependencyList.from_source_index deprecated the source_index argument.
   * Deprecated Dependency.new(/regex/).
@@ -5369,7 +5371,7 @@ build arguments.
   * Deprecated all of Gem::GemPathSearcher.
   * Deprecated Gem::Specification#default_executable.
 
-## Enhancements:
+### Enhancements:
 
   * Gem::SourceIndex functionality has been moved to Gem::Specification.
     Gem::SourceIndex is completely disconnected from Gem::Specification
@@ -5421,7 +5423,7 @@ build arguments.
     extensions.
   * `gem pristine` can now restore multiple gems.
 
-## Bug fixes:
+### Bug fixes:
 
   * DependencyInstaller passed around a source_index instance but used
     Gem.source_index.
@@ -5433,15 +5435,15 @@ build arguments.
   * `gem pristine` can now restore non-latest gems where the cached gem was
     removed.
 
-# 1.7.1 / 2011-03-32
+## 1.7.1 / 2011-03-32
 
-## Bug fixes:
+### Bug fixes:
   * Fixed missing file in Manifest.txt.  (Also a bug in hoe was fixed where
     `rake check_manifest` showing a diff would not exit with an error.)
 
-# 1.7.0 / 2011-03-32
+## 1.7.0 / 2011-03-32
 
-## Deprecations:
+### Deprecations:
   * Deprecated Gem.all_load_paths, latest_load_paths, promote_load_path, and
     cache.
   * Deprecated RemoteFetcher#open_uri_or_path.
@@ -5453,7 +5455,7 @@ build arguments.
     test_suite_file(=).
   * Deprecated Specification#has_rdoc= and default_executable=
 
-## Enhancements:
+### Enhancements:
   * Added stupid simple deprecation module.
   * Added --spec option to `gem unpack` to output a gem's original metadata
   * Added packaging option to Specification#validate
@@ -5485,7 +5487,7 @@ build arguments.
   * UpdateCommand#gems_to_update now returns (name, version) pairs.
   * UpdateCommand#which_to_update now takes an optional system argument.
 
-## Bug fixes:
+### Bug fixes:
   * Added missing remote fetcher require to pristine command (aarnell)
   * Building gems now checks to ensure all required fields are non-nil
   * Fix option parser when summary is nil.
@@ -5501,17 +5503,17 @@ build arguments.
     Elias Baixas
   * `gem update` now uniq's command line arguments.
 
-# 1.6.2 / 2011-03-08
+## 1.6.2 / 2011-03-08
 
-## Bug fixes:
+### Bug fixes:
 
 * require of an activated gem could cause activation conflicts.  Fixes
   Bug #29056 by Dave Verwer.
 * `gem outdated` now works with up-to-date prerelease gems.
 
-# 1.6.1 / 2011-03-03
+## 1.6.1 / 2011-03-03
 
-## Bug fixes:
+### Bug fixes:
 
 * Installation no longer fails when a dependency from a version that won't be
   installed is unsatisfied.
@@ -5520,9 +5522,9 @@ build arguments.
 * Gem files are cached correctly again.  Patch #29051 by Mamoru Tasaka.
 * Tests now pass with non-022 umask.  Patch #29050 by Mamoru Tasaka.
 
-# 1.6.0 / 2011-02-29
+## 1.6.0 / 2011-02-29
 
-## Deprecations:
+### Deprecations:
 
 * RubyGems no longer requires 'thread'.  Rails < 3 will need to add require
   'thread' to their applications.
@@ -5531,7 +5533,7 @@ build arguments.
 * Gem::LoadError#version_requirements has been removed.  Use
   Gem::LoadError#requirement.
 
-## Enhancements:
+### Enhancements:
 
 * Rewrote how Gem::activate (gem and require) resolves dependencies.
 * Gem::LoadError#version_requirement has been removed. Use
@@ -5559,7 +5561,7 @@ build arguments.
   locally cached gem specifications.
 * SpecFetcher.fetch_spec can now take a string source_uri.
 
-## Bug fixes:
+### Bug fixes:
 
 * Added missing require of Gem::RemoteFetcher to the unpack command.
 * RubyGems now completely removes a previous install when reinstalling.
@@ -5572,28 +5574,26 @@ build arguments.
 * Gem::Security used FileUtils but didn't require it.  Reported by Elia Schito.
 * Gem::Uninstaller now respects --format-executable.
 
-# 1.5.3 / 2011-02-26
+## 1.5.3 / 2011-02-26
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix for a bug in Syck which causes install failures for gems packaged with
   Psych.  Bug #28965 by Aaron Patterson.
 
-# 1.5.2 / 2011-02-10
+## 1.5.2 / 2011-02-10
 
-## Bug fixes:
+### Bug fixes:
 
 * Fixed <tt>gem update --system</tt>.  RubyGems can now update itself again.
 
-# 1.5.1 / 2011-02-09
+## 1.5.1 / 2011-02-09
 
-#= NOTE: `gem update --system` is broken. See UPGRADING.rdoc.
-
-## Enhancements:
+### Enhancements:
 
 * Added ability to do gem update --system X.Y.Z.
 
-## Bug fixes:
+### Bug fixes:
 
 * Scrub !!null YAML from 1.9.2 (install and build).
 * Added missing requires for user_interaction.
@@ -5602,11 +5602,9 @@ build arguments.
 * Fixed SilentUI for cygwin; try /dev/null first then fall back to NUL.
 * RubyGems now enforces ruby 1.8.7 or newer.
 
-# 1.5.0 / 2011-01-31
+## 1.5.0 / 2011-01-31
 
-#= NOTE: `gem update --system` is broken. See UPGRADING.rdoc.
-
-## Enhancements:
+### Enhancements:
 
 * Finally fixed all known 1.9.x issues. Upgrading is now possible!
 * Merged huge 1.3.7/ruby-core changes to master.
@@ -5621,7 +5619,7 @@ build arguments.
 * Gem::SilentUI now behaves like Gem::StreamUI for asking questions.  Patch by
   Erik Hollensbe.
 
-## Bug fixes:
+### Bug fixes:
 
 * `gem update` was implicitly doing --system.
 * 1.9.3: Fixed encoding errors causing gem installs to die during rdoc phase.
@@ -5633,25 +5631,25 @@ build arguments.
   Erik Hollensbe.
 * rubygems-update lists its development dependencies again
 
-# 1.4.2 / 2011-01-06
+## 1.4.2 / 2011-01-06
 
-## Bug fixes:
+### Bug fixes:
 
 * Gem::Versions: "1.b1" != "1.b.1", but "1.b1" eql? "1.b.1". Fixes gem indexing.
 * Fixed Gem.find_files.
 * Removed otherwise unused #find_all_dot_rb. Only 6 days old and hella buggy.
 
-# 1.4.1 / 2010-12-31
+## 1.4.1 / 2010-12-31
 
 Since apparently nobody reads my emails, blog posts or the README:
 
 DO NOT UPDATE RUBYGEMS ON RUBY 1.9! See UPGRADING.rdoc for details.
 
-## Bug fixes:
+### Bug fixes:
 
 * Specification#load was untainting a frozen string (via `gem build *.spec`)
 
-# 1.4.0 / 2010-12-30
+## 1.4.0 / 2010-12-30
 
 NOTE: In order to better maintain rubygems and to get it in sync with
 the world (eg, 1.9's 1.3.7 is different from our 1.3.7), rubygems is
@@ -5661,7 +5659,7 @@ You have been warned!
 
 NOTE: We've switched to git/github. See README.rdoc for details.
 
-## Features:
+### Features:
 
 * Added --launch option to `gem server`. (gthiesfeld)
 * Added fuzzy name matching on install failures. (gstark/presidentbeef)
@@ -5671,7 +5669,7 @@ NOTE: We've switched to git/github. See README.rdoc for details.
 * --source is now additive with your current sources.
   Use --clear-sources first to maintain previous behavior.
 
-## Bug fixes:
+### Bug fixes:
 
 * Dependency "~>"s now respect lower-bound prerelease versions.
 * Ensure the gem directories exist on download.
@@ -5682,7 +5680,7 @@ NOTE: We've switched to git/github. See README.rdoc for details.
   Do not depend on rubygems to require stdlib stuff for you. (raggi/tmm1)
 * Treat 1.0.a10 like 1.0.a.10 for sorting, etc. Fixes #27903. (dchelimsky)
 
-# 1.3.7 / 2010-05-13
+## 1.3.7 / 2010-05-13
 
 NOTE:
 
@@ -5693,7 +5691,7 @@ http://gems.rubyforge.org with https://rubygems.org/
 
 http://gems.rubyforge.org will continue to work for the foreseeable future.
 
-## Features:
+### Features:
 
 * `gem` commands
   * `gem install` and `gem fetch` now report alternate platforms when a
@@ -5712,7 +5710,7 @@ http://gems.rubyforge.org will continue to work for the foreseeable future.
     in 1.3.6)
 * RubyGems now has platform support for IronRuby.  Patch #27951 by Will Green.
 
-## Bug fixes:
+### Bug fixes:
 
 * Require rubygems/custom_require if --disable-gem was set.  Bug #27700 by
   Roger Pack.
@@ -5724,9 +5722,9 @@ http://gems.rubyforge.org will continue to work for the foreseeable future.
 * Gem::PackageTask depends on the package dir like the other rake package
   tasks so dependencies can be hooked up correctly.
 
-# 1.3.6 / 2010-02-17
+## 1.3.6 / 2010-02-17
 
-## Features:
+### Features:
 
 * `gem` commands
   * Added `gem push` and `gem owner` for interacting with modern/Gemcutter
@@ -5738,7 +5736,7 @@ http://gems.rubyforge.org will continue to work for the foreseeable future.
     force rebuilding.  Patch #25982 by Akinori MUSHA.
 * Capital letters are now allowed in prerelease versions.
 
-## Bug fixes:
+### Bug fixes:
 
 * Development deps are no longer added to rubygems-update gem so older
   versions can update successfully.
@@ -5757,7 +5755,7 @@ http://gems.rubyforge.org will continue to work for the foreseeable future.
 * Gem::RemoteFetcher no longer copies the file if it is where we want it.
   Patch #27409 by Jakub Šťastný.
 
-## Deprecations:
+### Deprecations:
 
 * lib/rubygems/timer.rb has been removed.
 * Gem::Dependency#version_requirements is deprecated and will be removed on or
@@ -5766,23 +5764,23 @@ http://gems.rubyforge.org will continue to work for the foreseeable future.
 * Gem::manage_gems was removed in 1.3.3.
 * Time::today was removed in 1.3.3.
 
-# 1.3.5 / 2009-07-21
+## 1.3.5 / 2009-07-21
 
-## Bug fixes:
+### Bug fixes:
 
 * Fix use of prerelease gems.
 * Gem.bin_path no longer escapes path with spaces. Bug #25935 and #26458.
 
-## Deprecations:
+### Deprecations:
 
 * Bulk index update is no longer supported (the code currently remains, but not
   the tests)
 * Gem::manage_gems was removed in 1.3.3.
 * Time::today was removed in 1.3.3.
 
-# 1.3.4 / 2009-05-03
+## 1.3.4 / 2009-05-03
 
-## Bug fixes:
+### Bug fixes:
 
 * Fixed various warnings
 * Gem::ruby_version works correctly for 1.8 branch and trunk
@@ -5793,16 +5791,16 @@ http://gems.rubyforge.org will continue to work for the foreseeable future.
   drives.  Bug #25882 by Lars Christensen
 * Fix typo in Gem::Requirement#parse.  Bug #26000 by Mike Gunderloy.
 
-## Deprecations:
+### Deprecations:
 
 * Bulk index update is no longer supported (the code currently remains, but not
   the tests)
 * Gem::manage_gems was removed in 1.3.3.
 * Time::today was removed in 1.3.3.
 
-# 1.3.3 / 2009-05-04
+## 1.3.3 / 2009-05-04
 
-## Features:
+### Features:
 
 * `gem server` allows port names (from /etc/services) with --port.
 * `gem server` now has search that jumps to RDoc.  Patch #22959 by Vladimir
@@ -5812,7 +5810,7 @@ http://gems.rubyforge.org will continue to work for the foreseeable future.
 * Gem::Specification#has_rdoc= is deprecated and ignored (defaults to true)
 * RDoc is now generated regardless of Gem::Specification#has_rdoc?
 
-## Bug fixes:
+### Bug fixes:
 
 * `gem clean` now cleans up --user-install gems.  Bug #25516 by Brett
   Eisenberg.
@@ -5834,15 +5832,15 @@ http://gems.rubyforge.org will continue to work for the foreseeable future.
 * Raise Gem::LoadError if Kernel#gem fails due to previously-loaded gem.  Bug
   reported by Alf Mikula.
 
-## Deprecations:
+### Deprecations:
 
 * Gem::manage_gems has been removed.
 * Time::today has been removed early.  There was no way to make it warn and be
   easy to override with user code.
 
-# 1.3.2 / 2009-04-15
+## 1.3.2 / 2009-04-15
 
-## Features:
+### Features:
 
 * RubyGems now loads plugins from rubygems_plugin.rb in installed gems.
   This can be used to add commands (See Gem::CommandManager) or add
@@ -5858,9 +5856,9 @@ http://gems.rubyforge.org will continue to work for the foreseeable future.
 * Various improvements to build arguments for installing gems.
 * `gem contents` added --all and --no-prefix.
 * Gem::Specification
-  * #validate strips directories and errors on not-files.
-  * #description no longer removes newlines.
-  * #name must be a String.
+  * `#validate` strips directories and errors on not-files.
+  * `#description` no longer removes newlines.
+  * `#name` must be a String.
   * FIXME and TODO are no longer allowed in various fields.
   * Added support for a license attribute.  Feature #11041 (partial).
   * Removed Gem::Specification::list, too much process growth.  Bug #23668 by
@@ -5870,7 +5868,7 @@ http://gems.rubyforge.org will continue to work for the foreseeable future.
   * Modern indices can now be updated incrementally.
   * Legacy indices can be updated separately from modern.
 
-## Bug fixes:
+### Bug fixes:
 
 * Better gem activation error message. Patch #23082.
 * Kernel methods are now private.  Patch #20801 by James M. Lawrence.
@@ -5896,7 +5894,7 @@ http://gems.rubyforge.org will continue to work for the foreseeable future.
   * Deal with extraneous quotation mark when autogenerating .bat file on MS
     Windows.  Bug #22712.
 
-## Deprecations:
+### Deprecations:
 
 * Gem::manage_gems has been removed.
 * Time::today will be removed in RubyGems 1.4.
@@ -5904,9 +5902,9 @@ http://gems.rubyforge.org will continue to work for the foreseeable future.
 Special thanks to Chad Wooley for backwards compatibility testing and Luis
 Lavena and Daniel Berger for continuing windows support.
 
-# 1.3.1 / 2008-10-28
+## 1.3.1 / 2008-10-28
 
-## Bug fixes:
+### Bug fixes:
 
 * Disregard ownership of ~ under Windows while creating ~/.gem.  Fixes
   issues related to no uid support under Windows.
@@ -5917,13 +5915,13 @@ Lavena and Daniel Berger for continuing windows support.
 * Gem::location_of_caller now behaves on Windows.  Patch by Daniel Berger.
 * Silence PATH warning.
 
-## Deprecations:
+### Deprecations:
 
 * Gem::manage_gems will be removed on or after March 2009.
 
-# 1.3.0 / 2008-09-25
+## 1.3.0 / 2008-09-25
 
-## Features:
+### Features:
 
 * RubyGems doesn't print LOCAL/REMOTE titles for `gem query` and friends if
   stdout is not a TTY, except with --both.
@@ -5937,12 +5935,12 @@ Lavena and Daniel Berger for continuing windows support.
 * RubyGems now updates the ri cache when the rdoc gem is installed and
   documentation is generated.
 
-## Deprecations:
+### Deprecations:
 
 * Gem::manage_gems now warns when called.  It will be removed on or after March
   2009.
 
-## Bug fixes:
+### Bug fixes:
 
 * RubyGems 1.3.0+ now updates when no previous rubygems-update is installed.
   Bug #20775 by Hemant Kumar.
@@ -5966,7 +5964,7 @@ Lavena and Daniel Berger for continuing windows support.
 * `gem lock --strict` works again.  Patch #21814 by Sven Engelhardt.
 * Platform detection for Solaris was improved.  Patch #21911 by Bob Remeika.
 
-## Enhancements:
+### Enhancements:
 
 * `gem help install` now describes _version_ argument to executable stubs
 * `gem help environment` describes environment variables and ~/.gemrc and
@@ -5992,9 +5990,9 @@ Lavena and Daniel Berger for continuing windows support.
 * test/test_ext_configure_builder.rb
   * Locale-free patch by Yusuke Endoh [ruby-core:17444].
 
-# 1.2.0 / 2008-06-21
+## 1.2.0 / 2008-06-21
 
-## Features:
+### Features:
 
 * RubyGems no longer performs bulk updates and instead only fetches the gemspec
   files it needs.  Alternate sources will need to upgrade to RubyGems 1.2 to
@@ -6013,7 +6011,7 @@ Lavena and Daniel Berger for continuing windows support.
 * setup.rb now handles --vendor and --destdir for packagers
 * `gem stale` command that lists gems by last access time
 
-## Bug fixes:
+### Bug fixes:
 
 * File modes from gems are now honored, patch #19737
 * Marshal Gem::Specification objects from the future can now be loaded.
@@ -6028,7 +6026,7 @@ Lavena and Daniel Berger for continuing windows support.
 * Gem::DependencyInstaller resets installed gems every install, bug #19444
 * Gem.default_path is now honored if GEM_PATH is not set, patch #19502
 
-## Enhancements:
+### Enhancements:
 
 * setup.rb
   * stub files created by RubyGems 0.7.x and older are no longer removed.  When
@@ -6047,9 +6045,9 @@ Lavena and Daniel Berger for continuing windows support.
 * Gem::RemoteFetcher now performs persistent connections for HEAD requests,
   bug #7973
 
-# 1.1.1 / 2008-04-11
+## 1.1.1 / 2008-04-11
 
-## Bug fixes:
+### Bug fixes:
 
 * Gem.prefix now returns non-nil only when RubyGems was installed outside
   sitelibdir or libdir.
@@ -6064,9 +6062,9 @@ Lavena and Daniel Berger for continuing windows support.
 * Gem::RemoteFetcher handles Errno::ECONNABORTED.
 * Printing of release notes fixed.
 
-# 1.1.0 / 2008-03-29
+## 1.1.0 / 2008-03-29
 
-## Features:
+### Features:
 
 * RubyGems now uses persistent connections on index updates.  Index updates are
   much faster now.
@@ -6078,7 +6076,7 @@ Lavena and Daniel Berger for continuing windows support.
 * `gem spec` now extracts specifications from .gem files.
 * `gem query --installed` to aid automation of checking for gems.
 
-## Bug fixes:
+### Bug fixes:
 
 * RubyGems works with both Config and RbConfig now.
 * Executables are now cleaned upon uninstall.
@@ -6094,7 +6092,7 @@ Lavena and Daniel Berger for continuing windows support.
 * Gem stub scripts on windows now work outside Gem.bindir.
 * `gem sources -r` now works without network access.
 
-## Enhancements:
+### Enhancements:
 
 * RubyGems now requires Ruby > 1.8.3.
 * Release notes are now printed upon installation.
@@ -6105,26 +6103,26 @@ Lavena and Daniel Berger for continuing windows support.
 
 For a full list of changes to RubyGems, see the git log.
 
-# 1.0.1 / 2007-12-20
+## 1.0.1 / 2007-12-20
 
-## Bug fixes:
+### Bug fixes:
 
 * Installation on Ruby 1.8.3 through 1.8.5 fixed
 * `gem build` on 1.8.3 fixed
 
-## Enhancements:
+### Enhancements:
 
 * Since RubyGems 0.9.5, RubyGems is no longer supported on Ruby 1.8.2 or older,
   this is official in RubyGems 1.0.1.
 
-# 1.0.0 / 2007-12-20
+## 1.0.0 / 2007-12-20
 
-## Features:
+### Features:
 
 * RubyGems warns about various problems with gemspecs during gem building
 * More-consistent versioning for the RubyGems software
 
-## Enhancements:
+### Enhancements:
 
 * Fixed various bugs and problems with installing gems on Windows
 * Fixed using `gem server` for installing gems
@@ -6138,7 +6136,7 @@ For a full list of changes to RubyGems, see the git log.
 * `gem unpack` can now unpack into a specific directory with --target
 * OpenSSL is no longer required by default
 
-## Breaking changes:
+### Breaking changes:
 
 * Kernel#require_gem has been removed
 * Executables without a shebang will not be wrapped in a future version, this
@@ -6150,9 +6148,9 @@ For a full list of changes to RubyGems, see the git log.
 * Gem::Specification#autorequire= has been deprecated
 * Time::today will be removed in a future version
 
-# 0.9.5 / 2007-11-19
+## 0.9.5 / 2007-11-19
 
-## Features:
+### Features:
 
 * Platform support
 * Automatic installation of platform gems
@@ -6164,7 +6162,7 @@ For a full list of changes to RubyGems, see the git log.
 * Improved stubs and `gem.bat` on mswin, including better compatibility
   with the One-Click Installer.
 
-## Enhancements:
+### Enhancements:
 
 * Time::today is deprecated and will be removed at a future date
 * Gem::manage_gems is deprecated and will be removed at a future date
@@ -6209,13 +6207,13 @@ Special thanks to:
 * Tom Copeland
 * Wilson Bilkovich
 
-# 0.9.4 / 2007-05-23
+## 0.9.4 / 2007-05-23
 
 If you are experiencing problems with the source index (e.g. strange
 "No Method" errors), or problems with zlib (e.g. "Buffer Error"
 message), we recommend upgrading to RubyGems 0.9.4.
 
-## Bug fixes:
+### Bug fixes:
 
 * Several people have been experiencing problems with no method errors
   on the source index cache.  The source index cache is now a bit more
@@ -6227,9 +6225,9 @@ message), we recommend upgrading to RubyGems 0.9.4.
 * Several sub-commands were accidentally dropped from the "gem" command.
   These commands have been restored.
 
-# 0.9.3 / 2007-05-10
+## 0.9.3 / 2007-05-10
 
-## Bug fixes:
+### Bug fixes:
 
 The ZLib library on Windows will occasionally complains about a buffer error
 when unpacking gems.  The Gems software has a workaround for that problem, but
@@ -6237,19 +6235,19 @@ the workaround was only enabled for versions of ZLib 1.2.1 or earlier.  We
 have received several reports of the error occurring with ZLib 1.2.3, so we
 have permanently enabled the work around on all versions.
 
-# 0.9.2 / 2007-02-05
+## 0.9.2 / 2007-02-05
 
-## Bug fixes:
+### Bug fixes:
 
 * The "unpack" command now works properly.
 * User name and password are now passed properly to the authenticating
   proxy when downloading gems.
 
-# 0.9.1 / 2007-01-16
+## 0.9.1 / 2007-01-16
 
 See git log
 
-# 0.9.0 / 2006-06-28
+## 0.9.0 / 2006-06-28
 
 Finally, the much anticipated RubyGems version 0.9.0 is now available.
 This release includes a number of new features and bug fixes.  The
@@ -6257,7 +6255,7 @@ number one change is that we can now download the gem index
 incrementally.  This will greatly speed up the gem command when only a
 few gems are out of date.
 
-## Enhancements:
+### Enhancements:
 
 * The gem index is now downloaded incrementally, only updating entries
   that are out of date.  If more than 50 entries are out of date, we
@@ -6284,7 +6282,7 @@ few gems are out of date.
 * .rbw is now a supported suffix for RubyGem's custom require.
 * Several Ruby 1.9 compatibility fixes (Eric Hodel).
 
-## Bug fixes:
+### Bug fixes:
 
 * Added dashes to gemspecs generated in Ruby 1.8.3.  This solves some
   cross-Ruby version compatibility issues.
@@ -6296,7 +6294,7 @@ few gems are out of date.
 * Fixed prefix handling for native expressions (patch by Aaron Patterson).
 * Fixed several Upgrade => Update typos.
 
-# 0.8.11 / 2005-07-13
+## 0.8.11 / 2005-07-13
 
 * -y is a synonym for --include-dependencies.
 * Better handling of errors in the top level rescue clause.
@@ -6315,7 +6313,7 @@ few gems are out of date.
 * Added David Glasser's install-from-mirror patch.
 * Additional internal structural cleanup and test reorganization.
 
-# 0.8.10 / 2005-03-27
+## 0.8.10 / 2005-03-27
 
 * In multi-user environments, it is common to supply multiple versions of gems
   (for example Rails), allowing individual users to select the version of the
@@ -6326,16 +6324,16 @@ few gems are out of date.
   installed, then the "gem update --system" command will download a new
   update, but install the latest update prior to the download.
 
-# 0.8.9
+## 0.8.9
 
 Never released
 
-# 0.8.8 / 2005-03-14
+## 0.8.8 / 2005-03-14
 
 * Moved the master definition of class Requirement back under version.
   Kept the body of Requirement under Gem.
 
-# 0.8.7 / 2005-03-14
+## 0.8.7 / 2005-03-14
 
 Even though it has only been a few weeks since that last release,
 there are quite a number of new features in 0.8.7.  A complete list of
@@ -6388,11 +6386,11 @@ file system.  You can read more about them here:
 * gemconfigure: http://docs.rubygems.org/read/chapter/4#page73
 * gemwhich: http://docs.rubygems.org/read/chapter/17
 
-# 0.8.6 / 2005-02-27
+## 0.8.6 / 2005-02-27
 
 * Fixed a small bug with shebang construction
 
-# 0.8.5 / 2005-02-26
+## 0.8.5 / 2005-02-26
 
 Do you know how you used to dread getting the following message while
 installing gems?
@@ -6414,7 +6412,7 @@ us.  No RDoc generation was included in the following times.
 The new caching code is at least 3x faster than previous versions.  Woo
 Hoo!
 
-# 0.8.4 / 2005-01-01
+## 0.8.4 / 2005-01-01
 
 * Rubygems 0.8.3's installer was broken unless you already had an older
   version of RubyGems installed.  That's fixed.
@@ -6424,7 +6422,7 @@ Hoo!
 * Support for lower-cased Gem file names (for you, Paul Duncan :)
 * Erik Veenstra's patch for making Gem versions sortable.
 
-# 0.8.3 / 2004-12-07
+## 0.8.3 / 2004-12-07
 
 No real earth shattering news here, but there were a number of really
 annoying issues involving other libraries that RubyGems depends upon.
@@ -6466,11 +6464,11 @@ There has been some minor usability enhancements and changes ...
   names.  This was useful for him while testing libs that he had in
   development.
 
-# 0.8.1 / 2004-09-17
+## 0.8.1 / 2004-09-17
 
 * Quick release to capture some bug fixes.
 
-# 0.8.0 / 2004-09-15
+## 0.8.0 / 2004-09-15
 
 * Remove need for library stubs.  Set the RUBYOPT environment variable to
   include "rrubygems", and a normal require will find gem files.  Continue to
@@ -6493,15 +6491,15 @@ There has been some minor usability enhancements and changes ...
   to pick.
 * Added "gem unpack" for "unpacking" a gem to the current directory
 
-# 0.7.0 / 2004-07-09
+## 0.7.0 / 2004-07-09
 
 See git log
 
-# 0.6.1 / 2004-06-08
+## 0.6.1 / 2004-06-08
 
 See git log
 
-# 0.6.0 / 2004-06-08
+## 0.6.0 / 2004-06-08
 
 * Collapse output of --search and --list (and gem_server) operations so that
   each gem is listed only once, with each of its versions listed on the same
@@ -6514,7 +6512,7 @@ See git log
     spec.required_ruby_version = "> 1.8.0"
 * --install-stub defaults to true, so library stubs are created
 
-# 0.5.0 / 2004-06-06
+## 0.5.0 / 2004-06-06
 
 * Jim added the ability to specify version constraints to avoid API
   incompatibilities.  This has been the subject of much debate for the past
@@ -6537,11 +6535,11 @@ See git log
   automatically included.
 * Some small bug fixes
 
-# 0.4.0 / 2004-05-30
+## 0.4.0 / 2004-05-30
 
 * Minor bug fixes including Windows compatibility issues
 
-# 0.3.0 / 2004-04-30
+## 0.3.0 / 2004-04-30
 
 * Cleanup of command-line arguments and handling.  Most commands accept a
   --local or --remote modifier.
@@ -6562,6 +6560,6 @@ See git log
 * Generally improved error messages (still more work to do)
 * Rearranged gem directory structure for cleanliness.
 
-# 0.2.0 / 2004-03-14
+## 0.2.0 / 2004-03-14
 
 * Initial public release

--- a/bin/mdl
+++ b/bin/mdl
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.expand_path("../bundler/lib", __dir__))
+
+ENV["BUNDLE_GEMFILE"] = File.expand_path("../tool/bundler/lint_gems.rb", __dir__)
+require "bundler/setup"
+
+load Gem.bin_path("mdl", "mdl")

--- a/bundler/.changelog.yml
+++ b/bundler/.changelog.yml
@@ -1,20 +1,20 @@
 ---
 
-header_template: "# %new_version (%release_date)"
+header_template: "## %new_version (%release_date)"
 
 entry_template: "  - %title [#%pull_request_number](%pull_request_url)"
 
 release_date_format: "%B %-d, %Y"
 
 changelog_label_mapping:
-  "bundler: security": "## Security:"
-  "bundler: breaking change": "## Breaking changes:"
-  "bundler: deprecation": "## Deprecations:"
-  "bundler: feature": "## Features:"
-  "bundler: performance": "## Performance:"
-  "bundler: enhancement": "## Enhancements:"
-  "bundler: bug fix": "## Bug fixes:"
-  "bundler: documentation": "## Documentation:"
+  "bundler: security": "### Security:"
+  "bundler: breaking change": "### Breaking changes:"
+  "bundler: deprecation": "### Deprecations:"
+  "bundler: feature": "### Features:"
+  "bundler: performance": "### Performance:"
+  "bundler: enhancement": "### Enhancements:"
+  "bundler: bug fix": "### Bug fixes:"
+  "bundler: documentation": "### Documentation:"
   "bundler: skip changelog": null
 
 patch_level_labels:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,31 +1,33 @@
-# 2.6.9 (May 13, 2025)
+# Changelog
 
-## Enhancements:
+## 2.6.9 (May 13, 2025)
+
+### Enhancements:
 
   - Fix doctor command parsing of otool output [#8665](https://github.com/rubygems/rubygems/pull/8665)
   - Add SSL troubleshooting to `bundle doctor` [#8624](https://github.com/rubygems/rubygems/pull/8624)
   - Let `bundle lock --normalize-platforms` remove invalid platforms [#8631](https://github.com/rubygems/rubygems/pull/8631)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `bundle lock` sometimes allowing invalid platforms into the lockfile [#8630](https://github.com/rubygems/rubygems/pull/8630)
   - Fix false positive warning about insecure materialization in frozen mode [#8629](https://github.com/rubygems/rubygems/pull/8629)
 
-# 2.6.8 (April 13, 2025)
+## 2.6.8 (April 13, 2025)
 
-## Enhancements:
+### Enhancements:
 
   - Refine `bundle update --verbose` logs [#8627](https://github.com/rubygems/rubygems/pull/8627)
   - Improve bug report instructions [#8607](https://github.com/rubygems/rubygems/pull/8607)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `bundle update` crash in an edge case [#8626](https://github.com/rubygems/rubygems/pull/8626)
   - Fix `bundle lock --normalize-platforms` regression [#8620](https://github.com/rubygems/rubygems/pull/8620)
 
-# 2.6.7 (April 3, 2025)
+## 2.6.7 (April 3, 2025)
 
-## Enhancements:
+### Enhancements:
 
   - Fix crash when server compact index API implementation only lists versions [#8594](https://github.com/rubygems/rubygems/pull/8594)
   - Fix lockfile when a gem ends up accidentally under two different sources [#8579](https://github.com/rubygems/rubygems/pull/8579)
@@ -33,18 +35,18 @@
   - Support git 2.49 [#8581](https://github.com/rubygems/rubygems/pull/8581)
   - Improve wording of a few messages [#8570](https://github.com/rubygems/rubygems/pull/8570)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `bundle add` sometimes generating invalid lockfiles [#8586](https://github.com/rubygems/rubygems/pull/8586)
 
-## Performance:
+### Performance:
 
   - Implement pub_grub strategy interface [#8589](https://github.com/rubygems/rubygems/pull/8589)
   - Update vendored pub_grub [#8571](https://github.com/rubygems/rubygems/pull/8571)
 
-# 2.6.6 (March 13, 2025)
+## 2.6.6 (March 13, 2025)
 
-## Enhancements:
+### Enhancements:
 
   - Fix `ENAMETOOLONG` error when creating compact index cache [#5578](https://github.com/rubygems/rubygems/pull/5578)
   - Use shorthand hash syntax for bundle add [#8547](https://github.com/rubygems/rubygems/pull/8547)
@@ -54,35 +56,35 @@
   - Improve log messages when lockfile platforms are added [#8523](https://github.com/rubygems/rubygems/pull/8523)
   - Allow noop `bundle install` to work on read-only or protected folders [#8519](https://github.com/rubygems/rubygems/pull/8519)
 
-## Bug fixes:
+### Bug fixes:
 
   - Detect partial gem installs from a git source so that they are reinstalled on a successive run [#8539](https://github.com/rubygems/rubygems/pull/8539)
   - Modify `bundle doctor` to not report issue when files aren't writable [#8520](https://github.com/rubygems/rubygems/pull/8520)
 
-## Performance:
+### Performance:
 
   - Optimize resolution by removing an array allocation from `Candidate#<=>` [#8559](https://github.com/rubygems/rubygems/pull/8559)
 
-## Documentation:
+### Documentation:
 
   - Update docs for with/without consistency [#8555](https://github.com/rubygems/rubygems/pull/8555)
   - Recommend non-deprecated methods in `bundle exec` documentation [#8537](https://github.com/rubygems/rubygems/pull/8537)
   - Hint about default group when using `only` configuration option [#8536](https://github.com/rubygems/rubygems/pull/8536)
 
-# 2.6.5 (February 20, 2025)
+## 2.6.5 (February 20, 2025)
 
-## Enhancements:
+### Enhancements:
 
   - Fix lockfile platforms inconveniently added on JRuby [#8494](https://github.com/rubygems/rubygems/pull/8494)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix resolver issue due to ill-defined version ranges being created [#8503](https://github.com/rubygems/rubygems/pull/8503)
   - Make sure empty gems are not reinstalled every time [#8502](https://github.com/rubygems/rubygems/pull/8502)
 
-# 2.6.4 (February 17, 2025)
+## 2.6.4 (February 17, 2025)
 
-## Enhancements:
+### Enhancements:
 
   - Make Bundler never instantiate development dependencies [#8486](https://github.com/rubygems/rubygems/pull/8486)
   - Fix some invalid options to `gem` DSL not getting reported as invalid [#8480](https://github.com/rubygems/rubygems/pull/8480)
@@ -92,7 +94,7 @@
   - Add ruby_34 and ruby_35 as valid platform: [#8430](https://github.com/rubygems/rubygems/pull/8430)
   - Consider gems under `platform: :windows` filter in Gemfile when running on Windows with ARM architecture [#8428](https://github.com/rubygems/rubygems/pull/8428)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix regression when running `bundle update <foo>` would sometimes downgrade a top level dependency [#8491](https://github.com/rubygems/rubygems/pull/8491)
   - Fix dependency locking when Bundler finds incorrect lockfile dependencies [#8489](https://github.com/rubygems/rubygems/pull/8489)
@@ -103,24 +105,24 @@
   - Fix `bundle console` printing bug report template incorrectly [#8436](https://github.com/rubygems/rubygems/pull/8436)
   - Fix `--prefer-local` not respecting default gems [#8412](https://github.com/rubygems/rubygems/pull/8412)
 
-## Performance:
+### Performance:
 
   - Improve resolution performance [#8458](https://github.com/rubygems/rubygems/pull/8458)
 
-## Documentation:
+### Documentation:
 
   - Fix more broken links [#8416](https://github.com/rubygems/rubygems/pull/8416)
 
-# 2.6.3 (January 16, 2025)
+## 2.6.3 (January 16, 2025)
 
-## Enhancements:
+### Enhancements:
 
   - Don't fallback to evaluating YAML gemspecs as Ruby code [#8404](https://github.com/rubygems/rubygems/pull/8404)
   - Print message when blocking on file locks [#8299](https://github.com/rubygems/rubygems/pull/8299)
   - Add support for mise version manager file [#8356](https://github.com/rubygems/rubygems/pull/8356)
   - Add Ruby 3.5 to Gemfile DSL platform values [#8365](https://github.com/rubygems/rubygems/pull/8365)
 
-## Bug fixes:
+### Bug fixes:
 
   - Revert RubyGems plugins getting loaded on `Bundler.require` [#8410](https://github.com/rubygems/rubygems/pull/8410)
   - Fix platform specific gems sometimes being removed from the lockfile [#8401](https://github.com/rubygems/rubygems/pull/8401)
@@ -129,56 +131,56 @@
   - Fix `bundle outdated <GEM>` failing if not all gems are installed [#8361](https://github.com/rubygems/rubygems/pull/8361)
   - Fix `bundle install` crash on Windows [#8362](https://github.com/rubygems/rubygems/pull/8362)
 
-## Documentation:
+### Documentation:
 
   - Fix broken links in the documents [#8389](https://github.com/rubygems/rubygems/pull/8389)
 
-# 2.6.2 (December 23, 2024)
+## 2.6.2 (December 23, 2024)
 
-## Bug fixes:
+### Bug fixes:
 
   - Restart using `Process.argv0` only if `$PROGRAM_NAME` is not a script [#8343](https://github.com/rubygems/rubygems/pull/8343)
 
-## Documentation:
+### Documentation:
 
   - Fix typo in `bundle lock` man page synopsis (`--add-checkums` → `--add-checksums`) [#8350](https://github.com/rubygems/rubygems/pull/8350)
 
-# 2.6.1 (December 17, 2024)
+## 2.6.1 (December 17, 2024)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix missing `Gem::Uri.redact` on some Ruby 3.1 versions [#8337](https://github.com/rubygems/rubygems/pull/8337)
   - Fix `bundle lock --add-checksums` when gems are already installed [#8326](https://github.com/rubygems/rubygems/pull/8326)
 
-# 2.6.0 (December 16, 2024)
+## 2.6.0 (December 16, 2024)
 
-## Security:
+### Security:
 
   - Fix gemfury credentials written to logs in verbose mode [#8283](https://github.com/rubygems/rubygems/pull/8283)
   - Fix private registry credentials being written to logs [#8222](https://github.com/rubygems/rubygems/pull/8222)
 
-## Breaking changes:
+### Breaking changes:
 
   - Drop ruby 3.0 support [#8091](https://github.com/rubygems/rubygems/pull/8091)
   - Remove client-side MD5 ETag transition from compact index client [#7677](https://github.com/rubygems/rubygems/pull/7677)
 
-## Deprecations:
+### Deprecations:
 
   - Cancel `bundle console` deprecation [#8218](https://github.com/rubygems/rubygems/pull/8218)
   - Warn when platform of installed gem differs from platform in the lockfile [#8029](https://github.com/rubygems/rubygems/pull/8029)
   - Cancel deprecation of Gemfiles without a global source [#8213](https://github.com/rubygems/rubygems/pull/8213)
 
-## Features:
+### Features:
 
   - Add a `lockfile_checksums` configuration to include checksums in fresh lockfiles [#8219](https://github.com/rubygems/rubygems/pull/8219)
   - Add `bundle lock --add-checksums` to add checksums to an existing lockfile [#8214](https://github.com/rubygems/rubygems/pull/8214)
 
-## Performance:
+### Performance:
 
   - Enable a couple of performance cops [#8261](https://github.com/rubygems/rubygems/pull/8261)
   - Remove override of worker jobs for `bundle install --local` [#8248](https://github.com/rubygems/rubygems/pull/8248)
 
-## Enhancements:
+### Enhancements:
 
   - Support `bundle exec <relative-path-to-script>` when `Kernel.exec` is used under the hood [#8294](https://github.com/rubygems/rubygems/pull/8294)
   - Improve working with different rubies using the same lockfile [#8251](https://github.com/rubygems/rubygems/pull/8251)
@@ -189,7 +191,7 @@
   - Add a `--normalize-platforms` flag to `bundle lock` [#7896](https://github.com/rubygems/rubygems/pull/7896)
   - Add plugin hooks for Bundler.require [#3439](https://github.com/rubygems/rubygems/pull/3439)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix restarting with locked version when `$PROGRAM_NAME` has been changed [#8320](https://github.com/rubygems/rubygems/pull/8320)
   - Restore the previous cache format for git sources [#8296](https://github.com/rubygems/rubygems/pull/8296)
@@ -199,7 +201,7 @@
   - Fix `bundle remove` sometimes not removing gems [#8278](https://github.com/rubygems/rubygems/pull/8278)
   - Fix issue with git gems locking incorrect specs sometimes [#8269](https://github.com/rubygems/rubygems/pull/8269)
 
-## Documentation:
+### Documentation:
 
   - Normalize command flag documentation and make sure all flags are documented [#8313](https://github.com/rubygems/rubygems/pull/8313)
   - Add missing man pages for `bundle env` and `bundle licenses` [#8315](https://github.com/rubygems/rubygems/pull/8315)
@@ -209,16 +211,16 @@
   - Add debugging instruction on Windows [#8236](https://github.com/rubygems/rubygems/pull/8236)
   - Unify rubygems and bundler docs directory [#8159](https://github.com/rubygems/rubygems/pull/8159)
 
-# 2.5.23 (November 5, 2024)
+## 2.5.23 (November 5, 2024)
 
-## Enhancements:
+### Enhancements:
 
   - Add useful error message for plugin load [#7639](https://github.com/rubygems/rubygems/pull/7639)
   - Indent github workflow steps for generated gems [#8193](https://github.com/rubygems/rubygems/pull/8193)
   - Improve several permission errors [#8168](https://github.com/rubygems/rubygems/pull/8168)
   - Add `bundle add` `--quiet` option [#8157](https://github.com/rubygems/rubygems/pull/8157)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix incompatible encodings error when paths with UTF-8 characters are involved [#8196](https://github.com/rubygems/rubygems/pull/8196)
   - Update `--ext=rust` to support compiling the native extension from source [#7610](https://github.com/rubygems/rubygems/pull/7610)
@@ -227,47 +229,47 @@
   - Handle two `gemspec` usages in same Gemfile with same dep and compatible requirements [#7999](https://github.com/rubygems/rubygems/pull/7999)
   - Fix `bundle check` sometimes locking gems under the wrong source [#8148](https://github.com/rubygems/rubygems/pull/8148)
 
-## Documentation:
+### Documentation:
 
   - Remove confusing `bundle config` documentation [#8177](https://github.com/rubygems/rubygems/pull/8177)
   - Rename bundler inline's `install` parameter and clarify docs [#8170](https://github.com/rubygems/rubygems/pull/8170)
   - Clarify `bundle install --quiet` documentation [#8163](https://github.com/rubygems/rubygems/pull/8163)
 
-# 2.5.22 (October 16, 2024)
+## 2.5.22 (October 16, 2024)
 
-## Enhancements:
+### Enhancements:
 
   - Update vendored `uri` and `net-http` [#8112](https://github.com/rubygems/rubygems/pull/8112)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix bundler sometimes crashing because of trying to use a version of psych compiled for a different Ruby [#8104](https://github.com/rubygems/rubygems/pull/8104)
 
-# 2.5.21 (October 3, 2024)
+## 2.5.21 (October 3, 2024)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix bug report template printed when changing a path source to a git source in frozen mode [#8079](https://github.com/rubygems/rubygems/pull/8079)
   - Fix `stub.activated?` sometimes returning false after activation under bundler [#8073](https://github.com/rubygems/rubygems/pull/8073)
   - Fix old cache format detection when application is not source controlled [#8076](https://github.com/rubygems/rubygems/pull/8076)
   - Fix `bundler/inline` resetting ENV changes [#8059](https://github.com/rubygems/rubygems/pull/8059)
 
-# 2.5.20 (September 24, 2024)
+## 2.5.20 (September 24, 2024)
 
-## Enhancements:
+### Enhancements:
 
   - Don't try to auto-install dev versions of Bundler not available remotely [#8045](https://github.com/rubygems/rubygems/pull/8045)
   - Don't try to install locked bundler when `--local` is passed [#8041](https://github.com/rubygems/rubygems/pull/8041)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `bundler/inline` overwriting lockfiles [#8055](https://github.com/rubygems/rubygems/pull/8055)
   - Ensure refs directory in cached git source [#8047](https://github.com/rubygems/rubygems/pull/8047)
   - Fix `bundle outdated` with `--group` option [#8052](https://github.com/rubygems/rubygems/pull/8052)
 
-# 2.5.19 (September 18, 2024)
+## 2.5.19 (September 18, 2024)
 
-## Enhancements:
+### Enhancements:
 
   - Raise original errors when unexpected errors happen during Gemfile evaluation [#8003](https://github.com/rubygems/rubygems/pull/8003)
   - Make an exe file executable when generating new gems [#8020](https://github.com/rubygems/rubygems/pull/8020)
@@ -278,7 +280,7 @@
   - Reject unknown platforms when running `bundle lock --add-platform` [#7967](https://github.com/rubygems/rubygems/pull/7967)
   - Emit progress to stderr when `--print` is passed to `bundle lock` [#7957](https://github.com/rubygems/rubygems/pull/7957)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `bundle install --local` hitting the network when default gems are included [#8027](https://github.com/rubygems/rubygems/pull/8027)
   - Remove temporary `.lock` files unintentionally left around by gem installer [#8022](https://github.com/rubygems/rubygems/pull/8022)
@@ -288,18 +290,18 @@
   - Don't blow up when explicit version is removed from some git sources [#7973](https://github.com/rubygems/rubygems/pull/7973)
   - Fix `gem exec rails new project` failing on Ruby 3.2 [#7960](https://github.com/rubygems/rubygems/pull/7960)
 
-## Documentation:
+### Documentation:
 
   - Improve `bundle add` man page [#5903](https://github.com/rubygems/rubygems/pull/5903)
   - Add some documentation about backwards compatibility [#7964](https://github.com/rubygems/rubygems/pull/7964)
 
-# 2.5.18 (August 26, 2024)
+## 2.5.18 (August 26, 2024)
 
-## Enhancements:
+### Enhancements:
 
   - Don't remove existing platform gems when PLATFORMS section is badly indented [#7916](https://github.com/rubygems/rubygems/pull/7916)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix error message when Bundler refuses to install due to frozen being set without a lockfile [#7955](https://github.com/rubygems/rubygems/pull/7955)
   - Fix several issues with the `--prefer-local` flag [#7951](https://github.com/rubygems/rubygems/pull/7951)
@@ -307,19 +309,19 @@
   - Regenerate previous git application caches that didn't include bare repos [#7926](https://github.com/rubygems/rubygems/pull/7926)
   - Fix `bundle update <indirect_dep>` failing to upgrade when versions present in two different sources [#7915](https://github.com/rubygems/rubygems/pull/7915)
 
-## Documentation:
+### Documentation:
 
   - Change new gem README template to have copyable code blocks [#7935](https://github.com/rubygems/rubygems/pull/7935)
 
-# 2.5.17 (August 1, 2024)
+## 2.5.17 (August 1, 2024)
 
-## Enhancements:
+### Enhancements:
 
   - Print better log message when current platform is not present in the lockfile [#7891](https://github.com/rubygems/rubygems/pull/7891)
   - Explicitly encode `Gem::Dependency` to yaml [#7867](https://github.com/rubygems/rubygems/pull/7867)
   - Enable lockfile checksums on future Bundler 3 when there's no previous lockfile [#7805](https://github.com/rubygems/rubygems/pull/7805)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix truffleruby removing gems from lockfile [#7795](https://github.com/rubygems/rubygems/pull/7795)
   - Fix `bundle check` exit code when gem git source is not checked out [#7894](https://github.com/rubygems/rubygems/pull/7894)
@@ -327,9 +329,9 @@
   - Fix git source cache being used as the install location [#4469](https://github.com/rubygems/rubygems/pull/4469)
   - Fix `bundle exec gem uninstall` [#7886](https://github.com/rubygems/rubygems/pull/7886)
 
-# 2.5.16 (July 18, 2024)
+## 2.5.16 (July 18, 2024)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix platform removal regression when `platforms:` used in the Gemfile [#7864](https://github.com/rubygems/rubygems/pull/7864)
   - Fix standalone script when default gems with extensions are used [#7870](https://github.com/rubygems/rubygems/pull/7870)
@@ -337,104 +339,104 @@
   - Fix bad error messages when using `bundle add` with frozen mode set [#7845](https://github.com/rubygems/rubygems/pull/7845)
   - Fix generic platform gems getting incorrectly removed from lockfile [#7833](https://github.com/rubygems/rubygems/pull/7833)
 
-## Performance:
+### Performance:
 
   - Use `caller_locations` instead of splitting `caller` [#7708](https://github.com/rubygems/rubygems/pull/7708)
 
-# 2.5.15 (July 9, 2024)
+## 2.5.15 (July 9, 2024)
 
-## Enhancements:
+### Enhancements:
 
   - Support `--no-test`, `--no-ci`, and `--no-linter` options [#7780](https://github.com/rubygems/rubygems/pull/7780)
   - Allow bundle command in new gems with invalid metadata [#7707](https://github.com/rubygems/rubygems/pull/7707)
 
-## Bug fixes:
+### Bug fixes:
 
   - Protect creating RubyGems binstubs with a file lock [#7841](https://github.com/rubygems/rubygems/pull/7841)
   - Only allow valid values for `--test`, `--ci`, and `--linter` options [#7801](https://github.com/rubygems/rubygems/pull/7801)
   - Fix `bundle lock --add-platform <current_platform>` doing nothing [#7803](https://github.com/rubygems/rubygems/pull/7803)
   - Print a proper error when bin dir does not have writable permission bit [#7794](https://github.com/rubygems/rubygems/pull/7794)
 
-## Documentation:
+### Documentation:
 
   - Regenerate bundler docs for June 2024 [#7787](https://github.com/rubygems/rubygems/pull/7787)
 
-# 2.5.14 (June 21, 2024)
+## 2.5.14 (June 21, 2024)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix credentials being re-added when re-resolving without a full unlock [#7767](https://github.com/rubygems/rubygems/pull/7767)
   - Fix `bundle update <gem_name>` edge case [#7770](https://github.com/rubygems/rubygems/pull/7770)
   - Fix `bundle fund` when the gemfile contains optional groups [#7758](https://github.com/rubygems/rubygems/pull/7758)
 
-# 2.5.13 (June 14, 2024)
+## 2.5.13 (June 14, 2024)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix funding metadata not being printed in some situations [#7746](https://github.com/rubygems/rubygems/pull/7746)
   - Make sure to not re-resolve when a not fully specific local platform is locked [#7751](https://github.com/rubygems/rubygems/pull/7751)
   - Don't print bug report template when bin dir is not writable [#7748](https://github.com/rubygems/rubygems/pull/7748)
 
-# 2.5.12 (June 13, 2024)
+## 2.5.12 (June 13, 2024)
 
-## Enhancements:
+### Enhancements:
 
   - Keep credentials in lockfile if they are already there [#7720](https://github.com/rubygems/rubygems/pull/7720)
   - Auto switch to locked bundler version even when using binstubs [#7719](https://github.com/rubygems/rubygems/pull/7719)
   - Don't validate local gemspecs twice unnecessarily [#7725](https://github.com/rubygems/rubygems/pull/7725)
   - Improve default gem handling by treating default gems as any other gem [#7673](https://github.com/rubygems/rubygems/pull/7673)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix slow and incorrect resolution when adding `sorbet` to a Gemfile and the lockfile only includes "RUBY" in the platforms section [#7731](https://github.com/rubygems/rubygems/pull/7731)
   - Fix duplicated config keys generated when `fallback_timeout` uri option is used [#7704](https://github.com/rubygems/rubygems/pull/7704)
   - Fix `bundle exec` no longer working in truffleruby after explicit `require` of `pathname` was removed [#7703](https://github.com/rubygems/rubygems/pull/7703)
   - Don't let `bundle config` report a path without a Gemfile as "local app" [#7687](https://github.com/rubygems/rubygems/pull/7687)
 
-## Documentation:
+### Documentation:
 
   - Clarify BUNDLE_USER_CONFIG is a file [#7668](https://github.com/rubygems/rubygems/pull/7668)
 
-# 2.5.11 (May 28, 2024)
+## 2.5.11 (May 28, 2024)
 
-## Deprecations:
+### Deprecations:
 
   - Deprecate Bundler constants [#7653](https://github.com/rubygems/rubygems/pull/7653)
 
-## Enhancements:
+### Enhancements:
 
   - Bump `bundle gem` generated COC to Contributor Covenant 2.1 [#7692](https://github.com/rubygems/rubygems/pull/7692)
   - Retry a full clone when git server does not support shallow capabilities [#7649](https://github.com/rubygems/rubygems/pull/7649)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix regression when caching gems from secondary sources [#7659](https://github.com/rubygems/rubygems/pull/7659)
   - Fix error when Bundler installation is corrupted [#7642](https://github.com/rubygems/rubygems/pull/7642)
   - Fix crash caused by RubyGems `require` gem activation logic running before Bundler can properly register its own monkeypatches [#7647](https://github.com/rubygems/rubygems/pull/7647)
 
-## Performance:
+### Performance:
 
   - Update cache checksums to decrease string allocations [#7637](https://github.com/rubygems/rubygems/pull/7637)
   - Fix performance regression in applications with a local cache [#7680](https://github.com/rubygems/rubygems/pull/7680)
 
-## Documentation:
+### Documentation:
 
   - Recommend `bin/rake` over `rake` in contributing docs [#7648](https://github.com/rubygems/rubygems/pull/7648)
   - Monthly man update for May 2024 [#7640](https://github.com/rubygems/rubygems/pull/7640)
   - Clarify Bundler support policy [#7633](https://github.com/rubygems/rubygems/pull/7633)
 
-# 2.5.10 (May 3, 2024)
+## 2.5.10 (May 3, 2024)
 
-## Security:
+### Security:
 
   - Never write credentials to lockfiles [#7560](https://github.com/rubygems/rubygems/pull/7560)
 
-## Enhancements:
+### Enhancements:
 
   - Add auto_install support to require "bundler/setup" [#6561](https://github.com/rubygems/rubygems/pull/6561)
   - Add `--glob` flag to `bundle add` [#7557](https://github.com/rubygems/rubygems/pull/7557)
 
-## Bug fixes:
+### Bug fixes:
 
   - Make sure `bundle update <specific_gems>` can always update to the latest resolvable version of each requested gem [#7558](https://github.com/rubygems/rubygems/pull/7558)
   - Show better error when installed gemspecs are unreadable [#7603](https://github.com/rubygems/rubygems/pull/7603)
@@ -443,35 +445,35 @@
   - Properly resolve aliases when `bundle help` is run [#7601](https://github.com/rubygems/rubygems/pull/7601)
   - Fix issue installing gems with linux-musl variant on non musl linux [#7583](https://github.com/rubygems/rubygems/pull/7583)
 
-## Documentation:
+### Documentation:
 
   - Clarify `bundle check` behaviour in docs [#7613](https://github.com/rubygems/rubygems/pull/7613)
 
-# 2.5.9 (April 12, 2024)
+## 2.5.9 (April 12, 2024)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix installing plugins via relative paths [#7571](https://github.com/rubygems/rubygems/pull/7571)
 
-# 2.5.8 (April 11, 2024)
+## 2.5.8 (April 11, 2024)
 
-## Enhancements:
+### Enhancements:
 
   - Allow installing plugins from path via CLI [#6960](https://github.com/rubygems/rubygems/pull/6960)
   - Improve validation of `bundle plugin install` options [#7529](https://github.com/rubygems/rubygems/pull/7529)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix resolver error message when it runs out of versions due to `--strict --patch` filtering out everything [#7527](https://github.com/rubygems/rubygems/pull/7527)
   - Fix incorrect `bundle update --bundler` message [#7516](https://github.com/rubygems/rubygems/pull/7516)
 
-# 2.5.7 (March 22, 2024)
+## 2.5.7 (March 22, 2024)
 
-## Deprecations:
+### Deprecations:
 
   - Deprecate `bundle plugin install --local-git=` [#7048](https://github.com/rubygems/rubygems/pull/7048)
 
-## Enhancements:
+### Enhancements:
 
   - Ignore commented out keys in config file [#7514](https://github.com/rubygems/rubygems/pull/7514)
   - Fix exclusion of `.gemspec` file itself in `bundle gem` generated gemspec file [#7488](https://github.com/rubygems/rubygems/pull/7488)
@@ -479,83 +481,83 @@
   - Add `gitlab:` git source shorthand [#7449](https://github.com/rubygems/rubygems/pull/7449)
   - Use full path for `instance_eval` in `Bundler::DSL#eval_gemfile` [#7471](https://github.com/rubygems/rubygems/pull/7471)
 
-## Documentation:
+### Documentation:
 
   - Use https instead of http in documentation links [#7481](https://github.com/rubygems/rubygems/pull/7481)
 
-# 2.5.6 (February 6, 2024)
+## 2.5.6 (February 6, 2024)
 
-## Deprecations:
+### Deprecations:
 
   - Refactor lockfile generation and deprecate `Definition#lock` with explicit lockfile [#7047](https://github.com/rubygems/rubygems/pull/7047)
 
-## Enhancements:
+### Enhancements:
 
   - Bump `required_ruby_version` to be used in `bundle gem` template [#7430](https://github.com/rubygems/rubygems/pull/7430)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix musl platform not being added to the lockfile [#7441](https://github.com/rubygems/rubygems/pull/7441)
   - Let `Bundler.with_original_env` properly restore env variables originally empty [#7383](https://github.com/rubygems/rubygems/pull/7383)
 
-# 2.5.5 (January 18, 2024)
+## 2.5.5 (January 18, 2024)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix development dependency not being added if introduced by two gemspecs [#7358](https://github.com/rubygems/rubygems/pull/7358)
   - Fix ETag quoting regression in If-None-Match header of compact index request [#7352](https://github.com/rubygems/rubygems/pull/7352)
 
-## Documentation:
+### Documentation:
 
   - Refer to underscores as underscores [#7364](https://github.com/rubygems/rubygems/pull/7364)
 
-# 2.5.4 (January 4, 2024)
+## 2.5.4 (January 4, 2024)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix resolution when different platform specific gems have different dependencies [#7324](https://github.com/rubygems/rubygems/pull/7324)
 
-# 2.5.3 (December 22, 2023)
+## 2.5.3 (December 22, 2023)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix incorrect error when Gemfile overrides a gemspec development dependency [#7319](https://github.com/rubygems/rubygems/pull/7319)
 
-# 2.5.2 (December 21, 2023)
+## 2.5.2 (December 21, 2023)
 
-## Enhancements:
+### Enhancements:
 
   - Avoid vendored thor gem polluting the global namespace [#7305](https://github.com/rubygems/rubygems/pull/7305)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `bundle update --bundler` when latest version does not support current ruby [#7310](https://github.com/rubygems/rubygems/pull/7310)
   - Fix incorrect lockfiles being generated in some situations [#7307](https://github.com/rubygems/rubygems/pull/7307)
   - Fix incorrect re-resolve messages [#7306](https://github.com/rubygems/rubygems/pull/7306)
 
-# 2.5.1 (December 15, 2023)
+## 2.5.1 (December 15, 2023)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `ruby` Gemfile DSL with `file:` parameter no longer working [#7288](https://github.com/rubygems/rubygems/pull/7288)
 
-## Performance:
+### Performance:
 
   - Save array allocation for every dependency in Gemfile [#7270](https://github.com/rubygems/rubygems/pull/7270)
 
-# 2.5.0 (December 15, 2023)
+## 2.5.0 (December 15, 2023)
 
-## Breaking changes:
+### Breaking changes:
 
   - Drop ruby 2.6 and 2.7 support [#7116](https://github.com/rubygems/rubygems/pull/7116)
   - The `:mswin`, `:mswin64`, `:mingw`, and `:x64_mingw` Gemfile `platform` values are soft-deprecated and aliased to `:windows` [#6391](https://github.com/rubygems/rubygems/pull/6391)
 
-## Features:
+### Features:
 
   - Leverage ruby feature to warn when requiring default gems not included in the bundle that will be turned into bundled gems in the future [#6831](https://github.com/rubygems/rubygems/pull/6831)
   - Introduce `bundle config set version` feature to choose the version of Bundler that should be used and potentially disable using the `lockfile` version by setting it to `system` [#6817](https://github.com/rubygems/rubygems/pull/6817)
 
-## Performance:
+### Performance:
 
   - Use match? when regexp match data is unused [#7263](https://github.com/rubygems/rubygems/pull/7263)
   - Avoid some allocations when evaluating `ruby` Gemfile DSL [#7251](https://github.com/rubygems/rubygems/pull/7251)
@@ -565,7 +567,7 @@
   - Use a shared connection pool for fetching gems [#7079](https://github.com/rubygems/rubygems/pull/7079)
   - Reduce allocations when parsing compact index [#6971](https://github.com/rubygems/rubygems/pull/6971)
 
-## Enhancements:
+### Enhancements:
 
   - Add 3.4 as a supported ruby version in Gemfile DSL [#7264](https://github.com/rubygems/rubygems/pull/7264)
   - Improve install advice when some gems are not found [#7265](https://github.com/rubygems/rubygems/pull/7265)
@@ -582,22 +584,22 @@
   - Make lockfiles generated on macOS include a lock for Linux by default [#5700](https://github.com/rubygems/rubygems/pull/5700)
   - Only add a dummy bundler spec to the metadata source when necessary [#4443](https://github.com/rubygems/rubygems/pull/4443)
 
-## Bug fixes:
+### Bug fixes:
 
   - Resolve `ruby file: ".ruby-version"` relative to containing Gemfile [#7250](https://github.com/rubygems/rubygems/pull/7250)
   - Implement opaque ETag in Compact Index to avoid falling back to old index in servers with different etag implementations [#7122](https://github.com/rubygems/rubygems/pull/7122)
   - Fix `bundle install --system` deprecation advice [#7190](https://github.com/rubygems/rubygems/pull/7190)
   - Fix invalid platform removal missing adjacent platforms [#7170](https://github.com/rubygems/rubygems/pull/7170)
 
-## Documentation:
+### Documentation:
 
   - Add missing --prefer-local to Synopsis in bundle-install.1.ronn [#7194](https://github.com/rubygems/rubygems/pull/7194)
   - Update GitHub organization of Standard Ruby in `bundle gem` output and generated configuration [#6818](https://github.com/rubygems/rubygems/pull/6818)
   - Replace "prior to" with "immediately after" in `bundle gem` generated README file [#6338](https://github.com/rubygems/rubygems/pull/6338)
 
-# 2.4.22 (November 9, 2023)
+## 2.4.22 (November 9, 2023)
 
-## Enhancements:
+### Enhancements:
 
   - Add Bundler::Plugin.loaded? helper [#6964](https://github.com/rubygems/rubygems/pull/6964)
   - Give better error when previous installation folder is insecure to remove [#7030](https://github.com/rubygems/rubygems/pull/7030)
@@ -607,7 +609,7 @@
   - Restore using old way of passing Ruby version to resolver [#7066](https://github.com/rubygems/rubygems/pull/7066)
   - Bump vendored net-http-persistent to 4.0.2 [#6787](https://github.com/rubygems/rubygems/pull/6787)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix regression when installing native extensions on universal rubies [#7077](https://github.com/rubygems/rubygems/pull/7077)
   - Only remove bundler plugin gem when it's inside the cache [#7001](https://github.com/rubygems/rubygems/pull/7001)
@@ -616,9 +618,9 @@
   - Handle empty array at built-in YAML serializer [#7099](https://github.com/rubygems/rubygems/pull/7099)
   - Fix force_ruby_platform: when the lockfile only locks the ruby platform [#6936](https://github.com/rubygems/rubygems/pull/6936)
 
-# 2.4.21 (October 17, 2023)
+## 2.4.21 (October 17, 2023)
 
-## Enhancements:
+### Enhancements:
 
   - Avoid duplicates -rbundler/setup in RUBYOPT with Ruby preview [#7002](https://github.com/rubygems/rubygems/pull/7002)
   - Prevent gem activation in standalone mode [#6925](https://github.com/rubygems/rubygems/pull/6925)
@@ -626,7 +628,7 @@
   - Fix `bundle install` when older revisions of git source [#6980](https://github.com/rubygems/rubygems/pull/6980)
   - Remove usage of Dir.chdir that only execute a subprocess [#6930](https://github.com/rubygems/rubygems/pull/6930)
 
-## Bug fixes:
+### Bug fixes:
 
   - Don't delete the release version from pre-release string more than once [#7054](https://github.com/rubygems/rubygems/pull/7054)
   - Make the `lock` command not be affected by the `frozen` setting [#7034](https://github.com/rubygems/rubygems/pull/7034)
@@ -638,19 +640,19 @@
   - Fix `bundle lock --minor --update <dep>` edge case [#6992](https://github.com/rubygems/rubygems/pull/6992)
   - Stop bundler eagerly loading all specs with exts [#6945](https://github.com/rubygems/rubygems/pull/6945)
 
-## Performance:
+### Performance:
 
   - Reduce allocations when parsing lockfile [#6976](https://github.com/rubygems/rubygems/pull/6976)
   - Stop allocating the same settings keys repeatedly [#6963](https://github.com/rubygems/rubygems/pull/6963)
 
-## Documentation:
+### Documentation:
 
   - Improve formatting and global source information in `bundle plugin` man page [#7045](https://github.com/rubygems/rubygems/pull/7045)
   - Update man page of `bundle exec` to reflect default true of flag `--keep-file-descriptors` [#7033](https://github.com/rubygems/rubygems/pull/7033)
 
-# 2.4.20 (September 27, 2023)
+## 2.4.20 (September 27, 2023)
 
-## Enhancements:
+### Enhancements:
 
   - Bump actions/checkout to v4 in bundler gem template [#6966](https://github.com/rubygems/rubygems/pull/6966)
   - Add support for the `ruby-3.2.2` format in the `ruby file:` Gemfile directive, and explicitly test the `3.2.2@gemset` format as rejected [#6954](https://github.com/rubygems/rubygems/pull/6954)
@@ -658,7 +660,7 @@
   - Unify LockfileParser loading of SPECS section [#6933](https://github.com/rubygems/rubygems/pull/6933)
   - Only check circular deps when dependency api is available, not on full index sources [#6919](https://github.com/rubygems/rubygems/pull/6919)
 
-## Bug fixes:
+### Bug fixes:
 
   - Allow standalone mode to work on a Windows edge case [#6989](https://github.com/rubygems/rubygems/pull/6989)
   - Fix `bundle outdated` crashing when both `ref` and `branch` specified for a git gem in Gemfile [#6959](https://github.com/rubygems/rubygems/pull/6959)
@@ -667,7 +669,7 @@
   - Fix standalone install crashing when using legacy gemfiles with multiple global sources [#6918](https://github.com/rubygems/rubygems/pull/6918)
   - Resolve ruby version file relative to bundle root [#6892](https://github.com/rubygems/rubygems/pull/6892)
 
-## Performance:
+### Performance:
 
   - Lazily construct fetcher debug messages [#6973](https://github.com/rubygems/rubygems/pull/6973)
   - Avoid allocating empty hashes in Index [#6962](https://github.com/rubygems/rubygems/pull/6962)
@@ -676,71 +678,71 @@
   - Don't use full indexes unnecessarily on legacy Gemfiles [#6916](https://github.com/rubygems/rubygems/pull/6916)
   - Improve memory usage in Bundler::Settings, and thus improve boot time [#6884](https://github.com/rubygems/rubygems/pull/6884)
 
-# 2.4.19 (August 17, 2023)
+## 2.4.19 (August 17, 2023)
 
-## Enhancements:
+### Enhancements:
 
   - Add `file` option to `ruby` method in Gemfile [#6876](https://github.com/rubygems/rubygems/pull/6876)
   - Show better error when PAT can't authenticate to a private server [#6871](https://github.com/rubygems/rubygems/pull/6871)
   - Don't fallback to old dependency API when bad credentials are configured [#6869](https://github.com/rubygems/rubygems/pull/6869)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix git source conservativeness [#6850](https://github.com/rubygems/rubygems/pull/6850)
 
-## Documentation:
+### Documentation:
 
   - Clarify that `bundle info` takes a gem name [#6875](https://github.com/rubygems/rubygems/pull/6875)
 
-# 2.4.18 (August 2, 2023)
+## 2.4.18 (August 2, 2023)
 
-## Security:
+### Security:
 
   - Merge URI-0.12.2 for Bundler [#6779](https://github.com/rubygems/rubygems/pull/6779)
 
-## Enhancements:
+### Enhancements:
 
   - Update Magnus version in Rust extension gem template [#6843](https://github.com/rubygems/rubygems/pull/6843)
 
-## Documentation:
+### Documentation:
 
   - Update bundle-outdated(1) man to use table output [#6833](https://github.com/rubygems/rubygems/pull/6833)
 
-# 2.4.17 (July 14, 2023)
+## 2.4.17 (July 14, 2023)
 
-## Enhancements:
+### Enhancements:
 
   - Avoid printing "Using ..." messages when version has not changed [#6804](https://github.com/rubygems/rubygems/pull/6804)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `bundler/setup` unintendedly writing to the filesystem [#6814](https://github.com/rubygems/rubygems/pull/6814)
 
-# 2.4.16 (July 10, 2023)
+## 2.4.16 (July 10, 2023)
 
-## Bug fixes:
+### Bug fixes:
 
   - Exclude Bundler from missing locked dependencies check [#6792](https://github.com/rubygems/rubygems/pull/6792)
   - Fix another incorrect removal of "ruby" platform from lockfile when changing path sources [#6784](https://github.com/rubygems/rubygems/pull/6784)
   - Fix git source lockfile instability [#6786](https://github.com/rubygems/rubygems/pull/6786)
 
-## Documentation:
+### Documentation:
 
   - `gemfile.5`: Code format the default glob to escape Markdown [#6790](https://github.com/rubygems/rubygems/pull/6790)
 
-# 2.4.15 (June 29, 2023)
+## 2.4.15 (June 29, 2023)
 
-## Enhancements:
+### Enhancements:
 
   - Improve edge case error message [#6733](https://github.com/rubygems/rubygems/pull/6733)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `bundle lock --update --bundler` [#6213](https://github.com/rubygems/rubygems/pull/6213)
 
-# 2.4.14 (June 12, 2023)
+## 2.4.14 (June 12, 2023)
 
-## Enhancements:
+### Enhancements:
 
   - Stop publishing Gemfile in default gem template [#6723](https://github.com/rubygems/rubygems/pull/6723)
   - Avoid infinite loops when hitting resolution bugs [#6722](https://github.com/rubygems/rubygems/pull/6722)
@@ -749,59 +751,59 @@
   - Make `frozen` setting take precedence over `deployment` setting [#6685](https://github.com/rubygems/rubygems/pull/6685)
   - Show an error when trying to update bundler in frozen mode [#6684](https://github.com/rubygems/rubygems/pull/6684)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `deployment` vs `path` precedence [#6703](https://github.com/rubygems/rubygems/pull/6703)
   - Fix inline mode with multiple sources [#6699](https://github.com/rubygems/rubygems/pull/6699)
 
-# 2.4.13 (May 9, 2023)
+## 2.4.13 (May 9, 2023)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix unexpected fallbacks to full index by adding FalseClass and Time to the SafeMarshal list [#6655](https://github.com/rubygems/rubygems/pull/6655)
 
-## Documentation:
+### Documentation:
 
   - Fix broken hyperlinks in bundle cache documentation [#6606](https://github.com/rubygems/rubygems/pull/6606)
 
-# 2.4.12 (April 11, 2023)
+## 2.4.12 (April 11, 2023)
 
-## Enhancements:
+### Enhancements:
 
   - Remove reference to `pry` gem from generated `bin/console` file [#6515](https://github.com/rubygems/rubygems/pull/6515)
 
-# 2.4.11 (April 10, 2023)
+## 2.4.11 (April 10, 2023)
 
-## Security:
+### Security:
 
   - Use URI-0.12.1 (safe against CVE-2023-28755 ReDoS vulnerability) [#6558](https://github.com/rubygems/rubygems/pull/6558)
 
-## Enhancements:
+### Enhancements:
 
   - Remove one fallback to full indexes on big gemfiles [#6578](https://github.com/rubygems/rubygems/pull/6578)
   - Generate native gems with `-fvisibility=hidden` [#6541](https://github.com/rubygems/rubygems/pull/6541)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix resolver hangs when dealing with an incomplete lockfile [#6552](https://github.com/rubygems/rubygems/pull/6552)
   - Fix prereleases not being considered by gem version promoter when there's no lockfile [#6537](https://github.com/rubygems/rubygems/pull/6537)
 
-# 2.4.10 (March 27, 2023)
+## 2.4.10 (March 27, 2023)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix some unnecessary top level dependency downgrades [#6535](https://github.com/rubygems/rubygems/pull/6535)
   - Fix incorrect ruby platform removal from lockfile when adding Gemfile dependencies [#6540](https://github.com/rubygems/rubygems/pull/6540)
   - Fix installing plugins in frozen mode [#6543](https://github.com/rubygems/rubygems/pull/6543)
   - Restore "enumerability" of `SpecSet` [#6532](https://github.com/rubygems/rubygems/pull/6532)
 
-# 2.4.9 (March 20, 2023)
+## 2.4.9 (March 20, 2023)
 
-## Security:
+### Security:
 
   - Don't recommend `--full-index` on errors [#6493](https://github.com/rubygems/rubygems/pull/6493)
 
-## Enhancements:
+### Enhancements:
 
   - Fix duplicated specs in some error messages [#6475](https://github.com/rubygems/rubygems/pull/6475)
   - When running `bundle lock --update <name>`, checkout locked revision of unrelated git sources directly [#6459](https://github.com/rubygems/rubygems/pull/6459)
@@ -809,24 +811,24 @@
   - Use `RbSys::ExtensionTask` when creating new rust gems [#6352](https://github.com/rubygems/rubygems/pull/6352)
   - Don't ignore pre-releases when there's only one candidate [#6441](https://github.com/rubygems/rubygems/pull/6441)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix incorrect removal of ruby platform when auto-healing corrupted lockfiles [#6495](https://github.com/rubygems/rubygems/pull/6495)
   - Don't consider platform specific candidates when `force_ruby_platform` set [#6442](https://github.com/rubygems/rubygems/pull/6442)
   - Better deal with circular dependencies [#6330](https://github.com/rubygems/rubygems/pull/6330)
 
-## Documentation:
+### Documentation:
 
   - Add debugging docs [#6387](https://github.com/rubygems/rubygems/pull/6387)
   - Document our current release policy [#6450](https://github.com/rubygems/rubygems/pull/6450)
 
-# 2.4.8 (March 8, 2023)
+## 2.4.8 (March 8, 2023)
 
-## Security:
+### Security:
 
   - Safe load all marshaled data [#6384](https://github.com/rubygems/rubygems/pull/6384)
 
-## Enhancements:
+### Enhancements:
 
   - Better suggestion when `bundler/setup` fails due to missing gems and Gemfile is not the default [#6428](https://github.com/rubygems/rubygems/pull/6428)
   - Simplify the gem package file filter in the gemspec template [#6344](https://github.com/rubygems/rubygems/pull/6344)
@@ -834,18 +836,18 @@
   - Auto-heal on corrupted lockfile with missing deps [#6400](https://github.com/rubygems/rubygems/pull/6400)
   - Give a better message when Gemfile branch does not exist [#6383](https://github.com/rubygems/rubygems/pull/6383)
 
-## Bug fixes:
+### Bug fixes:
 
   - Respect --no-install option for git: sources [#6088](https://github.com/rubygems/rubygems/pull/6088)
   - Fix `gems.rb` lockfile for bundler version lookup in template [#6413](https://github.com/rubygems/rubygems/pull/6413)
 
-## Documentation:
+### Documentation:
 
   - Switch supporting explanations to all Ruby Central [#6419](https://github.com/rubygems/rubygems/pull/6419)
 
-# 2.4.7 (February 15, 2023)
+## 2.4.7 (February 15, 2023)
 
-## Enhancements:
+### Enhancements:
 
   - Add `--gemfile` flag to `bundle init` to configure gemfile name to generate [#6046](https://github.com/rubygems/rubygems/pull/6046)
   - Improve solve failure explanations by using better wording [#6366](https://github.com/rubygems/rubygems/pull/6366)
@@ -854,38 +856,38 @@
   - Improve wording of unmet dependencies warning [#6357](https://github.com/rubygems/rubygems/pull/6357)
   - Add Ruby 3.2 and 3.3 platforms to Gemfile DSL [#6346](https://github.com/rubygems/rubygems/pull/6346)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix crash in pub grub involving empty ranges [#6365](https://github.com/rubygems/rubygems/pull/6365)
   - Make gemspec file generated by `bundle gem` properly exclude itself from packaged gem [#6339](https://github.com/rubygems/rubygems/pull/6339)
   - Preserve relative path sources in standalone setup [#6327](https://github.com/rubygems/rubygems/pull/6327)
 
-# 2.4.6 (January 31, 2023)
+## 2.4.6 (January 31, 2023)
 
-## Enhancements:
+### Enhancements:
 
   - Don't warn on `bundle binstubs --standalone --all` [#6312](https://github.com/rubygems/rubygems/pull/6312)
 
-## Bug fixes:
+### Bug fixes:
 
   - Don't undo require decorations made by other gems [#6308](https://github.com/rubygems/rubygems/pull/6308)
   - Fix `bundler/inline` not properly installing gems with extensions when used more than once [#6306](https://github.com/rubygems/rubygems/pull/6306)
   - Fix `bundler/inline` not skipping installation when gems already there, when used more than once [#6305](https://github.com/rubygems/rubygems/pull/6305)
 
-# 2.4.5 (January 21, 2023)
+## 2.4.5 (January 21, 2023)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `bundler/inline` not resolving properly if gems not preinstalled [#6282](https://github.com/rubygems/rubygems/pull/6282)
   - Fix packages for external platforms being introduced in lockfile when Bundler retries resolution [#6285](https://github.com/rubygems/rubygems/pull/6285)
 
-## Documentation:
+### Documentation:
 
   - Update bundle-exec man page to not use deprecated `Bundler.with_clean_env` [#6284](https://github.com/rubygems/rubygems/pull/6284)
 
-# 2.4.4 (January 16, 2023)
+## 2.4.4 (January 16, 2023)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix platform specific gems removed from the lockfile [#6266](https://github.com/rubygems/rubygems/pull/6266)
   - Properly handle incompatibilities on platform specific gems [#6270](https://github.com/rubygems/rubygems/pull/6270)
@@ -894,13 +896,13 @@
   - Skip setting `BUNDLER_SETUP` on Ruby 2.6 [#6252](https://github.com/rubygems/rubygems/pull/6252)
   - Let resolver deal with legacy gems with equivalent version and different dependencies [#6219](https://github.com/rubygems/rubygems/pull/6219)
 
-# 2.4.3 (January 6, 2023)
+## 2.4.3 (January 6, 2023)
 
-## Enhancements:
+### Enhancements:
 
   - Enhance `bundle open` command to allow opening subdir/file of gem [#6146](https://github.com/rubygems/rubygems/pull/6146)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix pointing GitHub sources to PRs [#6241](https://github.com/rubygems/rubygems/pull/6241)
   - Fix version ranges incorrectly handling platforms [#6240](https://github.com/rubygems/rubygems/pull/6240)
@@ -908,65 +910,65 @@
   - When auto-removing RUBY platform don't add specific platform if not needed [#6233](https://github.com/rubygems/rubygems/pull/6233)
   - Fallback to selecting installable candidates if possible when materializing specs [#6225](https://github.com/rubygems/rubygems/pull/6225)
 
-## Documentation:
+### Documentation:
 
   - Fix several typos [#6224](https://github.com/rubygems/rubygems/pull/6224)
 
-# 2.4.2 (January 1, 2023)
+## 2.4.2 (January 1, 2023)
 
-## Performance:
+### Performance:
 
   - Speed up resolution by properly merging incompatibility ranges [#6215](https://github.com/rubygems/rubygems/pull/6215)
 
-## Documentation:
+### Documentation:
 
   - Remove stray word in `bundle config` man page [#6220](https://github.com/rubygems/rubygems/pull/6220)
 
-# 2.4.1 (December 24, 2022)
+## 2.4.1 (December 24, 2022)
 
-## Enhancements:
+### Enhancements:
 
   - Allow Bundler to run on old RubyGems + Ruby 2.7 without warnings [#6187](https://github.com/rubygems/rubygems/pull/6187)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix dependencies scoped to other platforms making resolver fail [#6189](https://github.com/rubygems/rubygems/pull/6189)
   - Restore annotated git tag support [#6186](https://github.com/rubygems/rubygems/pull/6186)
 
-# 2.4.0 (December 24, 2022)
+## 2.4.0 (December 24, 2022)
 
-## Security:
+### Security:
 
   - In README generated by `bundle gem`, do not fill rubygems.org install commands with the gem name automatically [#6093](https://github.com/rubygems/rubygems/pull/6093)
   - Use safe Marshal deserialization for dependency API response [#6141](https://github.com/rubygems/rubygems/pull/6141)
 
-## Breaking changes:
+### Breaking changes:
 
   - Remove Travis CI from gem skeleton [#6150](https://github.com/rubygems/rubygems/pull/6150)
   - Drop support for Ruby 2.3, 2.4, 2.5 and RubyGems 2.5, 2.6, 2.7 [#6107](https://github.com/rubygems/rubygems/pull/6107)
   - Completely remove "auto-sudo" feature [#5888](https://github.com/rubygems/rubygems/pull/5888)
 
-## Deprecations:
+### Deprecations:
 
   - Turn `--ext` option of `bundle gem` into string. Deprecate usage without explicit value [#6144](https://github.com/rubygems/rubygems/pull/6144)
 
-## Features:
+### Features:
 
   - Add `--ext=rust` support to `bundle gem` for creating simple gems with Rust extensions [#6149](https://github.com/rubygems/rubygems/pull/6149)
   - Migrate our resolver engine to PubGrub [#5960](https://github.com/rubygems/rubygems/pull/5960)
 
-## Performance:
+### Performance:
 
   - Make cloning git repos faster [#4475](https://github.com/rubygems/rubygems/pull/4475)
 
-## Enhancements:
+### Enhancements:
 
   - Add `bundle lock --update --bundler` [#6134](https://github.com/rubygems/rubygems/pull/6134)
   - Support for pre flag in `bundle update`/`bundle lock` [#5258](https://github.com/rubygems/rubygems/pull/5258)
   - Improve error message when changing Gemfile to a mistyped git ref [#6130](https://github.com/rubygems/rubygems/pull/6130)
   - Remove special handling of some `LoadError` and `NoMethodError` [#6115](https://github.com/rubygems/rubygems/pull/6115)
 
-## Bug fixes:
+### Bug fixes:
 
   - Don't unlock dependencies of a gemspec when its version changes [#6184](https://github.com/rubygems/rubygems/pull/6184)
   - Fix platform specific version for libv8-node and other allowlisted gems not being chosen in Truffleruby [#6169](https://github.com/rubygems/rubygems/pull/6169)
@@ -976,65 +978,65 @@
   - Fix display of previous gem version when previously downloaded already [#6110](https://github.com/rubygems/rubygems/pull/6110)
   - Fix hang when a lockfile gem does not resolve on the current platform [#6070](https://github.com/rubygems/rubygems/pull/6070)
 
-## Documentation:
+### Documentation:
 
   - Improve Bundler setup docs for development [#6154](https://github.com/rubygems/rubygems/pull/6154)
   - Fx link in bundle-platform man page [#6071](https://github.com/rubygems/rubygems/pull/6071)
 
-# 2.3.26 (November 16, 2022)
+## 2.3.26 (November 16, 2022)
 
-## Enhancements:
+### Enhancements:
 
   - Map 'universal' to the real arch in Bundler for prebuilt gem selection [#5978](https://github.com/rubygems/rubygems/pull/5978)
 
-## Documentation:
+### Documentation:
 
   - Fix '--force' option documentation of 'bundle clean' [#6050](https://github.com/rubygems/rubygems/pull/6050)
 
-# 2.3.25 (November 2, 2022)
+## 2.3.25 (November 2, 2022)
 
-## Bug fixes:
+### Bug fixes:
 
   - Properly sort specs when materializing [#6015](https://github.com/rubygems/rubygems/pull/6015)
   - Fix bad unfreeze recommendation [#6013](https://github.com/rubygems/rubygems/pull/6013)
 
-## Documentation:
+### Documentation:
 
   - Bring docs for gemfile(5) manpage up to date [#6007](https://github.com/rubygems/rubygems/pull/6007)
   - Fix `github` DSL docs to mention they use https protocol over git under the hood [#5993](https://github.com/rubygems/rubygems/pull/5993)
 
-# 2.3.24 (October 17, 2022)
+## 2.3.24 (October 17, 2022)
 
-## Enhancements:
+### Enhancements:
 
   - Only add extra resolver spec group for Ruby platform when needed [#5698](https://github.com/rubygems/rubygems/pull/5698)
   - Fix little UI issue when bundler shows duplicated gems in a list [#5965](https://github.com/rubygems/rubygems/pull/5965)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix incorrect materialization on Windows [#5975](https://github.com/rubygems/rubygems/pull/5975)
 
-# 2.3.23 (October 5, 2022)
+## 2.3.23 (October 5, 2022)
 
-## Enhancements:
+### Enhancements:
 
   - Update GitLab CI template with new one [#5944](https://github.com/rubygems/rubygems/pull/5944)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `bundle init` not respecting umask in generated gem's Gemfile [#5947](https://github.com/rubygems/rubygems/pull/5947)
 
-## Performance:
+### Performance:
 
   - Further speed up Bundler by not sorting specs unnecessarily [#5868](https://github.com/rubygems/rubygems/pull/5868)
 
-## Documentation:
+### Documentation:
 
   - Update Bundler new feature instructions [#5912](https://github.com/rubygems/rubygems/pull/5912)
 
-# 2.3.22 (September 7, 2022)
+## 2.3.22 (September 7, 2022)
 
-## Enhancements:
+### Enhancements:
 
   - Use a more accurate source code uri in gemspec [#5896](https://github.com/rubygems/rubygems/pull/5896)
   - Support `--path` option in `bundle add` [#5897](https://github.com/rubygems/rubygems/pull/5897)
@@ -1043,27 +1045,27 @@
   - Make `#to_lock` consistent between `Gem::Dependency` and `Bundler::Dependency` [#5872](https://github.com/rubygems/rubygems/pull/5872)
   - Support marshaled index specifications with `nil` required ruby version [#5824](https://github.com/rubygems/rubygems/pull/5824)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix resolution hanging on musl platforms [#5875](https://github.com/rubygems/rubygems/pull/5875)
   - Fix another regression affecting the sorbet family of gems [#5874](https://github.com/rubygems/rubygems/pull/5874)
 
-## Documentation:
+### Documentation:
 
   - Introduce bundle-console(1) man [#5901](https://github.com/rubygems/rubygems/pull/5901)
   - Introduce bundle-version(1) man [#5895](https://github.com/rubygems/rubygems/pull/5895)
   - Introduce bundle-help(1) man [#5886](https://github.com/rubygems/rubygems/pull/5886)
 
-# 2.3.21 (August 24, 2022)
+## 2.3.21 (August 24, 2022)
 
-## Enhancements:
+### Enhancements:
 
   - Backport non gnu libc linux support from RubyGems [#4488](https://github.com/rubygems/rubygems/pull/4488)
   - Improve `Bundler.rm_rf` error message [#5861](https://github.com/rubygems/rubygems/pull/5861)
   - Disallow both `--branch` and `--ref` at the same time in bundle-plugin [#5855](https://github.com/rubygems/rubygems/pull/5855)
   - Restore previous performance of private RubyGems servers [#5826](https://github.com/rubygems/rubygems/pull/5826)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix conservative update downgrading top level gems [#5847](https://github.com/rubygems/rubygems/pull/5847)
   - Fix edge case where `bundler/inline` unintentionally skips install [#5848](https://github.com/rubygems/rubygems/pull/5848)
@@ -1071,21 +1073,21 @@
   - Fix crash when incomplete locked specifications are found in transitive dependencies [#5840](https://github.com/rubygems/rubygems/pull/5840)
   - Fix Ruby platform incorrectly removed on `bundle update` [#5832](https://github.com/rubygems/rubygems/pull/5832)
 
-## Documentation:
+### Documentation:
 
   - Explain cancelled CLI deprecations clearly [#5864](https://github.com/rubygems/rubygems/pull/5864)
   - Improve `bundle config` command synopsis [#5854](https://github.com/rubygems/rubygems/pull/5854)
   - Introduce bundle-plugin(1) man [#5853](https://github.com/rubygems/rubygems/pull/5853)
 
-# 2.3.20 (August 10, 2022)
+## 2.3.20 (August 10, 2022)
 
-## Enhancements:
+### Enhancements:
 
   - Consistently ignore patchlevel when reporting `bundle platform --ruby` [#5793](https://github.com/rubygems/rubygems/pull/5793)
   - Make `--standalone` play nice with `--local` [#5762](https://github.com/rubygems/rubygems/pull/5762)
   - Implement `bundle install --prefer-local` [#5761](https://github.com/rubygems/rubygems/pull/5761)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix regression where yanked gems are now unintentionally updated when other gems are unlocked [#5812](https://github.com/rubygems/rubygems/pull/5812)
   - Automatically remove "ruby" from lockfile if incomplete [#5807](https://github.com/rubygems/rubygems/pull/5807)
@@ -1094,7 +1096,7 @@
   - Fix `bundle outdated` crash in debug mode [#5796](https://github.com/rubygems/rubygems/pull/5796)
   - Fix `ruby` DSL requirement matching for head and prerelease rubies [#5766](https://github.com/rubygems/rubygems/pull/5766)
 
-## Documentation:
+### Documentation:
 
   - Update Bundler support policies to match what we do these days [#5813](https://github.com/rubygems/rubygems/pull/5813)
   - Fix arguments for bundle-config(1) docs [#5804](https://github.com/rubygems/rubygems/pull/5804)
@@ -1103,9 +1105,9 @@
   - Add package/pack aliases to man pages for cache [#5785](https://github.com/rubygems/rubygems/pull/5785)
   - Add deprecation notice of bundle console [#5775](https://github.com/rubygems/rubygems/pull/5775)
 
-# 2.3.19 (July 27, 2022)
+## 2.3.19 (July 27, 2022)
 
-## Enhancements:
+### Enhancements:
 
   - Add `Bundler.settings[:only]` to install gems of the specified groups [#5759](https://github.com/rubygems/rubygems/pull/5759)
   - Add `ignore_funding_requests` config flag [#5767](https://github.com/rubygems/rubygems/pull/5767)
@@ -1114,16 +1116,16 @@
   - Reconcile error/warning message for multiple global sources with documentation [#5741](https://github.com/rubygems/rubygems/pull/5741)
   - Improve error message when gems cannot be found to include the source for each gem [#5729](https://github.com/rubygems/rubygems/pull/5729)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix yet another TruffleRuby platform selection regression [#5746](https://github.com/rubygems/rubygems/pull/5746)
   - Show a proper error if extension dir is not writable [#5726](https://github.com/rubygems/rubygems/pull/5726)
 
-## Performance:
+### Performance:
 
   - Lazily check incomplete lockfile to improve performance [#5546](https://github.com/rubygems/rubygems/pull/5546)
 
-## Documentation:
+### Documentation:
 
   - Add deprecation notice of bundle inject [#5776](https://github.com/rubygems/rubygems/pull/5776)
   - Add deprecation notice of `bundle viz` to man pages [#5765](https://github.com/rubygems/rubygems/pull/5765)
@@ -1132,62 +1134,62 @@
   - Improve global source(s) documentation [#5732](https://github.com/rubygems/rubygems/pull/5732)
   - Use https protocol for URLs for config mirror in bundler man [#5722](https://github.com/rubygems/rubygems/pull/5722)
 
-# 2.3.18 (July 14, 2022)
+## 2.3.18 (July 14, 2022)
 
-## Enhancements:
+### Enhancements:
 
   - Extend `gem` DSL with a `force_ruby_platform` option [#4049](https://github.com/rubygems/rubygems/pull/4049)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix misleading error if compact index cannot be copied [#5709](https://github.com/rubygems/rubygems/pull/5709)
   - Fix TruffleRuby no longer able to install lockfiles generated with other implementations [#5711](https://github.com/rubygems/rubygems/pull/5711)
   - Fix TruffleRuby no longer installing lockfiles using "ruby" platform correctly [#5694](https://github.com/rubygems/rubygems/pull/5694)
   - Fix crash when updating vendor cache of default gems [#5679](https://github.com/rubygems/rubygems/pull/5679)
 
-## Performance:
+### Performance:
 
   - Speed up `bundler/setup` by using the raw `Gemfile.lock` information without extra processing whenever possible [#5695](https://github.com/rubygems/rubygems/pull/5695)
 
-## Documentation:
+### Documentation:
 
   - Use modern style hashes in Gemfile DSL docs [#5674](https://github.com/rubygems/rubygems/pull/5674)
 
-# 2.3.17 (June 29, 2022)
+## 2.3.17 (June 29, 2022)
 
-## Enhancements:
+### Enhancements:
 
   - Add support for platform `:x64_mingw` to correctly lookup "x64-mingw-ucrt" [#5649](https://github.com/rubygems/rubygems/pull/5649)
   - Fix some errors being printed twice in `--verbose` mode [#5654](https://github.com/rubygems/rubygems/pull/5654)
   - Fix extension paths in generated standalone script [#5632](https://github.com/rubygems/rubygems/pull/5632)
 
-## Bug fixes:
+### Bug fixes:
 
   - Raise if ruby platform is forced and there are no ruby variants [#5495](https://github.com/rubygems/rubygems/pull/5495)
   - Fix `bundle package --no-install` no longer skipping install [#5639](https://github.com/rubygems/rubygems/pull/5639)
 
-## Performance:
+### Performance:
 
   - Improve performance of `Bundler::SpecSet#for` by using hash lookup of handled deps [#5537](https://github.com/rubygems/rubygems/pull/5537)
 
-## Documentation:
+### Documentation:
 
   - Fix formatting issue in `bundle add` man page [#5642](https://github.com/rubygems/rubygems/pull/5642)
 
-# 2.3.16 (June 15, 2022)
+## 2.3.16 (June 15, 2022)
 
-## Performance:
+### Performance:
 
   - Improve performance of installing gems from gem server sources [#5614](https://github.com/rubygems/rubygems/pull/5614)
 
-# 2.3.15 (June 1, 2022)
+## 2.3.15 (June 1, 2022)
 
-## Enhancements:
+### Enhancements:
 
   - Show better error when previous installation fails to be removed [#5564](https://github.com/rubygems/rubygems/pull/5564)
   - Show exception cause in bug report template [#5563](https://github.com/rubygems/rubygems/pull/5563)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `bundle remove` by invalidating cached `Bundle.definition` [#5443](https://github.com/rubygems/rubygems/pull/5443)
   - Fix generated standalone script when it includes default gems [#5586](https://github.com/rubygems/rubygems/pull/5586)
@@ -1199,160 +1201,160 @@
   - Ignore `Errno::EPERM` errors when creating `bundler.lock` [#5579](https://github.com/rubygems/rubygems/pull/5579)
   - Fix crash when printing resolution conflicts on metadata requirements [#5562](https://github.com/rubygems/rubygems/pull/5562)
 
-# 2.3.14 (May 18, 2022)
+## 2.3.14 (May 18, 2022)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix confusing inline mode install output [#5530](https://github.com/rubygems/rubygems/pull/5530)
   - Fix error message when locked version of a gem does not support running Ruby [#5525](https://github.com/rubygems/rubygems/pull/5525)
 
-## Performance:
+### Performance:
 
   - Improve `bundler/setup` performance again by not deduplicating intermediate results [#5533](https://github.com/rubygems/rubygems/pull/5533)
 
-## Documentation:
+### Documentation:
 
   - Fix typo in documentation [#5514](https://github.com/rubygems/rubygems/pull/5514)
   - Update man page for `require` option in `bundle add` command [#5513](https://github.com/rubygems/rubygems/pull/5513)
 
-# 2.3.13 (May 4, 2022)
+## 2.3.13 (May 4, 2022)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix missing required rubygems version when using old APIs [#5496](https://github.com/rubygems/rubygems/pull/5496)
   - Fix crash when gem used twice in Gemfile under different platforms [#5187](https://github.com/rubygems/rubygems/pull/5187)
 
-## Performance:
+### Performance:
 
   - Speed up `bundler/setup` time [#5503](https://github.com/rubygems/rubygems/pull/5503)
 
-# 2.3.12 (April 20, 2022)
+## 2.3.12 (April 20, 2022)
 
-## Enhancements:
+### Enhancements:
 
   - Improve Ruby version resolution conflicts [#5474](https://github.com/rubygems/rubygems/pull/5474)
   - Stop considering `RUBY_PATCHLEVEL` for resolution [#5472](https://github.com/rubygems/rubygems/pull/5472)
   - Add modern rubies as valid platform values in Gemfile DSL [#5469](https://github.com/rubygems/rubygems/pull/5469)
 
-# 2.3.11 (April 7, 2022)
+## 2.3.11 (April 7, 2022)
 
-## Enhancements:
+### Enhancements:
 
   - Bump actions/checkout to 3 in bundler gem template [#5445](https://github.com/rubygems/rubygems/pull/5445)
   - Prefer `__dir__` to `__FILE__` [#5444](https://github.com/rubygems/rubygems/pull/5444)
 
-## Documentation:
+### Documentation:
 
   - Update bundler documentation to reflect bundle config scope changes [#5441](https://github.com/rubygems/rubygems/pull/5441)
 
-# 2.3.10 (March 23, 2022)
+## 2.3.10 (March 23, 2022)
 
-## Enhancements:
+### Enhancements:
 
   - More helpful reporting of marshal loading issues [#5416](https://github.com/rubygems/rubygems/pull/5416)
   - Report Github Actions CI provider within user agent string [#5400](https://github.com/rubygems/rubygems/pull/5400)
   - Remove extra closing bracket in version warning [#5397](https://github.com/rubygems/rubygems/pull/5397)
 
-# 2.3.9 (March 9, 2022)
+## 2.3.9 (March 9, 2022)
 
-## Enhancements:
+### Enhancements:
 
   - Add newline to validate_platforms! message when platform is missing [#5353](https://github.com/rubygems/rubygems/pull/5353)
   - Suggest quicker `bundle add` for installation in `README.md` generated by `bundle gem` [#5337](https://github.com/rubygems/rubygems/pull/5337)
   - Make `--strict` flag of `update` and `outdated` commands consistent [#5379](https://github.com/rubygems/rubygems/pull/5379)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix regression when activating gem executables caused by Bundler monkey patches to RubyGems [#5386](https://github.com/rubygems/rubygems/pull/5386)
 
-# 2.3.8 (February 23, 2022)
+## 2.3.8 (February 23, 2022)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix corrupted lockfile when running `bundle check` and having to re-resolve locally [#5344](https://github.com/rubygems/rubygems/pull/5344)
   - Fix typo in multiple gemfiles warning [#5342](https://github.com/rubygems/rubygems/pull/5342)
 
-## Documentation:
+### Documentation:
 
   - Add clarification for bundle-config "with" option [#5346](https://github.com/rubygems/rubygems/pull/5346)
 
-# 2.3.7 (February 9, 2022)
+## 2.3.7 (February 9, 2022)
 
-## Enhancements:
+### Enhancements:
 
   - Don't activate `yaml` gem from Bundler [#5277](https://github.com/rubygems/rubygems/pull/5277)
   - Add Reverse Dependencies section to info command [#3966](https://github.com/rubygems/rubygems/pull/3966)
 
-## Bug fixes:
+### Bug fixes:
 
   - Don't silently persist `BUNDLE_WITH` and `BUNDLE_WITHOUT` envs locally [#5335](https://github.com/rubygems/rubygems/pull/5335)
   - Fix `bundle config` inside an application saving configuration globally [#4152](https://github.com/rubygems/rubygems/pull/4152)
 
-# 2.3.6 (January 26, 2022)
+## 2.3.6 (January 26, 2022)
 
-## Enhancements:
+### Enhancements:
 
   - Use `Gem::Platform.local` instead of `RUBY_PLATFORM` when displaying local platform [#5306](https://github.com/rubygems/rubygems/pull/5306)
   - Lock standard.yml to the required ruby version [#5284](https://github.com/rubygems/rubygems/pull/5284)
   - Use `Fiddle` in `bundle doctor` to check for dynamic library presence [#5173](https://github.com/rubygems/rubygems/pull/5173)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix edge case where gems were incorrectly removed from the lockfile [#5302](https://github.com/rubygems/rubygems/pull/5302)
   - Fix `force_ruby_platform` ignored when lockfile includes current specific platform [#5304](https://github.com/rubygems/rubygems/pull/5304)
   - Create minitest file to underscored path in "bundle gem" command with dashed gem name [#5273](https://github.com/rubygems/rubygems/pull/5273)
   - Fix regression with old marshaled specs having null `required_rubygems_version` [#5291](https://github.com/rubygems/rubygems/pull/5291)
 
-# 2.3.5 (January 12, 2022)
+## 2.3.5 (January 12, 2022)
 
-## Enhancements:
+### Enhancements:
 
   - Make `bundle update --bundler` actually lock to the latest bundler version (even if not yet installed) [#5182](https://github.com/rubygems/rubygems/pull/5182)
   - Use thor-1.2.1 [#5260](https://github.com/rubygems/rubygems/pull/5260)
   - Exclude bin directory for newgem template [#5259](https://github.com/rubygems/rubygems/pull/5259)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix metadata requirements being bypassed when custom gem servers are used [#5256](https://github.com/rubygems/rubygems/pull/5256)
   - Fix `rake build:checksum` writing checksum of package path, not package contents [#5250](https://github.com/rubygems/rubygems/pull/5250)
 
-# 2.3.4 (December 29, 2021)
+## 2.3.4 (December 29, 2021)
 
-## Enhancements:
+### Enhancements:
 
   - Improve error message when `BUNDLED WITH` version does not exist [#5205](https://github.com/rubygems/rubygems/pull/5205)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `bundle update --bundler` no longer updating lockfile [#5224](https://github.com/rubygems/rubygems/pull/5224)
 
-# 2.3.3 (December 24, 2021)
+## 2.3.3 (December 24, 2021)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix locked bundler not installed to the right path when `deployment` is set [#5217](https://github.com/rubygems/rubygems/pull/5217)
 
-# 2.3.2 (December 23, 2021)
+## 2.3.2 (December 23, 2021)
 
-## Enhancements:
+### Enhancements:
 
   - Remove unnecessary lockfile upgrade warning [#5209](https://github.com/rubygems/rubygems/pull/5209)
 
-# 2.3.1 (December 22, 2021)
+## 2.3.1 (December 22, 2021)
 
-## Enhancements:
+### Enhancements:
 
   - Vendor latest `thor` with fixes for latest `did_you_mean` deprecations [#5202](https://github.com/rubygems/rubygems/pull/5202)
   - Avoid unnecessary `shellwords` require on newer rubygems [#5195](https://github.com/rubygems/rubygems/pull/5195)
   - Re-exec prepending command with `Gem.ruby` if `$PROGRAM_NAME` is not executable [#5193](https://github.com/rubygems/rubygems/pull/5193)
 
-# 2.3.0 (December 21, 2021)
+## 2.3.0 (December 21, 2021)
 
-## Features:
+### Features:
 
   - Change `bundle install` with a lockfile to respect the `BUNDLED WITH` bundler version [#4076](https://github.com/rubygems/rubygems/pull/4076)
 
-## Enhancements:
+### Enhancements:
 
   - Cancel deprecation of custom git sources [#5147](https://github.com/rubygems/rubygems/pull/5147)
   - Print warning when running Bundler on potentially problematic RubyGems & Ruby combinations [#5177](https://github.com/rubygems/rubygems/pull/5177)
@@ -1364,23 +1366,23 @@
   - `bundle gem` generated MiniTest file and class now start with 'test' [#3893](https://github.com/rubygems/rubygems/pull/3893)
   - Add `Bundler::Definition.no_lock` accessor for skipping lockfile creation/update [#3401](https://github.com/rubygems/rubygems/pull/3401)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix crash when when no platform specific matches exist and show a proper error [#5168](https://github.com/rubygems/rubygems/pull/5168)
   - Ignore dependencies not actually locked from frozen check [#5152](https://github.com/rubygems/rubygems/pull/5152)
   - Fix `bundle cache --all-platforms` on Windows [#4552](https://github.com/rubygems/rubygems/pull/4552)
 
-## Documentation:
+### Documentation:
 
   - Fix gemspec template typo [#4545](https://github.com/rubygems/rubygems/pull/4545)
 
-# 2.2.33 (December 7, 2021)
+## 2.2.33 (December 7, 2021)
 
-## Security fixes:
+### Security fixes:
 
   - Pass "--" to git commands to separate positional and optional args [#5142](https://github.com/rubygems/rubygems/pull/5142)
 
-## Enhancements:
+### Enhancements:
 
   - Accept pull request URLs as github source [#5126](https://github.com/rubygems/rubygems/pull/5126)
   - Add `--version` parameter to `bundle info` command [#5137](https://github.com/rubygems/rubygems/pull/5137)
@@ -1390,7 +1392,7 @@
   - Add an initial rbs template to `bundle gem` skeleton [#5041](https://github.com/rubygems/rubygems/pull/5041)
   - Avoid shared libraries not getting environment passed right after argv in memory when `bundle exec` is used [#4815](https://github.com/rubygems/rubygems/pull/4815)
 
-## Bug fixes:
+### Bug fixes:
 
   - Don't cleanup paths from gems already activated from `$LOAD_PATH` [#5111](https://github.com/rubygems/rubygems/pull/5111)
   - Fix handling prereleases of 0 versions, like 0.0.0.dev or 0.0.0.SNAPSHOT [#5116](https://github.com/rubygems/rubygems/pull/5116)
@@ -1399,26 +1401,26 @@
   - Fix missing locked specs when depended on another platform [#5092](https://github.com/rubygems/rubygems/pull/5092)
   - Fix `bundle info` sometimes claiming that bundler has been deleted [#5097](https://github.com/rubygems/rubygems/pull/5097)
 
-## Documentation:
+### Documentation:
 
   - Ignore to generate the documentation from vendored libraries [#5118](https://github.com/rubygems/rubygems/pull/5118)
 
-# 2.2.32 (November 23, 2021)
+## 2.2.32 (November 23, 2021)
 
-## Enhancements:
+### Enhancements:
 
   - Clarify `bundle viz` deprecation [#5083](https://github.com/rubygems/rubygems/pull/5083)
   - Unlock dependencies that no longer match lockfile [#5068](https://github.com/rubygems/rubygems/pull/5068)
   - Use `shellsplit` instead of array of strings for git push [#5062](https://github.com/rubygems/rubygems/pull/5062)
   - Re-enable `default_ignores` option for standard [#5003](https://github.com/rubygems/rubygems/pull/5003)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix downgrading dependencies by changing the `Gemfile` and running `bundle update` [#5078](https://github.com/rubygems/rubygems/pull/5078)
 
-# 2.2.31 (November 8, 2021)
+## 2.2.31 (November 8, 2021)
 
-## Enhancements:
+### Enhancements:
 
   - Link to working `bundler-graph` plugin in `bundle viz` deprecation message [#5061](https://github.com/rubygems/rubygems/pull/5061)
   - Memoize materialized specs when requiring `bundler/setup` [#5033](https://github.com/rubygems/rubygems/pull/5033)
@@ -1428,14 +1430,14 @@
   - Support gemified `tsort` [#5032](https://github.com/rubygems/rubygems/pull/5032)
   - Add standard option alongside rubocop to `bundle gem` [#4411](https://github.com/rubygems/rubygems/pull/4411)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix system man pages no longer working after bundler overrides `MANPATH` [#5039](https://github.com/rubygems/rubygems/pull/5039)
   - Don't warn when a lockfile is locked to a dev version [#5018](https://github.com/rubygems/rubygems/pull/5018)
 
-# 2.2.30 (October 26, 2021)
+## 2.2.30 (October 26, 2021)
 
-## Enhancements:
+### Enhancements:
 
   - Add a custom SHA1 digest implementation to no longer depend on the digest gem before we know which version to activate [#4989](https://github.com/rubygems/rubygems/pull/4989)
   - Ensure vendored gems have licenses [#4998](https://github.com/rubygems/rubygems/pull/4998)
@@ -1446,35 +1448,35 @@
   - Unify issue template and ISSUES.md document [#4980](https://github.com/rubygems/rubygems/pull/4980)
   - Bump vendored connection_pool to 2.2.5 [#4738](https://github.com/rubygems/rubygems/pull/4738)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix error message pointing to non existing file when using a global gem cache [#4999](https://github.com/rubygems/rubygems/pull/4999)
   - Fix install crash when lockfile has missing dependencies for the current platform [#4941](https://github.com/rubygems/rubygems/pull/4941)
   - Make `bundle info` show a proper warning every time it finds a deleted gem [#4971](https://github.com/rubygems/rubygems/pull/4971)
 
-# 2.2.29 (October 8, 2021)
+## 2.2.29 (October 8, 2021)
 
-## Enhancements:
+### Enhancements:
 
   - Require at least Ruby 2.6.0 for gems created with recent rubies [#4920](https://github.com/rubygems/rubygems/pull/4920)
   - Include glob information in string representation of git sources to make generated lockfiles deterministic [#4947](https://github.com/rubygems/rubygems/pull/4947)
   - Add missing `rubygem_push` prerequisite [#4930](https://github.com/rubygems/rubygems/pull/4930)
 
-# 2.2.28 (September 23, 2021)
+## 2.2.28 (September 23, 2021)
 
-## Enhancements:
+### Enhancements:
 
   - Use example.com in new gem template, since it will never have a potentially dangerous backing website [#4918](https://github.com/rubygems/rubygems/pull/4918)
   - Deprecate `--install` flag to `bundle remove` and trigger install by default [#4891](https://github.com/rubygems/rubygems/pull/4891)
 
-# 2.2.27 (September 3, 2021)
+## 2.2.27 (September 3, 2021)
 
-## Enhancements:
+### Enhancements:
 
   - Optimize some requires [#4887](https://github.com/rubygems/rubygems/pull/4887)
   - Correctly redact credentials when using x-oauth-basic [#4866](https://github.com/rubygems/rubygems/pull/4866)
 
-## Bug fixes:
+### Bug fixes:
 
   - Add missing key `branches:` to template for GitHub Actions [#4883](https://github.com/rubygems/rubygems/pull/4883)
   - Fix `bundle plugin install` detection of already installed plugins [#4869](https://github.com/rubygems/rubygems/pull/4869)
@@ -1482,9 +1484,9 @@
   - Fix `bundle check` showing duplicated gems when multiple platforms are locked [#4854](https://github.com/rubygems/rubygems/pull/4854)
   - Fix `bundle check` incorrectly considering cached gems [#4853](https://github.com/rubygems/rubygems/pull/4853)
 
-# 2.2.26 (August 17, 2021)
+## 2.2.26 (August 17, 2021)
 
-## Enhancements:
+### Enhancements:
 
   - Remove `RUBYGEMS_GEMDEPS` warning [#4827](https://github.com/rubygems/rubygems/pull/4827)
   - Better defaults for GitHub Actions template generated by `bundle gem` [#4619](https://github.com/rubygems/rubygems/pull/4619)
@@ -1494,27 +1496,27 @@
   - Make script generated by `bundle install --standalone` resilient to moving the application to a differently nested folder when `path` sources are used [#4792](https://github.com/rubygems/rubygems/pull/4792)
   - Exclude CI files and issue templates from file list of gems generated by `bundle gem` [#4033](https://github.com/rubygems/rubygems/pull/4033)
 
-## Bug fixes:
+### Bug fixes:
 
   - Respect `BUNDLE_USER_HOME` env when choosing config location [#4828](https://github.com/rubygems/rubygems/pull/4828)
   - Fix `bundle gem` on path with spaces [#4816](https://github.com/rubygems/rubygems/pull/4816)
   - Fix bundler hitting the network in some cases where not allowed [#4805](https://github.com/rubygems/rubygems/pull/4805)
 
-# 2.2.25 (July 30, 2021)
+## 2.2.25 (July 30, 2021)
 
-## Deprecations:
+### Deprecations:
 
   - Deprecate Gemfile without an explicit global source [#4779](https://github.com/rubygems/rubygems/pull/4779)
   - Deprecate `bundle cache --path` [#4496](https://github.com/rubygems/rubygems/pull/4496)
 
-## Enhancements:
+### Enhancements:
 
   - Give better errors when materialization fails [#4788](https://github.com/rubygems/rubygems/pull/4788)
   - Lazily load `shellwords` library [#4786](https://github.com/rubygems/rubygems/pull/4786)
   - Show original error and backtrace directly on `bundle install` errors instead of a more brittle `gem install` hint [#4778](https://github.com/rubygems/rubygems/pull/4778)
   - Remove LoadError message in regards to requiring a relative file [#4772](https://github.com/rubygems/rubygems/pull/4772)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `BUNDLE_USER_CONFIG` no longer respected as config location [#4797](https://github.com/rubygems/rubygems/pull/4797)
   - Fix `--standalone` installation of default gems [#4782](https://github.com/rubygems/rubygems/pull/4782)
@@ -1522,39 +1524,39 @@
   - Fix bundler binstub version selection [#4775](https://github.com/rubygems/rubygems/pull/4775)
   - Fix interrupt handling in Bundler workers [#4767](https://github.com/rubygems/rubygems/pull/4767)
 
-# 2.2.24 (July 15, 2021)
+## 2.2.24 (July 15, 2021)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix development gem unintentionally removed on an edge case [#4751](https://github.com/rubygems/rubygems/pull/4751)
   - Fix dangling empty plugin hooks [#4755](https://github.com/rubygems/rubygems/pull/4755)
   - Fix `bundle plugin install --help` showing `bundle install`'s help [#4756](https://github.com/rubygems/rubygems/pull/4756)
   - Make sure `bundle check` shows uniq missing gems [#4749](https://github.com/rubygems/rubygems/pull/4749)
 
-## Performance:
+### Performance:
 
   - Slightly speed up `bundler/setup` [#4750](https://github.com/rubygems/rubygems/pull/4750)
 
-# 2.2.23 (July 9, 2021)
+## 2.2.23 (July 9, 2021)
 
-## Enhancements:
+### Enhancements:
 
   - Fix `bundle install` on truffleruby selecting incorrect variant for `sorbet-static` gem [#4625](https://github.com/rubygems/rubygems/pull/4625)
   - Spare meaningless warning on read-only bundle invocations [#4724](https://github.com/rubygems/rubygems/pull/4724)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix incorrect warning about duplicated gems in the Gemfile [#4732](https://github.com/rubygems/rubygems/pull/4732)
   - Fix `bundle plugin install foo` crashing [#4734](https://github.com/rubygems/rubygems/pull/4734)
 
-# 2.2.22 (July 6, 2021)
+## 2.2.22 (July 6, 2021)
 
-## Enhancements:
+### Enhancements:
 
   - Never downgrade indirect dependencies when running `bundle update` [#4713](https://github.com/rubygems/rubygems/pull/4713)
   - Fix `getaddrinfo` errors not treated as fatal on non darwin platforms [#4703](https://github.com/rubygems/rubygems/pull/4703)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `bundle update <gem>` sometimes hanging and `bundle lock --update` not being able to update an insecure lockfile to the new format if it requires downgrades [#4652](https://github.com/rubygems/rubygems/pull/4652)
   - Fix edge case combination of DSL methods and duplicated sources causing gems to not be found [#4711](https://github.com/rubygems/rubygems/pull/4711)
@@ -1563,63 +1565,63 @@
   - Fix some gems being unintentionally locked under multiple lockfile sections [#4701](https://github.com/rubygems/rubygems/pull/4701)
   - Fix `--conservative` flag unexpectedly updating indirect dependencies. NOTE: As part of this bug fix, some undocumented, unintentional code causing `bundle update --source <gem>` to update conservatively was fixed. Use the documented `bundle update --conservative <gem>` instead [#4692](https://github.com/rubygems/rubygems/pull/4692)
 
-# 2.2.21 (June 23, 2021)
+## 2.2.21 (June 23, 2021)
 
-## Security fixes:
+### Security fixes:
 
   - Auto-update insecure lockfile to split GEM source sections whenever possible [#4647](https://github.com/rubygems/rubygems/pull/4647)
 
-## Enhancements:
+### Enhancements:
 
   - Use a more limited number of threads when fetching in parallel from the Compact Index API [#4670](https://github.com/rubygems/rubygems/pull/4670)
   - Update TODO link in bundle gem template to https [#4671](https://github.com/rubygems/rubygems/pull/4671)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `bundle install --local` hitting the network when `cache_all_platforms` configured [#4677](https://github.com/rubygems/rubygems/pull/4677)
 
-# 2.2.20 (June 11, 2021)
+## 2.2.20 (June 11, 2021)
 
-## Enhancements:
+### Enhancements:
 
   - Don't print bug report template on server side errors [#4663](https://github.com/rubygems/rubygems/pull/4663)
   - Don't load `resolv` unnecessarily [#4640](https://github.com/rubygems/rubygems/pull/4640)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `bundle outdated` edge case [#4648](https://github.com/rubygems/rubygems/pull/4648)
   - Fix `bundle check` with scoped rubygems sources [#4639](https://github.com/rubygems/rubygems/pull/4639)
 
-## Performance:
+### Performance:
 
   - Don't use `extra_rdoc_files` with md files in gemspec to make installing bundler with docs faster [#4628](https://github.com/rubygems/rubygems/pull/4628)
 
-# 2.2.19 (May 31, 2021)
+## 2.2.19 (May 31, 2021)
 
-## Bug fixes:
+### Bug fixes:
 
   - Restore support for configuration keys with dashes [#4582](https://github.com/rubygems/rubygems/pull/4582)
   - Fix some cached gems being unintentionally ignored when using rubygems 3.2.18 [#4623](https://github.com/rubygems/rubygems/pull/4623)
 
-# 2.2.18 (May 25, 2021)
+## 2.2.18 (May 25, 2021)
 
-## Security fixes:
+### Security fixes:
 
   - Fix dependency confusion issues with implicit dependencies [#4609](https://github.com/rubygems/rubygems/pull/4609)
 
-## Enhancements:
+### Enhancements:
 
   - Use simpler notation for generated `required_ruby_version` [#4598](https://github.com/rubygems/rubygems/pull/4598)
   - Undeprecate bundle show [#4586](https://github.com/rubygems/rubygems/pull/4586)
   - Make sure link to new issue uses the proper template [#4592](https://github.com/rubygems/rubygems/pull/4592)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix platform specific gems being removed from the lockfile [#4580](https://github.com/rubygems/rubygems/pull/4580)
 
-# 2.2.17 (May 5, 2021)
+## 2.2.17 (May 5, 2021)
 
-## Enhancements:
+### Enhancements:
 
   - Improve authentication required error message to include an alternative using `ENV` [#4565](https://github.com/rubygems/rubygems/pull/4565)
   - Discard partial range responses without etag [#4563](https://github.com/rubygems/rubygems/pull/4563)
@@ -1631,19 +1633,19 @@
   - Prefer File.read instead of IO.read [#4530](https://github.com/rubygems/rubygems/pull/4530)
   - Add space after open curly bracket in Gemfile and gems.rb template [#4518](https://github.com/rubygems/rubygems/pull/4518)
 
-## Bug fixes:
+### Bug fixes:
 
   - Make sure specs are fetched from the right source when materializing [#4562](https://github.com/rubygems/rubygems/pull/4562)
   - Fix `bundle cache` with an up-to-date lockfile and specs not already installed [#4554](https://github.com/rubygems/rubygems/pull/4554)
   - Ignore `deployment` setting in inline mode [#4523](https://github.com/rubygems/rubygems/pull/4523)
 
-## Performance:
+### Performance:
 
   - Don't materialize resolutions when not necessary [#4556](https://github.com/rubygems/rubygems/pull/4556)
 
-# 2.2.16 (April 8, 2021)
+## 2.2.16 (April 8, 2021)
 
-## Enhancements:
+### Enhancements:
 
   - Add `--github-username` option and config to `bundle gem` [#3687](https://github.com/rubygems/rubygems/pull/3687)
   - Bump vendored `tmpdir` library copy [#4506](https://github.com/rubygems/rubygems/pull/4506)
@@ -1654,137 +1656,137 @@
   - Don't show duplicate entries in `bundle outdated` output [#4474](https://github.com/rubygems/rubygems/pull/4474)
   - Never downgrade top level gems when running `bundle update` [#4473](https://github.com/rubygems/rubygems/pull/4473)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix incorrect logic for filtering metadata matching candidates [#4497](https://github.com/rubygems/rubygems/pull/4497)
 
-# 2.2.15 (March 19, 2021)
+## 2.2.15 (March 19, 2021)
 
-## Enhancements:
+### Enhancements:
 
   - Add a hint about bundler installing executables for path gems [#4461](https://github.com/rubygems/rubygems/pull/4461)
   - Warn lockfiles with incorrect resolutions [#4459](https://github.com/rubygems/rubygems/pull/4459)
   - Don't generate duplicate redundant sources in the lockfile [#4456](https://github.com/rubygems/rubygems/pull/4456)
 
-## Bug fixes:
+### Bug fixes:
 
   - Respect running ruby when resolving platforms [#4449](https://github.com/rubygems/rubygems/pull/4449)
 
-# 2.2.14 (March 8, 2021)
+## 2.2.14 (March 8, 2021)
 
-## Security fixes:
+### Security fixes:
 
   - Lock GEM sources separately and fix locally installed specs confusing bundler [#4381](https://github.com/rubygems/rubygems/pull/4381)
 
-## Bug fixes:
+### Bug fixes:
 
   - Make `rake` available to other gems' installers right after it's installed [#4428](https://github.com/rubygems/rubygems/pull/4428)
   - Fix encoding issue on compact index updater [#4362](https://github.com/rubygems/rubygems/pull/4362)
 
-# 2.2.13 (March 3, 2021)
+## 2.2.13 (March 3, 2021)
 
-## Enhancements:
+### Enhancements:
 
   - Respect user configured default branch in README links in new generated gems [#4303](https://github.com/rubygems/rubygems/pull/4303)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix gems sometimes being pulled from irrelevant sources [#4418](https://github.com/rubygems/rubygems/pull/4418)
 
-# 2.2.12 (March 1, 2021)
+## 2.2.12 (March 1, 2021)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix sporadic warnings about `nil` gemspec on install/update and make those faster [#4409](https://github.com/rubygems/rubygems/pull/4409)
   - Fix deployment install with duplicate path gems added to Gemfile [#4410](https://github.com/rubygems/rubygems/pull/4410)
 
-# 2.2.11 (February 17, 2021)
+## 2.2.11 (February 17, 2021)
 
-## Bug fixes:
+### Bug fixes:
 
   - Revert disable_multisource changes [#4385](https://github.com/rubygems/rubygems/pull/4385)
 
-# 2.2.10 (February 15, 2021)
+## 2.2.10 (February 15, 2021)
 
-## Security fixes:
+### Security fixes:
 
   - Fix source priority for transitive dependencies and split lockfile rubygems source sections [#3655](https://github.com/rubygems/rubygems/pull/3655)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix adding platforms to lockfile sometimes conflicting on ruby requirements [#4371](https://github.com/rubygems/rubygems/pull/4371)
   - Fix bundler sometimes choosing ruby variants over java ones [#4367](https://github.com/rubygems/rubygems/pull/4367)
 
-## Documentation:
+### Documentation:
 
   - Update man pages to reflect to new default for bundle install jobs [#4188](https://github.com/rubygems/rubygems/pull/4188)
 
-# 2.2.9 (February 8, 2021)
+## 2.2.9 (February 8, 2021)
 
-## Enhancements:
+### Enhancements:
 
   - Stop removing existing platforms when force_ruby_platform is true [#4336](https://github.com/rubygems/rubygems/pull/4336)
 
-## Bug fixes:
+### Bug fixes:
 
   - Don't install platform specific gems on truffleruby [#4333](https://github.com/rubygems/rubygems/pull/4333)
 
-# 2.2.8 (February 2, 2021)
+## 2.2.8 (February 2, 2021)
 
-## Enhancements:
+### Enhancements:
 
   - Add a CHANGELOG.md file to gems generated by `bundle gem` [#4093](https://github.com/rubygems/rubygems/pull/4093)
   - Support gemified `set` [#4297](https://github.com/rubygems/rubygems/pull/4297)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix standalone Kernel.require visibility [#4337](https://github.com/rubygems/rubygems/pull/4337)
 
-## Performance:
+### Performance:
 
   - Fix resolver edge cases and speed up bundler [#4277](https://github.com/rubygems/rubygems/pull/4277)
 
-# 2.2.7 (January 26, 2021)
+## 2.2.7 (January 26, 2021)
 
-## Enhancements:
+### Enhancements:
 
   - Improve error messages when dependency on bundler conflicts with running version [#4308](https://github.com/rubygems/rubygems/pull/4308)
   - Avoid showing platforms with requirements in error messages [#4310](https://github.com/rubygems/rubygems/pull/4310)
   - Introduce disable_local_revision_check config [#4237](https://github.com/rubygems/rubygems/pull/4237)
   - Reverse rubygems require mixin with bundler standalone [#4299](https://github.com/rubygems/rubygems/pull/4299)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix releasing from a not yet pushed branch [#4309](https://github.com/rubygems/rubygems/pull/4309)
   - Install cache only once if it already exists [#4304](https://github.com/rubygems/rubygems/pull/4304)
   - Fix `force_ruby_platform` no longer being respected [#4302](https://github.com/rubygems/rubygems/pull/4302)
 
-## Performance:
+### Performance:
 
   - Fix resolver dependency comparison [#4289](https://github.com/rubygems/rubygems/pull/4289)
 
-# 2.2.6 (January 18, 2021)
+## 2.2.6 (January 18, 2021)
 
-## Enhancements:
+### Enhancements:
 
   - Improve resolver debugging [#4288](https://github.com/rubygems/rubygems/pull/4288)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix dependency locking for path source [#4293](https://github.com/rubygems/rubygems/pull/4293)
 
-## Performance:
+### Performance:
 
   - Speed up complex dependency resolves by creating DepProxy factory and cache [#4216](https://github.com/rubygems/rubygems/pull/4216)
 
-# 2.2.5 (January 11, 2021)
+## 2.2.5 (January 11, 2021)
 
-## Enhancements:
+### Enhancements:
 
   - Improve rubocop setup in the new gem template [#4220](https://github.com/rubygems/rubygems/pull/4220)
   - Support repositories with default branch not named master [#4224](https://github.com/rubygems/rubygems/pull/4224)
 
-## Bug fixes:
+### Bug fixes:
 
   - Let Net::HTTP decompress the index instead of doing it manually [#4081](https://github.com/rubygems/rubygems/pull/4081)
   - Workaround for another jruby crash when autoloading a constant [#4252](https://github.com/rubygems/rubygems/pull/4252)
@@ -1793,32 +1795,32 @@
   - Give a proper error if cache path does not have write access [#4215](https://github.com/rubygems/rubygems/pull/4215)
   - Fix running `rake release` from an ambiguous ref [#4219](https://github.com/rubygems/rubygems/pull/4219)
 
-# 2.2.4 (December 31, 2020)
+## 2.2.4 (December 31, 2020)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix bundle man pages display on truffleruby [#4209](https://github.com/rubygems/rubygems/pull/4209)
   - Fix Windows + JRuby no longer being able to install git sources [#4196](https://github.com/rubygems/rubygems/pull/4196)
 
-# 2.2.3 (December 22, 2020)
+## 2.2.3 (December 22, 2020)
 
-## Bug fixes:
+### Bug fixes:
 
   - Restore full compatibility with previous lockfiles [#4179](https://github.com/rubygems/rubygems/pull/4179)
   - Add all matching variants with the same platform specificity to the lockfile [#4180](https://github.com/rubygems/rubygems/pull/4180)
   - Fix bundler installing gems for a different platform when running in frozen mode and current platform not in the lockfile [#4172](https://github.com/rubygems/rubygems/pull/4172)
   - Fix crash when `bundle exec`'ing to bundler [#4175](https://github.com/rubygems/rubygems/pull/4175)
 
-# 2.2.2 (December 17, 2020)
+## 2.2.2 (December 17, 2020)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix resolver crash when a candidate has 0 matching platforms [#4163](https://github.com/rubygems/rubygems/pull/4163)
   - Restore change to copy global with/without config locally upon `bundle install` [#4154](https://github.com/rubygems/rubygems/pull/4154)
 
-# 2.2.1 (December 14, 2020)
+## 2.2.1 (December 14, 2020)
 
-## Bug fixes:
+### Bug fixes:
 
   - Ad-hoc fix for platform regression [#4127](https://github.com/rubygems/rubygems/pull/4127)
   - Workaround JRuby + Windows issue with net-http-persistent vendored code [#4138](https://github.com/rubygems/rubygems/pull/4138)
@@ -1827,9 +1829,9 @@
   - Fix `bundle outdated --strict` crash [#4133](https://github.com/rubygems/rubygems/pull/4133)
   - Autoload `Bundler::RemoteSpecification` to workaround crash on jruby [#4114](https://github.com/rubygems/rubygems/pull/4114)
 
-# 2.2.0 (December 7, 2020)
+## 2.2.0 (December 7, 2020)
 
-## Enhancements:
+### Enhancements:
 
   - New gem template: prefer `require_relative` to `require` [#4066](https://github.com/rubygems/rubygems/pull/4066)
   - Always show underlying error when fetching specs fails [#4061](https://github.com/rubygems/rubygems/pull/4061)
@@ -1839,7 +1841,7 @@
   - Remove extra empty line from README template [#4041](https://github.com/rubygems/rubygems/pull/4041)
   - Lazily load `erb` [#4011](https://github.com/rubygems/rubygems/pull/4011)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `Bundler::Plugin::API::Source#to_s` having empty source type [#4084](https://github.com/rubygems/rubygems/pull/4084)
   - Raise consistent errors with or without `bundle exec` [#4063](https://github.com/rubygems/rubygems/pull/4063)
@@ -1856,23 +1858,23 @@
   - Fix fileutils double load when using `bundler/inline` [#3991](https://github.com/rubygems/rubygems/pull/3991)
   - Accept responses with no etag header [#3865](https://github.com/rubygems/rubygems/pull/3865)
 
-## Documentation:
+### Documentation:
 
   - Fix typo of `bundle-install.1` (v2.1) [#4079](https://github.com/rubygems/rubygems/pull/4079)
   - Add commented out example and more information link to generated gemspec [#4034](https://github.com/rubygems/rubygems/pull/4034)
 
-# 2.2.0.rc.2 (October 6, 2020)
+## 2.2.0.rc.2 (October 6, 2020)
 
-## Features:
+### Features:
 
   - Add `bundle fund` command [#3390](https://github.com/rubygems/rubygems/pull/3390)
 
-## Enhancements:
+### Enhancements:
 
   - Fix ls-files matching regexp [#3845](https://github.com/rubygems/rubygems/pull/3845)
   - Remove redundant `bundler/setup` require from `spec_helper.rb` generated by `bundle gem` [#3791](https://github.com/rubygems/rubygems/pull/3791)
 
-## Bug fixes:
+### Bug fixes:
 
   - Deduplicate spec groups [#3965](https://github.com/rubygems/rubygems/pull/3965)
   - Fix some cases of running `bundler` on a path including brackets [#3854](https://github.com/rubygems/rubygems/pull/3854)
@@ -1896,11 +1898,11 @@
   - Fix `rake release` pushing all local tags instead of only the release tag [#3785](https://github.com/rubygems/rubygems/pull/3785)
   - Fix `rake release` aborting when credentials file is missing, even if properly configured through XDG [#3783](https://github.com/rubygems/rubygems/pull/3783)
 
-## Deprecations:
+### Deprecations:
 
   - Deprecate `bundle cache --all` flag [#3932](https://github.com/rubygems/rubygems/pull/3932)
 
-## Documentation:
+### Documentation:
 
   - Correct grammar in Gemfile docs [#3990](https://github.com/rubygems/rubygems/pull/3990)
   - Fix typo in `bundle pristine` warning message [#3959](https://github.com/rubygems/rubygems/pull/3959)
@@ -1908,14 +1910,14 @@
   - Note CLI flag deprecations in documentation [#3915](https://github.com/rubygems/rubygems/pull/3915)
   - Update man page and deprecation warning for binstubs --all [#3872](https://github.com/rubygems/rubygems/pull/3872)
 
-# 2.2.0.rc.1 (July 2, 2020)
+## 2.2.0.rc.1 (July 2, 2020)
 
-## Features:
+### Features:
 
   - Windows support. There's still gotchas and unimplemented features, but a Windows CI is now enforced.
   - Full multiplatform support. Bundler should now seamlessly handle multiplatform `Gemfile` or `gems.rb` files.
 
-## Enhancements:
+### Enhancements:
 
   - `bundle info` now includes gem metadata [#7376](https://github.com/rubygems/bundler/pull/7376)
   - `bundle list --without-group` and `bundle list --only-group` now support space separated list of groups in addition to single groups [#7404](https://github.com/rubygems/bundler/pull/7404)
@@ -1942,7 +1944,7 @@
   - Remove some requires that might workaround some autoloading issues on jruby [#3771](https://github.com/rubygems/rubygems/pull/3771)
   - Unswallow an error that should make some random crashes on jruby easier to troubleshoot [#3774](https://github.com/rubygems/rubygems/pull/3774)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `bundle pristine` removing gems with local overrides. Be conservative by printing a warning and skipping the removal [#7423](https://github.com/rubygems/bundler/pull/7423)
   - Fix multiplaform resolution edge cases [#7522](https://github.com/rubygems/bundler/pull/7522) and [#7578](https://github.com/rubygems/bundler/pull/7578)
@@ -1970,38 +1972,38 @@
   - Fix `--no-cache` to `bundle install` being unintentionally deprecated [#3688](https://github.com/rubygems/rubygems/pull/3688)
   - Avoid calling `LoadError#message` to fix performance regression in future ruby 3.0 [#3762](https://github.com/rubygems/rubygems/pull/3762)
 
-# 2.1.4 (January 5, 2020)
+## 2.1.4 (January 5, 2020)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `net-http-pipeline` no longer being allowed in Gemfiles if already installed in the system due to our vendored version of `net-http-persistent` optionally requiring it [#7529](https://github.com/bundler/bundler/pull/7529)
   - Fix inline gems no longer being requirable if no Gemfile is present in the directory hierarchy [#7537](https://github.com/bundler/bundler/pull/7537)
 
-# 2.1.3 (January 2, 2020)
+## 2.1.3 (January 2, 2020)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `rake build` when path has spaces on it [#7514](https://github.com/bundler/bundler/pull/7514)
   - Fix `rake release` git push tasks when the running shell has `git` as an alias of another command (like `hub`) [#7510](https://github.com/bundler/bundler/pull/7510)
   - Fix some circular require warnings [#7520](https://github.com/bundler/bundler/pull/7520)
   - Fix `bundle config set deployment true` recommended alternative to `bundle config --deployment` to behave in the same way as the `--deployment` flag [#7519](https://github.com/bundler/bundler/pull/7519)
 
-# 2.1.2 (December 20, 2019)
+## 2.1.2 (December 20, 2019)
 
-## Bug fixes:
+### Bug fixes:
 
   - Restore an explicit `require "rubygems"` on top `rubygems_integration.rb` to avoid some missing constant errors under some convoluted setups [#7505](https://github.com/rubygems/bundler/pull/7505)
 
-# 2.1.1 (December 17, 2019)
+## 2.1.1 (December 17, 2019)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix some cases of shelling out to `rubygems` still being silent [#7493](https://github.com/rubygems/bundler/pull/7493)
   - Restore compatibility with `rubygems-bundler` so that binstubs work under `RVM` [#7498](https://github.com/rubygems/bundler/pull/7498)
 
-# 2.1.0 (December 15, 2019)
+## 2.1.0 (December 15, 2019)
 
-## Features:
+### Features:
 
   - Add support for new default gems. In particular,
 
@@ -2011,27 +2013,27 @@
 
     plus other PRs removing or lazily loading usages of these gems from other places to not interfere with user's choice, such as [#7471](https://github.com/rubygems/bundler/pull/7471) or [#7473](https://github.com/bundler/bundler/pull/7473)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `bundle exec rake install` failing [#7474](https://github.com/rubygems/bundler/pull/7474)
   - Fix `bundle exec`'ing to rubygems being silent [#7442](https://github.com/rubygems/bundler/pull/7442)
   - Restore previous `BUNDLE_GEMFILE` in `bundler/inline` [#7418](https://github.com/rubygems/bundler/pull/7418)
   - Fix error when using `gem` DSL's `:glob` option for selecting gemspecs from a specific source [#7419](https://github.com/rubygems/bundler/pull/7419)
 
-## Enhancements:
+### Enhancements:
 
   - `bundle config` no longer warns when using "old interface" (might be deprecated again in the future) [#7475](https://github.com/rubygems/bundler/pull/7475)
   - `bundle update` no longer warns when used without arguments (might be deprecated again in the future) [#7475](https://github.com/rubygems/bundler/pull/7475)
 
-# 2.1.0.pre.3 (November 12, 2019)
+## 2.1.0.pre.3 (November 12, 2019)
 
-## Features:
+### Features:
 
   - Add caller information to some deprecation messages to make them easier to fix [#7361](https://github.com/rubygems/bundler/pull/7361)
   - Reconcile `bundle cache` vs `bundle package` everywhere. Now in docs, CLI help and everywhere else `bundle cache` is the preferred version and `bundle package` remains as an alias [#7389](https://github.com/rubygems/bundler/pull/7389)
   - Display some basic `bundler` documentation together with ruby's RDoc based documentation [#7394](https://github.com/rubygems/bundler/pull/7394)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix typos deprecation message and upgrading docs [#7374](https://github.com/rubygems/bundler/pull/7374)
   - Deprecation warnings about `taint` usage on ruby 2.7 [#7385](https://github.com/rubygems/bundler/pull/7385)
@@ -2040,14 +2042,14 @@
   - Stop using an insecure folder as a "fallback home" when user home is not defined [#7416](https://github.com/rubygems/bundler/pull/7416)
   - Fix `bundler/inline` warning about `Bundler.root` redefinition [#7417](https://github.com/rubygems/bundler/pull/7417)
 
-# 2.1.0.pre.2 (September 15, 2019)
+## 2.1.0.pre.2 (September 15, 2019)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `bundle clean` trying to delete non-existent directory ([#7340](https://github.com/rubygems/bundler/pull/7340))
   - Fix warnings about keyword argument separation on ruby 2.7 ([#7337](https://github.com/rubygems/bundler/pull/7337))
 
-# 2.1.0.pre.1 (August 28, 2019)
+## 2.1.0.pre.1 (August 28, 2019)
 
   One of the biggest changes in bundler 2.1.0 is that deprecations for upcoming
   breaking changes in bundler 3 will be turned on by default. We do this to grab
@@ -2071,13 +2073,13 @@
   [#7216](https://github.com/rubygems/bundler/pull/7216),
   [#7274](https://github.com/rubygems/bundler/pull/7274)
 
-## Deprecations:
+### Deprecations:
 
   * See the [the upgrading document](UPGRADING.md) for a detailed explanation of
     the deprecations that are getting enabled in bundler 2.1, and the future
     breaking changes in bundler 3.
 
-## Features:
+### Features:
 
   - Reimplement `config` command using subcommands ([#5981](https://github.com/rubygems/bundler/pull/5981))
   - Add `bundle plugin list` command ([#6120](https://github.com/rubygems/bundler/pull/6120))
@@ -2095,7 +2097,7 @@
   - Several improvements on new gem templates ([#6924](https://github.com/rubygems/bundler/pull/6924), [#6968](https://github.com/bundler/bundler/pull/6968), [#7209](https://github.com/bundler/bundler/pull/7209), [#7222](https://github.com/bundler/bundler/pull/7222), [#7238](https://github.com/bundler/bundler/pull/7238))
   - Add `--[no-]git` option to `bundle gem` to generate non source control gems. Useful for monorepos, for example ([#7263](https://github.com/rubygems/bundler/pull/7263))
 
-## Bug fixes:
+### Bug fixes:
 
   - Raise when the same gem is available in multiple sources, and show a suggestion to solve it ([#5985](https://github.com/rubygems/bundler/pull/5985))
   - Validate that bundler has permissions to write to the tmp directory, and raise with a meaningful error otherwise ([#5954](https://github.com/rubygems/bundler/pull/5954))
@@ -2133,7 +2135,7 @@
   - Fix `bundle doctor` command ([#7309](https://github.com/rubygems/bundler/pull/7309))
   - Fix bundler giving an unclear recommendation when duplicated gems are found in the Gemfile ([#7302](https://github.com/rubygems/bundler/pull/7302))
 
-## Documentation:
+### Documentation:
 
   - Fix typo on a file extension in `bundle.ronn` [#7146](https://github.com/rubygems/bundler/pull/7146)
   - Fix incorrect default value for `cache_path` configuration ([#7229](https://github.com/rubygems/bundler/pull/7229))
@@ -2145,9 +2147,9 @@
   environment, test suite, policies, contributing docs, and a bunch of cleanups of
   old compatibility code.
 
-# 2.0.2 (June 13, 2019)
+## 2.0.2 (June 13, 2019)
 
-## Enhancements:
+### Enhancements:
 
   - Fixes for Bundler integration with ruby-src ([#6941](https://github.com/rubygems/bundler/pull/6941), [#6973](https://github.com/bundler/bundler/pull/6973), [#6977](https://github.com/bundler/bundler/pull/6977), [#6315](https://github.com/bundler/bundler/pull/6315), [#7061](https://github.com/bundler/bundler/pull/7061))
   - Use `__dir__` instead of `__FILE__` when generating a gem with `bundle gem` ([#6503](https://github.com/rubygems/bundler/pull/6503))
@@ -2166,40 +2168,40 @@
   - Fixed an issue where the `github` source was not using `https` by default that we mentioned in the 2.0 release ([#7182](https://github.com/rubygems/bundler/pull/7182))
   - Fixed an issue where `rake release` was not outputting the message to users asking for a 2fa token ([#7199](https://github.com/rubygems/bundler/pull/7199))
 
-## Documentation:
+### Documentation:
 
   - Fix incorrect documented `BUNDLE_PATH_RELATIVE_TO_CWD` env var ([#6751](https://github.com/rubygems/bundler/pull/6751))
   - Update URLs in Bundler's documentation to use `https` ([#6935](https://github.com/rubygems/bundler/pull/6935))
 
-# 2.0.1 (January 4, 2019)
+## 2.0.1 (January 4, 2019)
 
-## Bug fixes:
+### Bug fixes:
 
   - Relaxed RubyGems requirement to `>= 2.5.0` ([#6867](https://github.com/rubygems/bundler/pull/6867))
 
-# 2.0.0 (January 3, 2019)
+## 2.0.0 (January 3, 2019)
 
   No changes.
 
-# 2.0.0.pre.3 (December 30, 2018)
+## 2.0.0.pre.3 (December 30, 2018)
 
-## Breaking changes:
+### Breaking changes:
 
   - Bundler 2 now requires RubyGems 3.0.0 at minimum
 
-## Bug fixes:
+### Bug fixes:
 
   - Ruby 2.6 compatibility fixes (@segiddins)
 
-## Enhancements:
+### Enhancements:
 
   - Import changes from Bundler 1.17.3 release
 
   Note: To upgrade your Gemfile to Bundler 2 you will need to run `bundle update --bundler`
 
-# 2.0.0.pre.2 (November 27, 2018)
+## 2.0.0.pre.2 (November 27, 2018)
 
-## Breaking changes:
+### Breaking changes:
 
   - `:github` source in the Gemfile now defaults to using HTTPS
 
@@ -2209,9 +2211,9 @@ Changes
 
   Note: To upgrade your Gemfile to Bundler 2 you will need to run `bundle update --bundler`
 
-# 2.0.0.pre.1 (November 9, 2018)
+## 2.0.0.pre.1 (November 9, 2018)
 
-## Breaking changes:
+### Breaking changes:
 
   - Dropped support for versions of Ruby under 2.3
   - Dropped support for version of RubyGems under 2.5
@@ -2219,32 +2221,32 @@ Changes
 
   Note: To upgrade your Gemfile to Bundler 2 you will need to run `bundle update --bundler`
 
-# 1.17.3 (December 27, 2018)
+## 1.17.3 (December 27, 2018)
 
-## Bug fixes:
+### Bug fixes:
 
  - Fix a Bundler error when installing gems on old versions of RubyGems ([#6839](https://github.com/rubygems/bundler/issues/6839), @colby-swandale)
  - Fix a rare issue where Bundler was removing itself after a `bundle clean` ([#6829](https://github.com/rubygems/bundler/issues/6829), @colby-swandale)
 
-## Documentation:
+### Documentation:
 
   - Add entry for the `bundle remove` command to the main Bundler manual page
 
-# 1.17.2 (December 11, 2018)
+## 1.17.2 (December 11, 2018)
 
  - Add compatibility for bundler merge with Ruby 2.6
 
-# 1.17.1 (October 25, 2018)
+## 1.17.1 (October 25, 2018)
 
  - Convert `Pathname`s to `String`s before sorting them, fixing #6760 and #6758 ([#6761](https://github.com/rubygems/bundler/pull/6761), @alexggordon)
 
-# 1.17.0 (October 25, 2018)
+## 1.17.0 (October 25, 2018)
 
   No changes.
 
-# 1.17.0.pre.2 (October 13, 2018)
+## 1.17.0.pre.2 (October 13, 2018)
 
-## Features:
+### Features:
 
   - Configure Bundler home, cache, config and plugin directories with `BUNDLE_USER_HOME`, `BUNDLE_USER_CACHE`, `BUNDLE_USER_CONFIG` and `BUNDLE_USER_PLUGIN` env vars ([#4333](https://github.com/rubygems/bundler/issues/4333), @gwerbin)
   - Add `--all` option to `bundle binstubs` that will generate an executable file for all gems with commands in the bundle
@@ -2258,9 +2260,9 @@ Changes
   - Improve deprecation warning message for `bundle show` command
   - Improve deprecation warning message for the `--force` option in `bundle install`
 
-# 1.17.0.pre.1 (September 24, 2018)
+## 1.17.0.pre.1 (September 24, 2018)
 
-## Features:
+### Features:
 
   - Check folder/file permissions of the Bundle home directory in the `bundle doctor` command ([#5786](https://github.com/rubygems/bundler/issues/5786), @ajwann)
   - Remove compiled gem extensions when running `bundle clean` ([#5596](https://github.com/rubygems/bundler/issues/5596), @akhramov)
@@ -2284,14 +2286,14 @@ Changes
   - Use the Gem Version Promoter for major gem updates ([#5993](https://github.com/rubygems/bundler/issues/5993), @segiddins)
   - Add config option to add the Ruby scope to `bundle config path` when configured globally (@segiddins)
 
-# 1.16.6 (October 5, 2018)
+## 1.16.6 (October 5, 2018)
 
-## Enhancements:
+### Enhancements:
 
   - Add an error message when adding a gem with `bundle add` that's already in the bundle ([#6341](https://github.com/rubygems/bundler/issues/6341), @agrim123)
   - Add Homepage, Source Code and Changelog URI metadata fields to the `bundle gem` gemspec template (@walf443)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix issue where updating a gem resulted in the gem's version being downgraded when `BUNDLE_ONLY_UPDATE_TO_NEWER_VERSIONS` was set ([#6529](https://github.com/rubygems/bundler/issues/6529), @theflow)
   - Fix some rescue calls that don't specify error type (@utilum)
@@ -2300,19 +2302,19 @@ Changes
   - Refactor check for OpenSSL in `bundle env` (@voxik)
   - Remove an unnecessary assignment in Metadata (@voxik)
 
-## Documentation:
+### Documentation:
 
   - Update docs to reflect revised guidance to check in Gemfile.lock into version control for gems ([#5879](https://github.com/rubygems/bundler/issues/5879), @arbonap)
   - Add documentation for the `--all` flag in `bundle update` (@agrim123)
   - Update README to use `bundle add` in usage examples (@hdf1986)
 
-# 1.16.5 (September 18, 2018)
+## 1.16.5 (September 18, 2018)
 
-## Enhancements:
+### Enhancements:
 
   - Add support for TruffleRuby (@eregon)
 
-## Bug fixes:
+### Bug fixes:
 
   - Avoid printing git errors when checking the version on incorrectly packaged versions of Bundler ([#6453](https://github.com/rubygems/bundler/issues/6453), @greysteil)
   - Fix issue where Bundler does not check the given class when comparing equality in DepProxy (@ChrisBr)
@@ -2322,15 +2324,15 @@ Changes
   - Check that Bundler::Deprecate is not an autoload constant ([#6163](https://github.com/rubygems/bundler/issues/6163), @eregon)
   - Prefer non-pre-release versions when performing a `bundle update --patch` ([#6684](https://github.com/rubygems/bundler/issues/6684), @segiddins)
 
-# 1.16.4 (August 17, 2018)
+## 1.16.4 (August 17, 2018)
 
-## Enhancements:
+### Enhancements:
 
   - Welcome new members to the Bundler core team (@indirect)
   - Don't mutate original error trees when determining version_conflict_message (@greysteil)
   - Update vendored Molinillo to 0.6.6 (@segiddins)
 
-## Bug fixes:
+### Bug fixes:
 
   - Reword bundle update regression message to be more clear to the user when a gem's version is downgraded ([#6584](https://github.com/rubygems/bundler/issues/6584), @ralphbolo)
   - Respect --conservative flag when updating a dependency group ([#6560](https://github.com/rubygems/bundler/issues/6560), @greysteil)
@@ -2339,17 +2341,17 @@ Changes
   - Use UTF-8 for reading files including Gemfile ([#6660](https://github.com/rubygems/bundler/issues/6660), @eregon)
   - Remove unnecessary `while` loop in path resolver helper (@ojab)
 
-## Documentation:
+### Documentation:
 
   - Document that `bundle show [--paths]` sorts results by name (@kemitchell)
 
-# 1.16.3 (July 17, 2018)
+## 1.16.3 (July 17, 2018)
 
-## Features:
+### Features:
 
   - Support URI::File of Ruby 2.6 (@hsbt)
 
-## Bug fixes:
+### Bug fixes:
 
   - Expand symlinks during setup to allow Bundler to load correctly when using symlinks in $GEM_HOME ([#6465](https://github.com/rubygems/bundler/issues/6465), @ojab, @indirect)
   - Dont let Bundler create temporary folders for gem installs which are owned by root ([#6258](https://github.com/rubygems/bundler/issues/6258), @colby-swandale)
@@ -2359,14 +2361,14 @@ Changes
   - Handle Errno::ENOTSUP in the Bundler Process Lock to prevent exceptions when using NFS mounts ([#6566](https://github.com/rubygems/bundler/issues/6566), @colby-swandale)
   - Respect encodings when reading gemspecs ([#6598](https://github.com/rubygems/bundler/issues/6598), @deivid-rodriguez)
 
-## Documentation:
+### Documentation:
 
   - Fix links between manual pages (@BanzaiMan)
   - Add warning to Gemfile documentation for the use of the `source` option when declaring gems ([#6280](https://github.com/rubygems/bundler/issues/6280), @forestgagnon)
 
-# 1.16.2 (April 20, 2018)
+## 1.16.2 (April 20, 2018)
 
-## Enhancements:
+### Enhancements:
 
   - Include the gem's source in the gem install error message when available (@papanikge)
   - Remove unnecessary executable bit from gem template (@voxik)
@@ -2375,7 +2377,7 @@ Changes
   - Use `Bundler.rubygems.inflate` instead of the Gem::Util method directly (@segiddins)
   - Remove unused instance variable (@segiddins)
 
-## Bug fixes:
+### Bug fixes:
 
   - Only trap INT signal and have Ruby's signal default handler be invoked (@shayonj)
   - Fix warning about the use of `__FILE__` in RubyGems integration testing (@MSP-Greg)
@@ -2401,7 +2403,7 @@ Changes
   - Support Bundler installing on a readonly filesystem without a home directory ([#6461](https://github.com/rubygems/bundler/issues/6461), @grosser)
   - Filter git uri credentials in source description (@segiddins)
 
-## Documentation:
+### Documentation:
 
   - Correct typos in `bundle binstubs` man page (@erikj, @samueloph)
   - Update links in `bundle gem` command documentation to use https (@KrauseFx)
@@ -2414,9 +2416,9 @@ Changes
   - Added license info to main README (@rubymorillo)
   - Document parameters and return value of Injector#inject (@tobias-grasse)
 
-# 1.16.1 (December 12, 2017)
+## 1.16.1 (December 12, 2017)
 
-## Bug fixes:
+### Bug fixes:
 
   - avoid hanging on complex resolver errors ([#6114](https://github.com/rubygems/bundler/issues/6114), @halfbyte)
   - avoid an error when running `bundle update --group` ([#6156](https://github.com/rubygems/bundler/issues/6156), @mattbrictson)
@@ -2427,9 +2429,9 @@ Changes
   - fail gracefully when loading a bundler-generated binstub when `bin/bundle` was not generated by bundler ([#6149](https://github.com/rubygems/bundler/issues/6149), @hsbt)
   - allow `bundle init` to be run even when a parent directory contains a gemfile ([#6205](https://github.com/rubygems/bundler/issues/6205), @colby-swandale)
 
-# 1.16.0 (October 31, 2017)
+## 1.16.0 (October 31, 2017)
 
-## Bug fixes:
+### Bug fixes:
 
   - avoid new RubyGems warning about unsafe YAML loading (to keep output consistent) (@segiddins)
   - load digest subclasses in a thread-safe manner (@segiddins, @colby-swandale)
@@ -2441,30 +2443,30 @@ Changes
   - reduce memory usage during dependency resolution ([#6114](https://github.com/rubygems/bundler/issues/6114), @greysteil)
   - ensure that the default bundler gem is not accidentally activated on ruby 2.5 when using local git overrides (@segiddins)
 
-# 1.16.0.pre.3 (October 4, 2017)
+## 1.16.0.pre.3 (October 4, 2017)
 
-## Features:
+### Features:
 
   - the output from `bundle env` includes more information, particularly both the compiled & loaded versions of OpenSSL (@indirect)
 
-## Bug fixes:
+### Bug fixes:
 
   - fix a bug where installing on FreeBSD would accidentally raise an error ([#6013](https://github.com/rubygems/bundler/issues/6013), @olleolleolle)
   - fix a regression in 1.16 where pre-release gems could accidentally be resolved even when the gemfile contained no pre-release requirements (@greysteil)
   - bundler will avoid making unnecessary network requests to fetch dependency data, fixing a regression introduced in 1.16 (@segiddins)
   - the outdated bundler version message is disabled by default until the message has been fine-tuned ([#6004](https://github.com/rubygems/bundler/issues/6004), @segiddins)
 
-# 1.16.0.pre.2 (September 6, 2017)
+## 1.16.0.pre.2 (September 6, 2017)
 
-## Bug fixes:
+### Bug fixes:
 
   - handle when a connection is missing a socket when warning about OpenSSL version (@greysteil)
   - the description for the `rake release` task now reflects `$RUBYGEMS_HOST` (@wadetandy)
   - fix a bug where `bundle update` would regress transitive dependencies (@greysteil)
 
-# 1.16.0.pre.1 (September 4, 2017)
+## 1.16.0.pre.1 (September 4, 2017)
 
-## Features:
+### Features:
 
   - allow using non-branch symbolic refs in a git source ([#4845](https://github.com/rubygems/bundler/issues/4845), @segiddins)
   - allow absolute paths in the `cache path` setting ([#5627](https://github.com/rubygems/bundler/issues/5627), @mal)
@@ -2483,7 +2485,7 @@ Changes
   - allow adding credentials to a gem source during deployment when `allow_deployment_source_credential_changes` is set (@adrian-gomez)
   - making an outdated (and insecure) TLS connection to rubygems.org will print a warning (@segiddins)
 
-## Bug fixes:
+### Bug fixes:
 
   - allow configuring a mirror fallback timeout without a trailing slash ([#4830](https://github.com/rubygems/bundler/issues/4830), @segiddins)
   - fix handling of mirrors for file: urls that contain upper-case characters (@segiddins)
@@ -2505,29 +2507,29 @@ Changes
   - allow `bundle binstubs --standalone` to work without `path` being set (@colby-swandale)
   - fix support for bundle paths that include jars or wars on jruby ([#5975](https://github.com/rubygems/bundler/issues/5975), @torcido)
 
-# 1.15.4 (August 19, 2017)
+## 1.15.4 (August 19, 2017)
 
-## Bug fixes:
+### Bug fixes:
 
   - handle file conflicts gracefully in `bundle gem` (@rafaelfranca, @segiddins)
   - bundler will fail gracefully when the bundle path contains the system path separator ([#5485](https://github.com/rubygems/bundler/issues/5485), ajwann)
   - failed gem downloads will be retried consistently across different RubyGems versions (@shayonj)
   - `bundle pristine` will respect build options while re-building native extensions (@NickLaMuro)
 
-# 1.15.3 (July 21, 2017)
+## 1.15.3 (July 21, 2017)
 
-## Bug fixes:
+### Bug fixes:
 
   - ensure that empty strings passed to `bundle config` are serialized & parsed properly ([#5881](https://github.com/rubygems/bundler/issues/5881), @segiddins)
   - avoid printing an outdated version warning when running a parseable command (@segiddins)
 
-# 1.15.2 (July 17, 2017)
+## 1.15.2 (July 17, 2017)
 
-## Features:
+### Features:
 
   - new gemfiles created by bundler will include an explicit `github` git source that uses `https` (@segiddins)
 
-## Bug fixes:
+### Bug fixes:
 
   - inline gemfiles work when `BUNDLE_BIN` is set ([#5847](https://github.com/rubygems/bundler/issues/5847), @segiddins)
   - avoid using the old dependency API when there are no changes to the compact index files ([#5373](https://github.com/rubygems/bundler/issues/5373), @greysteil)
@@ -2539,29 +2541,29 @@ Changes
   - allow `bundle viz` to work when another gem has a requirable `grapviz` file ([#5707](https://github.com/rubygems/bundler/issues/5707), @segiddins)
   - ensure bundler puts activated gems on the `$LOAD_PATH` in a consistent order ([#5696](https://github.com/rubygems/bundler/issues/5696), @segiddins)
 
-# 1.15.1 (June 2, 2017)
+## 1.15.1 (June 2, 2017)
 
-## Bug fixes:
+### Bug fixes:
 
   - `bundle lock --update GEM` will fail gracefully when the gem is not in the lockfile ([#5693](https://github.com/rubygems/bundler/issues/5693), @segiddins)
   - `bundle init --gemspec` will fail gracefully when the gemspec is invalid (@colby-swandale)
   - `bundle install --force` works when the gemfile contains git gems ([#5678](https://github.com/rubygems/bundler/issues/5678), @segiddins)
   - `bundle env` will print well-formed markdown when there are no settings ([#5677](https://github.com/rubygems/bundler/issues/5677), @segiddins)
 
-# 1.15.0 (May 19, 2017)
+## 1.15.0 (May 19, 2017)
 
   No changes.
 
-# 1.15.0.pre.4 (May 10, 2017)
+## 1.15.0.pre.4 (May 10, 2017)
 
-## Bug fixes:
+### Bug fixes:
 
   - avoid conflicts when `Gem.finish_resolve` is called after the bundle has been set up (@segiddins)
   - ensure that `Gem::Specification.find_by_name` always returns an object that can have `#to_spec` called on it ([#5592](https://github.com/rubygems/bundler/issues/5592), @jules2689)
 
-# 1.15.0.pre.3 (April 30, 2017)
+## 1.15.0.pre.3 (April 30, 2017)
 
-## Bug fixes:
+### Bug fixes:
 
   - avoid redundant blank lines in the readme generated by `bundle gem` (@koic)
   - ensure that `open-uri` is not loaded after `bundle exec` (@segiddins)
@@ -2569,17 +2571,17 @@ Changes
     a gem in the gemfile (@segiddins)
   - only shorten `ref` option for git gems when it is a SHA ([#5620](https://github.com/rubygems/bundler/issues/5620), @segiddins)
 
-# 1.15.0.pre.2 (April 23, 2017)
+## 1.15.0.pre.2 (April 23, 2017)
 
-## Bug fixes:
+### Bug fixes:
 
   - ensure pre-existing fit caches are updated from remote sources ([#5423](https://github.com/rubygems/bundler/issues/5423), @alextaylor000)
   - avoid duplicating specs in the lockfile after updating with the gem uninstalled ([#5599](https://github.com/rubygems/bundler/issues/5599), @segiddins)
   - ensure git gems have their extensions available at runtime ([#5594](https://github.com/rubygems/bundler/issues/5594), @jules2689, @segiddins)
 
-# 1.15.0.pre.1 (April 16, 2017)
+## 1.15.0.pre.1 (April 16, 2017)
 
-## Features:
+### Features:
 
   - print a notification when a newer version of bundler is available ([#4683](https://github.com/rubygems/bundler/issues/4683), @segiddins)
   - add man pages for all bundler commands ([#4988](https://github.com/rubygems/bundler/issues/4988), @feministy)
@@ -2595,7 +2597,7 @@ Changes
   - add the `bundle pristine` command to re-install gems from cached `.gem` files ([#4509](https://github.com/rubygems/bundler/issues/4509), @denniss)
   - add a `--parseable` option for `bundle config` (@JuanitoFatas, @colby-swandale)
 
-## Performance:
+### Performance:
 
   - speed up gemfile initialization by storing locked dependencies as a hash (@jules2689)
   - speed up gemfile initialization by making locked dependency comparison lazy, avoiding object allocation (@jules2689)
@@ -2604,7 +2606,7 @@ Changes
   - avoid diffing large arrays when no sources in the gemfile have changed (@segiddins)
   - avoid evaluating full gemspecs when running with RubyGems 2.5+ (@segiddins)
 
-## Bug fixes:
+### Bug fixes:
 
   - fix cases where `bundle update` would print a resolver conflict instead of updating the selected gems ([#5031](https://github.com/rubygems/bundler/issues/5031), [#5095](https://github.com/bundler/bundler/issues/5095), @segiddins)
   - print out a stack trace after an interrupt when running in debug mode (@segiddins)
@@ -2621,9 +2623,9 @@ Changes
   - print the underlying error when downloading gem metadata fails ([#5579](https://github.com/rubygems/bundler/issues/5579), @segiddins)
   - avoid deadlocking when installing with a lockfile that is missing dependencies ([#5378](https://github.com/rubygems/bundler/issues/5378), [#5480](https://github.com/bundler/bundler/issues/5480), [#5519](https://github.com/bundler/bundler/issues/5519), [#5526](https://github.com/bundler/bundler/issues/5526), [#5529](https://github.com/bundler/bundler/issues/5529), [#5549](https://github.com/bundler/bundler/issues/5549), [#5572](https://github.com/bundler/bundler/issues/5572), @segiddins)
 
-# 1.14.6 (March 3, 2017)
+## 1.14.6 (March 3, 2017)
 
-## Bug fixes:
+### Bug fixes:
 
   - avoid undefined constant `Bundler::Plugin::API::Source` exception ([#5409](https://github.com/rubygems/bundler/issues/5409), @segiddins)
   - avoid incorrect warnings about needing to enable `specific_platform` (@segiddins)
@@ -2631,9 +2633,9 @@ Changes
   - ensure `bundle outdated --local` shows all outdated gems ([#5430](https://github.com/rubygems/bundler/issues/5430), @denniss)
   - fix a case where ruby version requirements could lead to incorrect resolver conflicts ([#5425](https://github.com/rubygems/bundler/issues/5425), @segiddins)
 
-# 1.14.5 (February 22, 2017)
+## 1.14.5 (February 22, 2017)
 
-## Bug fixes:
+### Bug fixes:
 
   - avoid loading all unused gemspecs during `bundle exec` on RubyGems 2.3+ (@segiddins)
   - improve resolver performance when dependencies have zero or one total possibilities ignoring requirements ([#5444](https://github.com/rubygems/bundler/issues/5444), [#5457](https://github.com/bundler/bundler/issues/5457), @segiddins)
@@ -2646,9 +2648,9 @@ Changes
   - avoid gem version conflicts on openssl using Ruby 2.5 ([#5235](https://github.com/rubygems/bundler/issues/5235), @rhenium)
   - fail when installing in frozen mode and the dependencies for `gemspec` gems have changed without the lockfile being updated ([#5264](https://github.com/rubygems/bundler/issues/5264), @segiddins)
 
-# 1.14.4 (February 12, 2017)
+## 1.14.4 (February 12, 2017)
 
-## Bug fixes:
+### Bug fixes:
 
   - fail gracefully when attempting to overwrite an existing directory with `bundle gem` ([#5358](https://github.com/rubygems/bundler/issues/5358), @nodo)
   - fix a resolver bug that would cause bundler to report conflicts that it could resolve ([#5359](https://github.com/rubygems/bundler/issues/5359), [#5362](https://github.com/bundler/bundler/issues/5362), @segiddins)
@@ -2659,46 +2661,46 @@ Changes
   - stop `bundle show --outdated` from implicitly running `bundle update` ([#5375](https://github.com/rubygems/bundler/issues/5375), @colby-swandale)
   - allow the temporary home directory fallback to work for multiple users (@svoop)
 
-# 1.14.3 (January 24, 2017)
+## 1.14.3 (January 24, 2017)
 
-## Bug fixes:
+### Bug fixes:
 
   - fix the resolver attempting to activate ruby-platform gems when the bundle is only for other platforms ([#5349](https://github.com/rubygems/bundler/issues/5349), [#5356](https://github.com/bundler/bundler/issues/5356), @segiddins)
   - avoid re-resolving a locked gemfile that uses `gemspec` and includes development dependencies ([#5349](https://github.com/rubygems/bundler/issues/5349), @segiddins)
 
-# 1.14.2 (January 22, 2017)
+## 1.14.2 (January 22, 2017)
 
-## Bug fixes:
+### Bug fixes:
 
   - fix using `force_ruby_platform` on windows ([#5344](https://github.com/rubygems/bundler/issues/5344), @segiddins)
   - fix an incorrect version conflict error when using `gemspec` on multiple platforms ([#5340](https://github.com/rubygems/bundler/issues/5340), @segiddins)
 
-# 1.14.1 (January 21, 2017)
+## 1.14.1 (January 21, 2017)
 
-## Bug fixes:
+### Bug fixes:
 
   - work around a ruby 2.2.2 bug that caused a stack consistency error during installation ([#5342](https://github.com/rubygems/bundler/issues/5342), @segiddins)
 
-# 1.14.0 (January 20, 2017)
+## 1.14.0 (January 20, 2017)
 
-## Bug fixes:
+### Bug fixes:
 
   - ensure `Settings::Mirror` is autoloaded under the `Settings` namespace
     ([#5238](https://github.com/rubygems/bundler/issues/5238), @segiddins)
   - fix `bundler/inline` when `BUNDLE_GEMFILE=""` ([#5079](https://github.com/rubygems/bundler/issues/5079), @segiddins)
 
-# 1.14.0.pre.2 (January 11, 2017)
+## 1.14.0.pre.2 (January 11, 2017)
 
-## Bug fixes:
+### Bug fixes:
 
   - allow not selecting a gem when running `bundle open` ([#5301](https://github.com/rubygems/bundler/issues/5301), @segiddins)
   - support installing gems from git branches that contain shell metacharacters ([#5295](https://github.com/rubygems/bundler/issues/5295), @segiddins)
   - fix a resolver error that could leave dependencies unresolved ([#5294](https://github.com/rubygems/bundler/issues/5294), @segiddins)
   - fix a stack overflow error when invoking commands ([#5296](https://github.com/rubygems/bundler/issues/5296), @segiddins)
 
-# 1.14.0.pre.1 (December 29, 2016)
+## 1.14.0.pre.1 (December 29, 2016)
 
-## Features:
+### Features:
 
   - `bundle doctor` first runs `bundle check` (@segiddins)
   - the bundler trampoline is automatically enabled when the target version is greater than bundler 2 (@segiddins)
@@ -2718,12 +2720,12 @@ Changes
   - add support for the `ruby_25` gemfile filter (@amatsuda)
   - when installing with a lockfile that is missing dependencies, allow installation to proceed (but without parallelism) (@segiddins)
 
-## Performance:
+### Performance:
 
   - improve `require "bundler"` performance by ~5x (@segiddins)
   - allow install gems in parallel when running on rubygems 2+
 
-## Bug fixes:
+### Bug fixes:
 
   - config files with CRLF line endings can be read ([#4435](https://github.com/rubygems/bundler/issues/4435), @segiddins)
   - `bundle lock` activates gems for the current platform even if they were activated under a different platform for a separate dependency ([#4896](https://github.com/rubygems/bundler/issues/4896), @segiddins)
@@ -2753,42 +2755,42 @@ Changes
   - fail gracefully when creating threads fails (@segiddins)
   - avoid downloading metadata for gems that are only development dependencies (@Paxa)
 
-# 1.13.7 (December 25, 2016)
+## 1.13.7 (December 25, 2016)
 
-## Features:
+### Features:
 
   - add support for the `ruby_24` gemfile filter ([#5281](https://github.com/rubygems/bundler/issues/5281), @amatsuda)
 
-# 1.13.6 (October 22, 2016)
+## 1.13.6 (October 22, 2016)
 
-## Bug fixes:
+### Bug fixes:
 
   - make the `gem` method public again, fixing a regression in 1.13.4 ([#5102](https://github.com/rubygems/bundler/issues/5102), @segiddins)
 
-# 1.13.5 (October 15, 2016)
+## 1.13.5 (October 15, 2016)
 
-## Bug fixes:
+### Bug fixes:
 
   - Ensure a locked pre-release spec can always be re-resolved ([#5089](https://github.com/rubygems/bundler/issues/5089), @segiddins)
 
-# 1.13.4 (October 11, 2016)
+## 1.13.4 (October 11, 2016)
 
-## Bug fixes:
+### Bug fixes:
 
  - stop printing warning when compact index versions file is rewritten ([#5064](https://github.com/rubygems/bundler/issues/5064), @indirect)
  - fix `parent directory is world writable but not sticky` error on install ([#5043](https://github.com/rubygems/bundler/issues/5043), @indirect)
  - fix for `uninitialized constant Bundler::Plugin::API::Source` error ([#5010](https://github.com/rubygems/bundler/issues/5010), @hsbt, @aycabta)
  - make `update` options for major, minor, and patch updates consistent ([#4934](https://github.com/rubygems/bundler/issues/4934), @chrismo)
 
-# 1.13.3 (October 10, 2016)
+## 1.13.3 (October 10, 2016)
 
-## Bug fixes:
+### Bug fixes:
 
   - add support for weak etags to the new index (@segiddins)
 
-# 1.13.2 (September 30, 2016)
+## 1.13.2 (September 30, 2016)
 
-## Bug fixes:
+### Bug fixes:
 
   - allow `Settings` to be initialized without a root directory (@m1k3)
   - allow specifying ruby engines in the gemfile as a symbol ([#4919](https://github.com/rubygems/bundler/issues/4919), @JuanitoFatas)
@@ -2798,24 +2800,24 @@ Changes
   - fail gracefully when parsing the metadata for a gemspec from the compact index fails (@segiddins)
   - fix system gems not being copied to --path on bundle install (e.g. --deployment) ([#4974](https://github.com/rubygems/bundler/issues/4974), @chrismo)
 
-## Performance:
+### Performance:
 
   - avoid parsing the lockfile twice when evaluating gemfiles (@segiddins)
 
-# 1.13.1 (September 13, 2016)
+## 1.13.1 (September 13, 2016)
 
-## Bug fixes:
+### Bug fixes:
 
   - ensure that `Gem::Source` is available, fixing several exceptions ([#4944](https://github.com/rubygems/bundler/issues/4944), @dekellum)
   - ensure that dependency resolution works when multiple gems have the same dependency ([#4961](https://github.com/rubygems/bundler/issues/4961), @segiddins)
 
-# 1.13.0 (September 5, 2016)
+## 1.13.0 (September 5, 2016)
 
   No changes.
 
-# 1.13.0.rc.2 (August 21, 2016)
+## 1.13.0.rc.2 (August 21, 2016)
 
-## Features:
+### Features:
 
   - add setting `exec_disable_load` to force `exec` to spawn a new Ruby process (@segiddins)
   - add `doctor` command to help with issues like unlinked compiled gems ([#4765](https://github.com/rubygems/bundler/issues/4765), @mistydemeo)
@@ -2828,7 +2830,7 @@ Changes
   - add `only_update_to_newer_versions` setting to prevent downgrades during `update` (@segiddins)
   - expanded experimental plugin support to include hooks and sources (@asutoshpalai)
 
-## Bug fixes:
+### Bug fixes:
 
   - retry gem downloads ([#4846](https://github.com/rubygems/bundler/issues/4846), @jkeiser)
   - improve the CompactIndex to handle capitalized legacy gems ([#4867](https://github.com/rubygems/bundler/issues/4867), @segiddins)
@@ -2845,14 +2847,14 @@ Changes
   - show help only when `-h` or `--help` is passed to Bundler, not to `exec` ([#4801](https://github.com/rubygems/bundler/issues/4801), @segiddins)
   - handle symlinks to binstubs created by `--standalone` ([#4782](https://github.com/rubygems/bundler/issues/4782), @terinjokes)
 
-# 1.13.0.rc.1 (June 27, 2016)
+## 1.13.0.rc.1 (June 27, 2016)
 
-## Features:
+### Features:
 
   - when `bundle config major_deprecations` or `BUNDLE_MAJOR_DEPRECATIONS` is set, deprecation warnings for bundler 2 will be printed (@segiddins)
   - when running with `--verbose`, bundler will print the reason it is re-resolving a gemfile (@segiddins)
 
-## Bug fixes:
+### Bug fixes:
 
   - fix support for running RubyGems 1.x on Ruby 2.3 ([#4698](https://github.com/rubygems/bundler/issues/4698), @segiddins)
   - fix bundle exec'ing to a ruby file when gems are installed into a path ([#4592](https://github.com/rubygems/bundler/issues/4592), @chrismo)
@@ -2862,16 +2864,16 @@ Changes
   - fix re-resolving when there are multiple unchanged path sources (@segiddins)
   - de-init submodules when running git 2.9 and requesting a git gem without submodules (@segiddins)
 
-# 1.13.0.pre.1 (June 20, 2016)
+## 1.13.0.pre.1 (June 20, 2016)
 
-## Performance:
+### Performance:
 
   - speed up gemfile resolution during `bundle install` by between 4x-100x ([#4376](https://github.com/rubygems/bundler/issues/4376), @segiddins)
   - generally reduce object allocations when using bundler (@segiddins)
   - speed up bin generation for path gems with many files ([#2846](https://github.com/rubygems/bundler/issues/2846), @segiddins)
   - fix detecting path spec changes to avoid re-resolving unnecessarily (@jrafanie)
 
-## Features:
+### Features:
 
   - automatically trampoline to the bundler version locked in the lockfile, only updating to the running version on `bundle update --bundler` (@segiddins)
   - laying the groundwork for plugin support, which is currently unsuppported, undocumented, disabled by default, and liable to change without notice (@asutoshpalai)
@@ -2889,7 +2891,7 @@ Changes
   - add `--add-platform` option to `bundle lock` (@segiddins)
   - fail gracefully when a resolved spec's `required_ruby_version` or `required_rubygems_version` is incompatible (@segiddins)
 
-## Bug fixes:
+### Bug fixes:
 
   - implicitly unlock the resolved ruby version when the declared requirements in the gemfile are incompatible with the locked version ([#4595](https://github.com/rubygems/bundler/issues/4595), [#4627](https://github.com/bundler/bundler/issues/4627), @segiddins)
   - add support for quoted paths in `$PATH` ([#4323](https://github.com/rubygems/bundler/issues/4323), @segiddins)
@@ -2904,99 +2906,99 @@ Changes
   - allow running `bundle install --deployment` after `bundle package --all` with path gems ([#2175](https://github.com/rubygems/bundler/issues/2175), @allenzhao)
   - add support for patchlevels in ruby versions in the gemfile and gemspecs ([#4593](https://github.com/rubygems/bundler/issues/4593), @chalkos)
 
-# 1.12.6 (October 10, 2016)
+## 1.12.6 (October 10, 2016)
 
-## Bug fixes:
+### Bug fixes:
   - add support for weak etags to the new index (@segiddins)
 
-# 1.12.5 (May 25, 2016)
+## 1.12.5 (May 25, 2016)
 
-## Bug fixes:
+### Bug fixes:
   - only take over `--help` on `bundle exec` when the first two arguments are `exec` and `--help` ([#4596](https://github.com/rubygems/bundler/issues/4596), @segiddins)
   - don't require `require: true` dependencies that are excluded via `env` or `install_if` (@BrianHawley)
   - reduce the number of threads used simultaneously by bundler ([#4367](https://github.com/rubygems/bundler/issues/4367), @will-in-wi)
 
-# 1.12.4 (May 16, 2016)
+## 1.12.4 (May 16, 2016)
 
-## Bug fixes:
+### Bug fixes:
   - ensure concurrent use of the new index can't corrupt the cache ([#4519](https://github.com/rubygems/bundler/issues/4519), @domcleal)
   - allow missing rubygems credentials when pushing a gem with a custom host ([#4437](https://github.com/rubygems/bundler/issues/4437), @Cohen-Carlisle)
   - fix installing built-in specs with `--standalone` ([#4557](https://github.com/rubygems/bundler/issues/4557), @segiddins)
   - fix `bundle show` when a gem has a prerelease version that includes a `-` ([#4385](https://github.com/rubygems/bundler/issues/4385), @segiddins)
 
-# 1.12.3 (May 6, 2016)
+## 1.12.3 (May 6, 2016)
 
-## Bug fixes:
+### Bug fixes:
   - fix uncoditionally writing `.bundle/config` when running `bundle install` (@segiddins)
   - fall back to the dependency API and the full index when the home directory is not writable (@segiddins)
 
-# 1.12.2 (May 4, 2016)
+## 1.12.2 (May 4, 2016)
 
-## Bug fixes:
+### Bug fixes:
   - fix modifying a frozen string when the resolver conflicts on dependencies with requirements ([#4520](https://github.com/rubygems/bundler/issues/4520), @grzuy)
   - fix `bundle exec foo --help` not showing the invoked command's help ([#4480](https://github.com/rubygems/bundler/issues/4480), @b-ggs)
 
-# 1.12.1 (April 30, 2016)
+## 1.12.1 (April 30, 2016)
 
-## Bug fixes:
+### Bug fixes:
   - automatically fallback when the new index has a checksum mismatch instead of erroring (@segiddins)
   - fix computation of new index file local checksums on Windows ([#4472](https://github.com/rubygems/bundler/issues/4472), @mwrock)
   - properly handle certain resolver backtracking cases without erroring (@segiddins, [#4484](https://github.com/rubygems/bundler/issues/4484))
   - ensure the `$LOAD_PATH` contains specs' load paths in the correct order (@segiddins, [#4482](https://github.com/rubygems/bundler/issues/4482))
 
-# 1.12.0 (April 28, 2016)
+## 1.12.0 (April 28, 2016)
 
   No changes.
 
-# 1.12.0.rc.4 (April 21, 2016)
+## 1.12.0.rc.4 (April 21, 2016)
 
-## Bug fixes:
+### Bug fixes:
 
   - don't fail when `bundle outdated` is run with flags and the lockfile contains non-semver versions ([#4438](https://github.com/rubygems/bundler/issues/4438), @RochesterinNYC)
 
-# 1.12.0.rc.3 (April 19, 2016)
+## 1.12.0.rc.3 (April 19, 2016)
 
-## Bug fixes:
+### Bug fixes:
 
   - don't allow new attributes to dirty a lockfile when running `bundle exec`, `-rbundler/setup`, or `bundle check` (@segiddins)
 
-# 1.12.0.rc.2 (April 15, 2016)
+## 1.12.0.rc.2 (April 15, 2016)
 
-## Features:
+### Features:
 
   - `bundle outdated` handles all combinations of `--major`, `--minor`, and `--patch` ([#4396](https://github.com/rubygems/bundler/issues/4396), @RochesterinNYC)
 
-## Bug fixes:
+### Bug fixes:
 
   - prevent endless recursive copy for `bundle package --all` ([#4392](https://github.com/rubygems/bundler/issues/4392), @RochesterinNYC)
   - allow executables that are `load`ed to exit non-0 via an `at_exit` hook when invoked by `bundle exec` (@segiddins)
   - nested invocations of `bundle exec` properly preserve the `$PATH` and `$GEM_PATH` environment variables (@segiddins)
 
-# 1.12.0.rc (March 13, 2016)
+## 1.12.0.rc (March 13, 2016)
 
-## Performance:
+### Performance:
 
   - Download gem metadata from globally distributed CDN endpoints ([#4358](https://github.com/rubygems/bundler/issues/4358), @segiddins)
 
-## Bug fixes:
+### Bug fixes:
 
   - handle Ruby pre-releases built from source ([#4324](https://github.com/rubygems/bundler/issues/4324), @RochesterinNYC)
   - support binstubs from RubyGems 2.6 ([#4341](https://github.com/rubygems/bundler/issues/4341), @segiddins)
   - handle quotes present in in PATH ([#4326](https://github.com/rubygems/bundler/issues/4326), @segiddins)
 
-# 1.12.0.pre.2 (February 26, 2016)
+## 1.12.0.pre.2 (February 26, 2016)
 
-## Performance:
+### Performance:
 
   - speed up `bundle exec` by `load`ing the executable whenever possible, saving roughly .2 seconds per invocation (@segiddins)
 
-## Features:
+### Features:
 
   - add a `--patch` flag for `bundle outdated` (@RochesterinNYC)
   - add `Bundler.clean_env` and `Bundler.original_env` ([#4232](https://github.com/rubygems/bundler/issues/4232), @njam)
   - add `--frozen` support to `bundle package` ([#3356](https://github.com/rubygems/bundler/issues/3356), @RochesterinNYC)
 
-## Bug fixes:
+### Bug fixes:
 
   - place bundler loaded gems after `-I` and `RUBYLIB` (@Elffers)
   - give a better error message when filesystem access raises an `EPROTO` error ([#3581](https://github.com/rubygems/bundler/issues/3581), [#3932](https://github.com/bundler/bundler/issues/3932), [#4163](https://github.com/bundler/bundler/issues/4163), @RochesterinNYC)
@@ -3011,14 +3013,14 @@ Changes
   - skip rebuilding extensions for git gems if they are already built ([#4082](https://github.com/rubygems/bundler/issues/4082), @csfrancis, @indirect, @segiddins)
   - fix `bundle install` not installing when the `no_install` setting is set ([#3966](https://github.com/rubygems/bundler/issues/3966), @chulkilee, @segiddins)
 
-# 1.12.0.pre.1 (February 9, 2016)
+## 1.12.0.pre.1 (February 9, 2016)
 
-## Performance:
+### Performance:
 
   - speed up `bundle install` and `bundle update` by using the new compact gem index (@segiddins, @fotanus, @indirect)
   - speed up `bundle exec` by avoiding loading the gemfile twice ([#2951](https://github.com/rubygems/bundler/issues/2951), [#2952](https://github.com/bundler/bundler/issues/2952), @segiddins)
 
-## Features:
+### Features:
 
   - add support for using version operators to specify ruby versions in the Gemfile (@jtarchie)
   - redirect `--help` flag for plugins to that plugin's man page (@RochesterinNYC)
@@ -3030,7 +3032,7 @@ Changes
   - add support for ruby 2.4 ([#4266](https://github.com/rubygems/bundler/issues/4266), @segiddins)
   - add `bundle outdated --parseable` for machine-readable output (@RochesterinNYC)
 
-## Bug fixes:
+### Bug fixes:
 
   - fix `bundle package --all` recursing endlessly ([#4158](https://github.com/rubygems/bundler/issues/4158), @RochesterinNYC)
   - fail fast on more errors when fetching remote resources ([#4154](https://github.com/rubygems/bundler/issues/4154), @RochesterinNYC)
@@ -3053,35 +3055,35 @@ Changes
   - preserve the original `PATH` in `Bundler.with_clean_env` ([#4251](https://github.com/rubygems/bundler/issues/4251), @segiddins)
   - ensure standalone file paths are relative to the project root ([#4144](https://github.com/rubygems/bundler/issues/4144), @glennpratt)
 
-# 1.11.2 (December 15, 2015)
+## 1.11.2 (December 15, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - _really_ stop calling `required_ruby_version` on nil @specifications ([#4147](https://github.com/rubygems/bundler/issues/4147), @indirect)
 
-# 1.11.1 (December 15, 2015)
+## 1.11.1 (December 15, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - lazy-load Psych, again ([#4149](https://github.com/rubygems/bundler/issues/4149), @indirect)
   - allow gemspec gems on other platforms ([#4150](https://github.com/rubygems/bundler/issues/4150), @indirect)
   - fix --no-coc and --no-mit flags on `gem` ([#4148](https://github.com/rubygems/bundler/issues/4148), @RochesterinNYC)
   - stop calling `required_ruby_version` on nil @specifications ([#4147](https://github.com/rubygems/bundler/issues/4147), @indirect)
 
-# 1.11.0 (December 12, 2015)
+## 1.11.0 (December 12, 2015)
 
   No changes.
 
-# 1.11.0.pre.2 (December 6, 2015)
+## 1.11.0.pre.2 (December 6, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - fail gracefully when trying to execute a non-executable file ([#4081](https://github.com/rubygems/bundler/issues/4081), @fotanus)
   - fix a crash when pushing a gem via `rake release` (@segiddins)
 
-# 1.11.0.pre.1 (November 29, 2015)
+## 1.11.0.pre.1 (November 29, 2015)
 
-## Features:
+### Features:
 
   - actual Gemfile and lockfile filenames are used in messages ([#3672](https://github.com/rubygems/bundler/issues/3672), @segiddins)
   - the git remote for `rake release` is now customizable (@skateman)
@@ -3105,7 +3107,7 @@ Changes
   - add `pkg` to rake's clobber list ([#3676](https://github.com/rubygems/bundler/issues/3676), @jasonkarns)
   - retry fetching specs when fetching version metadata fails (@jingweno)
 
-## Bug fixes:
+### Bug fixes:
 
   - avoid showing bundler version warning messages twice (@fotanus)
   - fix running `bundle check` with `--path` when the gems are only installed globally (@akihiro17)
@@ -3137,93 +3139,93 @@ Changes
   - fix `bundle console` falling back to `irb` when the preferred console is unavailable (@felixbuenemann)
   - restrict platforms when referencing a `gemspec` in the `Gemfile` to those defined in the gemspec ([#4102](https://github.com/rubygems/bundler/issues/4102), @smellsblue)
 
-## Performance:
+### Performance:
 
   - speed up dependency resolution in pathological cases by 25x ([#3803](https://github.com/rubygems/bundler/issues/3803), @segiddins)
   - drop string allocations when searching for gems (@jrafanie)
 
-# 1.10.6 (July 22, 2015)
+## 1.10.6 (July 22, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - only warn on invalid gemspecs (@indirect)
   - fix installing dependencies in the correct order ([#3799](https://github.com/rubygems/bundler/issues/3799), @pducks32)
   - fix sorting of mixed DependencyLists ([#3762](https://github.com/rubygems/bundler/issues/3762), @tony-spataro-rs)
   - fix `install_if` conditionals when using the block form (@danieltdt)
 
-# 1.10.5 (June 24, 2015)
+## 1.10.5 (June 24, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - don't add or update BUNDLED WITH during `install` with no changes (@segiddins)
   - fix sorting of mixed DependencyLists with RubyGems >= 2.23 ([#3762](https://github.com/rubygems/bundler/issues/3762), @tony-spataro-rs)
   - speed up resolver for path and git gems (@segiddins)
   - fix `install --force` to not reinstall Bundler ([#3743](https://github.com/rubygems/bundler/issues/3743), @karlo57)
 
-# 1.10.4 (June 16, 2015)
+## 1.10.4 (June 16, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - don't add BUNDLED WITH to the lock when Spring runs `check` over and over (@indirect)
   - display "with native extensions" log output correctly (@ivantsepp)
   - alias `i` to `install`, `c` to `check`, and `e` to `exec` (@indirect)
 
-# 1.10.3 (June 3, 2015)
+## 1.10.3 (June 3, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - allow missing gemspec files when validating path and git gems ([#3686](https://github.com/rubygems/bundler/issues/3686), [#3698](https://github.com/bundler/bundler/issues/3698), @segiddins)
   - fix regression in `rake install` ([#3701](https://github.com/rubygems/bundler/issues/3701), [#3705](https://github.com/bundler/bundler/issues/3705), @segiddins)
   - fix regression when calling `gem` with `bundle exec` or `-rbundler/setup` ([#3699](https://github.com/rubygems/bundler/issues/3699), @segiddins)
   - fix `bundler/inline` requiring a newly-installed gem ([#3693](https://github.com/rubygems/bundler/issues/3693), @indirect, @segiddins)
 
-# 1.10.2 (May 29, 2015)
+## 1.10.2 (May 29, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - fix regression in `bundle update GEM` performance introduced in 1.10.0 ([#3687](https://github.com/rubygems/bundler/issues/3687), @segiddins)
 
-# 1.10.1 (May 28, 2015)
+## 1.10.1 (May 28, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - silence ruby warning when running CLI commands (@segiddins)
   - validate gemspecs in non-packaging mode ([#3681](https://github.com/rubygems/bundler/issues/3681), @segiddins)
   - ensure the same chdir mutex as RubyGems is used ([#3680](https://github.com/rubygems/bundler/issues/3680), @segiddins)
 
-# 1.10.0 (May 28, 2015)
+## 1.10.0 (May 28, 2015)
 
   No changes.
 
-# 1.10.0.rc (May 16, 2015)
+## 1.10.0.rc (May 16, 2015)
 
-## Features:
+### Features:
 
   - dramatically speed up resolving some slow Gemfiles ([#3635](https://github.com/rubygems/bundler/issues/3635), @segiddins)
   - track CI platforms running Bundler ([#3646](https://github.com/rubygems/bundler/issues/3646), @fotanus)
 
-## Bug fixes:
+### Bug fixes:
 
   - allow `viz` to work with prereleases ([#3621](https://github.com/rubygems/bundler/issues/3621), [#3217](https://github.com/bundler/bundler/issues/3217), @aprescott)
   - validate gemspecs used in path and git gems ([#3639](https://github.com/rubygems/bundler/issues/3639), @segiddins, @indirect)
   - stop printing config warnings when config is unchanged ([#3649](https://github.com/rubygems/bundler/issues/3649), @fotanus, @indirect)
   - Without groups saved via `config` are no longer ignored when the `--without` flag is used
 
-# 1.10.0.pre.2 (May 7, 2015)
+## 1.10.0.pre.2 (May 7, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - make BUNDLED WITH backwards compatible ([#3623](https://github.com/rubygems/bundler/issues/3623), @segiddins)
 
-# 1.10.0.pre.1 (May 5, 2015)
+## 1.10.0.pre.1 (May 5, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - always clean up tmp dirs ([#3277](https://github.com/rubygems/bundler/issues/3277), @hone, @indirect, @segiddins)
 
-# 1.10.0.pre (May 3, 2015)
+## 1.10.0.pre (May 3, 2015)
 
-## Features:
+### Features:
 
   - support gem extensions built into any directory on RubyGems 2.2+ ([#3582](https://github.com/rubygems/bundler/issues/3582), @voxik)
   - add 'bundler/inline' which provides a `gemfile` method ([#3440](https://github.com/rubygems/bundler/issues/3440), @segiddins)
@@ -3238,75 +3240,75 @@ Changes
   - make timeouts and retries configurable via `config` ([#3601](https://github.com/rubygems/bundler/issues/3601), @pducks32)
   - add `install_if` Gemfile method for conditional installs ([#3611](https://github.com/rubygems/bundler/issues/3611), @segiddins)
 
-## Bug fixes:
+### Bug fixes:
 
   - standalone mode now uses builtin gems correctly ([#3610](https://github.com/rubygems/bundler/issues/3610), @segiddins)
   - fix `rake spec:deps` on MinGW Ruby 2.0+ ([#3487](https://github.com/rubygems/bundler/issues/3487), @marutosi)
   - remember all y/n answers when generating gems ([#3579](https://github.com/rubygems/bundler/issues/3579), @pducks32)
 
-## Performance:
+### Performance:
 
   - use RubyGems stub specifications when possible ([#3580](https://github.com/rubygems/bundler/issues/3580), @segiddins)
 
-## Deprecations:
+### Deprecations:
 
   - deprecated the (never enabled) `bundle_ruby` binary (@smlance)
 
-# 1.9.10 (June 22, 2015)
+## 1.9.10 (June 22, 2015)
 
-## Features:
+### Features:
 
   - the `BUNDLED WITH` section of lockfiles generated by 1.10+ will be preserved (@segiddins)
 
-# 1.9.9 (May 16, 2015)
+## 1.9.9 (May 16, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - read mirror and credential settings from older versions ([#3557](https://github.com/rubygems/bundler/issues/3557), @Strech)
 
-# 1.9.8 (May 12, 2015)
+## 1.9.8 (May 12, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - fix regression in sudo mode introduced by 1.9.7 ([#3642](https://github.com/rubygems/bundler/issues/3642), @segiddins)
 
-# 1.9.7 (May 11, 2015)
+## 1.9.7 (May 11, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - always clean up tmp dirs ([#3277](https://github.com/rubygems/bundler/issues/3277), @hone, @indirect, @segiddins)
 
-# 1.9.6 (May 2, 2015)
+## 1.9.6 (May 2, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - use RubyGems spec stubs if available (@segiddins)
   - allow creating gems with names containing two dashes ([#3483](https://github.com/rubygems/bundler/issues/3483), @janlelis)
   - allow creating gems with names extending constants ([#3603](https://github.com/rubygems/bundler/issues/3603), @amatsuda)
 
-# 1.9.5 (April 29, 2015)
+## 1.9.5 (April 29, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - respect Gemfile sources when installing a gem present in two sources ([#3585](https://github.com/rubygems/bundler/issues/3585), @tmoore)
 
-# 1.9.4 (April 13, 2015)
+## 1.9.4 (April 13, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - fix regression in installing x86 and universal gems ([#3565](https://github.com/rubygems/bundler/issues/3565), @jdmundrawala)
   - improve error when gems are missing ([#3564](https://github.com/rubygems/bundler/issues/3564), @sealocal)
 
-# 1.9.3 (April 12, 2015)
+## 1.9.3 (April 12, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - handle removal of `specs` from rubygems/rubygems@620910 ([#3558](https://github.com/rubygems/bundler/issues/3558), @indirect)
   - install 'universal' gems on Windows ([#3066](https://github.com/rubygems/bundler/issues/3066), @jdmundrawala)
   - stop passing --local during `rake install` task ([#3236](https://github.com/rubygems/bundler/issues/3236), @indirect)
   - guard against all possible accidental public gem pushes ([#3533](https://github.com/rubygems/bundler/issues/3533), @indirect)
 
-# 1.9.2 (March 30, 2015)
+## 1.9.2 (March 30, 2015)
 
 ## Bug fixes:
 
@@ -3316,95 +3318,95 @@ Changes
   - keep gems locked when updating another gem from the same source ([#3520](https://github.com/rubygems/bundler/issues/3520), @indirect)
   - resolve race that could build gems without saved arguments ([#3404](https://github.com/rubygems/bundler/issues/3404), @indirect)
 
-# 1.9.1 (March 21, 2015)
+## 1.9.1 (March 21, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - avoid exception in 'bundler/gem_tasks' ([#3492](https://github.com/rubygems/bundler/issues/3492), @segiddins)
 
-# 1.9.0 (March 20, 2015)
+## 1.9.0 (March 20, 2015)
 
-# 1.9.0.rc (March 13, 2015)
+## 1.9.0.rc (March 13, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - make Bundler.which stop finding directories (@nohoho)
   - handle Bundler prereleases correctly ([#3470](https://github.com/rubygems/bundler/issues/3470), @segiddins)
   - add before_install to .travis.yml template for new gems (@kodnin)
 
-# 1.9.0.pre.1 (March 11, 2015)
+## 1.9.0.pre.1 (March 11, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - make `gem` command work again (@arthurnn)
 
-# 1.9.0.pre (March 11, 2015)
+## 1.9.0.pre (March 11, 2015)
 
-## Features:
+### Features:
 
   - prefer gemspecs closest to the directory root ([#3428](https://github.com/rubygems/bundler/issues/3428), @segiddins)
   - debug log for API request limits ([#3452](https://github.com/rubygems/bundler/issues/3452), @neerfri)
 
-## Enhancements:
+### Enhancements:
 
   - Molinillo resolver, shared with CocoaPods (@segiddins)
   - updated Thor to v0.19.1 (@segiddins)
 
-# 1.8.9 (May 2, 2015)
+## 1.8.9 (May 2, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - Use RubyGems spec stubs if available (@segiddins)
 
-# 1.8.8 (April 29, 2015)
+## 1.8.8 (April 29, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - Respect Gemfile sources when installing a gem present in two sources ([#3585](https://github.com/rubygems/bundler/issues/3585), @tmoore)
 
-# 1.8.7 (April 7, 2015)
+## 1.8.7 (April 7, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - stop suppressing errors inside gems that get required ([#3549](https://github.com/rubygems/bundler/issues/3549), @indirect)
 
-# 1.8.6 (March 30, 2015)
+## 1.8.6 (March 30, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - keep gems locked when updating another gem from the same source ([#3250](https://github.com/rubygems/bundler/issues/3250), @indirect)
   - resolve race that could build gems without saved arguments ([#3404](https://github.com/rubygems/bundler/issues/3404), @indirect)
 
-# 1.8.5 (March 11, 2015)
+## 1.8.5 (March 11, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - remove MIT license from gemspec when removing license file (@indirect)
   - respect 'no' immediately as well as saving it in `gem` config (@kirs)
 
-# 1.8.4 (March 5, 2015)
+## 1.8.4 (March 5, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - document --all-platforms option ([#3449](https://github.com/rubygems/bundler/issues/3449), @moeffju)
   - find gems from all sources on exec after install ([#3450](https://github.com/rubygems/bundler/issues/3450), @TimMoore)
 
-# 1.8.3 (February 24, 2015)
+## 1.8.3 (February 24, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - handle boolean values for gem settings (@EduardoBautista)
   - stop always looking for updated `path` gems ([#3414](https://github.com/rubygems/bundler/issues/3414), [#3417](https://github.com/bundler/bundler/issues/3417), [#3429](https://github.com/bundler/bundler/issues/3429), @TimMoore)
 
-# 1.8.2 (February 14, 2015)
+## 1.8.2 (February 14, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - allow config settings for gems with 'http' in the name again ([#3398](https://github.com/rubygems/bundler/issues/3398), @TimMoore)
 
-# 1.8.1 (February 13, 2015)
+## 1.8.1 (February 13, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - synchronize building git gem native extensions ([#3385](https://github.com/rubygems/bundler/issues/3385), @antifuchs & @indirect)
   - set gemspec bindir correctly ([#3392](https://github.com/rubygems/bundler/issues/3392), @TimMoore)
@@ -3413,32 +3415,32 @@ Changes
   - explain problem when caching causes permission error ([#3390](https://github.com/rubygems/bundler/issues/3390), @indirect)
   - normalize URLs in config keys ([#3391](https://github.com/rubygems/bundler/issues/3391), @indirect)
 
-# 1.8.0 (February 10, 2015)
+## 1.8.0 (February 10, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - gemfile `github` blocks now work ([#3379](https://github.com/rubygems/bundler/issues/3379), @indirect)
   - look up installed gems in remote sources ([#3300](https://github.com/rubygems/bundler/issues/3300), [#3368](https://github.com/bundler/bundler/issues/3368), [#3377](https://github.com/bundler/bundler/issues/3377), [#3380](https://github.com/bundler/bundler/issues/3380), [#3381](https://github.com/bundler/bundler/issues/3381), @indirect)
   - look up gems across all sources to satisfy dependencies ([#3365](https://github.com/rubygems/bundler/issues/3365), @keiths-osc)
   - request dependencies for no more than 100 gems at a time ([#3367](https://github.com/rubygems/bundler/issues/3367), @segiddins)
 
-# 1.8.0.rc (January 26, 2015)
+## 1.8.0.rc (January 26, 2015)
 
-## Features:
+### Features:
 
   - add `config disable_multisource` option to ensure sources can't compete (@indirect)
 
-## Bug fixes:
+### Bug fixes:
 
   - don't add extra quotes around long, quoted config values (@aroben, [#3338](https://github.com/rubygems/bundler/issues/3338))
 
-## Security fixes:
+### Security fixes:
 
   - warn when more than one top-level source is present (@indirect)
 
-# 1.8.0.pre (January 26, 2015)
+## 1.8.0.pre (January 26, 2015)
 
-## Features:
+### Features:
 
   - add metadata allowed_push_host to new gem template ([#3002](https://github.com/rubygems/bundler/issues/3002), @juanitofatas)
   - adds a `--no-install` flag to `bundle package` (@d-reinhold)
@@ -3460,165 +3462,165 @@ Changes
   - add `config gemfile /path` for other Gemfile locations (@dholdren)
   - add `github` method alonside the `git` method (@BenMorganIO)
 
-## Bug fixes:
+### Bug fixes:
 
   - reduce memory usage with threaded parallel workers (@Who828)
   - support read-only git gems (@pmahoney)
   - various resolver performance improvements (@dubek)
   - untaint git gem paths for Rubygems compatibility (@tdtds)
 
-## Documentation:
+### Documentation:
 
   - add missing Gemfile global `path` explanation (@agenteo)
 
-# 1.7.15 (April 29, 2015)
+## 1.7.15 (April 29, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - Respect Gemfile sources when installing a gem present in two sources ([#3585](https://github.com/rubygems/bundler/issues/3585), @tmoore)
 
-# 1.7.14 (March 30, 2015)
+## 1.7.14 (March 30, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - Keep gems locked when updating another gem from the same source ([#3250](https://github.com/rubygems/bundler/issues/3250), @indirect)
   - Don't add extra quotes around long, quoted config values (@aroben, [#3338](https://github.com/rubygems/bundler/issues/3338))
 
-# 1.7.13 (February 7, 2015)
+## 1.7.13 (February 7, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - Look up installed gems in remote sources ([#3300](https://github.com/rubygems/bundler/issues/3300), [#3368](https://github.com/bundler/bundler/issues/3368), [#3377](https://github.com/bundler/bundler/issues/3377), [#3380](https://github.com/bundler/bundler/issues/3380), [#3381](https://github.com/bundler/bundler/issues/3381), @indirect)
   - Look up gems across all sources to satisfy dependencies ([#3365](https://github.com/rubygems/bundler/issues/3365), @keiths-osc)
   - Request dependencies for no more than 100 gems at a time ([#3367](https://github.com/rubygems/bundler/issues/3367), @segiddins)
 
-# 1.7.12 (January 8, 2015)
+## 1.7.12 (January 8, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - Always send credentials for sources, fixing private Gemfury gems ([#3342](https://github.com/rubygems/bundler/issues/3342), @TimMoore)
 
-# 1.7.11 (January 4, 2015)
+## 1.7.11 (January 4, 2015)
 
-## Bug fixes:
+### Bug fixes:
 
   - Recognize `:mri_22` and `:mingw_22`, rather than just `:ruby_22` ([#3328](https://github.com/rubygems/bundler/issues/3328), @myabc)
 
-# 1.7.10 (December 29, 2014)
+## 1.7.10 (December 29, 2014)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix source blocks sometimes causing deployment mode to fail wrongly ([#3298](https://github.com/rubygems/bundler/issues/3298), @TimMoore)
 
-## Features:
+### Features:
 
   - Support `platform :mri_22` and related version bits ([#3309](https://github.com/rubygems/bundler/issues/3309), @thomasfedb)
 
-# 1.7.9 (December 9, 2014)
+## 1.7.9 (December 9, 2014)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix an issue where bundler sometime spams one gem in Gemfile.lock ([#3216](https://github.com/rubygems/bundler/issues/3216), @Who828)
   - Ensure bundle update installs the newer version of the gem ([#3089](https://github.com/rubygems/bundler/issues/3089), @Who828)
   - Fix an regression which stopped Bundler from resolving some Gemfiles ([#3059](https://github.com/rubygems/bundler/issues/3059), [#3248](https://github.com/bundler/bundler/issues/3248), @Who828)
 
-# 1.7.8 (December 6, 2014)
+## 1.7.8 (December 6, 2014)
 
-## Bug fixes:
+### Bug fixes:
 
   - Hide credentials while warning about gems with ambiguous sources ([#3256](https://github.com/rubygems/bundler/issues/3256), @TimMoore)
 
-# 1.7.7 (November 19, 2014)
+## 1.7.7 (November 19, 2014)
 
-## Bug fixes:
+### Bug fixes:
 
   - Ensure server credentials stored in config or ENV will be used ([#3180](https://github.com/rubygems/bundler/issues/3180), @arronmabrey)
   - Fix race condition causing errors while installing git-based gems ([#3174](https://github.com/rubygems/bundler/issues/3174), @Who828)
   - Use single quotes in config so YAML won't add more quotes ([#3261](https://github.com/rubygems/bundler/issues/3261), @indirect)
 
-# 1.7.6 (November 11, 2014)
+## 1.7.6 (November 11, 2014)
 
-## Bug fixes:
+### Bug fixes:
 
   - CA certificates that work with all OpenSSLs (@luislavena, @indirect)
 
-# 1.7.5 (November 10, 2014)
+## 1.7.5 (November 10, 2014)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix --deployment with source blocks and non-alphabetical gems ([#3224](https://github.com/rubygems/bundler/issues/3224), @TimMoore)
   - Vendor CA chain to validate new rubygems.org HTTPS certificate (@indirect)
 
-# 1.7.4 (October 19, 2014)
+## 1.7.4 (October 19, 2014)
 
-## Bug fixes:
+### Bug fixes:
 
   - Allow --deployment after `pack` while using source blocks ([#3167](https://github.com/rubygems/bundler/issues/3167), @TimMoore)
   - Use dependency API even when HTTP credentials are in ENV ([#3191](https://github.com/rubygems/bundler/issues/3191), @fvaleur)
   - Silence warnings (including root warning) in --quiet mode ([#3186](https://github.com/rubygems/bundler/issues/3186), @indirect)
   - Stop asking gem servers for gems already found locally ([#2909](https://github.com/rubygems/bundler/issues/2909), @dubek)
 
-# 1.7.3 (September 14, 2014)
+## 1.7.3 (September 14, 2014)
 
-## Bug fixes:
+### Bug fixes:
 
   - `extconf.rb` is now generated with the right path for `create_makefile` (@andremedeiros)
   - Fix various Ruby warnings (@piotrsanarki, @indirect)
 
-# 1.7.2 (August 23, 2014)
+## 1.7.2 (August 23, 2014)
 
-## Bug fixes:
+### Bug fixes:
 
   - Revert gem source sorting in lockfiles (@indirect)
 
-# 1.7.1 (August 20, 2014)
+## 1.7.1 (August 20, 2014)
 
-## Bug fixes:
+### Bug fixes:
 
   - Install gems from one source needed by gems in another source (@indirect)
   - Install the same gem versions even after some are installed (@TimMoore)
   - Download specs only when installing from servers (@indirect)
 
-# 1.7.0 (August 13, 2014)
+## 1.7.0 (August 13, 2014)
 
-## Security fixes:
+### Security fixes:
 
   - Fix for CVE-2013-0334, installing gems from an unexpected source (@TimMoore)
 
-## Features:
+### Features:
 
   - Gemfile `source` calls now take a block containing gems from that source (@TimMoore)
   - Added the `:source` option to `gem` to specify a source (@TimMoore)
 
-## Bug fixes:
+### Bug fixes:
 
   - Warn on ambiguous gems available from more than one source (@TimMoore)
 
-# 1.6.7 (October 19, 2014)
+## 1.6.7 (October 19, 2014)
 
-## Features:
+### Features:
 
   - warn to upgrade when using useless source blocks (@danfinnie)
 
-## Documentation:
+### Documentation:
 
   - explain how to use gem server credentials via ENV (@hwartig)
 
-# 1.6.6 (August 23, 2014)
+## 1.6.6 (August 23, 2014)
 
-## Bug fixes:
+### Bug fixes:
 
   - restore Gemfile credentials to Gemfile.lock (@indirect)
 
-# 1.6.5 (July 23, 2014)
+## 1.6.5 (July 23, 2014)
 
-## Bug fixes:
+### Bug fixes:
 
   - require openssl explicitly to fix rare HTTPS request failures (@indirect, [#3107](https://github.com/rubygems/bundler/issues/3107))
 
-# 1.6.4 (July 17, 2014)
+## 1.6.4 (July 17, 2014)
 
-## Bug fixes:
+### Bug fixes:
 
   - fix undefined constant error when can't find gem during binstubs ([#3095](https://github.com/rubygems/bundler/issues/3095), @jetaggart)
   - work when installed git gems are not writable ([#3092](https://github.com/rubygems/bundler/issues/3092), @pmahoney)
@@ -3628,18 +3630,18 @@ Changes
   - skip dependencies from other platforms (@mvz)
   - work when Rubygems was built without SSL (@andremedeiros)
 
-# 1.6.3 (June 16, 2014)
+## 1.6.3 (June 16, 2014)
 
-## Bug fixes:
+### Bug fixes:
 
   - fix regression when resolving many conflicts ([#2994](https://github.com/rubygems/bundler/issues/2994), @Who828)
   - use local gemspec for builtin gems during install --local ([#3041](https://github.com/rubygems/bundler/issues/3041), @Who828)
   - don't warn about sudo when installing on Windows ([#2984](https://github.com/rubygems/bundler/issues/2984), @indirect)
   - shell escape `bundle open` arguments (@indirect)
 
-# 1.6.2 (April 13, 2014)
+## 1.6.2 (April 13, 2014)
 
-## Bug fixes:
+### Bug fixes:
 
   - fix an exception when using builtin gems ([#2915](https://github.com/rubygems/bundler/issues/2915), [#2963](https://github.com/bundler/bundler/issues/2963), @gnufied)
   - cache gems that are built in to the running ruby ([#2975](https://github.com/rubygems/bundler/issues/2975), @indirect)
@@ -3647,23 +3649,23 @@ Changes
   - keep standalone working even with builtin gems (@indirect)
   - don't update vendor/cache in deployment mode ([#2921](https://github.com/rubygems/bundler/issues/2921), @indirect)
 
-## Features:
+### Features:
 
   - warn informatively when `bundle install` is run as root ([#2936](https://github.com/rubygems/bundler/issues/2936), @1337807)
 
-# 1.6.1 (April 2, 2014)
+## 1.6.1 (April 2, 2014)
 
-## Bug fixes:
+### Bug fixes:
 
   - update C extensions when git gem versions change ([#2948](https://github.com/rubygems/bundler/issues/2948), @dylanahsmith)
 
-## Features:
+### Features:
 
   - add support for C extensions in sudo mode on Rubygems 2.2
 
-# 1.6.0 (March 28, 2014)
+## 1.6.0 (March 28, 2014)
 
-## Bug fixes:
+### Bug fixes:
 
   - many Gemfiles that caused incorrect errors now resolve correctly (@Who828)
   - redirects across hosts now work on rubies without OpenSSL ([#2686](https://github.com/rubygems/bundler/issues/2686), @grddev)
@@ -3678,7 +3680,7 @@ Changes
   - handle exception installing when build_info owned by root (@Who828)
   - skip HTTP redirects from rubygems.org, huge speed boost (@Who828)
 
-## Features:
+### Features:
 
   - resolver rewritten to avoid recursion (@Who828)
   - add `git_source` for custom options like :github and :gist (@strzalek)
@@ -3693,20 +3695,20 @@ Changes
   - Avoid using threequals operator where possible (@as-cii)
   - Add `bundle update --group` to update specific group ([#2731](https://github.com/rubygems/bundler/issues/2731) @banyan)
 
-## Documentation:
+### Documentation:
 
   - Add missing switches for bundle-install(1) and bundle-update(1) (@as-cii)
 
-# 1.5.3 (February 6, 2014)
+## 1.5.3 (February 6, 2014)
 
-## Bug fixes:
+### Bug fixes:
 
   - find "missing" gems that are actually present ([#2780](https://github.com/rubygems/bundler/issues/2780), [#2818](https://github.com/bundler/bundler/issues/2818), [#2854](https://github.com/bundler/bundler/issues/2854))
   - use n-1 cores when given n jobs for parallel install (@jdickey)
 
-# 1.5.2 (January 10, 2014)
+## 1.5.2 (January 10, 2014)
 
-## Bug fixes:
+### Bug fixes:
 
   - fix integration with Rubygems 1.8.0-1.8.19
   - handle ENETDOWN exception during network requests
@@ -3715,36 +3717,36 @@ Changes
   - set git binstub permissions by umask (@v-yarotsky)
   - remove parallel install debug log
 
-# 1.5.1 (December 28, 2013)
+## 1.5.1 (December 28, 2013)
 
-## Bug fixes:
+### Bug fixes:
 
   - correctly find gems installed with Ruby by default
 
-# 1.5.0 (December 26, 2013)
+## 1.5.0 (December 26, 2013)
 
-## Features:
+### Features:
 
   - install missing gems if their specs are present (@hone)
 
-## Bug fixes:
+### Bug fixes:
 
   - use print for "Installing…" so messages are thread-safe (@TimMoore)
 
-# 1.5.0.rc.2 (December 18, 2013)
+## 1.5.0.rc.2 (December 18, 2013)
 
-## Features:
+### Features:
 
   - Support threaded installation on Rubygems 2.0.7+
   - Debug installation logs in .bundle/install.log
 
-## Bug fixes:
+### Bug fixes:
 
   - Try to catch gem installation race conditions
 
-# 1.5.0.rc.1 (November 9, 2013)
+## 1.5.0.rc.1 (November 9, 2013)
 
-## Features:
+### Features:
 
   - bundle update also accepts --jobs ([#2692](https://github.com/rubygems/bundler/issues/2692), @mrkn)
   - add fork URL to README for new `bundle gem` ([#2665](https://github.com/rubygems/bundler/issues/2665), @zzak)
@@ -3753,7 +3755,7 @@ Changes
   - don't redownload installed specs for `bundle install` ([#2680](https://github.com/rubygems/bundler/issues/2680), @cainlevy)
   - override gem sources with mirrors ([#2650](https://github.com/rubygems/bundler/issues/2650), @danielsdeleo, @mkristian)
 
-## Bug fixes:
+### Bug fixes:
 
   - fix sharing same SSL socket when forking workers for parallel install ([#2632](https://github.com/rubygems/bundler/issues/2632))
   - fix msg typo in GitNotAllowedError ([#2654](https://github.com/rubygems/bundler/issues/2654), @joyicecloud)
@@ -3763,9 +3765,9 @@ Changes
   - fix the bug that downloads every spec when API fetcher encounters an error
   - only retry network requests
 
-# 1.4.0.rc.1 (September 29, 2013)
+## 1.4.0.rc.1 (September 29, 2013)
 
-## Features:
+### Features:
 
   - add support for the x64-mingw32 platform ([#2356](https://github.com/rubygems/bundler/issues/2356), [#2590](https://github.com/bundler/bundler/issues/2590), @larskanis)
   - add :patchlevel option to ruby DSL
@@ -3780,16 +3782,16 @@ Changes
   - add `--retry` to retry failed network and git commands (@schneems)
   - include command and versions in User-Agent (@indirect, @joyicecloud)
 
-## Bug fixes:
+### Bug fixes:
 
   - allow passwordless Basic Auth ([#2606](https://github.com/rubygems/bundler/issues/2606), @rykov)
   - don't suggest `gem install foo` when `foo` is a git gem that fails (@kirs)
   - revert [#2569](https://github.com/rubygems/bundler/issues/2569), staying compatible with git: instead of https: for :github gems
   - handle exceptions while installing gems in parallel (@gnufied)
 
-# 1.4.0.pre.1 (August 4, 2013)
+## 1.4.0.pre.1 (August 4, 2013)
 
-## Features:
+### Features:
 
   - retry network requests while installing gems ([#2561](https://github.com/rubygems/bundler/issues/2561), @ascherger)
   - faster installs using gemspecs from the local system cache ([#2497](https://github.com/rubygems/bundler/issues/2497), @mipearson)
@@ -3806,16 +3808,16 @@ Changes
   - add quiet option to `bundle package` ([#2573](https://github.com/rubygems/bundler/issues/2573), @shtirlic)
   - use RUBYLIB instead of RUBYOPT for better Windows support ([#2536](https://github.com/rubygems/bundler/issues/2536), @equinux)
 
-## Bug fixes:
+### Bug fixes:
 
   - reduce stack size while resolving to fix JRuby overflow ([#2510](https://github.com/rubygems/bundler/issues/2510), @headius)
   - display GitErrors while loading specs in --verbose mode ([#2461](https://github.com/rubygems/bundler/issues/2461))
   - allow the same options hash to be passed to multiple gems ([#2447](https://github.com/rubygems/bundler/issues/2447))
   - handle missing binaries without an exception ([#2019](https://github.com/rubygems/bundler/issues/2019), @luismreis)
 
-# 1.3.6 (January 8, 2014)
+## 1.3.6 (January 8, 2014)
 
-## Bug fixes:
+### Bug fixes:
 
   - make gemspec path option preserve relative paths in lockfile (@bwillis)
   - use umask when creating binstubs ([#1618](https://github.com/rubygems/bundler/issues/1618), @v-yarotsky)
@@ -3833,60 +3835,60 @@ Changes
   - reinstall gems if they are missing with spec present
   - set binstub permissions using umask ([#1618](https://github.com/rubygems/bundler/issues/1618), @v-yarotsky)
 
-# 1.3.5 (April 3, 2013)
+## 1.3.5 (April 3, 2013)
 
-## Features:
+### Features:
 
   - progress indicator while resolver is running (@chief)
 
-## Bug fixes:
+### Bug fixes:
 
   - update local overrides with orphaned revisions (@jamesferguson)
   - revert to working quoting of RUBYOPT on Windows (@ogra)
   - use basic auth even when SSL is not available (@jayniz)
   - installing git gems without dependencies in deployment now works
 
-# 1.3.4 (March 15, 2013)
+## 1.3.4 (March 15, 2013)
 
-## Bug fixes:
+### Bug fixes:
 
   - load YAML on Rubygems versions that define module YAML
   - fix regression that broke --without on ruby 1.8.7
 
-# 1.3.3 (March 13, 2013)
+## 1.3.3 (March 13, 2013)
 
-## Features:
+### Features:
 
   - compatible with Rubygems 2.0.2 (higher and lower already work)
   - mention skipped groups in bundle install and bundle update output (@simi)
   - `gem` creates rake tasks for minitest (@coop) and rspec
 
-## Bug fixes:
+### Bug fixes:
 
   - require rbconfig for standalone mode
 
-# 1.3.2 (March 7, 2013)
+## 1.3.2 (March 7, 2013)
 
-## Features:
+### Features:
 
   - include rubygems.org CA chain
 
-## Bug fixes:
+### Bug fixes:
 
   - don't store --dry-run as a Bundler setting
 
-# 1.3.1 (March 3, 2013)
+## 1.3.1 (March 3, 2013)
 
-## Bug fixes:
+### Bug fixes:
 
   - include manpages in gem, restoring many help pages
   - handle more SSL certificate verification failures
   - check for the full version of SSL, which we need (@alup)
   - gem rake task 'install' now depends on task 'build' (@sunaku)
 
-# 1.3.0 (February 24, 2013)
+## 1.3.0 (February 24, 2013)
 
-## Features:
+### Features:
 
   - raise a useful error when the lockfile contains a merge conflict (@zofrex)
   - ensure `rake release` checks for uncommitted as well as unstaged (@benmoss)
@@ -3894,22 +3896,22 @@ Changes
   - set $MANPATH inside `exec` for gems with man pages (@sunaku)
   - partial gem names for `open` and `update` now return a list (@takkanm)
 
-## Bug fixes:
+### Bug fixes:
 
   - `update` now (again) finds gems that aren't listed in the Gemfile
   - `install` now (again) updates cached gems that aren't in the Gemfile
   - install Gemfiles with HTTP sources even without OpenSSL present
   - display CerficateFailureError message in full
 
-# 1.3.0.pre.8 (February 12, 2013)
+## 1.3.0.pre.8 (February 12, 2013)
 
-## Security fixes:
+### Security fixes:
 
   - validate SSL certificate chain during HTTPS network requests
   - don't send HTTP Basic Auth creds when redirected to other hosts (@perplexes)
   - add `--trust-policy` to `install`, like `gem install -P` (@CosmicCat, [#2293](https://github.com/rubygems/bundler/issues/2293))
 
-## Features:
+### Features:
 
   - optimize resolver when too new of a gem is already activated (@rykov, [#2248](https://github.com/rubygems/bundler/issues/2248))
   - update Net::HTTP::Persistent for SSL cert validation and no_proxy ENV
@@ -3922,7 +3924,7 @@ Changes
   - inform users when the resolver starts
   - disable reverse DNS to speed up API requests (@raggi)
 
-## Bug fixes:
+### Bug fixes:
 
   - raise errors while requiring dashed gems ([#1807](https://github.com/rubygems/bundler/issues/1807))
   - quote the Bundler path on Windows (@jgeiger, [#1862](https://github.com/rubygems/bundler/issues/1862), [#1856](https://github.com/bundler/bundler/issues/1856))
@@ -3932,16 +3934,16 @@ Changes
   - don't scare users with an error message during API fallback
   - `install --binstubs` is back to overwriting. thanks, SemVer.
 
-# 1.3.0.pre.7 (January 22, 2013)
+## 1.3.0.pre.7 (January 22, 2013)
 
-## Bug fixes:
+### Bug fixes:
 
   - stubs for gems with dev deps no longer cause exceptions ([#2272](https://github.com/rubygems/bundler/issues/2272))
   - don't suggest binstubs to --binstubs users
 
-# 1.3.0.pre.6 (January 22, 2013)
+## 1.3.0.pre.6 (January 22, 2013)
 
-## Features:
+### Features:
 
   - `binstubs` lists child gem bins if a gem has no binstubs
   - `bundle gem --edit` will open the new gemspec (@ndbroadbent)
@@ -3949,47 +3951,47 @@ Changes
   - `bundle env` prints info about bundler's environment (@peeja)
   - add `BUNDLE_IGNORE_CONFIG` environment variable support (@richo)
 
-## Bug fixes:
+### Bug fixes:
 
   - don't overwrite custom binstubs during `install --binstubs`
   - don't throw an exception if `binstubs` gem doesn't exist
   - `bundle config` now works in directories without a Gemfile
 
-# 1.3.0.pre.5 (January 9, 2013)
+## 1.3.0.pre.5 (January 9, 2013)
 
-## Features:
+### Features:
 
   - make `--standalone` require lines ruby engine/version agnostic
   - add `--dry-run` to `bundle clean` (@wfarr, [#2237](https://github.com/rubygems/bundler/issues/2237))
 
-## Bug fixes:
+### Bug fixes:
 
   - don't skip writing binstubs when doing `bundle install`
   - distinguish between ruby 1.9/2.0 when using :platforms (@spastorino)
 
-# 1.3.0.pre.4 (January 3, 2013)
+## 1.3.0.pre.4 (January 3, 2013)
 
-## Features:
+### Features:
 
   - `bundle binstubs <gem>` to setup individual binstubs
   - `bundle install --binstubs ""` will remove binstubs option
   - `bundle clean --dry-run` will print out gems instead of removing them
 
-## Bug fixes:
+### Bug fixes:
 
   - Avoid stack traces when Ctrl+C during bundle command (@mitchellh)
   - fix YAML parsing in in ruby-preview2
 
-# 1.3.0.pre.3 (December 21, 2012)
+## 1.3.0.pre.3 (December 21, 2012)
 
-## Features:
+### Features:
 
   - pushing gems during `rake release` can be disabled (@trans)
   - installing gems with `rake install` is much faster (@utkarshkukreti)
   - added platforms :ruby_20 and :mri_20, since the ABI has changed
   - added '--edit' option to open generated gemspec in editor
 
-## Bug fixes:
+### Bug fixes:
 
   - :git gems with extensions now work with Rubygems >= 2.0 (@jeremy)
   - revert SemVer breaking change to :github
@@ -3997,24 +3999,24 @@ Changes
   - https Gist URLs for compatibility with Gist 2.0 (@NARKOZ)
   - namespaced gems no longer generate a superfluous directory (@banyan)
 
-# 1.3.0.pre.2 (December 9, 2012)
+## 1.3.0.pre.2 (December 9, 2012)
 
-## Features:
+### Features:
 
   - `config` expands local overrides like `local.rack .` (@gkop, [#2205](https://github.com/rubygems/bundler/issues/2205))
   - `gem` generates files correctly for names like `jquery-rails` (@banyan, [#2201](https://github.com/rubygems/bundler/issues/2201))
   - use gems from gists with the :gist option in the Gemfile (@jgaskins)
 
-## Bug fixes:
+### Bug fixes:
 
   - Gemfile sources other than rubygems.org work even when .gemrc contains sources
   - caching git gems now caches specs, fixing e.g. git ls-files (@bison, [#2039](https://github.com/rubygems/bundler/issues/2039))
   - `show GEM` now warns if the directory has been deleted (@rohit, [#2070](https://github.com/rubygems/bundler/issues/2070))
   - git output hidden when running in --quiet mode (@rohit)
 
-# 1.3.0.pre (November 29, 2012)
+## 1.3.0.pre (November 29, 2012)
 
-## Features:
+### Features:
 
   - compatible with Ruby 2.0.0-preview2
   - compatible with Rubygems 2.0.0.preview2 (@drbrain, @evanphx)
@@ -4030,7 +4032,7 @@ Changes
   - `gem` command generates MIT license (@BrentWheeldon)
   - gem rake task 'release' reuses existing tags (@shtirlic)
 
-## Bug fixes:
+### Bug fixes:
 
   - JRuby new works with HTTPS gem sources (@davidcelis)
   - `install` installs both rake rake-built gems at once (@crowbot, [#2107](https://github.com/rubygems/bundler/issues/2107))
@@ -4042,14 +4044,14 @@ Changes
   - `gem` generates gemspecs that block double-requires
   - `gem` generates gemspecs that admit they depend on rake
 
-# 1.2.5 (February 24, 2013)
+## 1.2.5 (February 24, 2013)
 
-## Bug fixes:
+### Bug fixes:
 
   - install Gemfiles with HTTP sources even without OpenSSL present
   - display CerficateFailureError message in full
 
-# 1.2.4 (February 12, 2013)
+## 1.2.4 (February 12, 2013)
 
 ## Features:
 
@@ -4057,7 +4059,7 @@ Changes
   - inform users when the resolver starts
   - disable reverse DNS to speed up API requests (@raggi)
 
-## Bug fixes:
+### Bug fixes:
 
   - don't send user/pass when redirected to another host (@perplexes)
   - load gemspecs containing unicode (@gaffneyc, [#2301](https://github.com/rubygems/bundler/issues/2301))
@@ -4065,46 +4067,46 @@ Changes
   - resolve some ruby -w warnings (@chastell, [#2193](https://github.com/rubygems/bundler/issues/2193))
   - don't scare users with an error message during API fallback
 
-# 1.2.3 (November 29, 2012)
+## 1.2.3 (November 29, 2012)
 
-## Bug fixes:
+### Bug fixes:
 
   - fix exceptions while loading some gemspecs
 
-# 1.2.2 (November 14, 2012)
+## 1.2.2 (November 14, 2012)
 
-## Bug fixes:
+### Bug fixes:
 
   - support new Psych::SyntaxError for Ruby 2.0.0 (@tenderlove, @sol)
   - `bundle viz` works with git gems again (@hirochachacha)
   - recognize more cases when OpenSSL is not present
 
-# 1.2.1 (September 19, 2012)
+## 1.2.1 (September 19, 2012)
 
-## Bug fixes:
+### Bug fixes:
 
   - `bundle clean` now works with BUNDLE_WITHOUT groups again
   - have a net/http read timeout around the Gemcutter API Endpoint
 
-# 1.2.0 (August 30, 2012)
+## 1.2.0 (August 30, 2012)
 
-## Bug fixes:
+### Bug fixes:
 
   - raise original error message from LoadError's
 
-## Documentation:
+### Documentation:
 
   - `platform` man pages
 
-# 1.2.0.rc.2 (August 8, 2012)
+## 1.2.0.rc.2 (August 8, 2012)
 
-## Bug fixes:
+### Bug fixes:
 
   - `clean` doesn't remove gems that are included in the lockfile
 
-# 1.2.0.rc (July 17, 2012)
+## 1.2.0.rc (July 17, 2012)
 
-## Features:
+### Features:
 
   - `check` now has a `--dry-run` option (@svenfuchs, [#1811](https://github.com/rubygems/bundler/issues/1811))
   - loosen ruby directive for engines
@@ -4115,26 +4117,26 @@ Changes
   - fall back on the full index when experiencing syck errors ([#1419](https://github.com/rubygems/bundler/issues/1419))
   - handle syntax errors in Ruby gemspecs ([#1974](https://github.com/rubygems/bundler/issues/1974))
 
-## Bug fixes:
+### Bug fixes:
 
   - fix `pack`/`cache` with `--all` (@josevalim, [#1989](https://github.com/rubygems/bundler/issues/1989))
   - don't display warning message when `cache_all` is set
   - check for `nil` PATH ([#2006](https://github.com/rubygems/bundler/issues/2006))
   - Always try to keep original GEM_PATH (@drogus, [#1920](https://github.com/rubygems/bundler/issues/1920))
 
-# 1.2.0.pre.1 (May 27, 2012)
+## 1.2.0.pre.1 (May 27, 2012)
 
-## Features:
+### Features:
 
   - Git gems import submodules of submodules recursively (@nwwatson, [#1935](https://github.com/rubygems/bundler/issues/1935))
 
-## Bug fixes:
+### Bug fixes:
 
   - Exit from `check` with a non-zero status when frozen with no lock
   - Use `latest_release` in Capistrano and Vlad integration ([#1264](https://github.com/rubygems/bundler/issues/1264))
   - Work around a Ruby 1.9.3p194 bug in Psych when config files are empty
 
-## Documentation:
+### Documentation:
 
   - Add instructions for local git repos to the `config` manpage
   - Update the `Gemfile` manpage to include ruby versions (@stevenh512)
@@ -4142,9 +4144,9 @@ Changes
   - Unknown exceptions now link to ISSUES for help instead of a new ticket
   - Correct inline help for `clean --force` (@dougbarth, [#1911](https://github.com/rubygems/bundler/issues/1911))
 
-# 1.2.0.pre (May 4, 2012)
+## 1.2.0.pre (May 4, 2012)
 
-## Features:
+### Features:
 
   - bundle package now accepts --all to package git and path dependencies
   - bundle config now accepts --local, --global and --delete options
@@ -4160,31 +4162,31 @@ Changes
   - add ruby to DSL, to specify version of ruby
   - error out if the ruby version doesn't match
 
-## Performance:
+### Performance:
 
   - bundle exec shouldn't run Bundler.setup just setting the right rubyopts options is enough (@spastorino, [#1598](https://github.com/rubygems/bundler/issues/1598))
 
-## Bug fixes:
+### Bug fixes:
 
   - Avoid passing RUBYOPT changes in with_clean_env block (@eric1234, [#1604](https://github.com/rubygems/bundler/issues/1604))
   - Use the same ruby to run subprocesses as is running rake (@brixen)
 
-## Documentation:
+### Documentation:
 
   - Add :github documentation in DSL (@zofrex, [#1848](https://github.com/rubygems/bundler/issues/1848), [#1851](https://github.com/bundler/bundler/issues/1851), [#1852](https://github.com/bundler/bundler/issues/1852))
   - Add docs for the --no-cache option (@fluxx, [#1796](https://github.com/rubygems/bundler/issues/1796))
   - Add basic documentation for bin_path and bundle_path (@radar)
   - Add documentation for the run method in Bundler::Installer
 
-# 1.1.5 (July 17, 2012)
+## 1.1.5 (July 17, 2012)
 
-## Features:
+### Features:
 
   - Special case `ruby` directive from 1.2.0, so you can install Gemfiles that use it
 
-# 1.1.4 (May 27, 2012)
+## 1.1.4 (May 27, 2012)
 
-## Bug fixes:
+### Bug fixes:
 
   - Use `latest_release` in Capistrano and Vlad integration ([#1264](https://github.com/rubygems/bundler/issues/1264))
   - Unknown exceptions now link to ISSUES for help instead of a new ticket
@@ -4192,21 +4194,21 @@ Changes
   - Correct inline help for `clean --force` (@dougbarth, [#1911](https://github.com/rubygems/bundler/issues/1911))
   - Work around a Ruby 1.9.3p194 bug in Psych when config files are empty
 
-# 1.1.3 (March 23, 2012)
+## 1.1.3 (March 23, 2012)
 
-## Bug fixes:
+### Bug fixes:
 
   - escape the bundler root path (@tenderlove, [#1789](https://github.com/rubygems/bundler/issues/1789))
 
-# 1.1.2 (March 20, 2012)
+## 1.1.2 (March 20, 2012)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix --deployment for multiple PATH sections of the same source ([#1782](https://github.com/rubygems/bundler/issues/1782))
 
-# 1.1.1 (March 14, 2012)
+## 1.1.1 (March 14, 2012)
 
-## Bug fixes:
+### Bug fixes:
 
   - Rescue EAGAIN so the fetcher works on JRuby on Windows
   - Stop asking users to report gem installation errors
@@ -4215,78 +4217,78 @@ Changes
   - URI-encode gem names for dependency API (@rohit, [#1672](https://github.com/rubygems/bundler/issues/1672))
   - Fix `cache` edge case in rubygems 1.3.7 ([#1202](https://github.com/rubygems/bundler/issues/1202))
 
-## Performance:
+### Performance:
 
   - Reduce invocation of git ls-files in `bundle gem` gemspecs (@knu)
 
-# 1.1.0 (March 7, 2012)
+## 1.1.0 (March 7, 2012)
 
-## Bug fixes:
+### Bug fixes:
 
   - Clean up corrupted lockfiles on bundle installs
   - Prevent duplicate GIT sources
   - Fix post_install_message when uing the endpoint API
 
-# 1.1.rc.8 (March 3, 2012)
+## 1.1.rc.8 (March 3, 2012)
 
-## Performance:
+### Performance:
 
   - don't resolve if the Gemfile.lock and Gemfile haven't changed
 
-## Bug fixes:
+### Bug fixes:
 
   - Load gemspecs from git even when a released gem has the same version ([#1609](https://github.com/rubygems/bundler/issues/1609))
   - Declare an accurate Ruby version requirement of 1.8.7 or newer ([#1619](https://github.com/rubygems/bundler/issues/1619))
   - handle gemspec development dependencies correctly (@raggi, [#1639](https://github.com/rubygems/bundler/issues/1639))
   - Avoid passing RUBYOPT changes in with_clean_env block. (eric1234, [#1604](https://github.com/rubygems/bundler/issues/1604))
 
-# 1.1.rc.7 (December 29, 2011)
+## 1.1.rc.7 (December 29, 2011)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix bug where `clean` would break when using :path with no gemspec
 
-# 1.1.rc.6 (December 22, 2011)
+## 1.1.rc.6 (December 22, 2011)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix performance regression from 1.0 (@spastorino, [#1511](https://github.com/rubygems/bundler/issues/1511), [#1591](https://github.com/bundler/bundler/issues/1591), [#1592](https://github.com/bundler/bundler/issues/1592))
   - Load gems correctly when GEM_HOME is blank
   - Refresh gems so Bundler works from inside a bundle
   - Handle empty .bundle/config files without an error
 
-# 1.1.rc.5 (December 14, 2011)
+## 1.1.rc.5 (December 14, 2011)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix ASCII encoding errors with gem (rerelease with ruby 1.8)
 
-# 1.1.rc.4 (December 14, 2011)
+## 1.1.rc.4 (December 14, 2011)
 
-## Features:
+### Features:
 
   - `bundle viz` has the option to output a DOT file instead of a PNG (@hirochachacha, [#683](https://github.com/rubygems/bundler/issues/683))
 
-## Bug fixes:
+### Bug fixes:
 
   - Ensure binstubs generated when using --standalone point to the standalonde bundle (@cowboyd, [#1588](https://github.com/rubygems/bundler/issues/1588))
   - fix `bundle viz` (@hirochachacha, [#1586](https://github.com/rubygems/bundler/issues/1586))
 
-# 1.1.rc.3 (December 8, 2011)
+## 1.1.rc.3 (December 8, 2011)
 
-## Bug fixes:
+### Bug fixes:
 
   - fix relative_path so it checks Bundler.root is actually in the beginning of the path ([#1582](https://github.com/rubygems/bundler/issues/1582))
   - fix bundle outdated doesn't list all gems (@joelmoss, [#1521](https://github.com/rubygems/bundler/issues/1521))
 
-# 1.1.rc.2 (December 6, 2011)
+## 1.1.rc.2 (December 6, 2011)
 
-## Features:
+### Features:
 
   - Added README.md to `newgem` (@ognevsky, [#1574](https://github.com/rubygems/bundler/issues/1574))
   - Added LICENSE (MIT) to newgem (@ognevsky, [#1571](https://github.com/rubygems/bundler/issues/1571))
 
-## Bug fixes:
+### Bug fixes:
 
   - only auto-namespace requires for implied requires ([#1531](https://github.com/rubygems/bundler/issues/1531))
   - fix bundle clean output for git repos ([#1473](https://github.com/rubygems/bundler/issues/1473))
@@ -4301,38 +4303,38 @@ Changes
   - `bundle init` now uses https://rubygems.org (@jjb, [#1522](https://github.com/rubygems/bundler/issues/1522))
   - `bundle install/update` does not autoclean when using --path for semver
 
-## Documentation:
+### Documentation:
 
   - added documentation for --shebang option for `bundle install` (@lunks, [#1475](https://github.com/rubygems/bundler/issues/1475), [#1558](https://github.com/bundler/bundler/issues/1558))
 
-# 1.1.rc (October 3, 2011)
+## 1.1.rc (October 3, 2011)
 
-## Features:
+### Features:
 
   - add `--shebang` option to bundle install (@bensie, [#1467](https://github.com/rubygems/bundler/issues/1467))
   - build passes on ruby 1.9.3rc1 ([#1458](https://github.com/rubygems/bundler/issues/1458), [#1469](https://github.com/bundler/bundler/issues/1469))
   - hide basic auth credentials for custom sources ([#1440](https://github.com/rubygems/bundler/issues/1440), [#1463](https://github.com/bundler/bundler/issues/1463))
 
-## Bug fixes:
+### Bug fixes:
 
   - fix index search result caching ([#1446](https://github.com/rubygems/bundler/issues/1446), [#1466](https://github.com/bundler/bundler/issues/1466))
   - fix fetcher prints multiple times during install ([#1445](https://github.com/rubygems/bundler/issues/1445), [#1462](https://github.com/bundler/bundler/issues/1462))
   - don't mention API errors from non-rubygems.org sources
   - fix autoclean so it doesn't remove bins that are used ([#1459](https://github.com/rubygems/bundler/issues/1459), [#1460](https://github.com/bundler/bundler/issues/1460))
 
-## Documentation:
+### Documentation:
 
   - add :require => [...] to the gemfile(5) manpage (@nono, [#1468](https://github.com/rubygems/bundler/issues/1468))
 
-# 1.1.pre.10 (September 27, 2011)
+## 1.1.pre.10 (September 27, 2011)
 
-## Features:
+### Features:
 
   - `config system_bindir foo` added, works like "-n foo" in your .gemrc file
 
-# 1.1.pre.9 (September 18, 2011)
+## 1.1.pre.9 (September 18, 2011)
 
-## Features:
+### Features:
 
   - `clean` will now clean up all old .gem and .gemspec files, cleaning up older pres
   - `clean` will be automatically run after bundle install and update when using `--path` ([#1420](https://github.com/rubygems/bundler/issues/1420), [#1425](https://github.com/bundler/bundler/issues/1425))
@@ -4344,7 +4346,7 @@ Changes
   - load rubygems plugins in the bundle binary (@tpope, [#1364](https://github.com/rubygems/bundler/issues/1364))
   - make `--standalone` respect `--path` (@cowboyd, [#1361](https://github.com/rubygems/bundler/issues/1361))
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `clean` to handle nested gems in a git repo ([#1329](https://github.com/rubygems/bundler/issues/1329))
   - Fix conflict from revert of benchmark tool (@boffbowsh, [#1355](https://github.com/rubygems/bundler/issues/1355))
@@ -4355,32 +4357,32 @@ Changes
   - Fix caching issue in the resolver ([#1353](https://github.com/rubygems/bundler/issues/1353), [#1421](https://github.com/bundler/bundler/issues/1421))
   - Fix :github DSL option
 
-# 1.1.pre.8 (August 13, 2011)
+## 1.1.pre.8 (August 13, 2011)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix `bundle check` to not print fatal error message (@cldwalker, [#1347](https://github.com/rubygems/bundler/issues/1347))
   - Fix require_sudo when Gem.bindir isn't writeable ([#1352](https://github.com/rubygems/bundler/issues/1352))
   - Fix not asking Gemcutter API for dependency chain of git gems in --deployment ([#1254](https://github.com/rubygems/bundler/issues/1254))
   - Fix `install --binstubs` when using --path ([#1332](https://github.com/rubygems/bundler/issues/1332))
 
-# 1.1.pre.7 (August 8, 2011)
+## 1.1.pre.7 (August 8, 2011)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fixed invalid byte sequence error while installing gem on Ruby 1.9 ([#1341](https://github.com/rubygems/bundler/issues/1341))
   - Fixed exception when sudo was needed to install gems (@spastorino)
 
-# 1.1.pre.6 (August 8, 2011)
+## 1.1.pre.6 (August 8, 2011)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix cross repository dependencies ([#1138](https://github.com/rubygems/bundler/issues/1138))
   - Fix git dependency fetching from API endpoint ([#1254](https://github.com/rubygems/bundler/issues/1254))
   - Fixes for bundle outdated (@joelmoss, [#1238](https://github.com/rubygems/bundler/issues/1238))
   - Fix bundle standalone when using the endpoint ([#1240](https://github.com/rubygems/bundler/issues/1240))
 
-## Features:
+### Features:
 
   - Implement `to_ary` to avoid calls to method_missing (@tenderlove, [#1274](https://github.com/rubygems/bundler/issues/1274))
   - bundle clean removes old .gem files (@cldwalker, [#1293](https://github.com/rubygems/bundler/issues/1293))
@@ -4388,14 +4390,14 @@ Changes
   - Run pre-install, post-build, and post-install gem hooks for git gems (@warhammerkid, [#1120](https://github.com/rubygems/bundler/issues/1120))
   - create Gemfile.lock for empty Gemfile ([#1218](https://github.com/rubygems/bundler/issues/1218))
 
-# 1.1.pre.5 (June 11, 2011)
+## 1.1.pre.5 (June 11, 2011)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix LazySpecification on Ruby 1.9 (@dpiddy, [#1232](https://github.com/rubygems/bundler/issues/1232))
   - Fix HTTP proxy support (@leobessa, [#878](https://github.com/rubygems/bundler/issues/878))
 
-## Features:
+### Features:
 
   - Speed up `install --deployment` by using the API endpoint
   - Support Basic HTTP Auth for the API endpoint (@dpiddy, [#1229](https://github.com/rubygems/bundler/issues/1229))
@@ -4406,42 +4408,42 @@ Changes
   - Reduce memory use by removing Specification.new inside method_missing (@tenderlove, [#1222](https://github.com/rubygems/bundler/issues/1222))
   - Allow `check --path`
 
-# 1.1.pre.4 (May 5, 2011)
+## 1.1.pre.4 (May 5, 2011)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix bug that could prevent installing new gems
 
-# 1.1.pre.3 (May 4, 2011)
+## 1.1.pre.3 (May 4, 2011)
 
-## Features:
+### Features:
 
   - Add `bundle outdated` to show outdated gems (@joelmoss)
   - Remove BUNDLE_* from `Bundler.with_clean_env` (@wuputah)
   - Add Bundler.clean_system, and clean_exec (@wuputah)
   - Use git config for gem author name and email (@krekoten)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix error calling Bundler.rubygems.gem_path
   - Fix error when Gem.path returns Gem::FS instead of String
 
-# 1.1.pre.2 (April 28, 2011)
+## 1.1.pre.2 (April 28, 2011)
 
-## Features:
+### Features:
 
   - Add :github option to Gemfile DSL for easy git repos
   - Merge all fixes from 1.0.12 and 1.0.13
 
-# 1.1.pre.1 (February 2, 2011)
+## 1.1.pre.1 (February 2, 2011)
 
-## Bug fixes:
+### Bug fixes:
 
   - Compatibility with changes made by Rubygems 1.5
 
-# 1.1.pre (January 21, 2011)
+## 1.1.pre (January 21, 2011)
 
-## Features:
+### Features:
 
   - Add bundle clean. Removes unused gems from --path directory
   - Initial Gemcutter Endpoint API work, BAI Fetching source index
@@ -4450,42 +4452,42 @@ Changes
   - Make it possible to override a .gemspec dependency's source in the
     Gemfile
 
-## Breaking changes:
+### Breaking changes:
 
   - Removed bundle lock
   - Removed bundle install <path>
   - Removed bundle install --production
   - Removed bundle install --disable-shared-gems
 
-# 1.0.21 (September 30, 2011)
+## 1.0.21 (September 30, 2011)
 
   No changes.
 
-# 1.0.21.rc (September 29, 2011)
+## 1.0.21.rc (September 29, 2011)
 
-## Bug fixes:
+### Bug fixes:
 
   - Load Psych unless Syck is defined, because 1.9.2 defines YAML
 
-# 1.0.20 (September 27, 2011)
+## 1.0.20 (September 27, 2011)
 
-## Features:
+### Features:
 
   - Add platform :maglev (@timfel, [#1444](https://github.com/rubygems/bundler/issues/1444))
 
-## Bug fixes:
+### Bug fixes:
 
   - Ensure YAML is required even if Psych is found
   - Handle directory names that contain invalid regex characters
 
-# 1.0.20.rc (September 18, 2011)
+## 1.0.20.rc (September 18, 2011)
 
-## Features:
+### Features:
 
   - Rescue interrupts to `bundle` while loading bundler.rb ([#1395](https://github.com/rubygems/bundler/issues/1395))
   - Allow clearing without groups by passing `--without ''` ([#1259](https://github.com/rubygems/bundler/issues/1259))
 
-## Bug fixes:
+### Bug fixes:
 
   - Manually sort requirements in the lockfile ([#1375](https://github.com/rubygems/bundler/issues/1375))
   - Remove several warnings generated by ruby -w (@stephencelis)
@@ -4493,51 +4495,51 @@ Changes
   - Name modules for gems like 'test-foo_bar' correctly ([#1303](https://github.com/rubygems/bundler/issues/1303))
   - Don't require Psych if Syck is already loaded ([#1239](https://github.com/rubygems/bundler/issues/1239))
 
-# 1.0.19.rc (September 13, 2011)
+## 1.0.19.rc (September 13, 2011)
 
-## Features:
+### Features:
 
   - Compatibility with Rubygems 1.8.10 installer changes
   - Report gem installation failures clearly (@rwilcox, [#1380](https://github.com/rubygems/bundler/issues/1380))
   - Useful error for cap and vlad on first deploy (@nexmat, @kirs)
 
-## Bug fixes:
+### Bug fixes:
 
   - `exec` now works when the command contains 'exec'
   - Only touch lock after changes on Windows (@robertwahler, [#1358](https://github.com/rubygems/bundler/issues/1358))
   - Keep load paths when #setup is called multiple times (@radsaq, [#1379](https://github.com/rubygems/bundler/issues/1379))
 
-# 1.0.18 (August 16, 2011)
+## 1.0.18 (August 16, 2011)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix typo in DEBUG_RESOLVER (@geemus)
   - Fixes rake 0.9.x warning (@mtylty, [#1333](https://github.com/rubygems/bundler/issues/1333))
   - Fix `bundle cache` again for rubygems 1.3.x
 
-## Features:
+### Features:
 
   - Run the bundle install earlier in a Capistrano deployment (@cgriego, [#1300](https://github.com/rubygems/bundler/issues/1300))
   - Support hidden gemspec (@trans, @cldwalker, [#827](https://github.com/rubygems/bundler/issues/827))
   - Make fetch_specs faster (@zeha, [#1294](https://github.com/rubygems/bundler/issues/1294))
   - Allow overriding development deps loaded by #gemspec (@lgierth, [#1245](https://github.com/rubygems/bundler/issues/1245))
 
-# 1.0.17 (August 8, 2011)
+## 1.0.17 (August 8, 2011)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix rake issues with rubygems 1.3.x ([#1342](https://github.com/rubygems/bundler/issues/1342))
   - Fixed invalid byte sequence error while installing gem on Ruby 1.9 ([#1341](https://github.com/rubygems/bundler/issues/1341))
 
-# 1.0.16 (August 8, 2011)
+## 1.0.16 (August 8, 2011)
 
-## Features:
+### Features:
 
   - Performance fix for MRI 1.9 (@efficientcloud, [#1288](https://github.com/rubygems/bundler/issues/1288))
   - Shortcuts (like `bundle i`) for all commands (@amatsuda)
   - Correctly identify missing child dependency in error message
 
-## Bug fixes:
+### Bug fixes:
 
   - Allow Windows network share paths with forward slashes (@mtscout6, [#1253](https://github.com/rubygems/bundler/issues/1253))
   - Check for rubygems.org credentials so `rake release` doesn't hang ([#980](https://github.com/rubygems/bundler/issues/980))
@@ -4545,30 +4547,30 @@ Changes
   - Fix `bundle install --without` on kiji (@tmm1, [#1287](https://github.com/rubygems/bundler/issues/1287))
   - Get rid of warning in ruby 1.9.3 (@smartinez87, [#1231](https://github.com/rubygems/bundler/issues/1231))
 
-## Documentation:
+### Documentation:
 
   - Documentation for `gem ..., :require => false` (@kmayer, [#1292](https://github.com/rubygems/bundler/issues/1292))
   - Gems provide "executables", they are rarely also binaries (@fxn, [#1242](https://github.com/rubygems/bundler/issues/1242))
 
-# 1.0.15 (June 9, 2011)
+## 1.0.15 (June 9, 2011)
 
-## Features:
+### Features:
 
   - Improved Rubygems integration, removed many deprecation notices
 
-## Bug fixes:
+### Bug fixes:
 
   - Escape URL arguments to git correctly on Windows (1.0.14 regression)
 
-# 1.0.14 (May 27, 2011)
+## 1.0.14 (May 27, 2011)
 
-## Features:
+### Features:
 
   - Rubinius platform :rbx (@rkbodenner)
   - Include gem rake tasks with "require 'bundler/gem_tasks" (@indirect)
   - Include user name and email from git config in new gemspec (@ognevsky)
 
-## Bug fixes:
+### Bug fixes:
 
   - Set file permissions after checking out git repos (@tissak)
   - Remove deprecated call to Gem::SourceIndex#all_gems (@mpj)
@@ -4581,30 +4583,30 @@ Changes
   - Handle certain directories already existing (@raggi)
   - Escape filenames containing regex characters (@indirect)
 
-# 1.0.13 (May 4, 2011)
+## 1.0.13 (May 4, 2011)
 
-## Features:
+### Features:
 
   - Compatibility with Rubygems master (soon to be v1.8) (@evanphx)
   - Informative error when --path points to a broken symlink
   - Support Rake 0.9 and greater (@e2)
   - Output full errors for non-TTYs e.g. pow (@josh)
 
-## Bug fixes:
+### Bug fixes:
 
   - Allow spaces in gem path names for gem tasks (@rslifka)
   - Have cap run bundle install from release_path (@martinjagusch)
   - Quote git refspec so zsh doesn't expand it (@goneflyin)
 
-# 1.0.12 (April 8, 2011)
+## 1.0.12 (April 8, 2011)
 
-## Features:
+### Features:
 
   - Add --no-deployment option to `install` for disabling it on dev machines
   - Better error message when git fails and cache is present (@parndt)
   - Honor :bundle_cmd in cap `rake` command (@voidlock, @cgriego)
 
-## Bug fixes:
+### Bug fixes:
 
   - Compatibility with Rubygems 1.7 and Rails 2.3 and vendored gems (@evanphx)
   - Fix changing gem order in lock (@gucki)
@@ -4613,38 +4615,38 @@ Changes
   - Fix gems without a gemspec and directories in bin/ (@epall)
   - Fix --no-prune option for `bundle install` (@cmeiklejohn)
 
-# 1.0.11 (April 1, 2011)
+## 1.0.11 (April 1, 2011)
 
-## Features:
+### Features:
 
   - Compatibility with Rubygems 1.6 and 1.7
   - Better error messages when a git command fails
 
-## Bug fixes:
+### Bug fixes:
 
   - Don't always update gemspec gems (@carllerche)
   - Remove ivar warnings (@jackdempsey)
   - Fix occasional git failures in zsh (@jonah-carbonfive)
   - Consistent lock for gems with double deps like Cap (@akahn)
 
-# 1.0.10 (February 1, 2011)
+## 1.0.10 (February 1, 2011)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix a regression loading YAML gemspecs from :git and :path gems
   - Requires, namespaces, etc. to work with changes in Rubygems 1.5
 
-# 1.0.9 (January 19, 2011)
+## 1.0.9 (January 19, 2011)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix a bug where Bundler.require could remove gems from the load
     path. In Rails apps with a default application.rb, this removed
     all gems in groups other than :default and Rails.env
 
-# 1.0.8 (January 18, 2011)
+## 1.0.8 (January 18, 2011)
 
-## Features:
+### Features:
 
   - Allow overriding gemspec() deps with :git deps
   - Add --local option to `bundle update`
@@ -4652,7 +4654,7 @@ Changes
   - Use `less` as help pager instead of `more`
   - Run `bundle exec rake` instead of `rake` in Capistrano tasks
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix --no-cache option for `bundle install`
   - Allow Vlad deploys to work without Capistrano gem installed
@@ -4664,21 +4666,21 @@ Changes
   - Check git process exit status correctly
   - Fix some warnings in 1.9.3-trunk (thanks tenderlove)
 
-# 1.0.7 (November 17, 2010)
+## 1.0.7 (November 17, 2010)
 
-## Bug fixes:
+### Bug fixes:
 
   - Remove Bundler version from the lockfile because it broke
     backwards compatibility with 1.0.0-1.0.5. Sorry. :(
 
-# 1.0.6 (November 16, 2010)
+## 1.0.6 (November 16, 2010)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix regression in `update` that caused long/wrong results
   - Allow git gems on other platforms while installing ([#579](https://github.com/rubygems/bundler/issues/579))
 
-## Features:
+### Features:
 
   - Speed up `install` command using various optimizations
   - Significantly increase performance of resolver
@@ -4686,15 +4688,15 @@ Changes
   - Warn if the lockfile was generated by a newer version
   - Set generated gems' homepage to "", so Rubygems will warn
 
-# 1.0.5 (November 13, 2010)
+## 1.0.5 (November 13, 2010)
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix regression disabling all operations that employ sudo
 
-# 1.0.4 (November 12, 2010)
+## 1.0.4 (November 12, 2010)
 
-## Bug fixes:
+### Bug fixes:
 
   - Expand relative :paths from Bundler.root (eg ./foogem)
   - Allow git gems in --without groups while --frozen
@@ -4708,7 +4710,7 @@ Changes
   - Disable colored output in --deployment
   - Preserve line endings in lockfile
 
-## Features:
+### Features:
 
   - Add support for 'mingw32' platform (aka RubyInstaller)
   - Large speed increase when Gemfile.lock is already present
@@ -4717,9 +4719,9 @@ Changes
   - Remove Open3 from GemHelper (now it works on Windows™®©)
   - Allow setting roles in built-in cap and vlad tasks
 
-# 1.0.3 (October 15, 2010)
+## 1.0.3 (October 15, 2010)
 
-## Bug fixes:
+### Bug fixes:
 
   - Use bitwise or in #hash to reduce the chance of overflow
   - `bundle update` now works with :git + :tag updates
@@ -4733,15 +4735,15 @@ Changes
   - Improve output when installing to a path
   - The tests all pass! Yay!
 
-# 1.0.2 (October 2, 2010)
+## 1.0.2 (October 2, 2010)
 
-## Bug fixes:
+### Bug fixes:
 
   - Actually include the man pages in the gem, so help works
 
-# 1.0.1 (October 1, 2010)
+## 1.0.1 (October 1, 2010)
 
-## Features:
+### Features:
 
   - Vlad deployment recipe, `require 'bundler/vlad'`
   - Prettier bundle graphs
@@ -4751,7 +4753,7 @@ Changes
   - Allow subclassing of GemHelper for custom tasks
   - Chdir to gem directory during `bundle open`
 
-## Bug fixes:
+### Bug fixes:
 
   - Allow gemspec requirements with a list of versions
   - Accept lockfiles with windows line endings
@@ -4761,13 +4763,13 @@ Changes
   - Flesh out gem_helper tasks, raise errors correctly
   - Respect RBConfig::CONFIG['ruby_install_name'] in binstubs
 
-# 1.0.0 (August 29, 2010)
+## 1.0.0 (August 29, 2010)
 
-## Features:
+### Features:
 
   - You can now define `:bundle_cmd` in the capistrano task
 
-## Bug fixes:
+### Bug fixes:
 
   - Various bugfixes to the built-in rake helpers
   - Fix a bug where shortrefs weren't unique enough and were
@@ -4783,14 +4785,14 @@ Changes
   - Detect new Rubygems sources in the Gemfile and update
     the lockfile
 
-# 1.0.0.rc.6 (August 23, 2010)
+## 1.0.0.rc.6 (August 23, 2010)
 
-## Features:
+### Features:
 
   - Much better documentation for most of the commands and Gemfile
     format
 
-## Bug fixes:
+### Bug fixes:
 
   - Don't attempt to create directories if they already exist
   - Fix the capistrano task so that it actually runs
@@ -4801,20 +4803,20 @@ Changes
   - Expand paths in Gemfile relative to the Gemfile and not the current
     working directory.
 
-# 1.0.0.rc.5 (August 10, 2010)
+## 1.0.0.rc.5 (August 10, 2010)
 
-## Features:
+### Features:
 
   - Make the Capistrano task more concise.
 
-## Bug fixes:
+### Bug fixes:
 
   - Fix a regression with determining whether or not to use sudo
   - Allow using the --gemfile flag with the --deployment flag
 
-# 1.0.0.rc.4 (August 9, 2010)
+## 1.0.0.rc.4 (August 9, 2010)
 
-## Features:
+### Features:
 
   - `bundle gem NAME` command to generate a new gem with Gemfile
   - Bundle config file location can be specified by BUNDLE_APP_CONFIG
@@ -4822,7 +4824,7 @@ Changes
     (default with --deployment)
   - Basic Capistrano task now added as 'bundler/capistrano'
 
-## Bug fixes:
+### Bug fixes:
 
   - Multiple bundler process no longer share a tmp directory
   - `bundle update GEM` always updates dependencies of GEM as well
@@ -4833,9 +4835,9 @@ Changes
   - Fetch gems from vendor/cache, even without --local
   - Sort lockfile by platform as well as spec
 
-# 1.0.0.rc.3 (August 3, 2010)
+## 1.0.0.rc.3 (August 3, 2010)
 
-## Features:
+### Features:
 
   - Deprecate --production flag for --deployment, since the former
     was causing confusion with the :production group
@@ -4844,14 +4846,14 @@ Changes
   - Improve message from `bundle check` under various conditions
   - Better error when a changed Gemfile conflicts with Gemfile.lock
 
-## Bug fixes:
+### Bug fixes:
 
   - Create bin/ directory if it is missing, then install binstubs
   - Error nicely on the edge case of a pinned gem with no spec
   - Do not require gems for other platforms
   - Update git sources along with the gems they contain
 
-# 1.0.0.rc.2 (July 29, 2010)
+## 1.0.0.rc.2 (July 29, 2010)
 
   - `bundle install path` was causing confusion, so we now print
     a clarifying warning. The preferred way to install to a path
@@ -4899,11 +4901,11 @@ Changes
   snappy while maintaining the benefits of clean, deploy-time
   isolation.
 
-# 1.0.0.rc.1 (July 26, 2010)
+## 1.0.0.rc.1 (July 26, 2010)
 
   - Fixed a bug with `bundle install` on multiple machines and git
 
-# 1.0.0.beta.10 (July 25, 2010)
+## 1.0.0.beta.10 (July 25, 2010)
 
   - Last release before 1.0.0.rc.1
   - Added :mri as a valid platform (platforms :mri { gem "ruby-debug" })
@@ -4918,7 +4920,7 @@ Changes
   - Add build options
     - `bundle config build.mysql --with-mysql-config=/path/to/config`
 
-# 1.0.0.beta.9 (July 21, 2010)
+## 1.0.0.beta.9 (July 21, 2010)
 
   - Fix install failure when switching from a path to git source
   - Fix `bundle exec bundle *` in a bundle with --disable-shared-gems
@@ -4926,15 +4928,15 @@ Changes
   - Shim Gem.refresh. This is used by Unicorn
   - Fix install failure when a path's dependencies changed
 
-# 1.0.0.beta.8 (July 20, 2010)
+## 1.0.0.beta.8 (July 20, 2010)
 
   - Fix a Beta 7 bug involving Ruby 1.9
 
-# 1.0.0.beta.7 (July 20, 2010, yanked)
+## 1.0.0.beta.7 (July 20, 2010, yanked)
 
   - Running `bundle install` twice in a row with a git source always crashed
 
-# 1.0.0.beta.6 (July 20, 2010, yanked)
+## 1.0.0.beta.6 (July 20, 2010, yanked)
 
   - Create executables with bundle install --binstubs
   - You can customize the location (default is app/bin) with --binstubs other/location
@@ -4956,29 +4958,29 @@ Changes
   - Fix cases where the same dependency appeared several times in the Gemfile.lock
   - Fix a bug where require errors were being swallowed during Bundler.require
 
-# 1.0.0.beta.1
+## 1.0.0.beta.1
 
   - No `bundle lock` command. Locking happens automatically on install or update
   - No .bundle/environment.rb. Require 'bundler/setup' instead.
   - $BUNDLE_HOME defaults to $GEM_HOME instead of ~/.bundle
   - Remove lockfiles generated by 0.9
 
-# 0.9.26
+## 0.9.26
 
-## Features:
+### Features:
 
   - error nicely on incompatible 0.10 lockfiles
 
-# 0.9.25 (May 3, 2010)
+## 0.9.25 (May 3, 2010)
 
-## Bug fixes:
+### Bug fixes:
 
   - explicitly coerce Pathname objects to Strings for Ruby 1.9
   - fix some newline weirdness in output from install command
 
-# 0.9.24 (April 22, 2010)
+## 0.9.24 (April 22, 2010)
 
-## Features:
+### Features:
 
   - fetch submodules for git sources
   - limit the bundled version of bundler to the same as the one installing
@@ -4987,7 +4989,7 @@ Changes
   - raise Bundler::GemNotFound instead of calling exit! inside library code
   - Rubygems 1.3.5 compatibility for the adventurous, not supported by me :)
 
-## Bug fixes:
+### Bug fixes:
 
   - don't try to regenerate environment.rb if it is read-only
   - prune outdated gems with the platform "ruby"
@@ -4995,16 +4997,16 @@ Changes
   - don't re-write environment.rb if running after it has been loaded
   - do not monkeypatch Specification#load_paths twice when inside a bundle
 
-# 0.9.23 (April 20, 2010)
+## 0.9.23 (April 20, 2010)
 
-## Bug fixes:
+### Bug fixes:
 
   - cache command no longer prunes gems created by an older rubygems version
   - cache command no longer prunes gems that are for other platforms
 
-# 0.9.22 (April 20, 2010)
+## 0.9.22 (April 20, 2010)
 
-## Features:
+### Features:
 
   - cache command now prunes stale .gem files from vendor/cache
   - init --gemspec command now generates development dependencies
@@ -5012,7 +5014,7 @@ Changes
   - remove .gem files generated after installing a gem from a :path ([#286](https://github.com/rubygems/bundler/issues/286))
   - improve install/lock messaging ([#284](https://github.com/rubygems/bundler/issues/284))
 
-## Bug fixes:
+### Bug fixes:
 
   - ignore cached gems that are for another platform ([#288](https://github.com/rubygems/bundler/issues/288))
   - install Windows gems that have no architecture set, like rcov ([#277](https://github.com/rubygems/bundler/issues/277))
@@ -5021,72 +5023,72 @@ Changes
   - add GemspecError so it can be raised without (further) error ([#292](https://github.com/rubygems/bundler/issues/292))
   - create a parent directory before cloning for git 1.5 compatibility ([#285](https://github.com/rubygems/bundler/issues/285))
 
-# 0.9.21 (April 16, 2010)
+## 0.9.21 (April 16, 2010)
 
-## Bug fixes:
+### Bug fixes:
 
   - don't raise 'omg wtf' when lockfile is outdated
 
-# 0.9.20 (April 15, 2010)
+## 0.9.20 (April 15, 2010)
 
-## Features:
+### Features:
 
   - load YAML format gemspecs
   - no backtraces when calling Bundler.setup if gems are missing
   - no backtraces when trying to exec a file without the executable bit
 
-## Bug fixes:
+### Bug fixes:
 
   - fix infinite recursion in Bundler.setup after loading a bundled Bundler gem
   - request install instead of lock when env.rb is out of sync with Gemfile.lock
 
-# 0.9.19 (April 12, 2010)
+## 0.9.19 (April 12, 2010)
 
-## Features:
+### Features:
 
   - suggest `bundle install --relock` when the Gemfile has changed ([#272](https://github.com/rubygems/bundler/issues/272))
   - source support for Rubygems servers without prerelease gem indexes ([#262](https://github.com/rubygems/bundler/issues/262))
 
-## Bug fixes:
+### Bug fixes:
 
   - don't set up all groups every time Bundler.setup is called while locked ([#263](https://github.com/rubygems/bundler/issues/263))
   - fix #full_gem_path for git gems while locked ([#268](https://github.com/rubygems/bundler/issues/268))
   - eval gemspecs at the top level, not inside the Bundler class ([#269](https://github.com/rubygems/bundler/issues/269))
 
 
-# 0.9.18 (April 8, 2010)
+## 0.9.18 (April 8, 2010)
 
-## Features:
+### Features:
 
   - console command that runs irb with bundle (and optional group) already loaded
 
-## Bug fixes:
+### Bug fixes:
 
   - Bundler.setup now fully disables system gems, even when unlocked ([#266](https://github.com/rubygems/bundler/issues/266), [#246](https://github.com/bundler/bundler/issues/246))
     - fixes Yard, which found plugins in Gem.source_index that it could not load
     - makes behaviour of `Bundler.require` consistent between locked and unlocked loads
 
-# 0.9.17 (April 7, 2010)
+## 0.9.17 (April 7, 2010)
 
-## Features:
+### Features:
 
   - Bundler.require now calls Bundler.setup automatically
   - Gem::Specification#add_bundler_dependencies added for gemspecs
 
-## Bug fixes:
+### Bug fixes:
 
   - Gem paths are not longer duplicated while loading bundler
   - exec no longer duplicates RUBYOPT if it is already set correctly
 
-# 0.9.16 (April 3, 2010)
+## 0.9.16 (April 3, 2010)
 
-## Features:
+### Features:
 
   - exit gracefully on INT signal
   - resolver output now indicates whether remote sources were checked
   - print error instead of backtrace when exec cannot find a binary ([#241](https://github.com/rubygems/bundler/issues/241))
 
-## Bug fixes:
+### Bug fixes:
 
   - show, check, and open commands work again while locked (oops)
   - show command for git gems
@@ -5097,9 +5099,9 @@ Changes
   - fix Gem::Spec#git_version to not error on unloaded specs
   - improve deprecation, Gemfile, and command error messages ([#242](https://github.com/rubygems/bundler/issues/242))
 
-# 0.9.15 (April 1, 2010)
+## 0.9.15 (April 1, 2010)
 
-## Features:
+### Features:
 
   - use the env_file if possible instead of doing a runtime resolve
      - huge speedup when calling Bundler.setup while locked
@@ -5107,15 +5109,15 @@ Changes
      - regenerates env_file if it was generated by an older version
   - update cached/packed gems when you update gems via bundle install
 
-## Bug fixes:
+### Bug fixes:
 
   - prep for Rubygems 1.3.7 changes
   - install command now pulls git branches correctly ([#211](https://github.com/rubygems/bundler/issues/211))
   - raise errors on invalid options in the Gemfile
 
-# 0.9.14 (March 30, 2010)
+## 0.9.14 (March 30, 2010)
 
-## Features:
+### Features:
 
   - install command output vastly improved
     - installation message now accurate, with 'using' and 'installing'
@@ -5126,31 +5128,31 @@ Changes
   - show command now aliased as 'list'
   - VISUAL env var respected for GUI editors
 
-## Bug fixes:
+### Bug fixes:
 
   - exec command now finds binaries from gems with no gemspec
   - note source of Gemfile resolver errors
   - don't blow up if git urls are changed
 
-# 0.9.13 (March 23, 2010)
+## 0.9.13 (March 23, 2010)
 
-## Bug fixes:
+### Bug fixes:
 
   - exec command now finds binaries from gems installed via :path
   - gem dependencies are pulled in even if their type is nil
   - paths with spaces have double-quotes to work on Windows
   - set GEM_PATH in environment.rb so generators work with Rails 2
 
-# 0.9.12 (March 17, 2010)
+## 0.9.12 (March 17, 2010)
 
   - refactoring, internal cleanup, more solid specs
 
-## Features:
+### Features:
 
   - check command takes a --without option
   - check command exits 1 if the check fails
 
-## Bug fixes:
+### Bug fixes:
 
   - perform a topological sort on resolved gems ([#191](https://github.com/rubygems/bundler/issues/191))
   - gems from git work even when paths or repos have spaces ([#196](https://github.com/rubygems/bundler/issues/196))
@@ -5159,11 +5161,11 @@ Changes
   - virtual gemspecs are now saved in environment.rb for use when loading
   - unify the Installer's local index and the runtime index ([#204](https://github.com/rubygems/bundler/issues/204))
 
-# 0.9.11 (March 9, 2010)
+## 0.9.11 (March 9, 2010)
 
   - added roadmap with future development plans
 
-## Features:
+### Features:
 
   - install command can take the path to the gemfile with --gemfile ([#125](https://github.com/rubygems/bundler/issues/125))
   - unknown command line options are now rejected ([#163](https://github.com/rubygems/bundler/issues/163))
@@ -5175,7 +5177,7 @@ Changes
   - improve backtraces when a gemspec is invalid
   - improve performance by installing gems from the cache if present
 
-## Bug fixes:
+### Bug fixes:
 
   - normalize parameters to Bundler.require ([#153](https://github.com/rubygems/bundler/issues/153))
   - check now checks installed gems rather than cached gems ([#162](https://github.com/rubygems/bundler/issues/162))
@@ -5187,26 +5189,26 @@ Changes
   - don't reinstall packed gems
   - fix gems with git sources that are private repositories
 
-# 0.9.10 (March 1, 2010)
+## 0.9.10 (March 1, 2010)
 
   - depends on Rubygems 1.3.6
 
-## Bug fixes:
+### Bug fixes:
 
   - support locking after install --without
   - don't reinstall gems from the cache if they're already in the bundle
   - fixes for Ruby 1.8.7 and 1.9
 
-# 0.9.9 (February 25, 2010)
+## 0.9.9 (February 25, 2010)
 
-## Bug fixes:
+### Bug fixes:
 
   - don't die if GEM_HOME is an empty string
   - fixes for Ruby 1.8.6 and 1.9
 
-# 0.9.8 (February 23, 2010)
+## 0.9.8 (February 23, 2010)
 
-## Features:
+### Features:
 
   - pack command which both caches and locks
   - descriptive error if a cached gem is missing
@@ -5218,27 +5220,27 @@ Changes
   - print a useful warning if building a gem fails
   - allow manual configuration via BUNDLE_PATH
 
-## Bug fixes:
+### Bug fixes:
 
   - eval gemspecs in the gem directory so relative paths work
   - make default spec for git sources valid
   - don't reinstall gems that are already packed
 
-# 0.9.7 (February 17, 2010)
+## 0.9.7 (February 17, 2010)
 
-## Bug fixes:
+### Bug fixes:
 
   - don't say that a gem from an excluded group is "installing"
   - improve crippling rubygems in locked scenarios
 
-# 0.9.6 (February 16, 2010)
+## 0.9.6 (February 16, 2010)
 
-## Features:
+### Features:
 
   - allow String group names
   - a number of improvements in the documentation and error messages
 
-## Bug fixes:
+### Bug fixes:
 
   - set SourceIndex#spec_dirs to solve a problem involving Rails 2.3 in unlocked mode
   - ensure Rubygems is fully loaded in Ruby 1.9 before patching it
@@ -5247,9 +5249,9 @@ Changes
   - make the tests platform agnostic so we can confirm that they're green on JRuby
   - fixes for Ruby 1.9
 
-# 0.9.5 (February 12, 2010)
+## 0.9.5 (February 12, 2010)
 
-## Features:
+### Features:
 
   - added support for :path => "relative/path"
   - added support for older versions of git
@@ -5257,7 +5259,7 @@ Changes
   - Bundler.require fails silently if a library does not have a file on the load path with its name
   - Basic support for multiple rubies by namespacing the default bundle path using the version and engine
 
-## Bug fixes:
+### Bug fixes:
 
   - if the bundle is locked and .bundle/environment.rb is not present when Bundler.setup is called, generate it
   - same if it's not present with `bundle check`

--- a/bundler/README.md
+++ b/bundler/README.md
@@ -6,7 +6,7 @@ Bundler makes sure Ruby applications run the same code on every machine.
 
 It does this by managing the gems that the application depends on. Given a list of gems, it can automatically download and install those gems, as well as any other gems needed by the gems that are listed. Before installing gems, it checks the versions of every gem to make sure that they are compatible, and can all be loaded at the same time. After the gems have been installed, Bundler can help you update some or all of them when new versions become available. Finally, it records the exact versions that have been installed, so that others can install the exact same gems.
 
-### Installation and usage
+## Installation and usage
 
 To install (or update to the latest version):
 
@@ -27,32 +27,32 @@ bundle exec rspec
 
 See [bundler.io](https://bundler.io) for the full documentation.
 
-### Troubleshooting
+## Troubleshooting
 
 For help with common problems, see [TROUBLESHOOTING](../doc/bundler/TROUBLESHOOTING.md).
 
 Still stuck? Try [filing an issue](https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md).
 
-### Other questions
+## Other questions
 
 To see what has changed in recent versions of Bundler, see the [CHANGELOG](CHANGELOG.md).
 
 To get in touch with the Bundler core team and other Bundler users, please join [the Bundler slack](https://join.slack.com/t/bundler/shared_invite/zt-1rrsuuv3m-OmXKWQf8K6iSla4~F1DBjQ).
 
-### Contributing
+## Contributing
 
 If you'd like to contribute to Bundler, that's awesome, and we <3 you. We've put together [the Bundler contributor guide](https://github.com/rubygems/rubygems/blob/master/doc/bundler/contributing/README.md) with all of the information you need to get started.
 
 If you'd like to request a substantial change to Bundler or its documentation, refer to the [Bundler RFC process](https://github.com/rubygems/rfcs) for more information.
 
-### Supporting
+## Supporting
 
 RubyGems is managed by [Ruby Central](https://rubycentral.org), a non-profit organization that supports the Ruby community through projects like this one, as well as [RubyConf](https://rubyconf.org), [RailsConf](https://railsconf.org), and [RubyGems.org](https://rubygems.org). You can support Ruby Central by attending or [sponsoring](sponsors@rubycentral.org) a conference, or by [joining as a supporting member](https://rubycentral.org/#/portal/signup).
 
-### Code of Conduct
+## Code of Conduct
 
 Everyone interacting in the Bundler project's codebases, issue trackers, chat rooms, and mailing lists is expected to follow the [Bundler code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
 
-### License
+## License
 
 Bundler is available under an [MIT License](https://github.com/rubygems/rubygems/blob/master/bundler/LICENSE.md).

--- a/doc/bundler/POLICIES.md
+++ b/doc/bundler/POLICIES.md
@@ -2,7 +2,7 @@
 
 This document is an attempt to record the policies and processes that are used to govern the Bundler project--it's not fixed or permanent, and will likely evolve as events warrant.
 
-### Our Goals
+## Our Goals
 
 0. Treat everyone like a valuable human being, worthy of respect and empathy. No exceptions.
 1. Strive to empower users, the Ruby developers who use Bundler. For example, there is no such thing as user error, only insufficient UX design.
@@ -11,7 +11,7 @@ This document is an attempt to record the policies and processes that are used t
 
 These policies are intended to be examples of how to apply these goals, and we realize that we can't possibly cover every edge case or loophole. In any case where policies turn out to conflict with these goals, the goals should win.
 
-### Compatibility guidelines
+## Compatibility guidelines
 
 Bundler tries for perfect backwards compatibility. That means that if something worked in version 1.x, it should continue to work in 1.y and 1.z. That thing may or may not continue to work in 2.x. We may not always get it right, and there may be extenuating circumstances that force us into choosing between different kinds of breakage, but compatibility is very important to us. Infrastructure should be as unsurprising as possible.
 
@@ -59,7 +59,7 @@ As of May, 2024, that means Bundler 2.5 is the only supported version, but the B
 
 These policies are not a guarantee that any particular fix will be backported. Instead, this is a way for us to set an upper limit on the versions of Ruby, RubyGems, and Bundler that we have to consider while making changes. Without the limit, the number of versions grows exponentially over time and quickly becomes overwhelming, which leads to maintainer burnout. We want to avoid that.
 
-### Release guidelines
+## Release guidelines
 
 **tl;dr**: Majors about once per year, minors for any finished features with docs, patches for any committed bugfix.
 
@@ -77,7 +77,7 @@ The experience of using Bundler should not include surprises. If users are surpr
 
 Changing existing behavior is also surprising. If reducing user surprise will result in a backwards-incompatible change, that change should include at least one major version of deprecation warning before the breaking change is made.
 
-### Issue guidelines
+## Issue guidelines
 
 Anyone is welcome to open an issue, or comment on an issue. Issue comments without useful content (like “me too”) may be removed.
 
@@ -85,7 +85,7 @@ Opening an issue to ask for help may eventually get you help, but chances are he
 
 Issues will be handled as soon as possible, which may take some time. Including a script that can be used to reproduce your issue is a great way to help maintainers help you. If you can, writing a failing test for your issue is even more helpful.
 
-### Contribution and pull request guidelines
+## Contribution and pull request guidelines
 
 Anyone is welcome to [contribute to Bundler](README.md). Contributed code will be released under the same license as the existing codebase.
 
@@ -98,17 +98,17 @@ Every pull request should explain:
 3. What changes to fix that problem are included in the PR, and
 4. Why that implementation was chosen out of the possible options.
 
-### RFC guidelines
+## RFC guidelines
 
 Large changes often benefit from being written out more completely, read by others, and discussed. The [Bundler RFC repo](https://github.com/rubygems/rfcs) is the preferred place for that to happen.
 
-### Maintainer team guidelines
+## Maintainer team guidelines
 
 Always create pull requests rather than pushing directly to the primary branch. Try to get code review and merge approval from someone other than yourself whenever possible.
 
 Contributors who have contributed regularly for more than six months (or implemented a completely new feature for a minor release) are eligible to join the maintainer team. Unless vetoed by an existing maintainer, these contributors will be asked to join the maintainer team. If they accept, new maintainers will be given permissions to view maintainer playbooks, accept pull requests, and release new versions.
 
-### Enforcement guidelines
+## Enforcement guidelines
 
 First off, Bundler's policies and enforcement of those policies are subsidiary to [Bundler's code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) in any case where they conflict. The first priority is treating human beings with respect and empathy, and figuring out project guidelines and sticking to them will always come after that.
 

--- a/doc/bundler/documentation/WRITING.md
+++ b/doc/bundler/documentation/WRITING.md
@@ -1,4 +1,6 @@
-# Writing docs for man pages
+# Writing documentation for Bundler
+
+## Writing docs for man pages
 
 *Any commands or file paths in this document assume that you are inside [the bundler/ directory of the rubygems/rubygems repository](https://github.com/rubygems/rubygems/tree/master/bundler).*
 
@@ -6,7 +8,7 @@ A primary source of help for Bundler users are the man pages: the output printed
 
 _Note: `bundler` and `bundle` may be used interchangeably in the CLI. This guide uses `bundle` because it's cuter._
 
-## What goes in man pages?
+### What goes in man pages?
 
 We use man pages for Bundler commands used in the CLI (command line interface). They can vary in length from large (see `bundle install`) to very short (see `bundle clean`).
 
@@ -18,13 +20,13 @@ Our goal is to have a man page for every command.
 
 Don't see a man page for a command? Make a new page and send us a PR! We also welcome edits to existing pages.
 
-## Creating a new man page
+### Creating a new man page
 
 To create a new man page, simply create a new `.ronn` file in the `lib/bundler/man/` directory.
 
 For example: to create a man page for the command `bundle cookies` (not a real command, sadly), I would create a file `lib/bundler/man/bundle-cookies.1.ronn` and add my documentation there.
 
-## Formatting
+### Formatting
 
 Our man pages use ronn formatting, a combination of Markdown and standard man page conventions. It can be a little weird getting used to it at first, especially if you've used Markdown a lot.
 
@@ -34,7 +36,7 @@ In general, make your page look like the other pages: utilize sections like `##O
 
 If you're not sure if the formatting looks right, that's ok! Make a pull request with what you've got and we'll take a peek.
 
-## Previewing
+### Previewing
 
 To preview your changes as they will print out for Bundler users, you'll need to run a series of commands:
 
@@ -46,7 +48,7 @@ $ man ./lib/bundler/man/bundle-cookies.1
 
 If you make more changes to `bundle-cookies.1.ronn`, you'll need to run the `bin/rake man:build` again before previewing.
 
-## Testing
+### Testing
 
 We have tests for our documentation! The most important test file to run before you make your pull request is the one for the `help` command and another for documentation quality.
 
@@ -55,7 +57,7 @@ $ bin/rspec ./spec/commands/help_spec.rb
 $ bin/rspec ./spec/quality_spec.rb
 ```
 
-# Writing docs for [the Bundler documentation site](https://bundler.io)
+## Writing docs for [the Bundler documentation site](https://bundler.io)
 
 If you'd like to submit a pull request for any of the primary commands or utilities on [the Bundler documentation site](https://bundler.io), please follow the instructions above for writing documentation for man pages from the `rubygems/rubygems` repository. They are the same in each case.
 

--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -7,8 +7,8 @@ require_relative "../command"
 # RubyGems checkout or tarball.
 
 class Gem::Commands::SetupCommand < Gem::Command
-  HISTORY_HEADER = %r{^#\s*[\d.a-zA-Z]+\s*/\s*\d{4}-\d{2}-\d{2}\s*$}
-  VERSION_MATCHER = %r{^#\s*([\d.a-zA-Z]+)\s*/\s*\d{4}-\d{2}-\d{2}\s*$}
+  HISTORY_HEADER = %r{^##\s*[\d.a-zA-Z]+\s*/\s*\d{4}-\d{2}-\d{2}\s*$}
+  VERSION_MATCHER = %r{^##\s*([\d.a-zA-Z]+)\s*/\s*\d{4}-\d{2}-\d{2}\s*$}
 
   ENV_PATHS = %w[/usr/bin/env /bin/env].freeze
 

--- a/test/rubygems/test_gem_commands_setup_command.rb
+++ b/test/rubygems/test_gem_commands_setup_command.rb
@@ -380,20 +380,22 @@ class TestGemCommandsSetupCommand < Gem::TestCase
 
     File.open "CHANGELOG.md", "w" do |io|
       io.puts <<-HISTORY_TXT
-# #{Gem::VERSION} / 2013-03-26
+# Changelog
 
-## Bug fixes:
+## #{Gem::VERSION} / 2013-03-26
+
+### Bug fixes:
   * Fixed release note display for LANG=C when installing rubygems
   * π is tasty
 
-# 2.0.2 / 2013-03-06
+## 2.0.2 / 2013-03-06
 
-## Bug fixes:
+### Bug fixes:
   * Other bugs fixed
 
-# 2.0.1 / 2013-03-05
+## 2.0.1 / 2013-03-05
 
-## Bug fixes:
+### Bug fixes:
   * Yet more bugs fixed
       HISTORY_TXT
     end
@@ -403,9 +405,9 @@ class TestGemCommandsSetupCommand < Gem::TestCase
     end
 
     expected = <<-EXPECTED
-# #{Gem::VERSION} / 2013-03-26
+## #{Gem::VERSION} / 2013-03-26
 
-## Bug fixes:
+### Bug fixes:
   * Fixed release note display for LANG=C when installing rubygems
   * π is tasty
 

--- a/tool/bundler/lint_gems.rb
+++ b/tool/bundler/lint_gems.rb
@@ -4,3 +4,5 @@ source "https://rubygems.org"
 
 gem "rubocop", ">= 1.52.1", "< 2"
 gem "rubocop-performance", "~> 1.23"
+
+gem "mdl", "~> 0.13", platform: :ruby

--- a/tool/bundler/lint_gems.rb.lock
+++ b/tool/bundler/lint_gems.rb.lock
@@ -2,10 +2,36 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
+    chef-utils (18.7.10)
+      concurrent-ruby
+    concurrent-ruby (1.3.5)
+    ffi (1.17.2-x64-mingw-ucrt)
+    ffi-win32-extensions (1.0.4)
+      ffi
     json (2.10.2)
     json (2.10.2-java)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
+    mdl (0.13.0)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.1)
+      mixlib-cli (~> 2.1, >= 2.1.1)
+      mixlib-config (>= 2.2.1, < 4)
+      mixlib-shellout
+    mixlib-cli (2.1.8)
+    mixlib-config (3.0.27)
+      tomlrb
+    mixlib-shellout (3.3.9)
+      chef-utils
+    mixlib-shellout (3.3.9-x64-mingw-ucrt)
+      chef-utils
+      ffi-win32-extensions (~> 1.0.3)
+      win32-process (~> 0.9)
+      wmi-lite (~> 1.0)
     parallel (1.26.3)
     parser (3.3.7.3)
       ast (~> 2.4.1)
@@ -15,6 +41,7 @@ GEM
     racc (1.8.1-java)
     rainbow (3.1.1)
     regexp_parser (2.10.0)
+    rexml (3.4.1)
     rubocop (1.75.1)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -34,9 +61,13 @@ GEM
       rubocop (>= 1.72.1, < 2.0)
       rubocop-ast (>= 1.38.0, < 2.0)
     ruby-progressbar (1.13.0)
+    tomlrb (2.0.3)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    win32-process (0.10.0)
+      ffi (>= 1.0.0)
+    wmi-lite (1.0.7)
 
 PLATFORMS
   java
@@ -47,15 +78,27 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  mdl (~> 0.13)
   rubocop (>= 1.52.1, < 2)
   rubocop-performance (~> 1.23)
 
 CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  chef-utils (18.7.10) sha256=cd93433e50d526d496a37f6ca3b07b65dc29f37b8c63231f22aa15924c4b99a4
+  concurrent-ruby (1.3.5) sha256=813b3e37aca6df2a21a3b9f1d497f8cbab24a2b94cab325bffe65ee0f6cbebc6
+  ffi (1.17.2-x64-mingw-ucrt) sha256=15d2da54ee578657a333a6059ed16eaba1cbd794ceecd15944825b65c8381ac0
+  ffi-win32-extensions (1.0.4) sha256=9d01a511a7ea957d8f73a06892f3ccfa49dcb32be95c4edb86b5ba3103edea00
   json (2.10.2) sha256=34e0eada93022b2a0a3345bb0b5efddb6e9ff5be7c48e409cfb54ff8a36a8b06
   json (2.10.2-java) sha256=fe31faac61ea21ea1448c35450183f84e85c2b94cc6522c241959ba9d1362006
+  kramdown (2.5.1) sha256=87bbb6abd9d3cebe4fc1f33e367c392b4500e6f8fa19dd61c0972cf4afe7368c
+  kramdown-parser-gfm (1.1.0) sha256=fb39745516427d2988543bf01fc4cf0ab1149476382393e0e9c48592f6581729
   language_server-protocol (3.17.0.4) sha256=c484626478664fd13482d8180947c50a8590484b1258b99b7aedb3b69df89669
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
+  mdl (0.13.0) sha256=207a5e26a4c4e19095b39be0201834a69d31d838982a57eba343918dba1c86a8
+  mixlib-cli (2.1.8) sha256=e6f27be34d580f6ed71731ca46b967e57793a627131c1f6e1ed2dad39ea3bdf9
+  mixlib-config (3.0.27) sha256=d7748b1898e4f16502afec1de00b5ad65c6de405114b1b0c65ec61b1a9100148
+  mixlib-shellout (3.3.9) sha256=0edf5ee3b07526de8eb5219af051752fb8df2691dc030ce233e248dedf4fd388
+  mixlib-shellout (3.3.9-x64-mingw-ucrt) sha256=0169db7b7dc6304903c7205588ca1194b3d3aab722c1f0090c2a8f42f67a6c57
   parallel (1.26.3) sha256=d86babb7a2b814be9f4b81587bf0b6ce2da7d45969fab24d8ae4bf2bb4d4c7ef
   parser (3.3.7.3) sha256=5803acc132cf1155fac2656bf02d3fb9223dccd66f1aa538dac095b785fa4d64
   prism (1.4.0) sha256=dc0e3e00e93160213dc2a65519d9002a4a1e7b962db57d444cf1a71565bb703e
@@ -63,12 +106,16 @@ CHECKSUMS
   racc (1.8.1-java) sha256=54f2e6d1e1b91c154013277d986f52a90e5ececbe91465d29172e49342732b98
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   regexp_parser (2.10.0) sha256=cb6f0ddde88772cd64bff1dbbf68df66d376043fe2e66a9ef77fcb1b0c548c61
+  rexml (3.4.1) sha256=c74527a9a0a04b4ec31dbe0dc4ed6004b960af943d8db42e539edde3a871abca
   rubocop (1.75.1) sha256=c12900c55b0b52e6ed1384f7f7575beb92047019ce37ca14b9572d80239adc29
   rubocop-ast (1.43.0) sha256=92cd649e336ce10212cb2f2b29028f487777ecc477f108f437a1dce1ee3db79a
   rubocop-performance (1.24.0) sha256=e5bd39ff3e368395b9af886927cc37f5892f43db4bd6c8526594352d5b4440b5
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  tomlrb (2.0.3) sha256=c2736acf24919f793334023a4ff396c0647d93fce702a73c9d348deaa815d4f7
   unicode-display_width (3.1.4) sha256=8caf2af1c0f2f07ec89ef9e18c7d88c2790e217c482bfc78aaa65eadd5415ac1
   unicode-emoji (4.0.4) sha256=2c2c4ef7f353e5809497126285a50b23056cc6e61b64433764a35eff6c36532a
+  win32-process (0.10.0) sha256=ad2d401c62f56f922f3fabb7a55fd2b65ea85becbad3b5d9093ffe59c386f542
+  wmi-lite (1.0.7) sha256=116ef5bb470dbe60f58c2db9047af3064c16245d6562c646bc0d90877e27ddda
 
 BUNDLED WITH
    2.7.0.dev

--- a/tool/changelog.rb
+++ b/tool/changelog.rb
@@ -105,6 +105,8 @@ class Changelog
 
   def cut!(previous_version, included_pull_requests, extra_entry: nil)
     full_new_changelog = [
+      "# Changelog",
+      "",
       format_header,
       "",
       unreleased_notes_for(included_pull_requests, extra_entry: extra_entry),


### PR DESCRIPTION
Headings should represent the structure of the document.
There should be only one h1 per page, and it should be avoided to skip ranks.

https://www.w3.org/WAI/tutorials/page-structure/headings/