### PR TITLE
Reset variables that can cause specs to fail if set

### DIFF
--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -9,12 +9,14 @@ if File.expand_path(__FILE__) =~ %r{([^\w/\.:\-])}
   abort "The bundler specs cannot be run from a path that contains special characters (particularly #{$1.inspect})"
 end
 
-# Bundler CLI will have different help text depending on whether this variable
-# is set, since the `-e` flag `bundle gem` with require an explicit value if
-# `EDITOR` is not set, but will use `EDITOR` by default is set. So make sure
-# it's `nil` before loading bundler to get a consistent help text, since some
-# tests rely on that.
+# Bundler CLI will have different help text depending on whether any of these
+# variables is set, since the `-e` flag `bundle gem` with require an explicit
+# value if they are not set, but will use their value by default if set. So make
+# sure they are `nil` before loading bundler to get a consistent help text,
+# since some tests rely on that.
 ENV["EDITOR"] = nil
+ENV["VISUAL"] = nil
+ENV["BUNDLER_EDITOR"] = nil
 require "bundler"
 
 require "rspec/core"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If `VISUAL` or `BUNDLER_EDITOR` are set, some cli specs fail.

## What is your fix for the problem, implemented in this PR?

Reset them before loading Bundler for tests.

Most likely fixes #8742.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
