### PR TITLE
Experiment 🧑‍🔬 | Limit Windows Bundler CI process count to minimize overhead

### DIFF
--- a/bundler/bin/parallel_rspec
+++ b/bundler/bin/parallel_rspec
@@ -4,4 +4,11 @@
 require_relative "../spec/support/setup"
 
 require "turbo_tests"
-TurboTests::CLI.new(ARGV).run
+
+args = ARGV.dup
+# Minimize process creation overhead in Windows by using fewer processes
+if Gem.win_platform? && !args.include?("--processes") && !args.include?("-p")
+  args.concat(["--processes", "2"])
+end
+
+TurboTests::CLI.new(args).run


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Developer problem is Windows Bundler CI runs take _**a really long time**_ to complete.

Part of https://github.com/rubygems/rubygems/issues/8785

## What is your fix for the problem, implemented in this PR?

This is an experimental branch that is trying to see if reducing the process count for Windows Bundler CI runs will reduce the time to complete by reducing overhead. The baseline we're trying to beat is:

- Bundler CI Windows on Ruby 3.2 ~90 minutes
- Bundler CI Windows on Ruby 3.3 ~80 minutes
- Bundler CI Windows on Ruby 3.4 ~70 minutes

If time taken is not decreased or perhaps even increased and no tweak seems possible I'll simply close this PR and delete the branch. :sweat_smile: 

For reference, the file modified is used in CI here. Could alternatively separate out Windows like we do for JRuby into its own CI run setup block or otherwise but this seemed like the simplest solution, especially given this is an experiment, for now.

https://github.com/rubygems/rubygems/blob/a192d10c819f5c054e890ef2ece05c27efd52f72/.github/workflows/bundler.yml#L79-L83

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
