### PR TITLE
Update gemspec based on provided github username when exists

### DIFF
--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -47,13 +47,16 @@ module Bundler
       git_author_name = use_git ? `git config user.name`.chomp : ""
       git_username = use_git ? `git config github.user`.chomp : ""
       git_user_email = use_git ? `git config user.email`.chomp : ""
+      github_username = github_username(git_username)
 
-      github_username = if options[:github_username].nil?
-        git_username
-      elsif options[:github_username] == false
-        ""
+      if github_username.empty?
+        homepage_uri = "TODO: Put your gem's website or public repo URL here."
+        source_code_uri = "TODO: Put your gem's public repo URL here."
+        changelog_uri = "TODO: Put your gem's CHANGELOG.md URL here."
       else
-        options[:github_username]
+        homepage_uri = "https://github.com/#{github_username}/#{name}"
+        source_code_uri = "https://github.com/#{github_username}/#{name}"
+        changelog_uri = "https://github.com/#{github_username}/#{name}/blob/main/CHANGELOG.md"
       end
 
       config = {
@@ -76,6 +79,9 @@ module Bundler
         rust_builder_required_rubygems_version: rust_builder_required_rubygems_version,
         minitest_constant_name: minitest_constant_name,
         ignore_paths: %w[bin/],
+        homepage_uri: homepage_uri,
+        source_code_uri: source_code_uri,
+        changelog_uri: changelog_uri,
       }
       ensure_safe_gem_name(name, constant_array)
 
@@ -478,6 +484,16 @@ module Bundler
 
     def standard_version
       "1.3"
+    end
+
+    def github_username(git_username)
+      if options[:github_username].nil?
+        git_username
+      elsif options[:github_username] == false
+        ""
+      else
+        options[:github_username]
+      end
     end
   end
 end

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -108,7 +108,7 @@ Ignore the current machine's platform and install only \fBruby\fR platform gems\
 Disallow any automatic changes to \fBGemfile\.lock\fR\. Bundler commands will be blocked unless the lockfile can be installed exactly as written\. Usually this will happen when changing the \fBGemfile\fR manually and forgetting to update the lockfile through \fBbundle lock\fR or \fBbundle install\fR\.
 .TP
 \fBgem\.github_username\fR (\fBBUNDLE_GEM__GITHUB_USERNAME\fR)
-Sets a GitHub username or organization to be used in \fBREADME\fR file when you create a new gem via \fBbundle gem\fR command\. It can be overridden by passing an explicit \fB\-\-github\-username\fR flag to \fBbundle gem\fR\.
+Sets a GitHub username or organization to be used in the \fBREADME\fR and \fB\.gemspec\fR files when you create a new gem via \fBbundle gem\fR command\. It can be overridden by passing an explicit \fB\-\-github\-username\fR flag to \fBbundle gem\fR\.
 .TP
 \fBgem\.push_key\fR (\fBBUNDLE_GEM__PUSH_KEY\fR)
 Sets the \fB\-\-key\fR parameter for \fBgem push\fR when using the \fBrake release\fR command with a private gemstash server\.

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -131,8 +131,8 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    Usually this will happen when changing the `Gemfile` manually and forgetting
    to update the lockfile through `bundle lock` or `bundle install`.
 * `gem.github_username` (`BUNDLE_GEM__GITHUB_USERNAME`):
-   Sets a GitHub username or organization to be used in `README` file when you
-   create a new gem via `bundle gem` command. It can be overridden by passing an
+   Sets a GitHub username or organization to be used in the `README` and `.gemspec` files
+   when you create a new gem via `bundle gem` command. It can be overridden by passing an
    explicit `--github-username` flag to `bundle gem`.
 * `gem.push_key` (`BUNDLE_GEM__PUSH_KEY`):
    Sets the `--key` parameter for `gem push` when using the `rake release`

--- a/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.summary = "TODO: Write a short summary, because RubyGems requires one."
   spec.description = "TODO: Write a longer description or delete this line."
-  spec.homepage = "TODO: Put your gem's website or public repo URL here."
+  spec.homepage = "<%= config[:homepage_uri] %>"
 <%- if config[:mit] -%>
   spec.license = "MIT"
 <%- end -%>
@@ -20,10 +20,11 @@ Gem::Specification.new do |spec|
 <%- end -%>
 
   spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
