### PR TITLE
Stop showing date when `bundle version` is run

### DIFF
--- a/bundler/lib/bundler/build_metadata.rb
+++ b/bundler/lib/bundler/build_metadata.rb
@@ -10,15 +10,9 @@ module Bundler
     # A hash representation of the build metadata.
     def self.to_h
       {
-        "Built At" => built_at,
         "Git SHA" => git_commit_sha,
         "Released Version" => release?,
       }
-    end
-
-    # A string representing the date the bundler gem was built.
-    def self.built_at
-      @built_at ||= Time.now.utc.strftime("%Y-%m-%d").freeze
     end
 
     # The SHA for the git commit the bundler gem was built from.

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -486,7 +486,7 @@ module Bundler
     def version
       cli_help = current_command.name == "cli_help"
       if cli_help || ARGV.include?("version")
-        build_info = " (#{BuildMetadata.built_at} commit #{BuildMetadata.git_commit_sha})"
+        build_info = " (commit #{BuildMetadata.git_commit_sha})"
       end
 
       if !cli_help && Bundler.feature_flag.print_only_version_number?

--- a/bundler/spec/bundler/build_metadata_spec.rb
+++ b/bundler/spec/bundler/build_metadata_spec.rb
@@ -4,17 +4,6 @@ require "bundler"
 require "bundler/build_metadata"
 
 RSpec.describe Bundler::BuildMetadata do
-  before do
-    allow(Time).to receive(:now).and_return(Time.at(0))
-    Bundler::BuildMetadata.instance_variable_set(:@built_at, nil)
-  end
-
-  describe "#built_at" do
-    it "returns %Y-%m-%d formatted time" do
-      expect(Bundler::BuildMetadata.built_at).to eq "1970-01-01"
-    end
-  end
-
   describe "#release?" do
     it "returns false as default" do
       expect(Bundler::BuildMetadata.release?).to be_falsey
@@ -41,7 +30,6 @@ RSpec.describe Bundler::BuildMetadata do
     subject { Bundler::BuildMetadata.to_h }
 
     it "returns a hash includes Built At, Git SHA and Released Version" do
-      expect(subject["Built At"]).to eq "1970-01-01"
       expect(subject["Git SHA"]).to be_instance_of(String)
       expect(subject["Released Version"]).to be_falsey
     end

--- a/bundler/spec/commands/version_spec.rb
+++ b/bundler/spec/commands/version_spec.rb
@@ -36,12 +36,12 @@ RSpec.describe "bundle version" do
   context "with version" do
     it "outputs the version with build metadata", bundler: "2" do
       bundle "version"
-      expect(out).to match(/\ABundler version #{Regexp.escape(Bundler::VERSION)} \(\d{4}-\d{2}-\d{2} commit #{COMMIT_HASH}\)\z/)
+      expect(out).to match(/\ABundler version #{Regexp.escape(Bundler::VERSION)} \(commit #{COMMIT_HASH}\)\z/)
     end
 
     it "outputs the version with build metadata", bundler: "4" do
       bundle "version"
-      expect(out).to match(/\A#{Regexp.escape(Bundler::VERSION)} \(\d{4}-\d{2}-\d{2} commit #{COMMIT_HASH}\)\z/)
+      expect(out).to match(/\A#{Regexp.escape(Bundler::VERSION)} \(commit #{COMMIT_HASH}\)\z/)
     end
   end
 end

--- a/bundler/spec/support/build_metadata.rb
+++ b/bundler/spec/support/build_metadata.rb
@@ -11,7 +11,6 @@ module Spec
     def write_build_metadata(dir: source_root)
       build_metadata = {
         git_commit_sha: git_commit_sha,
-        built_at: loaded_gemspec.date.utc.strftime("%Y-%m-%d"),
         release: true,
       }
 


### PR DESCRIPTION

## What was the end-user or developer problem that led to this PR?

Currently running `bundle version` shows 1980 as the release date 😅.

## What is your fix for the problem, implemented in this PR?

This is because it uses the `created_at` package metadata, which was never too meaningful and now set by default to an old date in the past for reproducibility.

Until we find a better way that does not rely on `Gem::Specification#date`, I figure we can omit release date

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
