### PR TITLE
Deprecate `x64-mingw32` in favour of `x64-mingw-ucrt`

### DIFF
--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "shared_helpers"
+
 module Bundler
   class LockfileParser
     include GemHelpers
@@ -139,6 +141,21 @@ module Bundler
         end
         @pos.advance!(line)
       end
+
+      if !Bundler.frozen_bundle? && @platforms.include?(Gem::Platform::X64_MINGW_LEGACY)
+        if @platforms.include?(Gem::Platform::X64_MINGW)
+          @platforms.delete(Gem::Platform::X64_MINGW_LEGACY)
+          SharedHelpers.major_deprecation(2,
+            "Found x64-mingw32 in lockfile, which is deprecated. Removing it. Support for x64-mingw32 will be removed in Bundler 3.0.",
+            removed_message: "Found x64-mingw32 in lockfile, which is no longer supported as of Bundler 3.0.")
+        else
+          @platforms[@platforms.index(Gem::Platform::X64_MINGW_LEGACY)] = Gem::Platform::X64_MINGW
+          SharedHelpers.major_deprecation(2,
+            "Found x64-mingw32 in lockfile, which is deprecated. Using x64-mingw-ucrt, the replacement for x64-mingw32 in modern rubies, instead. Support for x64-mingw32 will be removed in Bundler 3.0.",
+            removed_message: "Found x64-mingw32 in lockfile, which is no longer supported as of Bundler 3.0.")
+        end
+      end
+
       @most_specific_locked_platform = @platforms.min_by do |bundle_platform|
         platform_specificity_match(bundle_platform, local_platform)
       end

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -56,8 +56,8 @@ module Gem
     MSWIN = Gem::Platform.new("mswin32")
     MSWIN64 = Gem::Platform.new("mswin64")
     MINGW = Gem::Platform.new("x86-mingw32")
-    X64_MINGW = [Gem::Platform.new("x64-mingw32"),
-                 Gem::Platform.new("x64-mingw-ucrt")].freeze
+    X64_MINGW_LEGACY = Gem::Platform.new("x64-mingw32")
+    X64_MINGW = Gem::Platform.new("x64-mingw-ucrt")
     UNIVERSAL_MINGW = Gem::Platform.new("universal-mingw")
     WINDOWS = [MSWIN, MSWIN64, UNIVERSAL_MINGW].flatten.freeze
     X64_LINUX = Gem::Platform.new("x86_64-linux")

--- a/bundler/spec/bundler/lockfile_parser_spec.rb
+++ b/bundler/spec/bundler/lockfile_parser_spec.rb
@@ -95,6 +95,134 @@ RSpec.describe Bundler::LockfileParser do
     end
   end
 
