### PR TITLE
Exclude `.rspec` from `spec.files` in the `.gemspec` template

### DIFF
--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -108,6 +108,7 @@ module Bundler
             "spec/newgem_spec.rb.tt" => "spec/#{namespaced_path}_spec.rb"
           )
           config[:test_task] = :spec
+          config[:test_config_path] = ".rspec "
         when "minitest"
           # Generate path for minitest target file (FileList["test/**/test_*.rb"])
           #   foo     => test/test_foo.rb

--- a/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
     ls.readlines("\x0", chomp: true).reject do |f|
       (f == gemspec) ||
-        f.start_with?(*%w[bin/ test/ spec/ features/ .git <%= config[:ci_config_path] %>appveyor Gemfile])
+        f.start_with?(*%w[bin/ test/ spec/ features/ <%= config[:test_config_path] %>.git <%= config[:ci_config_path] %>appveyor Gemfile])
     end
   end
   spec.bindir = "exe"

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -403,6 +403,10 @@ RSpec.describe "bundle gem" do
       expect(bundled_app("#{gem_name}/test/#{require_path}.rb")).to_not exist
       expect(bundled_app("#{gem_name}/test/test_helper.rb")).to_not exist
     end
+
+    it "does not add .rspec into ignore list" do
+      expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to_not include("features/ .rspec .git")
+    end
   end
 
   context "README.md" do
@@ -743,6 +747,10 @@ RSpec.describe "bundle gem" do
         expect(bundled_app("#{gem_name}/spec/spec_helper.rb")).to exist
       end
 
+      it "contained .rspec into ignore list" do
+        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to include("features/ .rspec .git")
+      end
+
       it "depends on a specific version of rspec in generated Gemfile" do
         allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
         builder = Bundler::Dsl.new
@@ -795,6 +803,10 @@ RSpec.describe "bundle gem" do
         expect(bundled_app("#{gem_name}/.rspec")).to exist
         expect(bundled_app("#{gem_name}/spec/#{require_path}_spec.rb")).to exist
         expect(bundled_app("#{gem_name}/spec/spec_helper.rb")).to exist
+      end
+
+      it "contained .rspec into ignore list" do
+        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to include("features/ .rspec .git")
       end
     end
 
@@ -947,6 +959,10 @@ RSpec.describe "bundle gem" do
         expect(bundled_app("#{gem_name}/.rspec")).to exist
         expect(bundled_app("#{gem_name}/spec/#{require_path}_spec.rb")).to exist
         expect(bundled_app("#{gem_name}/spec/spec_helper.rb")).to exist
+      end
+
+      it "contained .rspec into ignore list" do
+        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to include("features/ .rspec .git")
       end
 
       it "hints that --test is already configured" do


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Using the default template, `.rspec` is included in `.gem` builds 

```console
$ tree -L 1 -a /path/to/xxx/pkg/xxx-0.1.0/data
/path/to/xxx/pkg/xxx-0.1.0/data   # <-- Unarchived from pkg/xxx-0.1.0/data.tar.gz
├── .rspec                        # <-- This one!
├── .standard.yml
├── CODE_OF_CONDUCT.md
├── lib
├── LICENSE.txt
├── Rakefile
├── README.md
└── sig
```

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Add `.rspec` into the the `.gemspec` template's `spec.files` exclude list.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
