### PR TITLE
Log simulated version in `version` output and verbose mode

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -113,13 +113,13 @@ module Bundler
     end
 
     def configured_bundle_path
-      @configured_bundle_path ||= settings.path.tap(&:validate!)
+      @configured_bundle_path ||= Bundler.settings.path.tap(&:validate!)
     end
 
     # Returns absolute location of where binstubs are installed to.
     def bin_path
       @bin_path ||= begin
-        path = settings[:bin] || "bin"
+        path = Bundler.settings[:bin] || "bin"
         path = Pathname.new(path).expand_path(root).expand_path
         mkdir_p(path)
         path
@@ -180,7 +180,7 @@ module Bundler
     # should be called first, before you instantiate anything like an
     # `Installer` that'll keep a reference to the old one instead.
     def auto_install
-      return unless settings[:auto_install]
+      return unless Bundler.settings[:auto_install]
 
       begin
         definition.specs
@@ -238,10 +238,10 @@ module Bundler
     end
 
     def frozen_bundle?
-      frozen = settings[:frozen]
+      frozen = Bundler.settings[:frozen]
       return frozen unless frozen.nil?
 
-      settings[:deployment]
+      Bundler.settings[:deployment]
     end
 
     def locked_gems
@@ -342,7 +342,7 @@ module Bundler
 
     def app_cache(custom_path = nil)
       path = custom_path || root
-      Pathname.new(path).join(settings.app_cache_path)
+      Pathname.new(path).join(Bundler.settings.app_cache_path)
     end
 
     def tmp(name = Process.pid.to_s)
@@ -454,7 +454,7 @@ module Bundler
     end
 
     def local_platform
-      return Gem::Platform::RUBY if settings[:force_ruby_platform]
+      return Gem::Platform::RUBY if Bundler.settings[:force_ruby_platform]
       Gem::Platform.local
     end
 
@@ -480,11 +480,11 @@ module Bundler
       # install binstubs there instead. Unfortunately, RubyGems doesn't expose
       # that directory at all, so rather than parse .gemrc ourselves, we allow
       # the directory to be set as well, via `bundle config set --local bindir foo`.
-      settings[:system_bindir] || Bundler.rubygems.gem_bindir
+      Bundler.settings[:system_bindir] || Bundler.rubygems.gem_bindir
     end
 
     def preferred_gemfile_name
-      settings[:init_gems_rb] ? "gems.rb" : "Gemfile"
+      Bundler.settings[:init_gems_rb] ? "gems.rb" : "Gemfile"
     end
 
     def use_system_gems?
@@ -567,7 +567,7 @@ module Bundler
     end
 
     def feature_flag
-      @feature_flag ||= FeatureFlag.new(settings[:simulate_version] || VERSION)
+      @feature_flag ||= FeatureFlag.new(Bundler.settings[:simulate_version] || VERSION)
     end
 
     def reset!

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -714,12 +714,7 @@ module Bundler
       command_name = cmd.name
       return if PARSEABLE_COMMANDS.include?(command_name)
       command = ["bundle", command_name] + args
-      options_to_print = options.dup
-      options_to_print.delete_if do |k, v|
-        next unless o = cmd.options[k]
-        o.default == v
-      end
-      command << Thor::Options.to_switches(options_to_print.sort_by(&:first)).strip
+      command << Thor::Options.to_switches(options.sort_by(&:first)).strip
       command.reject!(&:empty?)
       Bundler.ui.info "Running `#{command * " "}` with bundler #{Bundler::VERSION}"
     end

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -490,9 +490,9 @@ module Bundler
       end
 
       if !cli_help && Bundler.feature_flag.print_only_version_number?
-        Bundler.ui.info "#{Bundler::VERSION}#{build_info}"
+        Bundler.ui.info "#{Bundler.verbose_version}#{build_info}"
       else