+  describe "X64_MINGW_LEGACY platform handling" do
+    before { allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app("gems.rb")) }
+
+    describe "when X64_MINGW_LEGACY is present alone" do
+      let(:lockfile_with_legacy_platform) { <<~L }
+        GEM
+          remote: https://rubygems.org/
+          specs:
+            rake (10.3.2)
+
+        PLATFORMS
+          ruby
+          x64-mingw32
+
+        DEPENDENCIES
+          rake
+
+        BUNDLED WITH
+           3.6.9
+      L
+
+      context "when bundle is not frozen" do
+        before { allow(Bundler).to receive(:frozen_bundle?).and_return(false) }
+        subject { described_class.new(lockfile_with_legacy_platform) }
+
+        it "replaces X64_MINGW_LEGACY with X64_MINGW" do
+          allow(Bundler::SharedHelpers).to receive(:major_deprecation)
+          expect(subject.platforms.map(&:to_s)).to contain_exactly("ruby", "x64-mingw-ucrt")
+          expect(subject.platforms.map(&:to_s)).not_to include("x64-mingw32")
+        end
+
+        it "shows deprecation warning for replacement" do
+          expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(
+            2,
+            "Found x64-mingw32 in lockfile, which is deprecated. Using x64-mingw-ucrt, the replacement for x64-mingw32 in modern rubies, instead. Support for x64-mingw32 will be removed in Bundler 3.0.",
+            removed_message: "Found x64-mingw32 in lockfile, which is no longer supported as of Bundler 3.0."
+          )
+          subject
+        end
+      end
+
+      context "when bundle is frozen" do
+        before { allow(Bundler).to receive(:frozen_bundle?).and_return(true) }
+        subject { described_class.new(lockfile_with_legacy_platform) }
+
+        it "preserves X64_MINGW_LEGACY platform without replacement" do
+          expect(subject.platforms.map(&:to_s)).to contain_exactly("ruby", "x64-mingw32")
+        end
+
+        it "does not show any deprecation warnings" do
+          expect(Bundler::SharedHelpers).not_to receive(:major_deprecation)
+          subject
+        end
+      end
+    end
+
+    describe "when both X64_MINGW_LEGACY and X64_MINGW are present" do
+      let(:lockfile_with_both_platforms) { <<~L }
+        GEM
+          remote: https://rubygems.org/
+          specs:
+            rake (10.3.2)
+
+        PLATFORMS
+          ruby
+          x64-mingw32
+          x64-mingw-ucrt
+
+        DEPENDENCIES
+          rake
+
+        BUNDLED WITH
+           3.6.9
+      L
+
+      context "when bundle is not frozen" do
+        before { allow(Bundler).to receive(:frozen_bundle?).and_return(false) }
+        subject { described_class.new(lockfile_with_both_platforms) }
+
+        it "removes X64_MINGW_LEGACY and keeps X64_MINGW" do
+          allow(Bundler::SharedHelpers).to receive(:major_deprecation)
+          expect(subject.platforms.map(&:to_s)).to contain_exactly("ruby", "x64-mingw-ucrt")
+          expect(subject.platforms.map(&:to_s)).not_to include("x64-mingw32")
+        end
+
+        it "shows deprecation warning for removing legacy platform" do
+          expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(
+            2,
+            "Found x64-mingw32 in lockfile, which is deprecated. Removing it. Support for x64-mingw32 will be removed in Bundler 3.0.",
+            removed_message: "Found x64-mingw32 in lockfile, which is no longer supported as of Bundler 3.0."
+          )
+          subject
+        end
+      end
+    end
+
+    describe "when no X64_MINGW_LEGACY platform is present" do
+      let(:lockfile_with_modern_platforms) { <<~L }
+        GEM
+          remote: https://rubygems.org/
+          specs:
+            rake (10.3.2)
+
+        PLATFORMS
+          ruby
+          x64-mingw-ucrt
+
+        DEPENDENCIES
+          rake
+
+        BUNDLED WITH
+           3.6.9
+      L
+
+      before { allow(Bundler).to receive(:frozen_bundle?).and_return(false) }
+      subject { described_class.new(lockfile_with_modern_platforms) }
+
+      it "preserves all modern platforms without changes" do
+        expect(subject.platforms.map(&:to_s)).to contain_exactly("ruby", "x64-mingw-ucrt")
+      end
+
+      it "does not show any deprecation warnings" do
+        expect(Bundler::SharedHelpers).not_to receive(:major_deprecation)
+        subject
+      end
+    end
+  end
+
   describe "#initialize" do
     before { allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app("gems.rb")) }
     subject { described_class.new(lockfile_contents) }


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

End user wise the `x64-mingw32` deprecated platform, which no one on a supported Ruby (>= 3.2) should be using, can cause issues with lockfiles and gem installation.

Developer wise, the `x64-mingw32` platform is essentially tech debt at this point since it's been superseded both at the platform level and by Ruby itself which no longer needs them.

Part of addressing https://github.com/rubygems/rubygems/issues/8505, inspired by [this comment](https://github.com/rubygems/rubygems/issues/8505#issuecomment-2910405281)
Follow up to https://github.com/rubygems/rubygems/pull/8720

## What is your fix for the problem, implemented in this PR?

Updates `LockfileParser` to ignore `x64-mingw32` when `x64-mingw-ucrt` (modern equivalent) is present and otherwise replace said legacy platform with the modern one on the spot.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)