### PR TITLE
Fix `bundle console` printing bug report template on `NameError` during require

### DIFF
--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -71,7 +71,7 @@ module Bundler
               raise Bundler::GemRequireError.new e,
                 "There was an error while trying to load the gem '#{file}'."
             end
-          rescue RuntimeError => e
+          rescue StandardError => e
             raise Bundler::GemRequireError.new e,
               "There was an error while trying to load the gem '#{file}'."
           end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Followup to https://github.com/rubygems/rubygems/pull/8436

It fixed showing the template when requiring a non-existant file but user code can do much more than just trying to require other code.

I encountered this particular case because of load order issues, where a library wasn't able to properly require itself when loaded before some other library.

## What is your fix for the problem, implemented in this PR?

Rescue the much more generic `StandardError` instead. I believe this is fine, since no bundler/rubygems related code that runs inbetween that could be accidentally catched by this. There was no issue when using it plainly with rails but `bundle console` made issues.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
