### PR TITLE
Add `default_cli_command` documentation

### DIFF
--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -77,6 +77,9 @@ Whether Bundler should run \fBbundle clean\fR automatically after \fBbundle inst
 \fBconsole\fR (\fBBUNDLE_CONSOLE\fR)
 The console that \fBbundle console\fR starts\. Defaults to \fBirb\fR\.
 .TP
+\fBdefault_cli_command\fR (\fBBUNDLE_DEFAULT_CLI_COMMAND\fR)
+The command that running \fBbundle\fR without arguments should run\. Defaults to \fBcli_help\fR since Bundler 4, but can also be \fBinstall\fR which was the previous default\.
+.TP
 \fBdeployment\fR (\fBBUNDLE_DEPLOYMENT\fR)
 Equivalent to setting \fBfrozen\fR to \fBtrue\fR and \fBpath\fR to \fBvendor/bundle\fR\.
 .TP

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -99,6 +99,10 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    explicitly configured.
 * `console` (`BUNDLE_CONSOLE`):
    The console that `bundle console` starts. Defaults to `irb`.
+* `default_cli_command` (`BUNDLE_DEFAULT_CLI_COMMAND`):
+   The command that running `bundle` without arguments should run. Defaults to
+   `cli_help` since Bundler 4, but can also be `install` which was the previous
+   default.
 * `deployment` (`BUNDLE_DEPLOYMENT`):
    Equivalent to setting `frozen` to `true` and `path` to `vendor/bundle`.
 * `disable_checksum_validation` (`BUNDLE_DISABLE_CHECKSUM_VALIDATION`):


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I suspect most experienced users won't like this change in defaults.

## What is your fix for the problem, implemented in this PR?

Document the setting to toggle back the current default, so people can keep the current behavior if they want to.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
