### PR TITLE
Partially phase out `x64-mingw32` in favour of `x64-mingw-ucrt` (platforms)

### DIFF
--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -1257,11 +1257,6 @@ RSpec.describe "bundle lock" do
       end
 
       build_gem "raygun-apm", "1.0.78" do |s|
-        s.platform = "x64-mingw32"
-        s.required_ruby_version = "< #{next_ruby_minor}.dev"
-      end
-
-      build_gem "raygun-apm", "1.0.78" do |s|
         s.platform = "x64-mingw-ucrt"
         s.required_ruby_version = "< #{next_ruby_minor}.dev"
       end
@@ -1386,62 +1381,6 @@ RSpec.describe "bundle lock" do
         * sorbet-static-0.5.11989-x86_64-linux
     E
     expect(err).to include(nice_error)
-  end
-
-  it "does not crash on conflicting ruby requirements between platform versions in two different gems" do
-    build_repo4 do
-      build_gem "unf_ext", "0.0.8.2"
-
-      build_gem "unf_ext", "0.0.8.2" do |s|
-        s.required_ruby_version = [">= 2.4", "< #{previous_ruby_minor}"]
-        s.platform = "x64-mingw32"
-      end
-
-      build_gem "unf_ext", "0.0.8.2" do |s|
-        s.required_ruby_version = [">= #{previous_ruby_minor}", "< #{current_ruby_minor}"]
-        s.platform = "x64-mingw-ucrt"
-      end
-
-      build_gem "google-protobuf", "3.21.12"
-
-      build_gem "google-protobuf", "3.21.12" do |s|
-        s.required_ruby_version = [">= 2.5", "< #{previous_ruby_minor}"]
-        s.platform = "x64-mingw32"
-      end
-
-      build_gem "google-protobuf", "3.21.12" do |s|
-        s.required_ruby_version = [">= #{previous_ruby_minor}", "< #{current_ruby_minor}"]
-        s.platform = "x64-mingw-ucrt"
-      end
-    end
-
-    gemfile <<~G
-      source "https://gem.repo4"
-
-      gem "google-protobuf"
-      gem "unf_ext"
-    G
-
-    lockfile <<~L
-      GEM
-        remote: https://gem.repo4/
-        specs:
-          google-protobuf (3.21.12)
-          unf_ext (0.0.8.2)
-
-      PLATFORMS
-        x64-mingw-ucrt
-        x64-mingw32
-
-      DEPENDENCIES
-        google-protobuf
-        unf_ext
-
-      BUNDLED WITH
-         #{Bundler::VERSION}
-    L
-
-    bundle "install --verbose", artifice: "compact_index", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s, "DEBUG_RESOLVER" => "1" }
   end
 
   it "respects lower bound ruby requirements" do

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -421,7 +421,7 @@ RSpec.describe "bundle install from an existing gemspec" do
         simulate_new_machine
         simulate_platform("jruby") { bundle "install" }
         expect(lockfile).to include("platform_specific (1.0-java)")
-        simulate_platform("x64-mingw32") { bundle "install" }
+        simulate_platform("x64-mingw-ucrt") { bundle "install" }
       end
 
       context "on ruby" do
@@ -438,7 +438,7 @@ RSpec.describe "bundle install from an existing gemspec" do
               c.no_checksum "foo", "1.0"
               c.checksum gem_repo2, "platform_specific", "1.0"
               c.checksum gem_repo2, "platform_specific", "1.0", "java"
-              c.checksum gem_repo2, "platform_specific", "1.0", "x64-mingw32"
+              c.checksum gem_repo2, "platform_specific", "1.0", "x64-mingw-ucrt"
             end
 
             expect(lockfile).to eq <<~L
@@ -453,12 +453,12 @@ RSpec.describe "bundle install from an existing gemspec" do
                 specs:
                   platform_specific (1.0)
                   platform_specific (1.0-java)