-
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
-  spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
+  spec.metadata["source_code_uri"] = "<%= config[:source_code_uri] %>"
+  <%- if config[:changelog] -%>
+    spec.metadata["changelog_uri"] = "<%= config[:changelog_uri] %>"
+  <%- end -%>
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -1645,7 +1645,7 @@ RSpec.describe "bundle gem" do
     end
   end
 
-  context "without git config set" do
+  context "without git config github.user set" do
     before do
       git("config --global --unset github.user")
     end
@@ -1664,9 +1664,32 @@ RSpec.describe "bundle gem" do
       end
       it_behaves_like "--github-username option", "gh_user"
     end
+
+    context "when changelog is enabled" do
+      it "sets gemspec changelog_uri, homepage, homepage_uri, source_code_uri to TODOs" do
+        bundle "gem #{gem_name} --changelog"
+
+        expect(generated_gemspec.metadata["changelog_uri"]).
+          to eq("TODO: Put your gem's CHANGELOG.md URL here.")
+        expect(generated_gemspec.homepage).to eq("TODO: Put your gem's website or public repo URL here.")
+        expect(generated_gemspec.metadata["homepage_uri"]).to eq("TODO: Put your gem's website or public repo URL here.")
+        expect(generated_gemspec.metadata["source_code_uri"]).to eq("TODO: Put your gem's public repo URL here.")
+      end
+    end
+
+    context "when changelog is not enabled" do
+      it "sets gemspec homepage, homepage_uri, source_code_uri to TODOs and changelog_uri to nil" do
+        bundle "gem #{gem_name}"
+
+        expect(generated_gemspec.metadata["changelog_uri"]).to be_nil
+        expect(generated_gemspec.homepage).to eq("TODO: Put your gem's website or public repo URL here.")
+        expect(generated_gemspec.metadata["homepage_uri"]).to eq("TODO: Put your gem's website or public repo URL here.")
+        expect(generated_gemspec.metadata["source_code_uri"]).to eq("TODO: Put your gem's public repo URL here.")
+      end
+    end
   end
 
-  context "with git config set" do
+  context "with git config github.user set" do
     context "with github-username option in bundle config settings set to some value" do
       before do
         global_config "BUNDLE_GEM__GITHUB_USERNAME" => "different_username"
@@ -1681,6 +1704,29 @@ RSpec.describe "bundle gem" do
         global_config "BUNDLE_GEM__GITHUB_USERNAME" => "false"
       end
       it_behaves_like "--github-username option", "gh_user"
+    end
+
+    context "when changelog is enabled" do
+      it "sets gemspec changelog_uri, homepage, homepage_uri, source_code_uri based on git username" do
+        bundle "gem #{gem_name} --changelog"
+
+        expect(generated_gemspec.metadata["changelog_uri"]).
+          to eq("https://github.com/bundleuser/#{gem_name}/blob/main/CHANGELOG.md")
+        expect(generated_gemspec.homepage).to eq("https://github.com/bundleuser/#{gem_name}")
+        expect(generated_gemspec.metadata["homepage_uri"]).to eq("https://github.com/bundleuser/#{gem_name}")
+        expect(generated_gemspec.metadata["source_code_uri"]).to eq("https://github.com/bundleuser/#{gem_name}")
+      end
+    end
+
+    context "when changelog is not enabled" do
+      it "sets gemspec source_code_uri, homepage, homepage_uri but not changelog_uri" do
+        bundle "gem #{gem_name}"
+
+        expect(generated_gemspec.metadata["changelog_uri"]).to be_nil
+        expect(generated_gemspec.homepage).to eq("https://github.com/bundleuser/#{gem_name}")
+        expect(generated_gemspec.metadata["homepage_uri"]).to eq("https://github.com/bundleuser/#{gem_name}")
+        expect(generated_gemspec.metadata["source_code_uri"]).to eq("https://github.com/bundleuser/#{gem_name}")
+      end
     end
   end
 


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

When a GitHub username is passed for users with their username in their git config, let's use that to populate the gemspec file with some reasonable defaults. We already use the GH username at the bottom of the README when it exists but this commit extends using that value for the gemspec. 

## What is your fix for the problem, implemented in this PR?

When present, compose some of the URIs with the user provided info

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
