### PR TITLE
Experiment 🧑‍🔬 | Add cache layer for dependencies to Bundler CI

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -67,6 +67,16 @@ jobs:
           distribution: temurin
           java-version: 21.0.7
         if: matrix.ruby.name == 'jruby'
+      - name: Cache dependencies
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            ~/.bundle
+            vendor/bundle
+            .bundle
+          key: ${{ runner.os }}-ruby-${{ matrix.ruby.value }}-bundler-${{ matrix.bundler }}-${{ hashFiles('**/Gemfile.lock', 'tool/bundler/*.rb') }}
+          restore-keys: |
+            ${{ runner.os }}-ruby-${{ matrix.ruby.value }}-bundler-${{ matrix.bundler }}-
       - name: Install graphviz (Ubuntu)
         run: sudo apt-get install graphviz -y
         if: matrix.bundler == 2 && matrix.os.name == 'Ubuntu'


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Developer problem is Windows Bundler CI runs take _**a really long time**_ to complete.

Part of https://github.com/rubygems/rubygems/issues/8785

## What is your fix for the problem, implemented in this PR?

This is an experimental branch that is trying to see if caching dependencies for Bundler CI runs (note: for all, not just Windows runs), will reduce the time taken. The baseline we're trying to beat is:

- Bundler CI Windows on Ruby 3.2 ~95 minutes
- Bundler CI Windows on Ruby 3.3 ~80 minutes
- Bundler CI Windows on Ruby 3.4 ~75 minutes
- Bundler CI Ubuntu on Ruby 3.4 ~22 minutes
- Bundler CI macOS on Ruby 3.4 ~21 minutes

If time taken is not decreased or perhaps even increased and no tweak seems possible I'll simply close this PR and delete the branch. :sweat_smile: 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