-                  platform_specific (1.0-x64-mingw32)
+                  platform_specific (1.0-x64-mingw-ucrt)
 
               PLATFORMS
                 java
                 ruby
-                x64-mingw32
+                x64-mingw-ucrt
 
               DEPENDENCIES
                 foo!
@@ -479,7 +479,7 @@ RSpec.describe "bundle install from an existing gemspec" do
               c.no_checksum "foo", "1.0"
               c.checksum gem_repo2, "platform_specific", "1.0"
               c.checksum gem_repo2, "platform_specific", "1.0", "java"
-              c.checksum gem_repo2, "platform_specific", "1.0", "x64-mingw32"
+              c.checksum gem_repo2, "platform_specific", "1.0", "x64-mingw-ucrt"
             end
 
             expect(lockfile).to eq <<~L
@@ -493,12 +493,12 @@ RSpec.describe "bundle install from an existing gemspec" do
                 specs:
                   platform_specific (1.0)
                   platform_specific (1.0-java)
-                  platform_specific (1.0-x64-mingw32)
+                  platform_specific (1.0-x64-mingw-ucrt)
 
               PLATFORMS
                 java
                 ruby
-                x64-mingw32
+                x64-mingw-ucrt
 
               DEPENDENCIES
                 foo!
@@ -522,7 +522,7 @@ RSpec.describe "bundle install from an existing gemspec" do
               c.checksum gem_repo2, "indirect_platform_specific", "1.0"
               c.checksum gem_repo2, "platform_specific", "1.0"
               c.checksum gem_repo2, "platform_specific", "1.0", "java"
-              c.checksum gem_repo2, "platform_specific", "1.0", "x64-mingw32"
+              c.checksum gem_repo2, "platform_specific", "1.0", "x64-mingw-ucrt"
             end
 
             expect(lockfile).to eq <<~L
@@ -538,12 +538,12 @@ RSpec.describe "bundle install from an existing gemspec" do
                     platform_specific
                   platform_specific (1.0)
                   platform_specific (1.0-java)
-                  platform_specific (1.0-x64-mingw32)
+                  platform_specific (1.0-x64-mingw-ucrt)
 
               PLATFORMS
                 java
                 ruby
-                x64-mingw32
+                x64-mingw-ucrt
 
               DEPENDENCIES
                 foo!
@@ -596,14 +596,14 @@ RSpec.describe "bundle install from an existing gemspec" do
     before do
       build_lib("chef", path: tmp("chef")) do |s|
         s.version = "17.1.17"
-        s.write "chef-universal-mingw32.gemspec", build_spec("chef", "17.1.17", "universal-mingw32") {|sw| sw.runtime "win32-api", "~> 1.5.3" }.first.to_ruby
+        s.write "chef-universal-mingw-ucrt.gemspec", build_spec("chef", "17.1.17", "universal-mingw-ucrt") {|sw| sw.runtime "win32-api", "~> 1.5.3" }.first.to_ruby
       end
     end
 
     it "does not remove the platform specific specs from the lockfile when updating" do
       build_repo4 do
         build_gem "win32-api", "1.5.3" do |s|
-          s.platform = "universal-mingw32"
+          s.platform = "universal-mingw-ucrt"
         end
       end
 
@@ -614,8 +614,8 @@ RSpec.describe "bundle install from an existing gemspec" do
 
       checksums = checksums_section_when_enabled do |c|
         c.no_checksum "chef", "17.1.17"
-        c.no_checksum "chef", "17.1.17", "universal-mingw32"
-        c.checksum gem_repo4, "win32-api", "1.5.3", "universal-mingw32"
+        c.no_checksum "chef", "17.1.17", "universal-mingw-ucrt"
+        c.checksum gem_repo4, "win32-api", "1.5.3", "universal-mingw-ucrt"
       end
 
       initial_lockfile = <<~L
@@ -623,16 +623,16 @@ RSpec.describe "bundle install from an existing gemspec" do
           remote: ../chef
           specs:
             chef (17.1.17)
