### PR TITLE
Fix running `dbundle` development alias in Bundler 4 mode

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -177,7 +177,7 @@ jobs:
           echo "RGV=v$RGV" >> $GITHUB_ENV
         if: matrix.rubygems == 'dev'
       - name: Setup app depending on psych with initial Ruby
-        run: mkdir foo && cd foo && ruby ../bundler/spec/support/bundle.rb init && ruby ../bundler/spec/support/bundle.rb add psych -v 5.1.2
+        run: mkdir foo && cd foo && ../bundler/bin/bundle init && ../bundler/bin/bundle add psych -v 5.1.2
         shell: bash
         env:
           GEM_HOME: bar
@@ -188,7 +188,7 @@ jobs:
           ruby-version: 3.3
           bundler: none
       - name: Install gems with final ruby, using GEM_HOME created by the other Ruby
-        run: ruby ../bundler/spec/support/bundle.rb install
+        run: ../bundler/bin/bundle install
         working-directory: foo
         env:
           GEM_HOME: bar

--- a/.github/workflows/realworld-bundler.yml
+++ b/.github/workflows/realworld-bundler.yml
@@ -69,10 +69,10 @@ jobs:
           ruby-version: 3.4.4
           bundler: none
       - name: Prepare tapioca
-        run: ruby ../../../support/bundle.rb install
+        run: ../../../../bin/bundle install
         working-directory: bundler/spec/realworld/fixtures/tapioca
       - name: Run tapioca
-        run: ruby ../../../support/bundle.rb exec tapioca init
+        run: ../../../../bin/bundle exec tapioca init
         working-directory: bundler/spec/realworld/fixtures/tapioca
     timeout-minutes: 20
 

--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Sync tools
         run: |
           ruby tool/sync_default_gems.rb rubygems
+          mv spec/bundler/support/bundle spec/bin/bundle # TODO: fix `sync_default_gems.rb` script so we don't need to vendor the ruby-core binstub ourselves
         working-directory: ruby/ruby
       - name: Test RubyGems
         run: make -j2 -s test-all TESTS="rubygems --no-retry"

--- a/Rakefile
+++ b/Rakefile
@@ -106,12 +106,12 @@ end
 namespace :vendor do
   desc "Download vendored gems to tmp"
   task :bundle do
-    sh({ "BUNDLE_PATH" => "../../tmp/vendor", "BUNDLER_GEM_DEFAULT_DIR" => "../../tmp/vendor" }, "ruby", "--disable-gems", "-r./bundler/spec/support/hax.rb", "-I", "lib", "bundler/spec/support/bundle.rb", "install", "--gemfile=tool/bundler/vendor_gems.rb")
+    sh({ "BUNDLE_PATH" => "../../tmp/vendor", "BUNDLER_GEM_DEFAULT_DIR" => "../../tmp/vendor", "RUBYOPT" => "--disable-gems -r#{File.expand_path("bundler/spec/support/hax.rb", __dir__)} -Ilib" }, "bundler/bin/bundle", "install", "--gemfile=tool/bundler/vendor_gems.rb")
   end
 
   desc "Install patched vendored gems"
   task install: :bundle do
-    sh({ "BUNDLE_GEMFILE" => "tool/bundler/vendor_gems.rb", "BUNDLE_PATH" => "../../tmp/vendor", "BUNDLER_GEM_DEFAULT_DIR" => "../../tmp/vendor" }, "ruby", "-rpathname", "-r./bundler/spec/support/hax.rb", "-I", "lib", "bundler/spec/support/bundle.rb", "exec", "tool/automatiek/vendor.rb")
+    sh({ "BUNDLE_GEMFILE" => "tool/bundler/vendor_gems.rb", "BUNDLE_PATH" => "../../tmp/vendor", "BUNDLER_GEM_DEFAULT_DIR" => "../../tmp/vendor", "RUBYOPT" => "-rpathname -r#{File.expand_path("bundler/spec/support/hax.rb", __dir__)} -Ilib" }, "bundler/bin/bundle", "exec", "tool/automatiek/vendor.rb")
   end
 
   desc "Check vendored gems are up to date"
@@ -126,7 +126,7 @@ end
 namespace :rubocop do
   desc "Setup gems necessary to lint Ruby code"
   task(:setup) do
-    sh "ruby", "-I", "lib", "bundler/spec/support/bundle.rb", "install", "--gemfile=tool/bundler/lint_gems.rb"
+    sh({ "RUBYOPT" => "-Ilib" }, "bundler/bin/bundle", "install", "--gemfile=tool/bundler/lint_gems.rb")
   end
 
   desc "Run rubocop. Pass positional arguments as Rake arguments, e.g. `rake 'rubocop:run[-a]'`"

--- a/bundler/bin/bundle
+++ b/bundler/bin/bundle
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../spec/support/activate"
+
+load File.expand_path("bundle", Spec::Path.exedir)

