### PR TITLE
Fix redefinition warnings when using modern RubyGems with old Bundler

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -364,6 +364,7 @@ hide_lib_for_update/note.txt
 lib/rubygems.rb
 lib/rubygems/available_set.rb
 lib/rubygems/basic_specification.rb
+lib/rubygems/bundler_integration.rb
 lib/rubygems/bundler_version_finder.rb
 lib/rubygems/ci_detector.rb
 lib/rubygems/command.rb

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1144,7 +1144,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
 
     ENV["BUNDLE_GEMFILE"] ||= File.expand_path(path)
     require_relative "rubygems/user_interaction"
-    require "bundler"
+    require_relative "rubygems/bundler_integration"
     begin
       Gem::DefaultUserInteraction.use_ui(ui) do
         Bundler.ui.silence do

--- a/lib/rubygems/bundler_integration.rb
+++ b/lib/rubygems/bundler_integration.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "bundler/version"
+
+if Bundler::VERSION > "2.6.9"
+  require "bundler"
+else
+  previous_platforms = {}
+
+  platform_const_list = ["JAVA", "MSWIN", "MSWIN64", "MINGW", "X64_MINGW_LEGACY", "X64_MINGW", "UNIVERSAL_MINGW", "WINDOWS", "X64_LINUX", "X64_LINUX_MUSL"]
+
+  platform_const_list.each do |platform|
+    previous_platforms[platform] = Gem::Platform.const_get(platform)
+    Gem::Platform.send(:remove_const, platform)
+  end
+
+  require "bundler"
+
+  platform_const_list.each do |platform|
+    Gem::Platform.send(:remove_const, platform) if Gem::Platform.const_defined?(platform)
+    Gem::Platform.const_set(platform, previous_platforms[platform])
+  end
+end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

After #8703, using RubyGems features that use Bundler, when activated version of Bundler is 2.6.9 or older will result in a lot of redefinition warnings, like:

```
$ RUBYGEMS_GEMDEPS=- RUBYOPT=-I/Users/deivid/code/rubygems/rubygems/lib rake -T                  
/Users/deivid/.local/share/mise/installs/ruby/3.4.4/lib/ruby/3.4.0/bundler/rubygems_ext.rb:64: warning: already initialized constant Gem::Platform::JAVA
/Users/deivid/code/rubygems/rubygems/lib/rubygems/platform.rb:259: warning: previous definition of JAVA was here
/Users/deivid/.local/share/mise/installs/ruby/3.4.4/lib/ruby/3.4.0/bundler/rubygems_ext.rb:65: warning: already initialized constant Gem::Platform::MSWIN
/Users/deivid/code/rubygems/rubygems/lib/rubygems/platform.rb:260: warning: previous definition of MSWIN was here
/Users/deivid/.local/share/mise/installs/ruby/3.4.4/lib/ruby/3.4.0/bundler/rubygems_ext.rb:66: warning: already initialized constant Gem::Platform::MSWIN64
/Users/deivid/code/rubygems/rubygems/lib/rubygems/platform.rb:261: warning: previous definition of MSWIN64 was here
/Users/deivid/.local/share/mise/installs/ruby/3.4.4/lib/ruby/3.4.0/bundler/rubygems_ext.rb:67: warning: already initialized constant Gem::Platform::MINGW
/Users/deivid/code/rubygems/rubygems/lib/rubygems/platform.rb:262: warning: previous definition of MINGW was here
/Users/deivid/.local/share/mise/installs/ruby/3.4.4/lib/ruby/3.4.0/bundler/rubygems_ext.rb:68: warning: already initialized constant Gem::Platform::X64_MINGW
/Users/deivid/code/rubygems/rubygems/lib/rubygems/platform.rb:264: warning: previous definition of X64_MINGW was here
/Users/deivid/.local/share/mise/installs/ruby/3.4.4/lib/ruby/3.4.0/bundler/rubygems_ext.rb:70: warning: already initialized constant Gem::Platform::UNIVERSAL_MINGW
/Users/deivid/code/rubygems/rubygems/lib/rubygems/platform.rb:265: warning: previous definition of UNIVERSAL_MINGW was here
/Users/deivid/.local/share/mise/installs/ruby/3.4.4/lib/ruby/3.4.0/bundler/rubygems_ext.rb:71: warning: already initialized constant Gem::Platform::WINDOWS
/Users/deivid/code/rubygems/rubygems/lib/rubygems/platform.rb:266: warning: previous definition of WINDOWS was here
/Users/deivid/.local/share/mise/installs/ruby/3.4.4/lib/ruby/3.4.0/bundler/rubygems_ext.rb:72: warning: already initialized constant Gem::Platform::X64_LINUX
/Users/deivid/code/rubygems/rubygems/lib/rubygems/platform.rb:267: warning: previous definition of X64_LINUX was here
/Users/deivid/.local/share/mise/installs/ruby/3.4.4/lib/ruby/3.4.0/bundler/rubygems_ext.rb:73: warning: already initialized constant Gem::Platform::X64_LINUX_MUSL
/Users/deivid/code/rubygems/rubygems/lib/rubygems/platform.rb:268: warning: previous definition of X64_LINUX_MUSL was here
rake aborted!
No Rakefile found (looking for: rakefile, Rakefile, rakefile.rb, Rakefile.rb)
/Users/deivid/code/playground/foo/ruby/3.4.0/gems/rake-13.3.0/exe/rake:27:in '<top (required)>'
(See full trace by running task with --trace)
```

## What is your fix for the problem, implemented in this PR?

My fix is to remove constants before requiring an old version of Bundler, and then define them again. 

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