-            chef (17.1.17-universal-mingw32)
+            chef (17.1.17-universal-mingw-ucrt)
               win32-api (~> 1.5.3)
 
         GEM
           remote: https://gem.repo4/
           specs:
-            win32-api (1.5.3-universal-mingw32)
+            win32-api (1.5.3-universal-mingw-ucrt)
 
         PLATFORMS
-          #{lockfile_platforms("ruby", "x64-mingw32", "x86-mingw32")}
+          #{lockfile_platforms("ruby", "x64-mingw-ucrt", "x86-mingw32")}
 
         DEPENDENCIES
           chef!

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -367,12 +367,12 @@ RSpec.describe "bundle install with specific platforms" do
       simulate_platform "x86_64-darwin-15" do
         setup_multiplatform_gem
         install_gemfile(google_protobuf)
-        bundle "lock --add-platform=x64-mingw32"
+        bundle "lock --add-platform=x64-mingw-ucrt"
 
-        expect(the_bundle.locked_platforms).to include("x64-mingw32", "universal-darwin")
+        expect(the_bundle.locked_platforms).to include("x64-mingw-ucrt", "universal-darwin")
         expect(the_bundle.locked_gems.specs.map(&:full_name)).to include(*%w[
           google-protobuf-3.0.0.alpha.5.0.5.1-universal-darwin
-          google-protobuf-3.0.0.alpha.5.0.5.1-x64-mingw32
+          google-protobuf-3.0.0.alpha.5.0.5.1-x64-mingw-ucrt
         ])
       end
     end
@@ -1328,7 +1328,7 @@ RSpec.describe "bundle install with specific platforms" do
           s.platform = "arm-linux"
         end
         build_gem "nokogiri", "1.14.0" do |s|
-          s.platform = "x64-mingw32"
+          s.platform = "x64-mingw-ucrt"
         end
         build_gem "nokogiri", "1.14.0" do |s|
           s.platform = "java"
@@ -1823,11 +1823,11 @@ RSpec.describe "bundle install with specific platforms" do
     build_repo2 do
       build_gem("google-protobuf", "3.0.0.alpha.5.0.5.1")
       build_gem("google-protobuf", "3.0.0.alpha.5.0.5.1") {|s| s.platform = "x86_64-linux" }
-      build_gem("google-protobuf", "3.0.0.alpha.5.0.5.1") {|s| s.platform = "x64-mingw32" }
+      build_gem("google-protobuf", "3.0.0.alpha.5.0.5.1") {|s| s.platform = "x64-mingw-ucrt" }
       build_gem("google-protobuf", "3.0.0.alpha.5.0.5.1") {|s| s.platform = "universal-darwin" }
 
       build_gem("google-protobuf", "3.0.0.alpha.5.0.5") {|s| s.platform = "x86_64-linux" }
-      build_gem("google-protobuf", "3.0.0.alpha.5.0.5") {|s| s.platform = "x64-mingw32" }
+      build_gem("google-protobuf", "3.0.0.alpha.5.0.5") {|s| s.platform = "x64-mingw-ucrt" }
       build_gem("google-protobuf", "3.0.0.alpha.5.0.5")
 
       build_gem("google-protobuf", "3.0.0.alpha.5.0.4") {|s| s.platform = "universal-darwin" }

--- a/bundler/spec/resolver/platform_spec.rb
+++ b/bundler/spec/resolver/platform_spec.rb
@@ -48,11 +48,11 @@ RSpec.describe "Resolving platform craziness" do
   it "takes the latest ruby gem, even if an older platform specific version is available" do
     @index = build_index do
       gem "foo", "1.0.0"
-      gem "foo", "1.0.0", "x64-mingw32"
+      gem "foo", "1.0.0", "x64-mingw-ucrt"
       gem "foo", "1.1.0"
     end
     dep "foo"
