### PR TITLE
Fix flaky test failures in mirror probing specs

### DIFF
--- a/bundler/spec/install/gems/mirror_probe_spec.rb
+++ b/bundler/spec/install/gems/mirror_probe_spec.rb
@@ -1,33 +1,23 @@
 # frozen_string_literal: true
 
 RSpec.describe "fetching dependencies with a not available mirror" do
-  let(:host) { "127.0.0.1" }
-
   before do
-    require_rack_test
-    setup_server
-    setup_mirror
-  end
+    build_repo2
 
-  after do
-    Artifice.deactivate
-    @server_thread.kill
-    @server_thread.join
+    gemfile <<-G
+      source "https://gem.repo2"
+      gem 'weakling'
+    G
   end
 
   context "with a specific fallback timeout" do
     before do
-      global_config("BUNDLE_MIRROR__HTTP://127__0__0__1:#{@server_port}/__FALLBACK_TIMEOUT/" => "true",
-                    "BUNDLE_MIRROR__HTTP://127__0__0__1:#{@server_port}/" => @mirror_uri)
+      global_config("BUNDLE_MIRROR__HTTPS://GEM__REPO2/__FALLBACK_TIMEOUT/" => "true",
+                    "BUNDLE_MIRROR__HTTPS://GEM__REPO2/" => "https://gem.mirror")
     end
 
     it "install a gem using the original uri when the mirror is not responding" do
-      gemfile <<-G
-        source "#{@server_uri}"
-        gem 'weakling'
-      G
-
-      bundle :install, artifice: nil
+      bundle :install, env: { "BUNDLER_SPEC_FAKE_RESOLVE" => "gem.mirror" }, verbose: true
 
       expect(out).to include("Installing weakling")
       expect(out).to include("Bundle complete")
@@ -38,16 +28,11 @@ RSpec.describe "fetching dependencies with a not available mirror" do
   context "with a global fallback timeout" do
     before do
       global_config("BUNDLE_MIRROR__ALL__FALLBACK_TIMEOUT/" => "1",
-                    "BUNDLE_MIRROR__ALL" => @mirror_uri)
+                    "BUNDLE_MIRROR__ALL" => "https://gem.mirror")
     end
 
     it "install a gem using the original uri when the mirror is not responding" do
-      gemfile <<-G
-        source "#{@server_uri}"
-        gem 'weakling'
-      G
-
-      bundle :install, artifice: nil
+      bundle :install, env: { "BUNDLER_SPEC_FAKE_RESOLVE" => "gem.mirror" }
 
       expect(out).to include("Installing weakling")
       expect(out).to include("Bundle complete")
@@ -57,73 +42,27 @@ RSpec.describe "fetching dependencies with a not available mirror" do
 
   context "with a specific mirror without a fallback timeout" do
     before do
-      global_config("BUNDLE_MIRROR__HTTP://127__0__0__1:#{@server_port}/" => @mirror_uri)
+      global_config("BUNDLE_MIRROR__HTTPS://GEM__REPO2/" => "https://gem.mirror")
     end
 
     it "fails to install the gem with a timeout error when the mirror is not responding" do
-      gemfile <<-G
-        source "#{@server_uri}"
-        gem 'weakling'
-      G
+      bundle :install, artifice: "compact_index_mirror_down", raise_on_error: false
 
