### PR TITLE
Handle `GEM_HOME` not existing yet when running `bundle update --bundler`

### DIFF
--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -61,11 +61,7 @@ module Bundler
     end
 
     def ensure_writable_dir(dir)
-      super
-    rescue Gem::FilePermissionError
-      # Ignore permission checks in RubyGems. Instead, go on, and try to write
-      # for real. We properly handle permission errors when they happen.
-      nil
+      FileUtils.mkdir_p dir, mode: options[:dir_mode] && 0o755
     end
 
     def generate_plugins

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -953,11 +953,7 @@ TEXT
   end
 
   def ensure_writable_dir(dir) # :nodoc:
-    begin
-      Dir.mkdir dir, *[options[:dir_mode] && 0o755].compact
-    rescue SystemCallError
-      raise unless File.directory? dir
-    end
+    FileUtils.mkdir_p dir, mode: options[:dir_mode] && 0o755
 
     raise Gem::FilePermissionError.new(dir) unless File.writable? dir
   end

--- a/test/rubygems/installer_test_case.rb
+++ b/test/rubygems/installer_test_case.rb
@@ -221,6 +221,23 @@ class Gem::InstallerTestCase < Gem::TestCase
                        force: force)
   end
 
+  def test_ensure_writable_dir_creates_missing_parent_directories
+    installer = setup_base_installer(false)
+
+    non_existent_parent = File.join(@tempdir, "non_existent_parent")
+    target_dir = File.join(non_existent_parent, "target_dir")
+
+    refute Dir.exist?(non_existent_parent), "Parent directory should not exist"
+    refute Dir.exist?(target_dir), "Target directory should not exist"
+
+    assert_nothing_raised do
+      installer.send(:ensure_writable_dir, target_dir)
+    end
+
+    assert Dir.exist?(target_dir), "Target directory should be created"
+    assert Dir.exist?(non_existent_parent), "Parent directory should be created"
+  end
+
   @@symlink_supported = nil
 
   # This is needed for Windows environment without symlink support enabled (the default


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In short, installing a Ruby then running `bundle install ---bundler` to update Bundler for the given Ruby fails to work if the expected directories are not already set up. The following quote from the issue below describes it well:

> I installed a new version of Ruby, and tried to upgrade to the latest Bundler without having installed any other gems yet. It seems like `gem install bundler` is able to handle a missing $GEM_HOME, but `bundle install --bundler` is not.

Resolves https://github.com/rubygems/rubygems/issues/8683

## What is your fix for the problem, implemented in this PR?

In short, replaces `Dir.mkdir` with `FileUtils.mkdir_p` in both RubyGems and Bundler implementations of `ensure_writable_dir` to ensure setup can create necessary parent directories if they're not already present. Also adds a test that attempts to reproduce the specified issue for both RubyGems and `bundle update --bundler`.

Method doc references
- https://docs.ruby-lang.org/en/3.4/Dir.html#method-c-mkdir
- https://docs.ruby-lang.org/en/3.4/FileUtils.html#method-c-mkdir_p

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)