-    platforms "x64-mingw32"
+    platforms "x64-mingw-ucrt"
 
     should_resolve_as %w[foo-1.1.0]
   end
@@ -61,12 +61,12 @@ RSpec.describe "Resolving platform craziness" do
     @index = build_index do
       gem "bar", "1.0.0"
       gem "foo", "1.0.0"
-      gem "foo", "1.0.0", "x64-mingw32" do
+      gem "foo", "1.0.0", "x64-mingw-ucrt" do
         dep "bar", "< 1"
       end
     end
     dep "foo"
-    platforms "x64-mingw32"
+    platforms "x64-mingw-ucrt"
 
     should_resolve_as %w[foo-1.0.0]
   end
@@ -74,12 +74,12 @@ RSpec.describe "Resolving platform craziness" do
   it "prefers the platform specific gem to the ruby version" do
     @index = build_index do
       gem "foo", "1.0.0"
-      gem "foo", "1.0.0", "x64-mingw32"
+      gem "foo", "1.0.0", "x64-mingw-ucrt"
     end
     dep "foo"
-    platforms "x64-mingw32"
+    platforms "x64-mingw-ucrt"
 
-    should_resolve_as %w[foo-1.0.0-x64-mingw32]
+    should_resolve_as %w[foo-1.0.0-x64-mingw-ucrt]
   end
 
   describe "on a linux platform" do
@@ -159,15 +159,15 @@ RSpec.describe "Resolving platform craziness" do
     before do
       @index = build_index do
         gem "foo", "1.0.0"
-        gem "foo", "1.0.0", "x64-mingw32"
+        gem "foo", "1.0.0", "x64-mingw-ucrt"
         gem "foo", "1.1.0"
-        gem "foo", "1.1.0", "x64-mingw32" do |s|
+        gem "foo", "1.1.0", "x64-mingw-ucrt" do |s|
           s.required_ruby_version = [">= 2.0", "< 2.4"]
         end
         gem "Ruby\0", "2.5.1"
       end
       dep "Ruby\0", "2.5.1"
-      platforms "x64-mingw32"
+      platforms "x64-mingw-ucrt"
     end
 
     it "takes the latest ruby gem" do
@@ -186,18 +186,18 @@ RSpec.describe "Resolving platform craziness" do
   it "takes the latest ruby gem with required_ruby_version if the platform specific gem doesn't match the required_ruby_version" do
     @index = build_index do
       gem "foo", "1.0.0"
-      gem "foo", "1.0.0", "x64-mingw32"
+      gem "foo", "1.0.0", "x64-mingw-ucrt"
       gem "foo", "1.1.0" do |s|
         s.required_ruby_version = [">= 2.0"]
       end
-      gem "foo", "1.1.0", "x64-mingw32" do |s|
+      gem "foo", "1.1.0", "x64-mingw-ucrt" do |s|
         s.required_ruby_version = [">= 2.0", "< 2.4"]
       end
       gem "Ruby\0", "2.5.1"
     end
     dep "foo"
     dep "Ruby\0", "2.5.1"
-    platforms "x64-mingw32"
+    platforms "x64-mingw-ucrt"
 
     should_resolve_as %w[foo-1.1.0]
   end
@@ -205,18 +205,18 @@ RSpec.describe "Resolving platform craziness" do
   it "takes the latest ruby gem if the platform specific gem doesn't match the required_ruby_version with multiple platforms" do
     @index = build_index do
       gem "foo", "1.0.0"
-      gem "foo", "1.0.0", "x64-mingw32"
+      gem "foo", "1.0.0", "x64-mingw-ucrt"
       gem "foo", "1.1.0" do |s|
         s.required_ruby_version = [">= 2.0"]
       end
-      gem "foo", "1.1.0", "x64-mingw32" do |s|
+      gem "foo", "1.1.0", "x64-mingw-ucrt" do |s|
         s.required_ruby_version = [">= 2.0", "< 2.4"]
       end
       gem "Ruby\0", "2.5.1"
     end
     dep "foo"
     dep "Ruby\0", "2.5.1"
