### PR TITLE
Simulate Bundler 4 in a better way

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -71,7 +71,7 @@ jobs:
         run: sudo apt-get install graphviz -y
         if: matrix.bundler == 2 && matrix.os.name == 'Ubuntu'
       - name: Set version
-        run: echo "BUNDLER_4_MODE=true" >> $GITHUB_ENV
+        run: echo "BUNDLE_SIMULATE_VERSION=4" >> $GITHUB_ENV
         if: matrix.bundler == 4
       - name: Prepare dependencies
         run: |

--- a/.github/workflows/realworld-bundler.yml
+++ b/.github/workflows/realworld-bundler.yml
@@ -50,7 +50,7 @@ jobs:
           ruby-version: ${{ matrix.ruby.value }}
           bundler: none
       - name: Set version
-        run: echo "BUNDLER_4_MODE=true" >> $GITHUB_ENV
+        run: echo "BUNDLE_SIMULATE_VERSION=4" >> $GITHUB_ENV
         if: matrix.bundler == 4
       - name: Prepare dependencies
         run: bin/rake dev:deps
@@ -106,7 +106,7 @@ jobs:
           ruby-version: ${{ matrix.ruby.value }}
           bundler: none
       - name: Set version
-        run: echo "BUNDLER_4_MODE=true" >> $GITHUB_ENV
+        run: echo "BUNDLE_SIMULATE_VERSION=4" >> $GITHUB_ENV
         if: matrix.bundler == 4
       - name: Prepare dependencies
         run: bin/rake dev:deps

--- a/.github/workflows/system-rubygems-bundler.yml
+++ b/.github/workflows/system-rubygems-bundler.yml
@@ -48,7 +48,7 @@ jobs:
         run: sudo apt-get install graphviz -y
         if: matrix.bundler == 2
       - name: Set version
-        run: echo "BUNDLER_4_MODE=true" >> $GITHUB_ENV
+        run: echo "BUNDLE_SIMULATE_VERSION=4" >> $GITHUB_ENV
         if: matrix.bundler == 4
       - name: Prepare dependencies
         run: |

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -567,7 +567,7 @@ module Bundler
     end
 
     def feature_flag
-      @feature_flag ||= FeatureFlag.new(VERSION)
+      @feature_flag ||= FeatureFlag.new(settings[:simulate_version] || VERSION)
     end
 
     def reset!

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -583,7 +583,6 @@ module Bundler
 
     def reset_paths!
       @bin_path = nil
-      @bundler_major_version = nil
       @bundle_path = nil
       @configure = nil
       @configured_bundle_path = nil

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -173,7 +173,7 @@ module Bundler
       self_manager.restart_with_locked_bundler_if_needed
     end
 
-    # Automatically install dependencies if Bundler.settings[:auto_install] exists.
+    # Automatically install dependencies if settings[:auto_install] exists.
     # This is set through config cmd `bundle config set --global auto_install 1`.
     #
     # Note that this method `nil`s out the global Definition object, so it
@@ -480,11 +480,11 @@ module Bundler
       # install binstubs there instead. Unfortunately, RubyGems doesn't expose
       # that directory at all, so rather than parse .gemrc ourselves, we allow
       # the directory to be set as well, via `bundle config set --local bindir foo`.
-      Bundler.settings[:system_bindir] || Bundler.rubygems.gem_bindir
+      settings[:system_bindir] || Bundler.rubygems.gem_bindir
     end
 
     def preferred_gemfile_name
-      Bundler.settings[:init_gems_rb] ? "gems.rb" : "Gemfile"
+      settings[:init_gems_rb] ? "gems.rb" : "Gemfile"
     end
 
     def use_system_gems?

