### PR TITLE
Disable some scorecard rules

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -48,8 +48,18 @@ jobs:
           # - See https://github.com/ossf/scorecard-action#publishing-results.
           publish_results: true
 
+      - name: Filter SARIF to skip irrelevant rules
+        env:
+          SCORECARD_SKIPPED_RULE_IDS: CodeReviewID,FuzzingID,CIIBestPracticesID
+        run: |
+          SCORECARD_SKIPPED_RULE_IDS_IN_JSON=$(echo $SCORECARD_SKIPPED_RULE_IDS | jq -cR 'split(",")')
+          # Trim the SARIF file to remove skipped rule detections
+          cat results.sarif | jq '.runs[].results |= map(select(.ruleId as $id | '$SCORECARD_SKIPPED_RULE_IDS_IN_JSON' | all($id != .)))' > filteredResults.sarif
+          # Print the skipped rule detections
+          cat results.sarif | jq '.runs[].results | map(select(.ruleId as $id | '$SCORECARD_SKIPPED_RULE_IDS_IN_JSON' | any($id == .))) | select(. | length > 0)'
+
       # Upload the results to GitHub's code scanning dashboard.
       - name: Upload to code-scanning
         uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
         with:
-          sarif_file: results.sarif
+          sarif_file: filteredResults.sarif


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I'd like us to have no code scanning alerts, and eventually be able to enforce having no code scanning alerts on every PR.

However, we have code scanning alerts we don't want to enforce right now.

## What is your fix for the problem, implemented in this PR?

Unfortunately the scorecard action removed allowing to configure only specific rules in https://github.com/ossf/scorecard-action/pull/16. I think bringing back the feature is being discussed in https://github.com/ossf/scorecard-action/issues/1107, but for now it's not there.

However, I've seen this workaround posted [here](https://github.com/ossf/scorecard-action/issues/1098#issuecomment-1464826283), so I thought we could try it.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
