### PR TITLE
Implement eql?, ==, hash for Bundler::RemoteSpecification

### DIFF
--- a/bundler/lib/bundler/remote_specification.rb
+++ b/bundler/lib/bundler/remote_specification.rb
@@ -42,6 +42,20 @@ module Bundler
       end
     end
 
+    def ==(other) # :nodoc:
+      self.class === other &&
+        name == other.name &&
+        version == other.version &&
+        platform == other.platform
+    end
+
+    alias_method :eql?, :== # :nodoc:
+
+    def hash # :nodoc:
+      name.hash ^ version.hash ^ platform.hash
+    end
+
+
     # Compare this specification against another object. Using sort_obj
     # is compatible with Gem::Specification and other Bundler or RubyGems
     # objects. Otherwise, use the default Object comparison.
@@ -73,7 +87,7 @@ module Bundler
     # @return [Array] an object you can use to compare and sort this
     #   specification against other specifications
     def sort_obj
-      [@name, @version, @platform == Gem::Platform::RUBY ? -1 : 1]
+      [@name, @version, Gem::Platform.sort_priority(@platform)]
     end
 
     def to_s


### PR DESCRIPTION
Same implementation as used for Gem::Specification

Otherwise, Comparable would use <=> for == and the object implementations for hash and eql, which wouldnt match how other specification-like objects behave

Ideally this will be no functional change, but I wanted to get this all proper in case those methods ever do become relevant

Signed-off-by: Samuel Giddins <segiddins@segiddins.me>

<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)