### PR TITLE
Fix `gem pristine` not recompiling extensions sometimes

### DIFF
--- a/test/rubygems/test_gem_commands_pristine_command.rb
+++ b/test/rubygems/test_gem_commands_pristine_command.rb
@@ -125,8 +125,8 @@ class TestGemCommandsPristineCommand < Gem::TestCase
       @cmd.execute
     end
 
-    assert File.exist?(gem_bin)
-    assert File.exist?(gem_stub)
+    assert_path_exist gem_bin
+    assert_path_exist gem_stub
 
     out = @ui.output.split "\n"
 
@@ -537,8 +537,8 @@ class TestGemCommandsPristineCommand < Gem::TestCase
       @cmd.execute
     end
 
-    assert File.exist? gem_exec
-    refute File.exist? gem_lib
+    assert_path_exist gem_exec
+    assert_path_not_exist gem_lib
   end
 
   def test_execute_only_plugins
@@ -572,9 +572,9 @@ class TestGemCommandsPristineCommand < Gem::TestCase
       @cmd.execute
     end
 
-    refute File.exist? gem_exec
-    assert File.exist? gem_plugin
-    refute File.exist? gem_lib
+    assert_path_not_exist gem_exec
+    assert_path_exist gem_plugin
+    assert_path_not_exist gem_lib
   end
 
   def test_execute_bindir
@@ -606,8 +606,8 @@ class TestGemCommandsPristineCommand < Gem::TestCase
       @cmd.execute
     end
 
-    refute File.exist? gem_exec
-    assert File.exist? gem_bindir
+    assert_path_not_exist gem_exec
+    assert_path_exist gem_bindir
   end
 
   def test_execute_unknown_gem_at_remote_source


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes `gem pristine` does not recompile extensions when it should.

## What is your fix for the problem, implemented in this PR?

Special logic added for default gems in https://github.com/rubygems/rubygems/pull/8130 was actually affecting non default gems too. Make sure that does not happen.

Fixes #8746.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
