### PR TITLE
Exclude `.rubocop.yml` and `.standard.yml` from `spec.files` in the `.gemspec` template

### DIFF
--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -184,10 +184,12 @@ module Bundler
         config[:linter_version] = rubocop_version
         Bundler.ui.info "RuboCop enabled in config"
         templates.merge!("rubocop.yml.tt" => ".rubocop.yml")
+        config[:linter_config_path] = ".rubocop.yml "
       when "standard"
         config[:linter_version] = standard_version
         Bundler.ui.info "Standard enabled in config"
         templates.merge!("standard.yml.tt" => ".standard.yml")
+        config[:linter_config_path] = ".standard.yml "
       end
 
       if config[:exe]

--- a/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
     ls.readlines("\x0", chomp: true).reject do |f|
       (f == gemspec) ||
-        f.start_with?(*%w[bin/ test/ spec/ features/ .git <%= config[:ci_config_path] %>appveyor Gemfile])
+        f.start_with?(*%w[bin/ test/ spec/ features/ .git <%= config[:ci_config_path] %>appveyor <%= config[:linter_config_path] %>Gemfile])
     end
   end
   spec.bindir = "exe"

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -181,6 +181,10 @@ RSpec.describe "bundle gem" do
       it "generates a default .rubocop.yml" do
         expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
       end
+
+      it "contained .rubocop.yml into ignore list" do
+        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to include("appveyor .rubocop.yml Gemfile")
+      end
     end
   end
 
@@ -209,6 +213,10 @@ RSpec.describe "bundle gem" do
 
       it "doesn't generate a default .rubocop.yml" do
         expect(bundled_app("#{gem_name}/.rubocop.yml")).to_not exist
+      end
+
+      it "does not add .rubocop.yml into ignore list" do
+        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to_not include("appveyor .rubocop.yml Gemfile")
       end
     end
   end
@@ -240,6 +248,10 @@ RSpec.describe "bundle gem" do
     it "generates a default .rubocop.yml" do
       expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
     end
+
+    it "contained .rubocop.yml into ignore list" do
+      expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to include("appveyor .rubocop.yml Gemfile")
+    end
   end
 
   shared_examples_for "--linter=standard flag" do
@@ -266,6 +278,10 @@ RSpec.describe "bundle gem" do
 
     it "generates a default .standard.yml" do
       expect(bundled_app("#{gem_name}/.standard.yml")).to exist
+    end
+
+    it "contained .standard.yml into ignore list" do
+      expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to include("appveyor .standard.yml Gemfile")
     end
   end
 
@@ -304,8 +320,16 @@ RSpec.describe "bundle gem" do
       expect(bundled_app("#{gem_name}/.rubocop.yml")).to_not exist
     end
 
+    it "does not add .rubocop.yml into ignore list" do
+      expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to_not include("appveyor .rubocop.yml Gemfile")
+    end
+
     it "doesn't generate a default .standard.yml" do
       expect(bundled_app("#{gem_name}/.standard.yml")).to_not exist
+    end
+
+    it "does not add .standard.yml into ignore list" do
+      expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to_not include("appveyor .standard.yml Gemfile")
     end
   end
 
@@ -1166,29 +1190,48 @@ RSpec.describe "bundle gem" do
     end
 
     context "--linter with no argument" do
-      it "does not generate any linter config" do
+      before do
         bundle "gem #{gem_name}"
+      end
 
+      it "does not generate any linter config" do
         expect(bundled_app("#{gem_name}/.rubocop.yml")).to_not exist
         expect(bundled_app("#{gem_name}/.standard.yml")).to_not exist
+      end
+
+      it "does not add any linter config file into ignore list" do
+        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to_not include("appveyor .rubocop.yml Gemfile")
+        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to_not include("appveyor .standard.yml Gemfile")
       end
     end
 
     context "--linter set to rubocop" do
-      it "generates a RuboCop config" do
+      before do
         bundle "gem #{gem_name} --linter=rubocop"
+      end
 
+      it "generates a RuboCop config" do
         expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
         expect(bundled_app("#{gem_name}/.standard.yml")).to_not exist
+      end
+
+      it "contained .rubocop.yml into ignore list" do
+        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to include("appveyor .rubocop.yml Gemfile")
       end
     end
 
     context "--linter set to standard" do