-    platforms "x86_64-linux", "x64-mingw32"
+    platforms "x86_64-linux", "x64-mingw-ucrt"
 
     should_resolve_as %w[foo-1.1.0]
   end
@@ -342,7 +342,7 @@ RSpec.describe "Resolving platform craziness" do
   describe "with mingw32" do
     before :each do
       @index = build_index do
-        platforms "mingw32 mswin32 x64-mingw32 x64-mingw-ucrt" do |platform|
+        platforms "mingw32 mswin32 x64-mingw-ucrt" do |platform|
           gem "thin", "1.2.7", platform
         end
         gem "win32-api", "1.5.1", "universal-mingw32"
@@ -363,10 +363,10 @@ RSpec.describe "Resolving platform craziness" do
       should_resolve_as %w[thin-1.2.7-mingw32]
     end
 
-    it "finds x64-mingw32 gems" do
-      platforms "x64-mingw32"
+    it "finds x64-mingw-ucrt gems" do
+      platforms "x64-mingw-ucrt"
       dep "thin"
-      should_resolve_as %w[thin-1.2.7-x64-mingw32]
+      should_resolve_as %w[thin-1.2.7-x64-mingw-ucrt]
     end
 
     it "finds universal-mingw gems on x86-mingw" do
@@ -376,7 +376,7 @@ RSpec.describe "Resolving platform craziness" do
     end
 
     it "finds universal-mingw gems on x64-mingw" do
-      platform "x64-mingw32"
+      platform "x64-mingw-ucrt"
       dep "win32-api"
       should_resolve_as %w[win32-api-1.5.1-universal-mingw32]
     end

--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -411,7 +411,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
         s.add_dependency "platform_specific"
       end
     end
-    simulate_platform "x64-mingw32" do
+    simulate_platform "x64-mingw-ucrt" do
       lockfile <<-L
         GEM
           remote: https://gem.repo2/
@@ -421,7 +421,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
               platform_specific
 
         PLATFORMS
-          x64-mingw32
+          x64-mingw-ucrt
           x86-mingw32
 
         DEPENDENCIES
@@ -434,11 +434,11 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
       G
 
       expect(out).to include("lockfile does not have all gems needed for the current platform")
-      expect(the_bundle).to include_gem "platform_specific 1.0 x64-mingw32"
+      expect(the_bundle).to include_gem "platform_specific 1.0 x64-mingw-ucrt"
     end
   end
 
-  %w[x86-mswin32 x64-mswin64 x86-mingw32 x64-mingw32 x64-mingw-ucrt aarch64-mingw-ucrt].each do |platform|
+  %w[x86-mswin32 x64-mswin64 x86-mingw32 x64-mingw-ucrt x64-mingw-ucrt aarch64-mingw-ucrt].each do |platform|
     it "allows specifying platform windows on #{platform} platform" do
       simulate_platform platform do
         lockfile <<-L

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -111,10 +111,6 @@ module Spec
         end
 
         build_gem "platform_specific" do |s|
-          s.platform = "x64-mingw32"
-        end
-
-        build_gem "platform_specific" do |s|
           s.platform = "x64-mingw-ucrt"
         end
 

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -452,12 +452,6 @@ module Spec
       ruby_major_minor.map.with_index {|s, i| i == 1 ? s + 1 : s }.join(".")
     end
 
-    def previous_ruby_minor
-      return "2.7" if ruby_major_minor == [3, 0]
-
-      ruby_major_minor.map.with_index {|s, i| i == 1 ? s - 1 : s }.join(".")
-    end
-
     def ruby_major_minor
       Gem.ruby_version.segments[0..1]
     end

