### PR TITLE
Fix `--bindir <foo>` flag to gem install failing when `<foo>` is not in the default GEM_HOME and its parent directory does not exist yet

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -953,11 +953,7 @@ TEXT
   end
 
   def ensure_writable_dir(dir) # :nodoc:
-    begin
-      Dir.mkdir dir, *[options[:dir_mode] && 0o755].compact
-    rescue SystemCallError
-      raise unless File.directory? dir
-    end
+    FileUtils.mkdir_p dir, mode: options[:dir_mode] && 0o755
 
     raise Gem::FilePermissionError.new(dir) unless File.writable? dir
   end

--- a/test/rubygems/installer_test_case.rb
+++ b/test/rubygems/installer_test_case.rb
@@ -221,6 +221,23 @@ class Gem::InstallerTestCase < Gem::TestCase
                        force: force)
   end
 
+  def test_ensure_writable_dir_creates_missing_parent_directories
+    installer = setup_base_installer(false)
+
+    non_existent_parent = File.join(@tempdir, "non_existent_parent")
+    target_dir = File.join(non_existent_parent, "target_dir")
+
+    refute_directory_exists non_existent_parent, "Parent directory should not exist yet"
+    refute_directory_exists target_dir, "Target directory should not exist yet"
+
+    assert_nothing_raised do
+      installer.send(:ensure_writable_dir, target_dir)
+    end
+
+    assert_directory_exists non_existent_parent, "Parent directory should exist now"
+    assert_directory_exists target_dir, "Target directory should exist now"
+  end
+
   @@symlink_supported = nil
 
   # This is needed for Windows environment without symlink support enabled (the default

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -1583,4 +1583,31 @@ ERROR:  Possible alternatives: non_existent_with_hint
       assert_includes @ui.output, "A new release of RubyGems is available: 1.2.3 → 2.0.0!"
     end
   end
+
+  def test_execute_bindir_with_nonexistent_parent_dirs
+    spec_fetcher do |fetcher|
+      fetcher.gem "a", 2 do |s|
+        s.executables = %w[a_bin]
+        s.files = %w[bin/a_bin]
+      end
+    end
+
+    @cmd.options[:args] = %w[a]
+
+    nested_bin_dir = File.join(@tempdir, "not", "exists")
+    refute_directory_exists nested_bin_dir, "Nested bin directory should not exist yet"
+
+    @cmd.options[:bin_dir] = nested_bin_dir
+
+    use_ui @ui do
+      assert_raise Gem::MockGemUi::SystemExitException, @ui.error do
+        @cmd.execute
+      end
+    end
+
+    assert_directory_exists nested_bin_dir, "Nested bin directory should exist now"
+    assert_path_exist File.join(nested_bin_dir, "a_bin")
+
+    assert_equal %w[a-2], @cmd.installed_specs.map(&:full_name)
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

It's possible to specify a custom directory into which you want to install executables with RubyGems via a CLI flag. This usually functions fine but if the custom directory specified has non-existent parent directories the installation with almost certainly crash due to RubyGems' usage of `Dir.mkdir` which does not automatically create parent directories.

## What is your fix for the problem, implemented in this PR?

In short, replaces `Dir.mkdir` with `FileUtils.mkdir_p` in RubyGems' `ensure_writable_dir` method to ensure RubyGems can create necessary parent directories if they're not already present.

Method doc references
- https://docs.ruby-lang.org/en/3.4/Dir.html#method-c-mkdir
- https://docs.ruby-lang.org/en/3.4/FileUtils.html#method-c-mkdir_p

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)