### PR TITLE
Fail fast when connection errors happen

### DIFF
--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -91,6 +91,27 @@ module Bundler
       Errno::EHOSTUNREACH,
     ].freeze
 
+    NET_ERRORS = [
+      :HTTPBadGateway,
+      :HTTPBadRequest,
+      :HTTPFailedDependency,
+      :HTTPForbidden,
+      :HTTPInsufficientStorage,
+      :HTTPMethodNotAllowed,
+      :HTTPMovedPermanently,
+      :HTTPNoContent,
+      :HTTPNotFound,
+      :HTTPNotImplemented,
+      :HTTPPreconditionFailed,
+      :HTTPRequestEntityTooLarge,
+      :HTTPRequestURITooLong,
+      :HTTPUnauthorized,
+      :HTTPUnprocessableEntity,
+      :HTTPUnsupportedMediaType,
+      :HTTPVersionNotSupported,
+    ].freeze
+    deprecate_constant :NET_ERRORS
+
     # Exceptions classes that should bypass retry attempts. If your password didn't work the
     # first time, it's not going to the third time.
     FAIL_ERRORS = [

--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -72,7 +72,7 @@ module Bundler
       end
     end
 
-    HTTP_ERRORS = Downloader::HTTP_ERRORS
+    HTTP_ERRORS = (Downloader::HTTP_RETRYABLE_ERRORS + Downloader::HTTP_NON_RETRYABLE_ERRORS).freeze
     deprecate_constant :HTTP_ERRORS
 
     NET_ERRORS = [

--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -72,24 +72,8 @@ module Bundler
       end
     end
 
-    HTTP_ERRORS = [
-      Gem::Timeout::Error,
-      EOFError,
-      SocketError,
-      Errno::EADDRNOTAVAIL,
-      Errno::ENETDOWN,
-      Errno::ENETUNREACH,
-      Errno::EINVAL,
-      Errno::ECONNRESET,
-      Errno::ETIMEDOUT,
-      Errno::EAGAIN,
-      Gem::Net::HTTPBadResponse,
-      Gem::Net::HTTPHeaderSyntaxError,
-      Gem::Net::ProtocolError,
-      Gem::Net::HTTP::Persistent::Error,
-      Zlib::BufError,
-      Errno::EHOSTUNREACH,
-    ].freeze
+    HTTP_ERRORS = Downloader::HTTP_ERRORS
+    deprecate_constant :HTTP_ERRORS
 
     NET_ERRORS = [
       :HTTPBadGateway,

--- a/bundler/lib/bundler/fetcher/downloader.rb
+++ b/bundler/lib/bundler/fetcher/downloader.rb
@@ -88,8 +88,11 @@ module Bundler
         raise CertificateFailureError.new(uri)
       rescue *HTTP_ERRORS => e
         Bundler.ui.trace e
-        if e.is_a?(SocketError) || e.message.to_s.include?("host down:")
-          raise NetworkDownError, "Could not reach host #{uri.host}. Check your network " \
+        if e.is_a?(SocketError) || e.is_a?(Errno::EADDRNOTAVAIL) || e.is_a?(Errno::ENETUNREACH) || e.is_a?(Gem::Net::HTTP::Persistent::Error)
+          host = uri.host
+          host_port = "#{host}:#{uri.port}"
+          host = host_port if filtered_uri.to_s.include?(host_port)
+          raise NetworkDownError, "Could not reach host #{host}. Check your network " \
             "connection and try again."
         else
           raise HTTPError, "Network error while fetching #{filtered_uri}" \

--- a/bundler/lib/bundler/fetcher/downloader.rb
+++ b/bundler/lib/bundler/fetcher/downloader.rb
@@ -6,14 +6,15 @@ module Bundler
       HTTP_NON_RETRYABLE_ERRORS = [
         SocketError,
         Errno::EADDRNOTAVAIL,
+        Errno::ENETDOWN,
         Errno::ENETUNREACH,
         Gem::Net::HTTP::Persistent::Error,
+        Errno::EHOSTUNREACH,
       ].freeze
 
       HTTP_RETRYABLE_ERRORS = [
         Gem::Timeout::Error,
         EOFError,
-        Errno::ENETDOWN,
         Errno::EINVAL,
         Errno::ECONNRESET,
         Errno::ETIMEDOUT,
@@ -22,7 +23,6 @@ module Bundler
         Gem::Net::HTTPHeaderSyntaxError,
         Gem::Net::ProtocolError,
         Zlib::BufError,
-        Errno::EHOSTUNREACH,
       ].freeze
 
       attr_reader :connection

--- a/bundler/lib/bundler/fetcher/downloader.rb
+++ b/bundler/lib/bundler/fetcher/downloader.rb
@@ -3,6 +3,25 @@
 module Bundler
   class Fetcher
     class Downloader
+      HTTP_ERRORS = [
+        Gem::Timeout::Error,
+        EOFError,
+        SocketError,
+        Errno::EADDRNOTAVAIL,
+        Errno::ENETDOWN,
+        Errno::ENETUNREACH,
+        Errno::EINVAL,
+        Errno::ECONNRESET,
+        Errno::ETIMEDOUT,
+        Errno::EAGAIN,
+        Gem::Net::HTTPBadResponse,
+        Gem::Net::HTTPHeaderSyntaxError,
+        Gem::Net::ProtocolError,
+        Gem::Net::HTTP::Persistent::Error,
+        Zlib::BufError,
+        Errno::EHOSTUNREACH,
+      ].freeze
+
       attr_reader :connection
       attr_reader :redirect_limit
 

--- a/bundler/spec/bundler/fetcher/downloader_spec.rb
+++ b/bundler/spec/bundler/fetcher/downloader_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Bundler::Fetcher::Downloader do
           /`bundle config set --global www\.uri-to-fetch\.com username:password`.*`BUNDLE_WWW__URI___TO___FETCH__COM`/m)
       end
 
-      context "when the there are credentials provided in the request" do
+      context "when there are credentials provided in the request" do
         let(:uri) { Gem::URI("http://user:password@www.uri-to-fetch.com") }
 
         it "should raise a Bundler::Fetcher::BadAuthenticationError that doesn't contain the password" do
@@ -116,7 +116,7 @@ RSpec.describe Bundler::Fetcher::Downloader do
           to raise_error(Bundler::Fetcher::FallbackError, "Gem::Net::HTTPNotFound: http://www.uri-to-fetch.com/api/v2/endpoint")
       end
 
-      context "when the there are credentials provided in the request" do
+      context "when there are credentials provided in the request" do
         let(:uri) { Gem::URI("http://username:password@www.uri-to-fetch.com/api/v2/endpoint") }
 
         it "should raise a Bundler::Fetcher::FallbackError that doesn't contain the password" do
@@ -233,7 +233,7 @@ RSpec.describe Bundler::Fetcher::Downloader do
             "Network error while fetching http://www.uri-to-fetch.com/api/v2/endpoint (other error about network)")
         end
 
-        context "when the there are credentials provided in the request" do
+        context "when there are credentials provided in the request" do
           let(:uri) { Gem::URI("http://username:password@www.uri-to-fetch.com/api/v2/endpoint") }
           before do
             allow(net_http_get).to receive(:basic_auth).with("username", "password")

--- a/bundler/spec/bundler/fetcher/downloader_spec.rb
+++ b/bundler/spec/bundler/fetcher/downloader_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe Bundler::Fetcher::Downloader do
       let(:error)   { RuntimeError.new(message) }
 
       before do
-        stub_const("Bundler::Fetcher::HTTP_ERRORS", [RuntimeError])
+        stub_const("#{described_class}::HTTP_ERRORS", [RuntimeError])
         allow(connection).to receive(:request).with(uri, net_http_get) { raise error }
       end
 

--- a/bundler/spec/bundler/fetcher/downloader_spec.rb
+++ b/bundler/spec/bundler/fetcher/downloader_spec.rb
@@ -244,13 +244,23 @@ RSpec.describe Bundler::Fetcher::Downloader do
         end
       end
 
-      context "when error message is about no route to host" do
+      context "when error is about connection refused" do
         let(:error_class) { Gem::Net::HTTP::Persistent::Error }
+        let(:message) { "connection refused down: http://www.uri-to-fetch.com" }
+
+        it "should raise a Bundler::Fetcher::NetworkDownError" do
+          expect { subject.request(uri, options) }.to raise_error(Bundler::Fetcher::NetworkDownError,
+            /Could not reach host www.uri-to-fetch.com/)
+        end
+      end
+
+      context "when error is about no route to host" do
+        let(:error_class) { SocketError }
         let(:message) { "Failed to open TCP connection to www.uri-to-fetch.com:443 " }
 
-        it "should raise a Bundler::Fetcher::HTTPError" do
-          expect { subject.request(uri, options) }.to raise_error(Bundler::HTTPError,
-            "Network error while fetching http://www.uri-to-fetch.com/api/v2/endpoint (#{message})")
+        it "should raise a Bundler::Fetcher::NetworkDownError" do
+          expect { subject.request(uri, options) }.to raise_error(Bundler::Fetcher::NetworkDownError,
+            /Could not reach host www.uri-to-fetch.com/)
         end
       end
     end

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -697,7 +697,7 @@ RSpec.describe "bundle install with gem sources" do
         end
       G
 
-      expect(err).to include("Could not fetch specs from http://0.0.0.0:9384/")
+      expect(err).to eq("Could not reach host 0.0.0.0:9384. Check your network connection and try again.")
       expect(err).not_to include("file://")
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I believe once this error happens, it will keep happening no matter if you retry the same request or fallback to another API in the same server.

## What is your fix for the problem, implemented in this PR?

My fix is to fail fast when all `Gem::Net::HTTP::Persistent::Error`'s happen, which is a class wrapping both `Errno::ECONNREFUSED` and `Errno::EHOSTDOWN`.

https://github.com/rubygems/rubygems/blob/72d03bb2ce5420c8ba6d3a028a2e4bf2f2cbe743/bundler/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb#L649-L668

This has the advantage of not having to decide our behavior depending on the error message, which is brittle.

I extracted this from #8773 to make the change a bit more focused.

I also restored `Bundler::Fetcher::NET_ERRORS` which I abruptly removed in 627a7615f2247c32ba17fbbcb8c443791f4fb081, but I thought now I'd be a bit more careful.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
