### PR TITLE
Remove `features/` (Cucumber) from gemspec template

### DIFF
--- a/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
     ls.readlines("\x0", chomp: true).reject do |f|
       (f == gemspec) ||
-        f.start_with?(*%w[<%= config[:ignore_paths].join(" ") %>])
+        f.start_with?(*%w[bin/ test/ spec/ .git <%= config[:ci_config_path] %>appveyor Gemfile])
     end
   end
   spec.bindir = "exe"


### PR DESCRIPTION
The default gemspec template contains a file exclusion for `features/` which is the convention for [Cucumber](https://github.com/cucumber/cucumber-ruby). It looks like this was added around 15 years ago by @myronmarston in https://github.com/rubygems/bundler/pull/653.

Cucumber still exists, but it's far less common these days. I think it's time to remove it from the template.

## What was the end-user or developer problem that led to this PR?

It's confusing for people new to Ruby who are unaware of Cucumber.

## What is your fix for the problem, implemented in this PR?

Remove `features/` from the template.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] ~Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes~ There is no corresponding test.
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
