### PR TITLE
Fix signing HEAD and date formatting in S3 signer

### DIFF
--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -267,7 +267,7 @@ class Gem::RemoteFetcher
 
   def fetch_s3(uri, mtime = nil, head = false)
     begin
-      public_uri = s3_uri_signer(uri).sign
+      public_uri = s3_uri_signer(uri, head).sign
     rescue Gem::S3URISigner::ConfigurationError, Gem::S3URISigner::InstanceProfileError => e
       raise FetchError.new(e.message, "s3://#{uri.host}")
     end
@@ -275,8 +275,8 @@ class Gem::RemoteFetcher
   end
 
   # we have our own signing code here to avoid a dependency on the aws-sdk gem
-  def s3_uri_signer(uri)
-    Gem::S3URISigner.new(uri)
+  def s3_uri_signer(uri, head)
+    Gem::S3URISigner.new(uri, head)
   end
 
   ##

--- a/lib/rubygems/s3_uri_signer.rb
+++ b/lib/rubygems/s3_uri_signer.rb
@@ -27,9 +27,11 @@ class Gem::S3URISigner
   end
 
   attr_accessor :uri
+  attr_accessor :head
 
-  def initialize(uri)
+  def initialize(uri, head)
     @uri = uri
+    @head = head
   end
 
   ##
@@ -73,7 +75,7 @@ class Gem::S3URISigner
 
   def generate_canonical_request(canonical_host, query_params)
     [
-      "GET",
+      head ? "HEAD" : "GET",
       uri.path,
       query_params,
       "host:#{canonical_host}",

--- a/lib/rubygems/s3_uri_signer.rb
+++ b/lib/rubygems/s3_uri_signer.rb
@@ -38,7 +38,7 @@ class Gem::S3URISigner
     s3_config = fetch_s3_config
 
     current_time = Time.now.utc
-    date_time = current_time.strftime("%Y%m%dT%H%m%SZ")
+    date_time = current_time.strftime("%Y%m%dT%H%M%SZ")
     date = date_time[0,8]
 
     credential_info = "#{date}/#{s3_config.region}/s3/aws4_request"

--- a/test/rubygems/test_gem_remote_fetcher_s3.rb
+++ b/test/rubygems/test_gem_remote_fetcher_s3.rb
@@ -47,7 +47,7 @@ class TestGemRemoteFetcherS3 < Gem::TestCase
 
     data = fetcher.fetch_s3 Gem::URI.parse(url)
 
-    assert_equal "https://my-bucket.s3.#{region}.amazonaws.com/gems/specs.4.8.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=testuser%2F20190624%2F#{region}%2Fs3%2Faws4_request&X-Amz-Date=20190624T050641Z&X-Amz-Expires=86400#{token ? "&X-Amz-Security-Token=" + token : ""}&X-Amz-SignedHeaders=host&X-Amz-Signature=#{signature}", $fetched_uri.to_s
+    assert_equal "https://my-bucket.s3.#{region}.amazonaws.com/gems/specs.4.8.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=testuser%2F20190624%2F#{region}%2Fs3%2Faws4_request&X-Amz-Date=20190624T051941Z&X-Amz-Expires=86400#{token ? "&X-Amz-Security-Token=" + token : ""}&X-Amz-SignedHeaders=host&X-Amz-Signature=#{signature}", $fetched_uri.to_s
     assert_equal "success", data
   ensure
     $fetched_uri = nil
@@ -59,7 +59,7 @@ class TestGemRemoteFetcherS3 < Gem::TestCase
     }
     url = "s3://my-bucket/gems/specs.4.8.gz"
     Time.stub :now, Time.at(1_561_353_581) do
-      assert_fetch_s3 url, "20f974027db2f3cd6193565327a7c73457a138efb1a63ea248d185ce6827d41b"
+      assert_fetch_s3 url, "b5cb80c1301f7b1c50c4af54f1f6c034f80b56d32f000a855f0a903dc5a8413c"
     end
   ensure
     Gem.configuration[:s3_source] = nil
@@ -71,7 +71,7 @@ class TestGemRemoteFetcherS3 < Gem::TestCase
     }
     url = "s3://my-bucket/gems/specs.4.8.gz"
     Time.stub :now, Time.at(1_561_353_581) do
-      assert_fetch_s3 url, "4afc3010757f1fd143e769f1d1dabd406476a4fc7c120e9884fd02acbb8f26c9", nil, "us-west-2"
+      assert_fetch_s3 url, "ef07487bfd8e3ca594f8fc29775b70c0a0636f51318f95d4f12b2e6e1fd8c716", nil, "us-west-2"
     end
   ensure
     Gem.configuration[:s3_source] = nil
@@ -83,7 +83,7 @@ class TestGemRemoteFetcherS3 < Gem::TestCase
     }
     url = "s3://my-bucket/gems/specs.4.8.gz"
     Time.stub :now, Time.at(1_561_353_581) do
-      assert_fetch_s3 url, "935160a427ef97e7630f799232b8f208c4a4e49aad07d0540572a2ad5fe9f93c", "testtoken"
+      assert_fetch_s3 url, "e709338735f9077edf8f6b94b247171c266a9605975e08e4a519a123c3322625", "testtoken"
     end
   ensure
     Gem.configuration[:s3_source] = nil