--- a/bundler/spec/bundler/shared_helpers_spec.rb
+++ b/bundler/spec/bundler/shared_helpers_spec.rb
@@ -423,7 +423,7 @@ RSpec.describe Bundler::SharedHelpers do
       it "sets BUNDLE_BIN_PATH to the bundle executable file" do
         subject.set_bundle_environment
         bin_path = ENV["BUNDLE_BIN_PATH"]
-        expect(bin_path).to eq(bindir.join("bundle").to_s)
+        expect(bin_path).to eq(exedir.join("bundle").to_s)
         expect(File.exist?(bin_path)).to be true
       end
     end

--- a/bundler/spec/support/bundle
+++ b/bundler/spec/support/bundle
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../bundler/support/activate"
+
+load File.expand_path("bundle", Spec::Path.exedir)

--- a/bundler/spec/support/bundle.rb
+++ b/bundler/spec/support/bundle.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
-require_relative "activate"
+require_relative "path"
 
-load File.expand_path("bundle", Spec::Path.bindir)
+warn "#{__FILE__} is deprecated. Please use #{Spec::Path.dev_binstub} instead"
+
+load Spec::Path.dev_binstub

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -45,8 +45,16 @@ module Spec
       @dev_gemfile ||= tool_dir.join("dev_gems.rb")
     end
 
+    def dev_binstub
+      @dev_binstub ||= bindir.join("bundle")
+    end
+
     def bindir
-      @bindir ||= source_root.join(ruby_core? ? "libexec" : "exe")
+      @bindir ||= source_root.join(ruby_core? ? "spec/bin" : "bin")
+    end
+
+    def exedir
+      @exedir ||= source_root.join(ruby_core? ? "libexec" : "exe")
     end
 
     def installed_bindir
@@ -63,7 +71,7 @@ module Spec
 
     def path
       env_path = ENV["PATH"]
-      env_path = env_path.split(File::PATH_SEPARATOR).reject {|path| path == bindir.to_s }.join(File::PATH_SEPARATOR) if ruby_core?
+      env_path = env_path.split(File::PATH_SEPARATOR).reject {|path| path == exedir.to_s }.join(File::PATH_SEPARATOR) if ruby_core?
       env_path
     end
 

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -52,7 +52,7 @@ module Spec
     def setup_test_paths
       ENV["BUNDLE_PATH"] = nil
       ENV["PATH"] = [Path.system_gem_path("bin"), ENV["PATH"]].join(File::PATH_SEPARATOR)
-      ENV["PATH"] = [Path.bindir, ENV["PATH"]].join(File::PATH_SEPARATOR) if Path.ruby_core?
+      ENV["PATH"] = [Path.exedir, ENV["PATH"]].join(File::PATH_SEPARATOR) if Path.ruby_core?
     end
 
     def install_test_deps
@@ -100,7 +100,7 @@ module Spec
 
       require "shellwords"
       # We don't use `Open3` here because it does not work on JRuby + Windows
-      output = `ruby #{File.expand_path("support/bundle.rb", Path.spec_dir)} #{args.shelljoin}`
+      output = `ruby #{Path.dev_binstub} #{args.shelljoin}`
       raise output unless $?.success?
       output
     ensure

