### PR TITLE
Cache git sources with commit SHA refs

### DIFF
--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -305,8 +305,8 @@ module Bundler
         end
 
         def has_revision_cached?
-          return unless @revision && path.exist?
-          git("cat-file", "-e", @revision, dir: path)
+          return unless commit && path.exist?
+          git("cat-file", "-e", commit, dir: path)
           true
         rescue GitError
           false

--- a/bundler/spec/bundler/source/git/git_proxy_spec.rb
+++ b/bundler/spec/bundler/source/git/git_proxy_spec.rb
@@ -252,4 +252,75 @@ RSpec.describe Bundler::Source::Git::GitProxy do
       end
     end
   end
+
+  describe "#checkout" do
+    context "when the repository isn't cloned" do
+      before do
+        allow(path).to receive(:exist?).and_return(false)
+      end
+
+      it "clones the repository" do
+        allow(git_proxy).to receive(:git_local).with("--version").and_return("git version 2.14.0")
+        expect(git_proxy).to receive(:capture).with([*base_clone_args, "--", uri, path.to_s], nil).and_return(["", "", clone_result])
+        subject.checkout
+      end
+    end
+
+    context "when the repository is cloned" do
+      before do
+        allow(path).to receive(:exist?).and_return(true)
+      end
+
+      context "with a locked revision" do
+        let(:revision) { Digest::SHA1.hexdigest("ruby") }
+
+        context "when the revision exists locally" do
+          it "uses the cached revision" do
+            allow(git_proxy).to receive(:git_local).with("--version").and_return("git version 2.14.0")
+            expect(git_proxy).to receive(:git).with("cat-file", "-e", revision, dir: path).and_return(true)
+            subject.checkout
+          end
+        end
+
+        context "when the revision doesn't exist locally" do
+          it "fetches the specific revision" do
+            allow(git_proxy).to receive(:git_local).with("--version").and_return("git version 2.14.0")
+            expect(git_proxy).to receive(:git).with("cat-file", "-e", revision, dir: path).and_raise(Bundler::GitError)
+            expect(git_proxy).to receive(:capture).with(["fetch", "--force", "--quiet", "--no-tags", "--depth", "1", "--", uri, "#{revision}:refs/#{revision}-sha"], path).and_return(["", "", clone_result])
+            subject.checkout
+          end
+        end
+      end
+
+      context "with no explicit ref" do
+        it "fetches the HEAD revision" do
+          parsed_revision = Digest::SHA1.hexdigest("ruby")
+          allow(git_proxy).to receive(:git_local).with("rev-parse", "--abbrev-ref", "HEAD", dir: path).and_return(parsed_revision)
+          allow(git_proxy).to receive(:git_local).with("--version").and_return("git version 2.14.0")
+          expect(git_proxy).to receive(:capture).with(["fetch", "--force", "--quiet", "--no-tags", "--depth", "1", "--", uri, "refs/heads/#{parsed_revision}:refs/heads/#{parsed_revision}"], path).and_return(["", "", clone_result])
+          subject.checkout
+        end
+      end
+
+      context "with a commit ref" do
+        let(:ref) { Digest::SHA1.hexdigest("ruby") }
+
+        it "fetches the specific revision" do
+          allow(git_proxy).to receive(:git_local).with("--version").and_return("git version 2.14.0")
+          expect(git_proxy).to receive(:capture).with(["fetch", "--force", "--quiet", "--no-tags", "--depth", "1", "--", uri, "#{ref}:refs/#{ref}-sha"], path).and_return(["", "", clone_result])
+          subject.checkout
+        end
+      end
+
+      context "with a non-commit ref" do
+        let(:ref) { "HEAD" }
+
+        it "fetches all revisions" do
+          allow(git_proxy).to receive(:git_local).with("--version").and_return("git version 2.14.0")
+          expect(git_proxy).to receive(:capture).with(["fetch", "--force", "--quiet", "--no-tags", "--", uri, "refs/*:refs/*"], path).and_return(["", "", clone_result])
+          subject.checkout
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

The `bundle update` command always re-fetches git sources. However, that isn't strictly necessary in cases where the dependency is pinned to a specific commit SHA and the revision is already cached locally. Using the cache could marginally speed up the `update` command by avoiding an unnecessary git fetch.

I was poking around in the codebase to understand how the `update` command works and I noticed that this could potentially be cached. It's not a huge improvement in most cases and potentially there are unwanted side effects to this that I don't understand. However, the change was simple so I thought it might be worth opening a PR.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

This PR updates the `GitProxy#has_revision_cached?` method to use the commit SHA (if there is one) instead of just the `@revision` attribute (which is only set when the source is locked) when checking if the revision is cached. It uses the `#commit` method which will return either a commit SHA ref or the locked revision or nil: https://github.com/rubygems/rubygems/blob/54b7bd3669a56e1993b381fbca7a1b2d76339451/bundler/lib/bundler/source/git/git_proxy.rb#L251-L253

I couldn't see any tests for `GitProxy#checkout` so I added some for the main scenarios that are affected by this change. Let me know if this is already tested already somewhere else.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