-        Bundler.ui.info "Bundler version #{Bundler::VERSION}#{build_info}"
+        Bundler.ui.info "Bundler version #{Bundler.verbose_version}#{build_info}"
       end
     end
 
@@ -716,7 +716,7 @@ module Bundler
       command = ["bundle", command_name] + args
       command << Thor::Options.to_switches(options.sort_by(&:first)).strip
       command.reject!(&:empty?)
-      Bundler.ui.info "Running `#{command * " "}` with bundler #{Bundler::VERSION}"
+      Bundler.ui.info "Running `#{command * " "}` with bundler #{Bundler.verbose_version}"
     end
 
     def warn_on_outdated_bundler

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -182,6 +182,9 @@ Whether Bundler should silence deprecation warnings for behavior that will be ch
 \fBsilence_root_warning\fR (\fBBUNDLE_SILENCE_ROOT_WARNING\fR)
 Silence the warning Bundler prints when installing gems as root\.
 .TP
+\fBsimulate_version\fR (\fBBUNDLE_SIMULATE_VERSION\fR)
+The virtual version Bundler should use for activating feature flags\. Can be used to simulate all the new functionality that will be enabled in a future major version\.
+.TP
 \fBssl_ca_cert\fR (\fBBUNDLE_SSL_CA_CERT\fR)
 Path to a designated CA certificate file or folder containing multiple certificates for trusted CAs in PEM format\.
 .TP

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -194,6 +194,10 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    be changed in the next major version.
 * `silence_root_warning` (`BUNDLE_SILENCE_ROOT_WARNING`):
    Silence the warning Bundler prints when installing gems as root.
+* `simulate_version` (`BUNDLE_SIMULATE_VERSION`):
+   The virtual version Bundler should use for activating feature flags. Can be
+   used to simulate all the new functionality that will be enabled in a future
+   major version.
 * `ssl_ca_cert` (`BUNDLE_SSL_CA_CERT`):
    Path to a designated CA certificate file or folder containing multiple
    certificates for trusted CAs in PEM format.

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -87,6 +87,7 @@ module Bundler
       gemfile
       path
       shebang
+      simulate_version
       system_bindir
       trust-policy
       version

--- a/bundler/lib/bundler/version.rb
+++ b/bundler/lib/bundler/version.rb
@@ -10,4 +10,12 @@ module Bundler
   def self.gem_version
     @gem_version ||= Gem::Version.create(VERSION)
   end
