### PR TITLE
Fix `Bundler.original_env['GEM_HOME']` when Bundler is trampolined

### DIFF
--- a/bundler/lib/bundler/self_manager.rb
+++ b/bundler/lib/bundler/self_manager.rb
@@ -68,7 +68,9 @@ module Bundler
 
     def restart_with(version)
       configured_gem_home = ENV["GEM_HOME"]
+      configured_orig_gem_home = ENV["BUNDLER_ORIG_GEM_HOME"]
       configured_gem_path = ENV["GEM_PATH"]
+      configured_orig_gem_path = ENV["BUNDLER_ORIG_GEM_PATH"]
 
       argv0 = File.exist?($PROGRAM_NAME) ? $PROGRAM_NAME : Process.argv0
       cmd = [argv0, *ARGV]
@@ -76,7 +78,13 @@ module Bundler
 
       Bundler.with_original_env do
         Kernel.exec(
-          { "GEM_HOME" => configured_gem_home, "GEM_PATH" => configured_gem_path, "BUNDLER_VERSION" => version.to_s },
+          {
+            "GEM_HOME" => configured_gem_home,
+            "BUNDLER_ORIG_GEM_HOME" => configured_orig_gem_home,
+            "GEM_PATH" => configured_gem_path,
+            "BUNDLER_ORIG_GEM_PATH" => configured_orig_gem_path,
+            "BUNDLER_VERSION" => version.to_s,
+          },
           *cmd
         )
       end

--- a/bundler/spec/runtime/self_management_spec.rb
+++ b/bundler/spec/runtime/self_management_spec.rb
@@ -82,6 +82,10 @@ RSpec.describe "Self management" do
       bundle "-v"
       expect(out).to eq(previous_minor)
 
+      # Preserves original gem home when auto-switching
+      bundle "exec ruby -e 'puts Bundler.original_env[\"GEM_HOME\"]'"
+      expect(out).to eq(ENV["GEM_HOME"])
+
       # ruby-core test setup has always "lib" in $LOAD_PATH so `require "bundler/setup"` always activate the local version rather than using RubyGems gem activation stuff
       unless ruby_core?
         # App now uses locked version, even when not using the CLI directly


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If you have a specific non system path configured and have a different version of Bundler locked than the one installed globally, Bundler installs the locked version to the configured path and then trampolines to it.

When trampolining, however, `Bundler.original_env['GEM_HOME']` value is incorrect, which prevents running commands in a `Bundler.unbundled_env` context.

## What is your fix for the problem, implemented in this PR?

Make sure to preserve the original values when trampolining, so that other helpers can later restore them.

Fixes https://github.com/rubygems/rubygems/issues/7567.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
