### PR TITLE
Add a SECURITY.md file

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -4,6 +4,7 @@ LICENSE.txt
 MIT.txt
 Manifest.txt
 README.md
+SECURITY.md
 bundler/CHANGELOG.md
 bundler/LICENSE.md
 bundler/README.md

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+We deeply appreciate any effort to discover and disclose security vulnerabilities responsibly.
+
+For any security bug or issue with the RubyGems client or RubyGems.org service, please email security@rubygems.org with details about the problem or submit a report using [HackerOne](https://hackerone.com/rubygems).
+
+For additional information about RubyGems security, please see https://rubygems.org/pages/security.


### PR DESCRIPTION
To document our security policy.

## What was the end-user or developer problem that led to this PR?

We have no SECURITY.md file to inform users about our security policy.

## What is your fix for the problem, implemented in this PR?

I copied the file from https://github.com/rubygems/rubygems.org.

Alternatively, we could create a `.github` repo and place it there, and all repos under the rubygems org would inherit it. See https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