--- a/doc/bundler/development/SETUP.md
+++ b/doc/bundler/development/SETUP.md
@@ -26,7 +26,7 @@ To work on Bundler, you'll probably want to do a couple of things:
 
 * Set up a shell alias to run Bundler from your clone, e.g. a Bash alias ([follow these instructions](https://www.moncefbelyamani.com/create-aliases-in-bash-profile-to-assign-shortcuts-for-common-terminal-commands/) for adding aliases to your `~/.bashrc` profile):
 
-        alias dbundle='ruby /path/to/bundler/repo/spec/support/bundle.rb'
+        alias dbundle='ruby /[repo root]/bundler/bin/bundle'
 
 On Windows, you can add this to your [PowerShell profile][profile] (you can use `vim $profile` on the command line if you have `vim` installed):
 
@@ -34,7 +34,7 @@ On Windows, you can add this to your [PowerShell profile][profile] (you can use 
 $Env:RUBYOPT="-rdebug"
 function dbundle
 {
-	& "ruby.exe" E:\[source path]\rubygems\bundler\spec\support\bundle.rb $args
+	& "ruby.exe" E:\[repo root]\bundler\bin\bundle $args
 }
 ```
 

--- a/doc/rubygems/CONTRIBUTING.md
+++ b/doc/rubygems/CONTRIBUTING.md
@@ -52,7 +52,7 @@ To run commands like `gem install` from the repo:
 
 To run commands like `bundle install` from the repo:
 
-    ruby bundler/spec/support/bundle.rb install
+    bundler/bin/bundle install
 
 ### Running Tests
 

--- a/tool/release.rb
+++ b/tool/release.rb
@@ -111,10 +111,8 @@ class Release
 
   def self.install_dependencies!
     system(
-      "ruby",
-      "-I",
-      File.expand_path("../lib", __dir__),
-      File.expand_path("../bundler/spec/support/bundle.rb", __dir__),
+      { "RUBYOPT" => "-I#{File.expand_path("../lib", __dir__)}" },
+      File.expand_path("../bundler/bin/bundle", __dir__),
       "install",
       "--gemfile=#{File.expand_path("bundler/release_gems.rb", __dir__)}",
       exception: true


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Running `dbundle` development alias in Bundler 4 mode crashes Bundler:

````
$ BUNDLE_SIMULATE_VERSION=4 dbundle
Bundler version 2.7.0.dev (2025-06-26 commit 89f7f5f760f)

--- ERROR REPORT TEMPLATE -------------------------------------------------------

```
NoMethodError: undefined method '[]' for nil
  /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/cli.rb:95:in 'block in Bundler::CLI#cli_help'
          /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/cli.rb:95:in 'Array#each'
          /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/cli.rb:95:in 'Enumerable#group_by'
          /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/cli.rb:95:in 'Bundler::CLI#cli_help'
          /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/vendor/thor/lib/thor/command.rb:28:in 'Bundler::Thor::Command#run'
          /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in 'Bundler::Thor::Invocation#invoke_command'
          /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/vendor/thor/lib/thor.rb:538:in 'Bundler::Thor.dispatch'
          /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/cli.rb:35:in 'Bundler::CLI.dispatch'
          /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/vendor/thor/lib/thor/base.rb:584:in 'Bundler::Thor::Base::ClassMethods#start'
          /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/cli.rb:29:in 'Bundler::CLI.start'
          /Users/deivid/code/rubygems/rubygems/bundler/exe/bundle:28:in 'block in <top (required)>'
          /Users/deivid/code/rubygems/rubygems/bundler/lib/bundler/friendly_errors.rb:118:in 'Bundler.with_friendly_errors'
          /Users/deivid/code/rubygems/rubygems/bundler/exe/bundle:20:in '<top (required)>'
          /Users/deivid/code/rubygems/rubygems/bundler/spec/support/bundle.rb:5:in 'Kernel#load'
          /Users/deivid/code/rubygems/rubygems/bundler/spec/support/bundle.rb:5:in '<main>'

```

## Environment

```
Bundler       2.7.0.dev
  Platforms   ruby, arm64-darwin-24
Ruby          3.4.4p34 (2025-05-14 revision a38531fd3f617bf734ef7d6c595325f69985ea1d) [arm64-darwin-24]
  Full Path   /Users/deivid/.local/share/mise/installs/ruby/3.4.4/bin/ruby
  Config Dir  /Users/deivid/.local/share/mise/installs/ruby/3.4.4/etc
RubyGems      3.7.0.dev
  Gem Home    /Users/deivid/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0
  Gem Path    /Users/deivid/.gem/ruby/3.4.0:/Users/deivid/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0
  User Home   /Users/deivid
  User Path   /Users/deivid/.gem/ruby/3.4.0
  Bin Dir     /Users/deivid/.local/share/mise/installs/ruby/3.4.4/bin
Tools         
  Git         2.49.0
  RVM         not installed
  rbenv       not installed
  chruby      not installed
```

## Bundler Build Metadata

```
Built At          2025-06-26
Git SHA           89f7f5f760f
Released Version  false
```

## Bundler settings

```
path.system
  Set for your local app (/Users/deivid/code/rubygems/rubygems/.bundle/config): true
simulate_version
  Set via BUNDLE_SIMULATE_VERSION: "4"
```

--- TEMPLATE END ----------------------------------------------------------------

Unfortunately, an unexpected error occurred, and Bundler cannot continue.

First, try this link to see if there are any existing issue reports for this error:
https://github.com/rubygems/rubygems/search?q=undefined+method+%27%5B%5D%27+for+nil&type=Issues

If there aren't any reports for this error yet, please fill in the new issue form located at https://github.com/rubygems/rubygems/issues/new?labels=Bundler&template=bundler-related-issue.md. Make sure to copy and paste the full output of this command under the "What happened instead?" section.
````

## What is your fix for the problem, implemented in this PR?

My initial idea was to change the regexp here:

https://github.com/rubygems/rubygems/blob/61f714f1b71416f1f15abe8809238fd921235846/bundler/lib/bundler/cli.rb#L95

to account for the `bundle.rb` we currently use to run a development (not installed) version of Bundler.

But then I thought it was maybe best to move `bundler/spec/support/bundle.rb` to a proper binstub in `bundler/bin/bundle`, since it does not require adding code to `lib` just to fix a development only issue, and since it makes the way Bundler is run in development more similar to the way Bundler is run in real life.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
