### PR TITLE
Add missing `require "fileutils"` in lib/rubygems/installer.rb

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -953,6 +953,7 @@ TEXT
   end
 
   def ensure_writable_dir(dir) # :nodoc:
+    require "fileutils"
     FileUtils.mkdir_p dir, mode: options[:dir_mode] && 0o755
 
     raise Gem::FilePermissionError.new(dir) unless File.writable? dir


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Ruby head builds are failing when running `bundle install` in GitHub Actions.

```
NameError: uninitialized constant Gem::Installer::FileUtils
  /home/runner/.rubies/ruby-head/lib/ruby/3.5.0+2/rubygems/installer.rb:956:in 'Gem::Installer#ensure_writable_dir'
```

This is due to changes in PR #8783

## What is your fix for the problem, implemented in this PR?

A one-line change.  Currently, `require "fileutils"` appears twice in `installer.rb`, so I assume there's some reason for loading it on demand.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
