### PR TITLE
Fix default branch CI

### DIFF
--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -18,6 +18,9 @@ jobs:
   python_linters:
     name: Python linter ${{ matrix.command }}
     runs-on: ubuntu-24.04
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -49,7 +49,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
         if: matrix.command == 'zizmor'
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We have a red CI on master since we merged #8702.

## What is your fix for the problem, implemented in this PR?

I think it's missing the proper permissions to write to code scanning dashboard. Just a guess because the `scorecards.yml` workflow uses the same action and sets these permissions and it's working fine.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