--- a/bundler/spec/support/indexes.rb
+++ b/bundler/spec/support/indexes.rb
@@ -122,7 +122,7 @@ module Spec
         end
 
         versions "1.0 1.2 1.2.1 1.2.2 1.3 1.3.0.1 1.3.5 1.4.0 1.4.2 1.4.2.1" do |version|
-          platforms "ruby java mswin32 mingw32 x64-mingw32" do |platform|
+          platforms "ruby java mswin32 mingw32 x64-mingw-ucrt" do |platform|
             next if version == v("1.4.2.1") && platform != pl("x86-mswin32")
             next if version == v("1.4.2") && platform == pl("x86-mswin32")
             gem "nokogiri", version, platform do

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -408,18 +408,11 @@ class TestGemPlatform < Gem::TestCase
 
   def test_equals3_universal_mingw
     uni_mingw  = Gem::Platform.new "universal-mingw"
-    mingw32    = Gem::Platform.new "x64-mingw32"
     mingw_ucrt = Gem::Platform.new "x64-mingw-ucrt"
 
-    util_set_arch "x64-mingw32"
-    assert((uni_mingw === Gem::Platform.local), "uni_mingw === mingw32")
-    assert((mingw32 === Gem::Platform.local), "mingw32 === mingw32")
-    refute((mingw_ucrt === Gem::Platform.local), "mingw32 === mingw_ucrt")
-
     util_set_arch "x64-mingw-ucrt"
-    assert((uni_mingw === Gem::Platform.local), "uni_mingw === mingw32")
+    assert((uni_mingw === Gem::Platform.local), "uni_mingw === mingw_ucrt")
     assert((mingw_ucrt === Gem::Platform.local), "mingw_ucrt === mingw_ucrt")
-    refute((mingw32 === Gem::Platform.local), "mingw32 === mingw_ucrt")
   end
 
   def test_equals3_version

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1029,7 +1029,7 @@ dependencies: []
 
     gem = "mingw"
     v   = "1.1.1"
-    platforms = ["x86-mingw32", "x64-mingw32"]
+    platforms = ["x86-mingw32", "x64-mingw-ucrt"]
 
     # create specs
     platforms.each do |plat|


### PR DESCRIPTION
> [!NOTE]  
> This PR has been scaled back a but from fully replacing `x64-mingw32` with `x64-mingw-ucrt` to partially replacing it/phasing it out, mostly on the spec side, with some additional cleanup.

## What was the end-user or developer problem that led to this PR?

The end-user problem is that RubyGems/Bundler is still concerning itself with `x64-mingw32` despite it no longer being a platform anyone on a supported Ruby (i.e. > 3.1) needs to concern themself with. This leads to non-ideal `Gemfile.lock` platform diffs and even gem installation issues.

The developer problem is not really a problem but simply the fact that there's quite a bit of `x64-mingw32` code and whatnot we can simply remove/replace i.e. tech debt at this point.

Part of addressing https://github.com/rubygems/rubygems/issues/8505

CC @hsbt, thanks for helping me get my environment setup at RubyKaigi 2025 in Matuyama. Finally, here's the PR/change/cleanup I was talking about. Took some time to get back to it. :sweat_smile: 

## What is your fix for the problem, implemented in this PR?

This PR replaces `x64-mingw32` with `x64-mingw-ucrt`, given the following reasons:
- the `x64-mingw32` platform has been superseded by `x64-mingw-ucrt`.
- the `mingw-ucrt` platform is present as of Windows 10, which was released 10 years ago in 2015 and all versions prior to 10 are end-of-life, even 10 will be by mid October 2025.
- newer rubies (>= 3.1 IIRC) use the `mingw-ucrt` platform instead of the `mingw32` platform, meaning using the deprecated platform can cause issues during gem installation.

The only remaining usage of `x64-mingw32` I can find is in `vcr_cassettes`. Not sure what we want to do with all of those. I don't _think_ we can simply update them. Open to suggestions. :pray: 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes (tests already exist, simply updated them)
- [x] Write code to solve the problem (no net new code)
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages) (no net new code)