### PR TITLE
Introduce a `verbose` setting to enable verbose output for all commands

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -77,7 +77,7 @@ module Bundler
       self.options ||= {}
       unprinted_warnings = Bundler.ui.unprinted_warnings
       Bundler.ui = UI::Shell.new(options)
-      Bundler.ui.level = "debug" if options[:verbose]
+      Bundler.ui.level = "debug" if options[:verbose] || Bundler.settings[:verbose]
       unprinted_warnings.each {|w| Bundler.ui.warn(w) }
     end
 

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -77,7 +77,7 @@ module Bundler
       self.options ||= {}
       unprinted_warnings = Bundler.ui.unprinted_warnings
       Bundler.ui = UI::Shell.new(options)
-      Bundler.ui.level = "debug" if options["verbose"]
+      Bundler.ui.level = "debug" if options[:verbose]
       unprinted_warnings.each {|w| Bundler.ui.warn(w) }
     end
 

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -203,6 +203,9 @@ Require passing \fB\-\-all\fR to \fBbundle update\fR when everything should be u
 \fBuser_agent\fR (\fBBUNDLE_USER_AGENT\fR)
 The custom user agent fragment Bundler includes in API requests\.
 .TP
+\fBverbose\fR (\fBBUNDLE_VERBOSE\fR)
+Whether Bundler should print verbose output\. Defaults to \fBfalse\fR, unless the \fB\-\-verbose\fR CLI flag is used\.
+.TP
 \fBversion\fR (\fBBUNDLE_VERSION\fR)
 The version of Bundler to use when running under Bundler environment\. Defaults to \fBlockfile\fR\. You can also specify \fBsystem\fR or \fBx\.y\.z\fR\. \fBlockfile\fR will use the Bundler version specified in the \fBGemfile\.lock\fR, \fBsystem\fR will use the system version of Bundler, and \fBx\.y\.z\fR will use the specified version of Bundler\.
 .TP

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -214,6 +214,9 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    and disallow passing no options to `bundle update`.
 * `user_agent` (`BUNDLE_USER_AGENT`):
    The custom user agent fragment Bundler includes in API requests.
+* `verbose` (`BUNDLE_VERBOSE`):
+   Whether Bundler should print verbose output. Defaults to `false`, unless the
+   `--verbose` CLI flag is used.
 * `version` (`BUNDLE_VERSION`):
    The version of Bundler to use when running under Bundler environment.
    Defaults to `lockfile`. You can also specify `system` or `x.y.z`.

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -44,6 +44,7 @@ module Bundler
       silence_deprecations
       silence_root_warning
       update_requires_all_flag
+      verbose
     ].freeze
 
     REMEMBERED_KEYS = %w[

--- a/bundler/spec/bundler/cli_spec.rb
+++ b/bundler/spec/bundler/cli_spec.rb
@@ -131,6 +131,18 @@ RSpec.describe "bundle executable" do
     end
   end
 
+  context "with verbose configuration" do
+    before do
+      bundle "config verbose true"
+    end
+
+    it "prints the running command" do
+      gemfile "source 'https://gem.repo1'"
+      bundle "info bundler"
+      expect(out).to start_with("Running `bundle info bundler` with bundler #{Bundler::VERSION}")
+    end
+  end
+
   describe "bundle outdated" do
     let(:run_command) do
       bundle "install"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If you want verbose output for all commands, you have to pass `--verbose` explicitly for all commands.

If could be useful, for example, for debugging some CI workflow, to globally set an environment variable or configuration, and get verbose output enabled consistently for all commands.

## What is your fix for the problem, implemented in this PR?

Introduce a `verbose` setting to do this.

Closes #8789.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