@@ -98,7 +98,7 @@ class TestGemRemoteFetcherS3 < Gem::TestCase
     }
     url = "s3://my-bucket/gems/specs.4.8.gz"
     Time.stub :now, Time.at(1_561_353_581) do
-      assert_fetch_s3 url, "20f974027db2f3cd6193565327a7c73457a138efb1a63ea248d185ce6827d41b"
+      assert_fetch_s3 url, "b5cb80c1301f7b1c50c4af54f1f6c034f80b56d32f000a855f0a903dc5a8413c"
     end
   ensure
     ENV.each_key {|key| ENV.delete(key) if key.start_with?("AWS") }
@@ -114,7 +114,7 @@ class TestGemRemoteFetcherS3 < Gem::TestCase
     }
     url = "s3://my-bucket/gems/specs.4.8.gz"
     Time.stub :now, Time.at(1_561_353_581) do
-      assert_fetch_s3 url, "4afc3010757f1fd143e769f1d1dabd406476a4fc7c120e9884fd02acbb8f26c9", nil, "us-west-2"
+      assert_fetch_s3 url, "ef07487bfd8e3ca594f8fc29775b70c0a0636f51318f95d4f12b2e6e1fd8c716", nil, "us-west-2"
     end
   ensure
     ENV.each_key {|key| ENV.delete(key) if key.start_with?("AWS") }
@@ -130,7 +130,7 @@ class TestGemRemoteFetcherS3 < Gem::TestCase
     }
     url = "s3://my-bucket/gems/specs.4.8.gz"
     Time.stub :now, Time.at(1_561_353_581) do
-      assert_fetch_s3 url, "935160a427ef97e7630f799232b8f208c4a4e49aad07d0540572a2ad5fe9f93c", "testtoken"
+      assert_fetch_s3 url, "e709338735f9077edf8f6b94b247171c266a9605975e08e4a519a123c3322625", "testtoken"
     end
   ensure
     ENV.each_key {|key| ENV.delete(key) if key.start_with?("AWS") }
@@ -140,7 +140,7 @@ class TestGemRemoteFetcherS3 < Gem::TestCase
   def test_fetch_s3_url_creds
     url = "s3://testuser:testpass@my-bucket/gems/specs.4.8.gz"
     Time.stub :now, Time.at(1_561_353_581) do
-      assert_fetch_s3 url, "20f974027db2f3cd6193565327a7c73457a138efb1a63ea248d185ce6827d41b"
+      assert_fetch_s3 url, "b5cb80c1301f7b1c50c4af54f1f6c034f80b56d32f000a855f0a903dc5a8413c"
     end
   end
 
@@ -151,7 +151,7 @@ class TestGemRemoteFetcherS3 < Gem::TestCase
 
     url = "s3://my-bucket/gems/specs.4.8.gz"
     Time.stub :now, Time.at(1_561_353_581) do
-      assert_fetch_s3 url, "20f974027db2f3cd6193565327a7c73457a138efb1a63ea248d185ce6827d41b", nil, "us-east-1",
+      assert_fetch_s3 url, "b5cb80c1301f7b1c50c4af54f1f6c034f80b56d32f000a855f0a903dc5a8413c", nil, "us-east-1",
                       '{"AccessKeyId": "testuser", "SecretAccessKey": "testpass"}'
     end
   ensure
@@ -165,7 +165,7 @@ class TestGemRemoteFetcherS3 < Gem::TestCase
 
     url = "s3://my-bucket/gems/specs.4.8.gz"
     Time.stub :now, Time.at(1_561_353_581) do
-      assert_fetch_s3 url, "4afc3010757f1fd143e769f1d1dabd406476a4fc7c120e9884fd02acbb8f26c9", nil, "us-west-2",
+      assert_fetch_s3 url, "ef07487bfd8e3ca594f8fc29775b70c0a0636f51318f95d4f12b2e6e1fd8c716", nil, "us-west-2",
                       '{"AccessKeyId": "testuser", "SecretAccessKey": "testpass"}'
     end
   ensure
@@ -179,7 +179,7 @@ class TestGemRemoteFetcherS3 < Gem::TestCase
 
     url = "s3://my-bucket/gems/specs.4.8.gz"
     Time.stub :now, Time.at(1_561_353_581) do
-      assert_fetch_s3 url, "935160a427ef97e7630f799232b8f208c4a4e49aad07d0540572a2ad5fe9f93c", "testtoken", "us-east-1",
+      assert_fetch_s3 url, "e709338735f9077edf8f6b94b247171c266a9605975e08e4a519a123c3322625", "testtoken", "us-east-1",
                       '{"AccessKeyId": "testuser", "SecretAccessKey": "testpass", "Token": "testtoken"}'
     end
   ensure


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?
This PR fixes two unrelated bugs in the s3 signer code. However, I'm bundling them in a single PR because the unit tests for the fixes are intertwined. The problems are:
1. The date formatting was wrong. To my knowledge, this had no user-impact despite sometimes using date times up-to 48 minutes off `Time.now()`. 
2. HTTP `HEAD` requests were incorrectly signed. A recent change to S3 escalated the severity of this problem from "just noise" to "breaks gem installs". S3 rolled back the change, however, this is a bug in rubygems and warrants a fix.

## What is your fix for the problem, implemented in this PR?
This PR implements straight-forward bugfixes to the two problems listed above. Stripe has been running with these patches internally for about a month and haven't seen any issues.

## Make sure the following tasks are checked
- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
