### PR TITLE
Update some reference to Bundler 3 to Bundler 4

### DIFF
--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -145,13 +145,13 @@ module Bundler
         if @platforms.include?(Gem::Platform::X64_MINGW)
           @platforms.delete(Gem::Platform::X64_MINGW_LEGACY)
           SharedHelpers.major_deprecation(2,
-            "Found x64-mingw32 in lockfile, which is deprecated. Removing it. Support for x64-mingw32 will be removed in Bundler 3.0.",
-            removed_message: "Found x64-mingw32 in lockfile, which is no longer supported as of Bundler 3.0.")
+            "Found x64-mingw32 in lockfile, which is deprecated. Removing it. Support for x64-mingw32 will be removed in Bundler 4.0.",
+            removed_message: "Found x64-mingw32 in lockfile, which is no longer supported as of Bundler 4.0.")
         else
           @platforms[@platforms.index(Gem::Platform::X64_MINGW_LEGACY)] = Gem::Platform::X64_MINGW
           SharedHelpers.major_deprecation(2,
-            "Found x64-mingw32 in lockfile, which is deprecated. Using x64-mingw-ucrt, the replacement for x64-mingw32 in modern rubies, instead. Support for x64-mingw32 will be removed in Bundler 3.0.",
-            removed_message: "Found x64-mingw32 in lockfile, which is no longer supported as of Bundler 3.0.")
+            "Found x64-mingw32 in lockfile, which is deprecated. Using x64-mingw-ucrt, the replacement for x64-mingw32 in modern rubies, instead. Support for x64-mingw32 will be removed in Bundler 4.0.",
+            removed_message: "Found x64-mingw32 in lockfile, which is no longer supported as of Bundler 4.0.")
         end
       end
 

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -66,7 +66,7 @@ Automatically run \fBbundle install\fR when gems are missing\.
 Install executables from gems in the bundle to the specified directory\. Defaults to \fBfalse\fR\.
 .TP
 \fBcache_all\fR (\fBBUNDLE_CACHE_ALL\fR)
-Cache all gems, including path and git gems\. This needs to be explicitly configured on bundler 1 and bundler 2, but will be the default on bundler 3\.
+Cache all gems, including path and git gems\. This needs to be explicitly before bundler 4, but will be the default on bundler 4\.
 .TP
 \fBcache_all_platforms\fR (\fBBUNDLE_CACHE_ALL_PLATFORMS\fR)
 Cache gems for all platforms\.
@@ -214,7 +214,7 @@ A space\-separated or \fB:\fR\-separated list of groups whose gems bundler shoul
 .SH "REMEMBERING OPTIONS"
 Flags passed to \fBbundle install\fR or the Bundler runtime, such as \fB\-\-path foo\fR or \fB\-\-without production\fR, are remembered between commands and saved to your local application's configuration (normally, \fB\./\.bundle/config\fR)\.
 .P
-However, this will be changed in bundler 3, so it's better not to rely on this behavior\. If these options must be remembered, it's better to set them using \fBbundle config\fR (e\.g\., \fBbundle config set \-\-local path foo\fR)\.
+However, this will be changed in bundler 4, so it's better not to rely on this behavior\. If these options must be remembered, it's better to set them using \fBbundle config\fR (e\.g\., \fBbundle config set \-\-local path foo\fR)\.
 .P
 The flags that can be configured are:
 .TP

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -89,7 +89,7 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    Defaults to `false`.
 * `cache_all` (`BUNDLE_CACHE_ALL`):
    Cache all gems, including path and git gems. This needs to be explicitly
-   configured on bundler 1 and bundler 2, but will be the default on bundler 3.
+   before bundler 4, but will be the default on bundler 4.
 * `cache_all_platforms` (`BUNDLE_CACHE_ALL_PLATFORMS`):
    Cache gems for all platforms.
 * `cache_path` (`BUNDLE_CACHE_PATH`):
@@ -229,7 +229,7 @@ Flags passed to `bundle install` or the Bundler runtime, such as `--path foo` or
 `--without production`, are remembered between commands and saved to your local
 application's configuration (normally, `./.bundle/config`).
 
