### PR TITLE
Fix rdoc issues when running `gem` commands in a `bundle exec` context

### DIFF
--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -346,6 +346,10 @@ module Bundler
       redefine_method(gem_class, :finish_resolve) do |*|
         []
       end
+
+      redefine_method(gem_class, :load_plugins) do |*|
+        load_plugin_files specs.flat_map(&:plugins)
+      end
     end
 
     def plain_specs

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -222,8 +222,6 @@ module Bundler
 
     # Used to give better error messages when activating specs outside of the current bundle
     def replace_bin_path(specs_by_name)
-      gem_class = (class << Gem; self; end)
-
       redefine_method(gem_class, :find_spec_for_exe) do |gem_name, *args|
         exec_name = args.first
         raise ArgumentError, "you must supply exec_name" unless exec_name
@@ -345,7 +343,7 @@ module Bundler
         Gem::Specification.all = specs
       end
 
-      redefine_method((class << Gem; self; end), :finish_resolve) do |*|
+      redefine_method(gem_class, :finish_resolve) do |*|
         []
       end
     end
@@ -446,6 +444,12 @@ module Bundler
 
     def default_stubs
       Gem::Specification.default_stubs("*.gemspec")
+    end
+
+    private
+
+    def gem_class
+      class << Gem; self; end
     end
   end
 

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -699,6 +699,27 @@ RSpec.describe "bundle exec" do
     end
   end
 
+  describe "running gem commands in presence of rubygems plugins" do
+    before do
+      build_repo4 do
+        build_gem "foo" do |s|
+          s.write "lib/rubygems_plugin.rb", "puts 'FAIL'"
+        end
+      end
+
+      system_gems "foo-1.0", path: default_bundle_path, gem_repo: gem_repo4
+
+      install_gemfile <<-G
+        source "https://gem.repo4"
+      G
+    end
+
+    it "does not load plugins outside of the bundle" do
+      bundle "exec #{gem_cmd} -v"
+      expect(out).not_to include("FAIL")
+    end
+  end
+
   context "`load`ing a ruby file instead of `exec`ing" do
     let(:path) { bundled_app("ruby_executable") }
     let(:shebang) { "#!/usr/bin/env ruby" }


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Currently, running `gem` commands in a `bundle exec` contexts loads all installed rubygems plugins. This creates several issues, in particular, related to double loads of the RDoc gem, when mixed versions are loaded from plugins and from building docs in `gem install` or `gem build`.

## What is your fix for the problem, implemented in this PR?

In a `bundle exec` context, only plugins from gems in the bundle should be loaded, so this PR overrides `Gem.load_plugins` to do that.

Fixes #8477.
Fixes #8674.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