-      bundle :install, artifice: nil, raise_on_error: false
-
-      expect(out).to include("Fetching source index from #{@mirror_uri}")
-
-      err_lines = err.split("\n")
-      expect(err_lines).to include(%r{\ARetrying fetcher due to error \(2/4\): Bundler::HTTPError Could not fetch specs from #{@mirror_uri}/ due to underlying error <})
-      expect(err_lines).to include(%r{\ARetrying fetcher due to error \(3/4\): Bundler::HTTPError Could not fetch specs from #{@mirror_uri}/ due to underlying error <})
-      expect(err_lines).to include(%r{\ARetrying fetcher due to error \(4/4\): Bundler::HTTPError Could not fetch specs from #{@mirror_uri}/ due to underlying error <})
-      expect(err_lines).to include(%r{\ACould not fetch specs from #{@mirror_uri}/ due to underlying error <})
+      expect(out).to be_empty
+      expect(err).to eq("Could not reach host gem.mirror. Check your network connection and try again.")
     end
   end
 
   context "with a global mirror without a fallback timeout" do
     before do
-      global_config("BUNDLE_MIRROR__ALL" => @mirror_uri)
+      global_config("BUNDLE_MIRROR__ALL" => "https://gem.mirror")
     end
 
     it "fails to install the gem with a timeout error when the mirror is not responding" do
-      gemfile <<-G
-        source "#{@server_uri}"
-        gem 'weakling'
-      G
+      bundle :install, artifice: "compact_index_mirror_down", raise_on_error: false
 
-      bundle :install, artifice: nil, raise_on_error: false
-
-      expect(out).to include("Fetching source index from #{@mirror_uri}")
-
-      err_lines = err.split("\n")
-      expect(err_lines).to include(%r{\ARetrying fetcher due to error \(2/4\): Bundler::HTTPError Could not fetch specs from #{@mirror_uri}/ due to underlying error <})
-      expect(err_lines).to include(%r{\ARetrying fetcher due to error \(3/4\): Bundler::HTTPError Could not fetch specs from #{@mirror_uri}/ due to underlying error <})
-      expect(err_lines).to include(%r{\ARetrying fetcher due to error \(4/4\): Bundler::HTTPError Could not fetch specs from #{@mirror_uri}/ due to underlying error <})
-      expect(err_lines).to include(%r{\ACould not fetch specs from #{@mirror_uri}/ due to underlying error <})
+      expect(out).to be_empty
+      expect(err).to eq("Could not reach host gem.mirror. Check your network connection and try again.")
     end
-  end
-
-  def setup_server
-    @server_port = find_unused_port
-    @server_uri = "http://#{host}:#{@server_port}"
-
-    require_relative "../../support/artifice/compact_index"
-    require_relative "../../support/silent_logger"
-
-    require "rackup/server"
-
-    @server_thread = Thread.new do
-      Rackup::Server.start(app: CompactIndexAPI,
-                           Host: host,
-                           Port: @server_port,
-                           server: "webrick",
-                           AccessLog: [],
-                           Logger: Spec::SilentLogger.new)
-    end.run
-
-    wait_for_server(host, @server_port)
-  end
-
-  def setup_mirror
-    @mirror_port = find_unused_port
-    @mirror_uri = "http://#{host}:#{@mirror_port}"
   end
 end

--- a/bundler/spec/support/artifice/compact_index_mirror_down.rb
+++ b/bundler/spec/support/artifice/compact_index_mirror_down.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative "helpers/compact_index"
+require_relative "helpers/artifice"
+require_relative "helpers/rack_request"
+
+module Artifice
+  module Net
+    class HTTPMirrorDown < HTTP
+      def connect
+        raise SocketError if address == "gem.mirror"
+
+        super
+      end
+    end
+
+    HTTP.endpoint = CompactIndexAPI
+  end
+
+  replace_net_http(Net::HTTPMirrorDown)
+end

--- a/bundler/spec/support/artifice/helpers/endpoint.rb
+++ b/bundler/spec/support/artifice/helpers/endpoint.rb
@@ -27,7 +27,7 @@ class Endpoint < Sinatra::Base
 
   set :raise_errors, true
   set :show_exceptions, false
-  set :host_authorization, permitted_hosts: [".example.org", ".local", ".repo", ".repo1", ".repo2", ".repo3", ".repo4", ".rubygems.org", ".security", ".source", ".test", "127.0.0.1"]
+  set :host_authorization, permitted_hosts: [".example.org", ".local", ".mirror", ".repo", ".repo1", ".repo2", ".repo3", ".repo4", ".rubygems.org", ".security", ".source", ".test", "127.0.0.1"]
 
   def call!(*)
     super.tap do

--- a/bundler/spec/support/hax.rb
+++ b/bundler/spec/support/hax.rb
@@ -51,4 +51,18 @@ module Gem
 
     File.singleton_class.prepend ReadOnly
   end
+
+  if ENV["BUNDLER_SPEC_FAKE_RESOLVE"]
+    module FakeResolv
+      def getaddrinfo(host, port)
+        if host == ENV["BUNDLER_SPEC_FAKE_RESOLVE"]
+          [["AF_INET", port, "127.0.0.1", "127.0.0.1", 2, 2, 17]]
+        else
+          super
+        end
+      end
+    end
+
+    Socket.singleton_class.prepend FakeResolv
+  end
 end


### PR DESCRIPTION


## What was the end-user or developer problem that led to this PR?

The mirror probing spec file was moved to our regular suite, which runs in parallel, recently. These specs rely on starting and stopping actual servers in localhost, but this does not play nice with parallelization, because a spec may kill the webserver another spec has created.

## What is your fix for the problem, implemented in this PR?

This commit moves mirror probing specs to not need to start servers in localhost and do something more similar to what the other specs do.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
