### PR TITLE
Remove hardcoded version of rake from Bundler tests

### DIFF
--- a/bundler/spec/commands/check_spec.rb
+++ b/bundler/spec/commands/check_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "bundle check" do
 
     bundle :check, raise_on_error: false
     expect(err).to include("The following gems are missing")
-    expect(err).to include(" * rake (13.2.1)")
+    expect(err).to include(" * rake (#{rake_version})")
     expect(err).to include(" * actionpack (2.3.2)")
     expect(err).to include(" * activerecord (2.3.2)")
     expect(err).to include(" * actionmailer (2.3.2)")
@@ -76,7 +76,7 @@ RSpec.describe "bundle check" do
     expect(exitstatus).to be > 0
     expect(err).to include("The following gems are missing")
     expect(err).to include(" * rails (2.3.2)")
-    expect(err).to include(" * rake (13.2.1)")
+    expect(err).to include(" * rake (#{rake_version})")
     expect(err).to include(" * actionpack (2.3.2)")
     expect(err).to include(" * activerecord (2.3.2)")
     expect(err).to include(" * actionmailer (2.3.2)")

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -24,10 +24,6 @@ module Spec
       Gem::Platform.new(platform)
     end
 
-    def rake_version
-      "13.2.1"
-    end
-
     def build_repo1
       build_repo gem_repo1 do
         FileUtils.cp rake_path, "#{gem_repo1}/gems/"

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -284,6 +284,10 @@ module Spec
       Dir["#{base_system_gems}/*/*/**/rake*.gem"].first
     end
 
+    def rake_version
+      File.basename(rake_path).delete_prefix("rake-").delete_suffix(".gem")
+    end
+
     def sinatra_dependency_paths
       deps = %w[
         mustermann


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Every time `rake` releases a new version, our ruby-core CI job starts failing. This is because this job does not use lockfiles because the stable branch of ruby does not use lockfiles.

## What is your fix for the problem, implemented in this PR?

I'm trying to fix that at https://github.com/ruby/ruby/pull/13472, but I also realized that if we stop hardcoding the version of `rake` in our specs, things should work either way.

So that's what this PR does.

This should fix currently failing CI.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
