### PR TITLE
Make sure to remove dev bundler installation after tests run

### DIFF
--- a/bundler/bin/parallel_rspec
+++ b/bundler/bin/parallel_rspec
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative "../spec/support/setup"
+require_relative "../spec/support/rubygems_ext"
 
-require "turbo_tests"
-TurboTests::CLI.new(ARGV).run
+Spec::Rubygems.with_test_deps do
+  require "turbo_tests"
+  TurboTests::CLI.new(ARGV).run
+end

--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -32,6 +32,7 @@ require_relative "support/indexes"
 require_relative "support/matchers"
 require_relative "support/permissions"
 require_relative "support/platforms"
+require_relative "support/rubygems_ext"
 
 $debug = false
 
@@ -80,30 +81,11 @@ RSpec.configure do |config|
   end
 
   config.before :suite do
-    Gem.ruby = ENV["RUBY"] if ENV["RUBY"]
-
-    require_relative "support/rubygems_ext"
     Spec::Rubygems.test_setup
+  end
 
-    # Simulate bundler has not yet been loaded
-    ENV.replace(ENV.to_hash.delete_if {|k, _v| k.start_with?(Bundler::EnvironmentPreserver::BUNDLER_PREFIX) })
-
-    ENV["BUNDLER_SPEC_RUN"] = "true"
-    ENV["BUNDLE_USER_CONFIG"] = ENV["BUNDLE_USER_CACHE"] = ENV["BUNDLE_USER_PLUGIN"] = nil
-    ENV["BUNDLE_APP_CONFIG"] = nil
-    ENV["BUNDLE_SILENCE_ROOT_WARNING"] = nil
-    ENV["RUBYGEMS_GEMDEPS"] = nil
-    ENV["XDG_CONFIG_HOME"] = nil
-    ENV["GEMRC"] = nil
-
-    # Don't wrap output in tests
-    ENV["THOR_COLUMNS"] = "10000"
-
-    extend(Spec::Builders)
-
-    build_repo1
-
-    reset_paths!
+  config.after :suite do
+    Spec::Rubygems.test_teardown
   end
 
   config.around :each do |example|

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -328,6 +328,12 @@ module Spec
       system_gems :bundler, path: pristine_system_gem_path
     end
 
+    def self.remove_dev_bundler
+      extend self
+
+      FileUtils.rm_r pristine_system_gem_path
+    end
+
     def install_gem(path, install_dir, default = false)
       raise "OMG `#{path}` does not exist!" unless File.exist?(path)
 

--- a/bundler/spec/support/setup.rb
+++ b/bundler/spec/support/setup.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require_relative "switch_rubygems"
-
-require_relative "rubygems_ext"
-Spec::Rubygems.install_test_deps
-
-require_relative "path"
-$LOAD_PATH.unshift(File.expand_path("../../lib", __dir__)) if Spec::Path.ruby_core?


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Since 4cfc41797f942923859cf5ba70b70f7575f101e9, we no longer clean up the dev bundler installation after specs are run.

This is problematic when testing in "Bundler 4 mode", because if you run specs in Bundler 4 mode and then go back to regular mode, a higher version of Bundler is left around installed, and that interferes with regular specs.

## What is your fix for the problem, implemented in this PR?

Fix is to restore a way to reset the installation of dev bundler after specs run.
 
## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