-However, this will be changed in bundler 3, so it's better not to rely on this
+However, this will be changed in bundler 4, so it's better not to rely on this
 behavior. If these options must be remembered, it's better to set them using
 `bundle config` (e.g., `bundle config set --local path foo`).
 

--- a/bundler/lib/bundler/man/bundle-inject.1
+++ b/bundler/lib/bundler/man/bundle-inject.1
@@ -20,7 +20,7 @@ bundle inject 'rack' '> 0'
 .P
 This will inject the 'rack' gem with a version greater than 0 in your [\fBGemfile(5)\fR][Gemfile(5)] and Gemfile\.lock\.
 .P
-The \fBbundle inject\fR command was deprecated in Bundler 2\.1 and will be removed in Bundler 3\.0\.
+The \fBbundle inject\fR command was deprecated in Bundler 2\.1 and will be removed in Bundler 4\.0\.
 .SH "OPTIONS"
 .TP
 \fB\-\-source=SOURCE\fR

--- a/bundler/lib/bundler/man/bundle-inject.1.ronn
+++ b/bundler/lib/bundler/man/bundle-inject.1.ronn
@@ -21,7 +21,7 @@ Example:
 This will inject the 'rack' gem with a version greater than 0 in your
 [`Gemfile(5)`][Gemfile(5)] and Gemfile.lock.
 
-The `bundle inject` command was deprecated in Bundler 2.1 and will be removed in Bundler 3.0.
+The `bundle inject` command was deprecated in Bundler 2.1 and will be removed in Bundler 4.0.
 
 ## OPTIONS
 

--- a/bundler/spec/bundler/lockfile_parser_spec.rb
+++ b/bundler/spec/bundler/lockfile_parser_spec.rb
@@ -129,8 +129,8 @@ RSpec.describe Bundler::LockfileParser do
         it "shows deprecation warning for replacement" do
           expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(
             2,
-            "Found x64-mingw32 in lockfile, which is deprecated. Using x64-mingw-ucrt, the replacement for x64-mingw32 in modern rubies, instead. Support for x64-mingw32 will be removed in Bundler 3.0.",
-            removed_message: "Found x64-mingw32 in lockfile, which is no longer supported as of Bundler 3.0."
+            "Found x64-mingw32 in lockfile, which is deprecated. Using x64-mingw-ucrt, the replacement for x64-mingw32 in modern rubies, instead. Support for x64-mingw32 will be removed in Bundler 4.0.",
+            removed_message: "Found x64-mingw32 in lockfile, which is no longer supported as of Bundler 4.0."
           )
           subject
         end
@@ -183,8 +183,8 @@ RSpec.describe Bundler::LockfileParser do
         it "shows deprecation warning for removing legacy platform" do
           expect(Bundler::SharedHelpers).to receive(:major_deprecation).with(
             2,
-            "Found x64-mingw32 in lockfile, which is deprecated. Removing it. Support for x64-mingw32 will be removed in Bundler 3.0.",
-            removed_message: "Found x64-mingw32 in lockfile, which is no longer supported as of Bundler 3.0."
+            "Found x64-mingw32 in lockfile, which is deprecated. Removing it. Support for x64-mingw32 will be removed in Bundler 4.0.",
+            removed_message: "Found x64-mingw32 in lockfile, which is no longer supported as of Bundler 4.0."
           )
           subject
         end

--- a/bundler/spec/cache/git_spec.rb
+++ b/bundler/spec/cache/git_spec.rb
@@ -452,7 +452,7 @@ RSpec.describe "bundle cache with git" do
       bundle :cache, "all-platforms" => true, :install => false
 
       # it did _NOT_ actually install the gem - neither in $GEM_HOME (bundler 2 mode),
-      # nor in .bundle (bundler 3 mode)
+      # nor in .bundle (bundler 4 mode)
       expect(Pathname.new(File.join(default_bundle_path, "gems/foo-1.0-#{ref}"))).to_not exist
       # it _did_ cache the gem in vendor/
       expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We decided to skip the Bundler 3 major release and go directly to Bundler 4, in order to fully sync RubyGems and Bundler version numbers. However, there are still some mentions to Bundler 3.

## What is your fix for the problem, implemented in this PR?

Reconcile everything.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