+
+  def self.verbose_version
+    @verbose_version ||= "#{VERSION}#{simulated_version ? " (simulating Bundler #{simulated_version})" : ""}"
+  end
+
+  def self.simulated_version
+    @simulated_version ||= Bundler.settings[:simulate_version]
+  end
 end

--- a/bundler/spec/bundler/cli_spec.rb
+++ b/bundler/spec/bundler/cli_spec.rb
@@ -122,11 +122,6 @@ RSpec.describe "bundle executable" do
       install_gemfile "source 'https://gem.repo1'", verbose: true
       expect(out).to start_with("Running `bundle install --verbose` with bundler #{Bundler::VERSION}")
     end
-
-    it "doesn't print defaults" do
-      install_gemfile "source 'https://gem.repo1'", verbose: true
-      expect(out).to start_with("Running `bundle install --verbose` with bundler #{Bundler::VERSION}")
-    end
   end
 
   describe "bundle outdated" do

--- a/bundler/spec/bundler/cli_spec.rb
+++ b/bundler/spec/bundler/cli_spec.rb
@@ -112,13 +112,22 @@ RSpec.describe "bundle executable" do
   end
 
   context "with --verbose" do
-    it "prints the running command" do
+    before do
       gemfile "source 'https://gem.repo1'"
+    end
+
+    it "prints the running command" do
       bundle "info bundler", verbose: true
       expect(out).to start_with("Running `bundle info bundler --verbose` with bundler #{Bundler::VERSION}")
 
       bundle "install", verbose: true
       expect(out).to start_with("Running `bundle install --verbose` with bundler #{Bundler::VERSION}")
+    end
+
+    it "prints the simulated version too when setting is enabled" do
+      bundle "config simulate_version 4", verbose: true
+      bundle "info bundler", verbose: true
+      expect(out).to start_with("Running `bundle info bundler --verbose` with bundler #{Bundler::VERSION} (simulating Bundler 4)")
     end
   end
 
@@ -246,10 +255,9 @@ RSpec.describe "bundler executable" do
   it "shows the bundler version just as the `bundle` executable does" do
     bundler "--version"
     expect(out).to eq("Bundler version #{Bundler::VERSION}")
-  end
 
-  it "shows the bundler version just as the `bundle` executable does", bundler: "4" do
+    bundle "config simulate_version 4"
     bundler "--version"
-    expect(out).to eq(Bundler::VERSION)
+    expect(out).to eq("#{Bundler::VERSION} (simulating Bundler 4)")
   end
 end

--- a/bundler/spec/bundler/cli_spec.rb
+++ b/bundler/spec/bundler/cli_spec.rb
@@ -116,10 +116,8 @@ RSpec.describe "bundle executable" do
       gemfile "source 'https://gem.repo1'"
       bundle "info bundler", verbose: true
       expect(out).to start_with("Running `bundle info bundler --verbose` with bundler #{Bundler::VERSION}")
-    end
 
-    it "doesn't print defaults" do
-      install_gemfile "source 'https://gem.repo1'", verbose: true
+      bundle "install", verbose: true
       expect(out).to start_with("Running `bundle install --verbose` with bundler #{Bundler::VERSION}")
     end
   end

--- a/bundler/spec/commands/version_spec.rb
+++ b/bundler/spec/commands/version_spec.rb
@@ -10,38 +10,35 @@ RSpec.describe "bundle version" do
   end
 
   context "with -v" do
-    it "outputs the version" do
+    it "outputs the version and virtual version if set" do
       bundle "-v"
       expect(out).to eq("Bundler version #{Bundler::VERSION}")
-    end
 
-    it "outputs the version", bundler: "4" do
+      bundle "config simulate_version 4"
       bundle "-v"
-      expect(out).to eq(Bundler::VERSION)
+      expect(out).to eq("#{Bundler::VERSION} (simulating Bundler 4)")
     end
   end
 
   context "with --version" do
-    it "outputs the version" do
+    it "outputs the version and virtual version if set" do
       bundle "--version"
       expect(out).to eq("Bundler version #{Bundler::VERSION}")
-    end
 
-    it "outputs the version", bundler: "4" do
+      bundle "config simulate_version 4"
       bundle "--version"
-      expect(out).to eq(Bundler::VERSION)
+      expect(out).to eq("#{Bundler::VERSION} (simulating Bundler 4)")
     end
   end
 
   context "with version" do
-    it "outputs the version with build metadata" do
+    it "outputs the version, virtual version if set, and build metadata" do
       bundle "version"
       expect(out).to match(/\ABundler version #{Regexp.escape(Bundler::VERSION)} \(\d{4}-\d{2}-\d{2} commit #{COMMIT_HASH}\)\z/)
-    end
 
-    it "outputs the version with build metadata", bundler: "4" do
+      bundle "config simulate_version 4"
       bundle "version"
-      expect(out).to match(/\A#{Regexp.escape(Bundler::VERSION)} \(\d{4}-\d{2}-\d{2} commit #{COMMIT_HASH}\)\z/)
+      expect(out).to match(/\A#{Regexp.escape(Bundler::VERSION)} \(simulating Bundler 4\) \(\d{4}-\d{2}-\d{2} commit #{COMMIT_HASH}\)\z/)
     end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The `simulate_version` setting completely changes how Bundler works, we should try to be super transparent when it is enabled.

## What is your fix for the problem, implemented in this PR?

Tweak version output and verbose mode to be transparent about Bundler simulating a different version than the real one.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
