### PR TITLE
Remove `print_only_version_number` setting

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -489,7 +489,7 @@ module Bundler
         build_info = " (#{BuildMetadata.built_at} commit #{BuildMetadata.git_commit_sha})"
       end
 
-      if !cli_help && Bundler.feature_flag.print_only_version_number?
+      if !cli_help && Bundler.feature_flag.bundler_4_mode?
         Bundler.ui.info "#{Bundler::VERSION}#{build_info}"
       else
         Bundler.ui.info "Bundler version #{Bundler::VERSION}#{build_info}"

--- a/bundler/lib/bundler/feature_flag.rb
+++ b/bundler/lib/bundler/feature_flag.rb
@@ -36,7 +36,6 @@ module Bundler
     settings_flag(:lockfile_checksums) { bundler_4_mode? }
     settings_flag(:path_relative_to_cwd) { bundler_4_mode? }
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }
-    settings_flag(:print_only_version_number) { bundler_4_mode? }
     settings_flag(:setup_makes_kernel_gem_public) { !bundler_4_mode? }
     settings_flag(:update_requires_all_flag) { bundler_5_mode? }
 

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -161,9 +161,6 @@ Enable Bundler's experimental plugin system\.
 \fBprefer_patch\fR (BUNDLE_PREFER_PATCH)
 Prefer updating only to next patch version during updates\. Makes \fBbundle update\fR calls equivalent to \fBbundler update \-\-patch\fR\.
 .TP
-\fBprint_only_version_number\fR (\fBBUNDLE_PRINT_ONLY_VERSION_NUMBER\fR)
-Print only version number from \fBbundler \-\-version\fR\.
-.TP
 \fBredirect\fR (\fBBUNDLE_REDIRECT\fR)
 The number of redirects allowed for network requests\. Defaults to \fB5\fR\.
 .TP

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -177,8 +177,6 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    Enable Bundler's experimental plugin system.
 * `prefer_patch` (BUNDLE_PREFER_PATCH):
    Prefer updating only to next patch version during updates. Makes `bundle update` calls equivalent to `bundler update --patch`.
-* `print_only_version_number` (`BUNDLE_PRINT_ONLY_VERSION_NUMBER`):
-   Print only version number from `bundler --version`.
 * `redirect` (`BUNDLE_REDIRECT`):
    The number of redirects allowed for network requests. Defaults to `5`.
 * `retry` (`BUNDLE_RETRY`):

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -40,7 +40,6 @@ module Bundler
       path.system
       plugins
       prefer_patch
-      print_only_version_number
       setup_makes_kernel_gem_public
       silence_deprecations
       silence_root_warning


### PR DESCRIPTION

## What was the end-user or developer problem that led to this PR?

I don't think it makes sense to make this tiny behavior change configurable. If someone wants to parse version output, and we have a public setting, they are going to need to accommodate their regexps to both values of the setting.

In addition to this, I plan to enhance version output with a note about "simulated version", and in that case, "print_only_version_number" would no longer hold, since what we print will be more than that in that case.

## What is your fix for the problem, implemented in this PR?

So, I'd like to remove the setting and change the output in Bundler 4 with no way to opt out.

Closes #8661.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
