### PR TITLE
Surpressing warning for CGI library of Ruby 3.5+

### DIFF
--- a/bundler/spec/bundler/friendly_errors_spec.rb
+++ b/bundler/spec/bundler/friendly_errors_spec.rb
@@ -2,7 +2,8 @@
 
 require "bundler"
 require "bundler/friendly_errors"
-require "cgi"
+require "cgi/escape"
+require "cgi/util" unless defined?(CGI::EscapeExt)
 
 RSpec.describe Bundler, "friendly errors" do
   context "with invalid YAML in .gemrc" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The following warning appeared with master version of ruby/ruby targeted to Ruby 3.5.

```
❯ bin/rspec ./spec/bundler/friendly_errors_spec.rb
/Users/hsbt/Documents/github.com/rubygems/rubygems/bundler/spec/bundler/friendly_errors_spec.rb:5: warning: CGI library is removed from Ruby 3.5. Please use cgi/escape instead for CGI.escape and CGI.unescape features.
If you need to use the full features of CGI library, Please install cgi gem.
```

## What is your fix for the problem, implemented in this PR?

The most part of `cgi` library will be removed from Ruby 3.5+. I replaced that only for `CGI.escape`.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
