### PR TITLE
Deprecate unused `Bundler::SpecSet` methods

### DIFF
--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -179,6 +179,8 @@ module Bundler
     end
 
     def -(other)
+      SharedHelpers.major_deprecation 2, "SpecSet#- has been removed with no replacement"
+
       SpecSet.new(to_a - other.to_a)
     end
 
@@ -210,6 +212,8 @@ module Bundler
     end
 
     def <<(spec)
+      SharedHelpers.major_deprecation 2, "SpecSet#<< has been removed with no replacement"
+
       @specs << spec
     end
 

--- a/bundler/spec/resolver/basic_spec.rb
+++ b/bundler/spec/resolver/basic_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe "Resolving" do
     it "resolves foo only to latest patch - changing dependency declared case" do
       # bar is locked AND a declared dependency in the Gemfile, so it will not move, and therefore
       # foo can only move up to 1.4.4.
-      @base << Bundler::LazySpecification.new("bar", Gem::Version.new("2.0.3"), nil)
+      @base = Bundler::SpecSet.new([Bundler::LazySpecification.new("bar", Gem::Version.new("2.0.3"), nil)])
       should_conservative_resolve_and_include :patch, ["foo"], %w[foo-1.4.4 bar-2.0.3]
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

These methods became essentially unused recently. I didn't remove them to be conservative but I see no reason to not deprecate them.

## What is your fix for the problem, implemented in this PR?

Deprecate the unused methods.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
