### PR TITLE
Update man pages for the `bundle doctor ssl` subcommand

### DIFF
--- a/bundler/lib/bundler/man/bundle-doctor.1
+++ b/bundler/lib/bundler/man/bundle-doctor.1
@@ -4,11 +4,18 @@
 .SH "NAME"
 \fBbundle\-doctor\fR \- Checks the bundle for common problems
 .SH "SYNOPSIS"
-\fBbundle doctor\fR [\-\-quiet] [\-\-gemfile=GEMFILE]
+\fBbundle doctor [diagnose]\fR [\-\-quiet] [\-\-gemfile=GEMFILE] [\-\-ssl]
+.br
+\fBbundle doctor ssl\fR [\-\-host=HOST] [\-\-tls\-version=VERSION] [\-\-verify\-mode=MODE]
+.br
+\fBbundle doctor\fR help [COMMAND]
 .SH "DESCRIPTION"
+You can diagnose common Bundler problems with this command such as checking gem environment or SSL/TLS issue\.
+.SH "SUB\-COMMANDS"
+.SS "diagnose (default command)"
 Checks your Gemfile and gem environment for common problems\. If issues are detected, Bundler prints them and exits status 1\. Otherwise, Bundler prints a success message and exits status 0\.
 .P
-Examples of common problems caught by bundle\-doctor include:
+Examples of common problems caught include:
 .IP "\(bu" 4
 Invalid Bundler settings
 .IP "\(bu" 4
@@ -20,11 +27,43 @@ Uninstalled gems
 .IP "\(bu" 4
 Missing dependencies
 .IP "" 0
-.SH "OPTIONS"
+.P
+\fBOPTIONS\fR
 .TP
 \fB\-\-quiet\fR
 Only output warnings and errors\.
 .TP
 \fB\-\-gemfile=GEMFILE\fR
 The location of the Gemfile(5) which Bundler should use\. This defaults to a Gemfile(5) in the current working directory\. In general, Bundler will assume that the location of the Gemfile(5) is also the project's root and will try to find \fBGemfile\.lock\fR and \fBvendor/cache\fR relative to this location\.
+.TP
+\fB\-\-ssl\fR
+Diagnose common SSL problems when connecting to https://rubygems\.org\.
+.IP
+This flag runs the \fBbundle doctor ssl\fR subcommand with default values underneath\.
+.SS "ssl"
+If you've experienced issues related to SSL certificates and/or TLS versions while connecting to https://rubygems\.org, this command can help troubleshoot common problems\. The diagnostic will perform a few checks such as:
+.IP "\(bu" 4
+Verify the Ruby OpenSSL version installed on your system\.
+.IP "\(bu" 4
+Check the OpenSSL library version used for compilation\.
+.IP "\(bu" 4
+Ensure CA certificates are correctly setup on your machine\.
+.IP "\(bu" 4
+Open a TLS connection and verify the outcome\.
+.IP "" 0
+.P
+\fBOPTIONS\fR
+.TP
+\fB\-\-host=HOST\fR
+Perform the diagnostic on HOST\. Defaults to \fBrubygems\.org\fR\.
+.TP
+\fB\-\-tls\-version=VERSION\fR
+Specify the TLS version when opening the connection to HOST\.
+.IP
+Accepted values are: \fB1\.1\fR or \fB1\.2\fR\.
+.TP
+\fB\-\-verify\-mode=MODE\fR
+Specify the TLS verify mode when opening the connection to HOST\. Defaults to \fBSSL_VERIFY_PEER\fR\.
+.IP
+Accepted values are: \fBCLIENT_ONCE\fR, \fBFAIL_IF_NO_PEER_CERT\fR, \fBNONE\fR, \fBPEER\fR\.
 

--- a/bundler/lib/bundler/man/bundle-doctor.1.ronn
+++ b/bundler/lib/bundler/man/bundle-doctor.1.ronn
@@ -3,16 +3,27 @@ bundle-doctor(1) -- Checks the bundle for common problems
 
 ## SYNOPSIS
 
