### PR TITLE
Removed duplicated binstub for `turbo_tests`

### DIFF
--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -27,7 +27,8 @@ jobs:
         with:
           repository: ruby/ruby
           path: ruby/ruby
-          ref: v3_4_4
+          ref: 3a6844a692cab3bd9078ce74c3d96c16c2f3f2fb
+          # ref: v3_4_4
           persist-credentials: false
       - name: Install libraries
         run: |
@@ -47,7 +48,6 @@ jobs:
       - name: Sync tools
         run: |
           ruby tool/sync_default_gems.rb rubygems
-          mv spec/bundler/bin/parallel_rspec spec/bin/parallel_rspec # TODO: fix `sync_default_gems.rb` script so we don't need to vendor the ruby-core binstub ourselves
         working-directory: ruby/ruby
       - name: Test RubyGems
         run: make -j2 -s test-all TESTS="rubygems --no-retry"

--- a/bundler/spec/bin/parallel_rspec
+++ b/bundler/spec/bin/parallel_rspec
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-# frozen_string_literal: true
-
-require_relative "../bundler/support/setup"
-
-require "turbo_tests"
-TurboTests::CLI.new(ARGV).run


### PR DESCRIPTION
## What is your fix for the problem, implemented in this PR?

I'm not sure this file is still required.

https://github.com/ruby/ruby/blob/master/tool/sync_default_gems.rb#L140 seems only using binstubs on `bundler/bin`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
