### PR TITLE
Remove unnecessary duplicate `x64-mingw-ucrt` entry in spec

### DIFF
--- a/bundler/spec/runtime/platform_spec.rb
+++ b/bundler/spec/runtime/platform_spec.rb
@@ -438,7 +438,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
     end
   end
 
-  %w[x86-mswin32 x64-mswin64 x86-mingw32 x64-mingw-ucrt x64-mingw-ucrt aarch64-mingw-ucrt].each do |platform|
+  %w[x86-mswin32 x64-mswin64 x86-mingw32 x64-mingw-ucrt aarch64-mingw-ucrt].each do |platform|
     it "allows specifying platform windows on #{platform} platform" do
       simulate_platform platform do
         lockfile <<-L


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

No end user problem.

Developer problem is there's a duplicate entry in a spec. My fault over in https://github.com/rubygems/rubygems/pull/8720.

![image](https://github.com/user-attachments/assets/411a7fc5-138b-4078-9519-a1117deb9d70)

## What is your fix for the problem, implemented in this PR?

:fire: :fire: :fire: :fire: :fire: 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