-`bundle doctor` [--quiet]
-                [--gemfile=GEMFILE]
+`bundle doctor [diagnose]` [--quiet]
+                           [--gemfile=GEMFILE]
+                           [--ssl]<br>
+`bundle doctor ssl` [--host=HOST]
+                    [--tls-version=VERSION]
+                    [--verify-mode=MODE]<br>
+`bundle doctor` help [COMMAND]
 
 ## DESCRIPTION
+
+You can diagnose common Bundler problems with this command such as checking gem environment or SSL/TLS issue.
+
+## SUB-COMMANDS
+
+### diagnose (default command)
 
 Checks your Gemfile and gem environment for common problems. If issues
 are detected, Bundler prints them and exits status 1. Otherwise,
 Bundler prints a success message and exits status 0.
 
-Examples of common problems caught by bundle-doctor include:
+Examples of common problems caught include:
 
 * Invalid Bundler settings
 * Mismatched Ruby versions
@@ -20,7 +31,7 @@ Examples of common problems caught by bundle-doctor include:
 * Uninstalled gems
 * Missing dependencies
 
-## OPTIONS
+**OPTIONS**
 
 * `--quiet`:
   Only output warnings and errors.
@@ -31,3 +42,36 @@ Examples of common problems caught by bundle-doctor include:
   will assume that the location of the Gemfile(5) is also the project's
   root and will try to find `Gemfile.lock` and `vendor/cache` relative
   to this location.
+
+* `--ssl`:
+  Diagnose common SSL problems when connecting to https://rubygems.org.
+
+  This flag runs the `bundle doctor ssl` subcommand with default values
+  underneath.
+
+### ssl
+
+If you've experienced issues related to SSL certificates and/or TLS versions while connecting
+to https://rubygems.org, this command can help troubleshoot common problems.
+The diagnostic will perform a few checks such as:
+
+* Verify the Ruby OpenSSL version installed on your system.
+* Check the OpenSSL library version used for compilation.
+* Ensure CA certificates are correctly setup on your machine.
+* Open a TLS connection and verify the outcome.
+
+**OPTIONS**
+
+* `--host=HOST`:
+  Perform the diagnostic on HOST. Defaults to `rubygems.org`.
+
+* `--tls-version=VERSION`:
+  Specify the TLS version when opening the connection to HOST.
+
+  Accepted values are: `1.1` or `1.2`.
+
+* `--verify-mode=MODE`:
+  Specify the TLS verify mode when opening the connection to HOST.
+  Defaults to `SSL_VERIFY_PEER`.
+
+  Accepted values are: `CLIENT_ONCE`, `FAIL_IF_NO_PEER_CERT`, `NONE`, `PEER`.


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The man pages for `bundle doctor` which shows up when running `bundle doctor --help` are no longer in sync with the CLI.

Ref #8802

## What is your fix for the problem, implemented in this PR?

### Context

In #8624, we introduced a change that modifies the structure of the `bundle doctor` command. The change added a new subcommand as well a new flag option `bundle doctor --ssl`

Bundler uses man pages to display help of Thor commands, those man pages are indepedent from Thor options and need to be kept in sync.

### Solution

Updated the man page for `bundle doctor`. Now that this command is a subcommand composed of `bundle doctor diagnose` (the default) , and `bundle doctor ssl`, I modified the man page to follow the same markdown structure as other subcommands such as [bundle plugin](https://github.com/rubygems/rubygems/blob/a902381660f8d17b5c4a93226678c23e046f464f/bundler/lib/bundler/man/bundle-plugin.1.ronn)

<img width="714" alt="image" src="https://github.com/user-attachments/assets/705c4380-a44d-43b4-98e3-d4fa84b912c4" />
<img width="709" alt="image" src="https://github.com/user-attachments/assets/e0395f96-d5e7-4c5f-9b8d-31049bbfaf83" />


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
