### PR TITLE
Cleanup dead code, RubyGems 3.3 is no longer supported

### DIFF
--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -386,7 +386,6 @@ RSpec.describe "bundle gem" do
 
   it "has no rubocop offenses when using --ext=rust and --linter=rubocop flag" do
     skip "ruby_core has an 'ast.rb' file that gets in the middle and breaks this spec" if ruby_core?
-    skip "RubyGems incompatible with Rust builder" if ::Gem::Version.new("3.3.11") > ::Gem.rubygems_version
 
     bundle "gem #{gem_name} --ext=rust --linter=rubocop"
     bundle_exec_rubocop
@@ -395,7 +394,6 @@ RSpec.describe "bundle gem" do
 
   it "has no rubocop offenses when using --ext=rust, --test=minitest, and --linter=rubocop flag" do
     skip "ruby_core has an 'ast.rb' file that gets in the middle and breaks this spec" if ruby_core?
-    skip "RubyGems incompatible with Rust builder" if ::Gem::Version.new("3.3.11") > ::Gem.rubygems_version
 
     bundle "gem #{gem_name} --ext=rust --test=minitest --linter=rubocop"
     bundle_exec_rubocop
@@ -404,7 +402,6 @@ RSpec.describe "bundle gem" do
 
   it "has no rubocop offenses when using --ext=rust, --test=rspec, and --linter=rubocop flag" do
     skip "ruby_core has an 'ast.rb' file that gets in the middle and breaks this spec" if ruby_core?
-    skip "RubyGems incompatible with Rust builder" if ::Gem::Version.new("3.3.11") > ::Gem.rubygems_version
 
     bundle "gem #{gem_name} --ext=rust --test=rspec --linter=rubocop"
     bundle_exec_rubocop
@@ -413,7 +410,6 @@ RSpec.describe "bundle gem" do
 
   it "has no rubocop offenses when using --ext=rust, --test=test-unit, and --linter=rubocop flag" do
     skip "ruby_core has an 'ast.rb' file that gets in the middle and breaks this spec" if ruby_core?
-    skip "RubyGems incompatible with Rust builder" if ::Gem::Version.new("3.3.11") > ::Gem.rubygems_version
 
     bundle "gem #{gem_name} --ext=rust --test=test-unit --linter=rubocop"
     bundle_exec_rubocop
@@ -1724,24 +1720,10 @@ RSpec.describe "bundle gem" do
       end
     end
 
-    context "--ext parameter set with rust and old RubyGems" do
-      it "fails in friendly way" do
-        if ::Gem::Version.new("3.3.11") <= ::Gem.rubygems_version
-          skip "RubyGems compatible with Rust builder"
-        end
-
-        expect do
-          bundle ["gem", gem_name, "--ext=rust"].compact.join(" ")
-        end.to raise_error(RuntimeError, /too old to build Rust extension/)
-      end
-    end
-
     context "--ext parameter set with rust" do
       let(:flags) { "--ext=rust" }
 
       before do
-        skip "RubyGems incompatible with Rust builder" if ::Gem::Version.new("3.3.11") > ::Gem.rubygems_version
-
         bundle ["gem", gem_name, flags].compact.join(" ")
       end
 

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -147,7 +147,6 @@ RSpec.shared_examples "bundle install --standalone" do
 
     it "works and points to the vendored copies, not to the default copies" do
       necessary_gems_in_bundle_path = ["optparse --version 0.1.1", "psych --version 3.3.2", "logger --version 1.4.3", "etc --version 1.4.3", "stringio --version 3.1.0"]
-      necessary_gems_in_bundle_path += ["yaml --version 0.1.1"] if Gem.rubygems_version < Gem::Version.new("3.4.a")
       realworld_system_gems(*necessary_gems_in_bundle_path, path: scoped_gem_path(bundled_app("bundle")))
 
       build_gem "foo", "1.0.0", to_system: true, default: true do |s|
@@ -186,7 +185,6 @@ RSpec.shared_examples "bundle install --standalone" do
     it "works for gems with extensions and points to the vendored copies, not to the default copies" do
       simulate_platform "arm64-darwin-23" do
         necessary_gems_in_bundle_path = ["optparse --version 0.1.1", "psych --version 3.3.2", "logger --version 1.4.3", "etc --version 1.4.3", "stringio --version 3.1.0", "shellwords --version 0.2.0", "open3 --version 0.2.1"]
-        necessary_gems_in_bundle_path += ["yaml --version 0.1.1"] if Gem.rubygems_version < Gem::Version.new("3.4.a")
         realworld_system_gems(*necessary_gems_in_bundle_path, path: scoped_gem_path(bundled_app("bundle")))
 
         build_gem "baz", "1.0.0", to_system: true, default: true, &:add_c_extension


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

None, just cleaning up old stuff.

## What is your fix for the problem, implemented in this PR?

Remove code that's no longer relevant.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