-      it "generates a Standard config" do
+      before do
         bundle "gem #{gem_name} --linter=standard"
+      end
 
+      it "generates a Standard config" do
         expect(bundled_app("#{gem_name}/.standard.yml")).to exist
         expect(bundled_app("#{gem_name}/.rubocop.yml")).to_not exist
+      end
+
+      it "contained .standard.yml into ignore list" do
+        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to include("appveyor .standard.yml Gemfile")
       end
     end
 
@@ -1204,29 +1247,48 @@ RSpec.describe "bundle gem" do
     end
 
     context "gem.linter setting set to none" do
-      it "doesn't generate any linter config" do
+      before do
         bundle "gem #{gem_name}"
+      end
 
+      it "doesn't generate any linter config" do
         expect(bundled_app("#{gem_name}/.rubocop.yml")).to_not exist
         expect(bundled_app("#{gem_name}/.standard.yml")).to_not exist
+      end
+
+      it "does not add any linter config file into ignore list" do
+        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to_not include("appveyor .rubocop.yml Gemfile")
+        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to_not include("appveyor .standard.yml Gemfile")
       end
     end
 
     context "gem.linter setting set to rubocop" do
-      it "generates a RuboCop config file" do
+      before do
         bundle "config set gem.linter rubocop"
         bundle "gem #{gem_name}"
+      end
 
+      it "generates a RuboCop config file" do
         expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
+      end
+
+      it "contained .rubocop.yml into ignore list" do
+        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to include("appveyor .rubocop.yml Gemfile")
       end
     end
 
     context "gem.linter setting set to standard" do
-      it "generates a Standard config file" do
+      before do
         bundle "config set gem.linter standard"
         bundle "gem #{gem_name}"
+      end
 
+      it "generates a Standard config file" do
         expect(bundled_app("#{gem_name}/.standard.yml")).to exist
+      end
+
+      it "contained .standard.yml into ignore list" do
+        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to include("appveyor .standard.yml Gemfile")
       end
     end
 
@@ -1239,6 +1301,10 @@ RSpec.describe "bundle gem" do
 
       it "generates rubocop config" do
         expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
+      end
+
+      it "contained .rubocop.yml into ignore list" do
+        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to include("appveyor .rubocop.yml Gemfile")
       end
 
       it "unsets gem.rubocop" do
@@ -1260,6 +1326,10 @@ RSpec.describe "bundle gem" do
 
       it "generates a RuboCop config file" do
         expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
+      end
+
+      it "contained .rubocop.yml into ignore list" do
+        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to include("appveyor .rubocop.yml Gemfile")
       end
 
       it "hints that --linter is already configured" do
@@ -1312,6 +1382,11 @@ RSpec.describe "bundle gem" do
       it "does not generate any linter config" do
         expect(bundled_app("#{gem_name}/.rubocop.yml")).to_not exist
         expect(bundled_app("#{gem_name}/.standard.yml")).to_not exist
+      end
+
+      it "does not add any linter config file into ignore list" do
+        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to_not include("appveyor .rubocop.yml Gemfile")
+        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to_not include("appveyor .standard.yml Gemfile")
       end
     end
 


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Using the default template, `.rubocop.yml` and `.standard.yml` are included in `.gem` builds 

```console
$ tree -L 1 -a /path/to/yyy/pkg/yyy-0.1.0/data
/path/to/yyy/pkg/yyy-0.1.0/data   # <-- Unarchived from pkg/yyy-0.1.0/data.tar.gz
├── .rubocop.yml                  # <-- This one!
├── CODE_OF_CONDUCT.md
├── lib
├── LICENSE.txt
├── Rakefile
├── README.md
└── sig

$ tree -L 1 -a /path/to/xxx/pkg/xxx-0.1.0/data
/path/to/xxx/pkg/xxx-0.1.0/data   # <-- Unarchived from pkg/xxx-0.1.0/data.tar.gz
├── .rspec
├── .standard.yml                 # <-- This one!
├── CODE_OF_CONDUCT.md
├── lib
├── LICENSE.txt
├── Rakefile
├── README.md
└── sig
```

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Add `.rubocop.yml` and `.standard.yml` into the the `.gemspec` template's `spec.files` exclude list.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