--- a/bundler/lib/bundler/environment_preserver.rb
+++ b/bundler/lib/bundler/environment_preserver.rb
@@ -6,7 +6,6 @@ module Bundler
     BUNDLER_KEYS = %w[
       BUNDLE_BIN_PATH
       BUNDLE_GEMFILE
-      BUNDLER_4_MODE
       BUNDLER_VERSION
       BUNDLER_SETUP
       GEM_HOME

--- a/bundler/lib/bundler/feature_flag.rb
+++ b/bundler/lib/bundler/feature_flag.rb
@@ -50,6 +50,8 @@ module Bundler
       @major_version >= target_major_version
     end
 
+    attr_reader :bundler_version
+
     def initialize(bundler_version)
       @bundler_version = Gem::Version.create(bundler_version)
       @major_version = @bundler_version.segments.first

--- a/bundler/lib/bundler/feature_flag.rb
+++ b/bundler/lib/bundler/feature_flag.rb
@@ -42,6 +42,14 @@ module Bundler
 
     settings_option(:default_cli_command) { bundler_4_mode? ? :cli_help : :install }
 
+    def removed_major?(target_major_version)
+      @major_version > target_major_version
+    end
+
+    def deprecated_major?(target_major_version)
+      @major_version >= target_major_version
+    end
+
     def initialize(bundler_version)
       @bundler_version = Gem::Version.create(bundler_version)
       @major_version = @bundler_version.segments.first

--- a/bundler/lib/bundler/self_manager.rb
+++ b/bundler/lib/bundler/self_manager.rb
@@ -98,7 +98,6 @@ module Bundler
 
     def autoswitching_applies?
       ENV["BUNDLER_VERSION"].nil? &&
-        ENV["BUNDLER_4_MODE"].nil? &&
         ruby_can_restart_with_same_arguments? &&
         lockfile_version
     end

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -133,13 +133,16 @@ module Bundler
         removed_message += suffix if removed_message
       end
 
-      bundler_major_version = Bundler.bundler_major_version
-      if bundler_major_version > major_version
+      require_relative "../bundler"
+
+      feature_flag = Bundler.feature_flag
+
+      if feature_flag.removed_major?(major_version)
         require_relative "errors"
         raise DeprecatedError, "[REMOVED] #{removed_message || message}"
       end
 
-      return unless bundler_major_version >= major_version && prints_major_deprecations?
+      return unless feature_flag.deprecated_major?(major_version) && prints_major_deprecations?
       Bundler.ui.warn("[DEPRECATED] #{message}")
     end
 
@@ -386,7 +389,6 @@ module Bundler
     end
 
     def prints_major_deprecations?
-      require_relative "../bundler"
       return false if Bundler.settings[:silence_deprecations]
       require_relative "deprecate"
       return false if Bundler::Deprecate.skip

--- a/bundler/lib/bundler/version.rb
+++ b/bundler/lib/bundler/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 
 module Bundler
-  VERSION = (ENV["BUNDLER_4_MODE"] == "true" ? "4.0.0" : "2.7.0.dev").freeze
+  VERSION = "2.7.0.dev".freeze
 
   def self.bundler_major_version
     @bundler_major_version ||= gem_version.segments.first

--- a/bundler/lib/bundler/version.rb
+++ b/bundler/lib/bundler/version.rb
@@ -4,7 +4,7 @@ module Bundler
   VERSION = (ENV["BUNDLER_4_MODE"] == "true" ? "4.0.0" : "2.7.0.dev").freeze
 
   def self.bundler_major_version
-    @bundler_major_version ||= VERSION.split(".").first.to_i
+    @bundler_major_version ||= gem_version.segments.first
   end
 
   def self.gem_version

--- a/bundler/spec/bundler/settings_spec.rb
+++ b/bundler/spec/bundler/settings_spec.rb
@@ -333,7 +333,7 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
       C
 
       expect(Bundler.ui).not_to receive(:warn)
-      expect(settings.all).to be_empty
+      expect(settings.all).to eq(simulated_version ? ["simulate_version"] : [])
     end
 
     it "converts older keys with dashes" do

--- a/bundler/spec/bundler/shared_helpers_spec.rb
+++ b/bundler/spec/bundler/shared_helpers_spec.rb
@@ -517,7 +517,7 @@ RSpec.describe Bundler::SharedHelpers do
   end
 
   describe "#major_deprecation" do
-    before { allow(Bundler).to receive(:bundler_major_version).and_return(37) }
+    before { allow(Bundler).to receive(:feature_flag).and_return(Bundler::FeatureFlag.new(37)) }
     before { allow(Bundler.ui).to receive(:warn) }
 
     it "prints and raises nothing below the deprecated major version" do

--- a/bundler/spec/commands/clean_spec.rb
+++ b/bundler/spec/commands/clean_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe "bundle clean" do
     bundle :clean
 
     digest = Digest(:SHA1).hexdigest(git_path.to_s)
-    cache_path = Bundler::VERSION.start_with?("2.") ? vendored_gems("cache/bundler/git/foo-1.0-#{digest}") : home(".bundle/cache/git/foo-1.0-#{digest}")
+    cache_path = Bundler.feature_flag.global_gem_cache? ? home(".bundle/cache/git/foo-1.0-#{digest}") : vendored_gems("cache/bundler/git/foo-1.0-#{digest}")
     expect(cache_path).to exist
   end
 

--- a/bundler/spec/commands/config_spec.rb
+++ b/bundler/spec/commands/config_spec.rb
@@ -453,7 +453,7 @@ E
     it "does not make bundler crash and ignores the configuration" do
       bundle "config list --parseable"
 
-      expect(out).to be_empty
+      expect(out).to eq(simulated_version ? "simulate_version=#{simulated_version}" : "")
       expect(err).to be_empty
 
       ruby(<<~RUBY)
@@ -476,26 +476,38 @@ E
   describe "subcommands" do
     it "list" do
       bundle "config list", env: { "BUNDLE_FOO" => "bar" }
-      expect(out).to eq "Settings are listed in order of priority. The top value will be used.\nfoo\nSet via BUNDLE_FOO: \"bar\""
+      expected = "Settings are listed in order of priority. The top value will be used.\nfoo\nSet via BUNDLE_FOO: \"bar\""
+      expected += "\n\nsimulate_version\nSet via BUNDLE_SIMULATE_VERSION: \"#{simulated_version}\"" if simulated_version
+      expect(out).to eq(expected)
 
       bundle "config list", env: { "BUNDLE_FOO" => "bar" }, parseable: true
-      expect(out).to eq "foo=bar"
+      expected = "foo=bar"
+      expected += "\nsimulate_version=#{simulated_version}" if simulated_version
+      expect(out).to eq(expected)
     end
 
     it "list with credentials" do
       bundle "config list", env: { "BUNDLE_GEMS__MYSERVER__COM" => "user:password" }
-      expect(out).to eq "Settings are listed in order of priority. The top value will be used.\ngems.myserver.com\nSet via BUNDLE_GEMS__MYSERVER__COM: \"user:[REDACTED]\""
+      expected = "Settings are listed in order of priority. The top value will be used.\ngems.myserver.com\nSet via BUNDLE_GEMS__MYSERVER__COM: \"user:[REDACTED]\""
+      expected += "\n\nsimulate_version\nSet via BUNDLE_SIMULATE_VERSION: \"#{simulated_version}\"" if simulated_version
+      expect(out).to eq(expected)
 
       bundle "config list", parseable: true, env: { "BUNDLE_GEMS__MYSERVER__COM" => "user:password" }
-      expect(out).to eq "gems.myserver.com=user:password"
+      expected = "gems.myserver.com=user:password"
+      expected += "\nsimulate_version=#{simulated_version}" if simulated_version
+      expect(out).to eq(expected)
     end
 
     it "list with API token credentials" do
       bundle "config list", env: { "BUNDLE_GEMS__MYSERVER__COM" => "api_token:x-oauth-basic" }
-      expect(out).to eq "Settings are listed in order of priority. The top value will be used.\ngems.myserver.com\nSet via BUNDLE_GEMS__MYSERVER__COM: \"[REDACTED]:x-oauth-basic\""
+      expected = "Settings are listed in order of priority. The top value will be used.\ngems.myserver.com\nSet via BUNDLE_GEMS__MYSERVER__COM: \"[REDACTED]:x-oauth-basic\""
+      expected += "\n\nsimulate_version\nSet via BUNDLE_SIMULATE_VERSION: \"#{simulated_version}\"" if simulated_version
+      expect(out).to eq(expected)
 
       bundle "config list", parseable: true, env: { "BUNDLE_GEMS__MYSERVER__COM" => "api_token:x-oauth-basic" }
-      expect(out).to eq "gems.myserver.com=api_token:x-oauth-basic"
+      expected = "gems.myserver.com=api_token:x-oauth-basic"
+      expected += "\nsimulate_version=#{simulated_version}" if simulated_version
+      expect(out).to eq(expected)
     end
 
     it "get" do

--- a/bundler/spec/commands/inject_spec.rb
+++ b/bundler/spec/commands/inject_spec.rb
@@ -79,11 +79,7 @@ Usage: "bundle inject GEM VERSION"
   context "when frozen" do
     before do
       bundle "install"
-      if Bundler.feature_flag.bundler_4_mode?
-        bundle "config set --local deployment true"
-      else
-        bundle "config set --local frozen true"
-      end
+      bundle "config set --local frozen true"
     end
 
     it "injects anyway" do

--- a/bundler/spec/commands/post_bundle_message_spec.rb
+++ b/bundler/spec/commands/post_bundle_message_spec.rb
@@ -119,8 +119,8 @@ RSpec.describe "post bundle message" do
           gem "myrack"
           gem "not-a-gem", :group => :development
         G
-        expect(err).to include <<-EOS.strip
-Could not find gem 'not-a-gem' in rubygems repository https://gem.repo1/ or installed locally.
+        expect(err).to include <<~EOS.strip
+          Could not find gem 'not-a-gem' in rubygems repository https://gem.repo1/ or installed locally.
         EOS
       end
 

--- a/bundler/spec/commands/post_bundle_message_spec.rb
+++ b/bundler/spec/commands/post_bundle_message_spec.rb
@@ -19,142 +19,147 @@ RSpec.describe "post bundle message" do
   let(:bundle_complete_message)    { "Bundle complete!" }
   let(:bundle_updated_message)     { "Bundle updated!" }
   let(:installed_gems_stats)       { "4 Gemfile dependencies, 5 gems now installed." }
-  let(:bundle_show_message)        { Bundler.bundler_major_version < 3 ? bundle_show_system_message : bundle_show_path_message }
 
-  describe "for fresh bundle install" do
+  describe "when installing to system gems" do
+    before do
+      bundle "config set --local path.system true"
+    end
+
     it "shows proper messages according to the configured groups" do
       bundle :install
-      expect(out).to include(bundle_show_message)
+      expect(out).to include(bundle_show_system_message)
       expect(out).not_to include("Gems in the group")
       expect(out).to include(bundle_complete_message)
       expect(out).to include(installed_gems_stats)
 
       bundle "config set --local without emo"
       bundle :install
-      expect(out).to include(bundle_show_message)
+      expect(out).to include(bundle_show_system_message)
       expect(out).to include("Gems in the group 'emo' were not installed")
       expect(out).to include(bundle_complete_message)
       expect(out).to include(installed_gems_stats)
 
       bundle "config set --local without emo test"
       bundle :install
-      expect(out).to include(bundle_show_message)
+      expect(out).to include(bundle_show_system_message)
       expect(out).to include("Gems in the groups 'emo' and 'test' were not installed")
       expect(out).to include(bundle_complete_message)
       expect(out).to include("4 Gemfile dependencies, 3 gems now installed.")
 
       bundle "config set --local without emo obama test"
       bundle :install
-      expect(out).to include(bundle_show_message)
+      expect(out).to include(bundle_show_system_message)
       expect(out).to include("Gems in the groups 'emo', 'obama' and 'test' were not installed")
       expect(out).to include(bundle_complete_message)
       expect(out).to include("4 Gemfile dependencies, 2 gems now installed.")
     end
 
-    describe "with `path` configured" do
-      let(:bundle_path) { "./vendor" }
-
-      it "shows proper messages according to the configured groups" do
-        bundle "config set --local path vendor"
-        bundle :install
-        expect(out).to include(bundle_show_path_message)
-        expect(out).to_not include("Gems in the group")
+    describe "for second bundle install run" do
+      it "without any options" do
+        2.times { bundle :install }
+        expect(out).to include(bundle_show_system_message)
+        expect(out).to_not include("Gems in the groups")
         expect(out).to include(bundle_complete_message)
-
-        bundle "config set --local path vendor"
-        bundle "config set --local without emo"
-        bundle :install
-        expect(out).to include(bundle_show_path_message)
-        expect(out).to include("Gems in the group 'emo' were not installed")
-        expect(out).to include(bundle_complete_message)
-
-        bundle "config set --local path vendor"
-        bundle "config set --local without emo test"
-        bundle :install
-        expect(out).to include(bundle_show_path_message)
-        expect(out).to include("Gems in the groups 'emo' and 'test' were not installed")
-        expect(out).to include(bundle_complete_message)
-
-        bundle "config set --local path vendor"
-        bundle "config set --local without emo obama test"
-        bundle :install
-        expect(out).to include(bundle_show_path_message)
-        expect(out).to include("Gems in the groups 'emo', 'obama' and 'test' were not installed")
-        expect(out).to include(bundle_complete_message)
-      end
-    end
-
-    describe "with an absolute `path` inside the cwd configured" do
-      let(:bundle_path) { bundled_app("cache") }
-
-      it "shows proper messages according to the configured groups" do
-        bundle "config set --local path #{bundle_path}"
-        bundle :install
-        expect(out).to include("Bundled gems are installed into `./cache`")
-        expect(out).to_not include("Gems in the group")
-        expect(out).to include(bundle_complete_message)
-      end
-    end
-
-    describe "with `path` configured to an absolute path outside the cwd" do
-      let(:bundle_path) { tmp("not_bundled_app") }
-
-      it "shows proper messages according to the configured groups" do
-        bundle "config set --local path #{bundle_path}"
-        bundle :install
-        expect(out).to include("Bundled gems are installed into `#{tmp("not_bundled_app")}`")
-        expect(out).to_not include("Gems in the group")
-        expect(out).to include(bundle_complete_message)
-      end
-    end
-
-    describe "with misspelled or non-existent gem name" do
-      before do
-        bundle "config set force_ruby_platform true"
-      end
-
-      it "should report a helpful error message" do
-        install_gemfile <<-G, raise_on_error: false
-          source "https://gem.repo1"
-          gem "myrack"
-          gem "not-a-gem", :group => :development
-        G
-        expect(err).to include <<~EOS.strip
-          Could not find gem 'not-a-gem' in rubygems repository https://gem.repo1/ or installed locally.
-        EOS
-      end
-
-      it "should report a helpful error message with reference to cache if available" do
-        install_gemfile <<-G
-          source "https://gem.repo1"
-          gem "myrack"
-        G
-        bundle :cache
-        expect(bundled_app("vendor/cache/myrack-1.0.0.gem")).to exist
-        install_gemfile <<-G, raise_on_error: false
-          source "https://gem.repo1"
-          gem "myrack"
-          gem "not-a-gem", :group => :development
-        G
-        expect(err).to include("Could not find gem 'not-a-gem' in").
-          and include("or in gems cached in vendor/cache.")
+        expect(out).to include(installed_gems_stats)
       end
     end
   end
 
-  describe "for second bundle install run", bundler: "2" do
-    it "without any options" do
-      2.times { bundle :install }
-      expect(out).to include(bundle_show_message)
-      expect(out).to_not include("Gems in the groups")
+  describe "with `path` configured" do
+    let(:bundle_path) { "./vendor" }
+
+    it "shows proper messages according to the configured groups" do
+      bundle "config set --local path vendor"
+      bundle :install
+      expect(out).to include(bundle_show_path_message)
+      expect(out).to_not include("Gems in the group")
       expect(out).to include(bundle_complete_message)
-      expect(out).to include(installed_gems_stats)
+
+      bundle "config set --local path vendor"
+      bundle "config set --local without emo"
+      bundle :install
+      expect(out).to include(bundle_show_path_message)
+      expect(out).to include("Gems in the group 'emo' were not installed")
+      expect(out).to include(bundle_complete_message)
+
+      bundle "config set --local path vendor"
+      bundle "config set --local without emo test"
+      bundle :install
+      expect(out).to include(bundle_show_path_message)
+      expect(out).to include("Gems in the groups 'emo' and 'test' were not installed")
+      expect(out).to include(bundle_complete_message)
+
+      bundle "config set --local path vendor"
+      bundle "config set --local without emo obama test"
+      bundle :install
+      expect(out).to include(bundle_show_path_message)
+      expect(out).to include("Gems in the groups 'emo', 'obama' and 'test' were not installed")
+      expect(out).to include(bundle_complete_message)
+    end
+  end
+
+  describe "with an absolute `path` inside the cwd configured" do
+    let(:bundle_path) { bundled_app("cache") }
+
+    it "shows proper messages according to the configured groups" do
+      bundle "config set --local path #{bundle_path}"
+      bundle :install
+      expect(out).to include("Bundled gems are installed into `./cache`")
+      expect(out).to_not include("Gems in the group")
+      expect(out).to include(bundle_complete_message)
+    end
+  end
+
+  describe "with `path` configured to an absolute path outside the cwd" do
+    let(:bundle_path) { tmp("not_bundled_app") }
+
+    it "shows proper messages according to the configured groups" do
+      bundle "config set --local path #{bundle_path}"
+      bundle :install
+      expect(out).to include("Bundled gems are installed into `#{tmp("not_bundled_app")}`")
+      expect(out).to_not include("Gems in the group")
+      expect(out).to include(bundle_complete_message)
+    end
+  end
+
+  describe "with misspelled or non-existent gem name" do
+    before do
+      bundle "config set force_ruby_platform true"
     end
 
+    it "should report a helpful error message" do
+      install_gemfile <<-G, raise_on_error: false
+        source "https://gem.repo1"
+        gem "myrack"
+        gem "not-a-gem", :group => :development
+      G
+      expect(err).to include <<~EOS.strip
+        Could not find gem 'not-a-gem' in rubygems repository https://gem.repo1/ or installed locally.
+      EOS
+    end
+
+    it "should report a helpful error message with reference to cache if available" do
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        gem "myrack"
+      G
+      bundle :cache
+      expect(bundled_app("vendor/cache/myrack-1.0.0.gem")).to exist
+      install_gemfile <<-G, raise_on_error: false
+        source "https://gem.repo1"
+        gem "myrack"
+        gem "not-a-gem", :group => :development
+      G
+      expect(err).to include("Could not find gem 'not-a-gem' in").
+        and include("or in gems cached in vendor/cache.")
+    end
+  end
+
+  describe "for second bundle install run after first run using --without", bundler: "2" do
     it "with --without one group" do
       bundle "install --without emo"
       bundle :install
-      expect(out).to include(bundle_show_message)
+      expect(out).to include(bundle_show_system_message)
       expect(out).to include("Gems in the group 'emo' were not installed")
       expect(out).to include(bundle_complete_message)
       expect(out).to include(installed_gems_stats)
@@ -163,7 +168,7 @@ RSpec.describe "post bundle message" do
     it "with --without two groups" do
       bundle "install --without emo test"
       bundle :install
-      expect(out).to include(bundle_show_message)
+      expect(out).to include(bundle_show_system_message)
       expect(out).to include("Gems in the groups 'emo' and 'test' were not installed")
       expect(out).to include(bundle_complete_message)
     end
@@ -171,7 +176,7 @@ RSpec.describe "post bundle message" do
     it "with --without more groups" do
       bundle "install --without emo obama test"
       bundle :install
-      expect(out).to include(bundle_show_message)
+      expect(out).to include(bundle_show_system_message)
       expect(out).to include("Gems in the groups 'emo', 'obama' and 'test' were not installed")
       expect(out).to include(bundle_complete_message)
     end

--- a/bundler/spec/commands/pristine_spec.rb
+++ b/bundler/spec/commands/pristine_spec.rb
@@ -49,13 +49,7 @@ RSpec.describe "bundle pristine" do
       bundle "pristine"
       bundle "-v"
 
-      expected = if Bundler.bundler_major_version < 3
-        "Bundler version"
-      else
-        Bundler::VERSION
-      end
-
-      expect(out).to start_with(expected)
+      expect(out).to end_with(Bundler::VERSION)
     end
   end
 

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -1544,7 +1544,9 @@ RSpec.describe "bundle update --bundler" do
   end
 
   it "updates the bundler version in the lockfile even if the latest version is not installed", :ruby_repo do
-    pristine_system_gems "bundler-2.99.9"
+    bundle "config path.system true"
+
+    pristine_system_gems "bundler-9.0.0"
 
     build_repo4 do
       build_gem "myrack", "1.0"
@@ -1552,13 +1554,16 @@ RSpec.describe "bundle update --bundler" do
       build_bundler "999.0.0"
     end
 
+    checksums = checksums_section do |c|
+      c.checksum(gem_repo4, "myrack", "1.0")
+    end
+
     install_gemfile <<-G
       source "https://gem.repo4"
       gem "myrack"
     G
-    lockfile lockfile.sub(/(^\s*)#{Bundler::VERSION}($)/, "2.99.9")
 
-    bundle :update, bundler: true, verbose: true, env: { "BUNDLER_4_MODE" => nil }
+    bundle :update, bundler: true, verbose: true
 
     expect(out).to include("Updating bundler to 999.0.0")
     expect(out).to include("Running `bundle update --bundler \"> 0.a\" --verbose` with bundler 999.0.0")
@@ -1575,7 +1580,7 @@ RSpec.describe "bundle update --bundler" do
 
       DEPENDENCIES
         myrack
-
+      #{checksums}
       BUNDLED WITH
          999.0.0
     L

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -1781,7 +1781,7 @@ RSpec.describe "bundle update --bundler" do
   end
 
   it "prints an error when trying to update bundler in frozen mode" do
-    system_gems "bundler-2.3.9"
+    system_gems "bundler-9.0.0"
 
     gemfile <<~G
       source "https://gem.repo2"
@@ -1798,10 +1798,12 @@ RSpec.describe "bundle update --bundler" do
       DEPENDENCIES
 
       BUNDLED WITH
-         2.1.4
+         9.0.0
     L
 
-    bundle "update --bundler=2.3.9", env: { "BUNDLE_FROZEN" => "true" }, raise_on_error: false
+    system_gems "bundler-9.9.9", path: local_gem_path
+
+    bundle "update --bundler=9.9.9", env: { "BUNDLE_FROZEN" => "true" }, raise_on_error: false
     expect(err).to include("An update to the version of bundler itself was requested, but the lockfile can't be updated because frozen mode is set")
   end
 end

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe "the lockfile format" do
          #{version}
     L
 
-    install_gemfile <<-G, verbose: true, env: { "BUNDLER_4_MODE" => nil }
+    install_gemfile <<-G, verbose: true
       source "https://gem.repo4"
 
       gem "myrack"

--- a/bundler/spec/realworld/slow_perf_spec.rb
+++ b/bundler/spec/realworld/slow_perf_spec.rb
@@ -131,14 +131,8 @@ RSpec.describe "bundle install with complex dependencies", realworld: true do
       end
     G
 
-    if Bundler.feature_flag.bundler_4_mode?
-      bundle "lock", env: { "DEBUG_RESOLVER" => "1" }, raise_on_error: false
+    bundle "lock", env: { "DEBUG_RESOLVER" => "1" }
 
-      expect(out).to include("backtracking").exactly(26).times
-    else
-      bundle "lock", env: { "DEBUG_RESOLVER" => "1" }
-
-      expect(out).to include("Solution found after 10 attempts")
-    end
+    expect(out).to include("Solution found after 10 attempts")
   end
 end

--- a/bundler/spec/runtime/self_management_spec.rb
+++ b/bundler/spec/runtime/self_management_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Self management" do
       "9.4.0"
     end
 
-    around do |example|
+    before do
       build_repo4 do
         build_bundler previous_minor
 
@@ -26,8 +26,6 @@ RSpec.describe "Self management" do
       G
 
       pristine_system_gems "bundler-#{current_version}"
-
-      with_env_vars("BUNDLER_4_MODE" => nil, &example)
     end
 
     it "installs locked version when using system path and uses it" do

--- a/bundler/spec/support/env.rb
+++ b/bundler/spec/support/env.rb
@@ -9,5 +9,9 @@ module Spec
     def rubylib
       ENV["RUBYLIB"].to_s.split(File::PATH_SEPARATOR)
     end
+
+    def simulated_version
+      ENV["BUNDLE_SIMULATE_VERSION"]
+    end
   end
 end

--- a/bundler/spec/support/filters.rb
+++ b/bundler/spec/support/filters.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 class RequirementChecker < Proc
-  def self.against(present, major_only: false)
-    present = present.split(".")[0] if major_only
-    provided = Gem::Version.new(present)
+  def self.against(provided, major_only: false)
+    provided = Gem::Version.new(provided.segments.first) if major_only
 
     new do |required|
       requirement = Gem::Requirement.new(required)
@@ -28,8 +27,8 @@ end
 RSpec.configure do |config|
   config.filter_run_excluding realworld: true
 
-  config.filter_run_excluding bundler: RequirementChecker.against(Bundler::VERSION, major_only: true)
-  config.filter_run_excluding rubygems: RequirementChecker.against(Gem::VERSION)
+  config.filter_run_excluding bundler: RequirementChecker.against(Bundler.feature_flag.bundler_version, major_only: true)
+  config.filter_run_excluding rubygems: RequirementChecker.against(Gem.rubygems_version)
   config.filter_run_excluding ruby_repo: !ENV["GEM_COMMAND"].nil?
   config.filter_run_excluding no_color_tty: Gem.win_platform? || !ENV["GITHUB_ACTION"].nil?
   config.filter_run_excluding permissions: Gem.win_platform?


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Overriding the version constant feels too magical and creates a set of problems. For example, Bundler will lock the simulated version, and that can cause issues when the lockfile is used under an environment not simulating Bundler 4 (it will try to auto-install and auto-switch to a version that does not exist).
    
On top of that, it can only be configured with an ENV variable which is not too flexible.
    
## What is your fix for the problem, implemented in this PR?

This PR takes a different approach of using a setting, which is configurable through ENV or `bundle config`, and pass the simulated version to `Bundler::FeatureFlag`. The real version is still the one set by `VERSION`, but anything that `Bundler::FeatureFlag` controls will use the logic of the "simulated version".
    
In particular, all feature flags and deprecation messages will respect the simulated version, and this is exactly the set of functionality that we want users to be able to easily try before releasing it.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
