### PR TITLE
Stop allowing calling `#gem` on random objects

### DIFF
--- a/bundler/lib/bundler/feature_flag.rb
+++ b/bundler/lib/bundler/feature_flag.rb
@@ -34,7 +34,6 @@ module Bundler
     settings_flag(:lockfile_checksums) { bundler_4_mode? }
     settings_flag(:path_relative_to_cwd) { bundler_4_mode? }
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }
-    settings_flag(:setup_makes_kernel_gem_public) { !bundler_4_mode? }
     settings_flag(:update_requires_all_flag) { bundler_5_mode? }
 
     settings_option(:default_cli_command) { bundler_4_mode? ? :cli_help : :install }

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -161,9 +161,6 @@ The number of redirects allowed for network requests\. Defaults to \fB5\fR\.
 \fBretry\fR (\fBBUNDLE_RETRY\fR)
 The number of times to retry failed network requests\. Defaults to \fB3\fR\.
 .TP
-\fBsetup_makes_kernel_gem_public\fR (\fBBUNDLE_SETUP_MAKES_KERNEL_GEM_PUBLIC\fR)
-Have \fBBundler\.setup\fR make the \fBKernel#gem\fR method public, even though RubyGems declares it as private\.
-.TP
 \fBshebang\fR (\fBBUNDLE_SHEBANG\fR)
 The program name that should be invoked for generated binstubs\. Defaults to the ruby install name used to generate the binstub\.
 .TP

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -178,9 +178,6 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    The number of redirects allowed for network requests. Defaults to `5`.
 * `retry` (`BUNDLE_RETRY`):
    The number of times to retry failed network requests. Defaults to `3`.
-* `setup_makes_kernel_gem_public` (`BUNDLE_SETUP_MAKES_KERNEL_GEM_PUBLIC`):
-   Have `Bundler.setup` make the `Kernel#gem` method public, even though
-   RubyGems declares it as private.
 * `shebang` (`BUNDLE_SHEBANG`):
    The program name that should be invoked for generated binstubs. Defaults to
    the ruby install name used to generate the binstub.

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -214,9 +214,6 @@ module Bundler
           e.requirement = dep.requirement
           raise e
         end
-
-        # backwards compatibility shim, see https://github.com/rubygems/bundler/issues/5102
-        kernel_class.send(:public, :gem) if Bundler.feature_flag.setup_makes_kernel_gem_public?
       end
     end
 

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -38,7 +38,6 @@ module Bundler
       path.system
       plugins
       prefer_patch
-      setup_makes_kernel_gem_public
       silence_deprecations
       silence_root_warning
       update_requires_all_flag

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1524,22 +1524,7 @@ end
   end
 
   describe "after setup" do
-    it "allows calling #gem on random objects" do
-      install_gemfile <<-G
-        source "https://gem.repo1"
-        gem "myrack"
-      G
-
-      ruby <<-RUBY
-        require "bundler/setup"
-        Object.new.gem "myrack"
-        puts Gem.loaded_specs["myrack"].full_name
-      RUBY
-
-      expect(out).to eq("myrack-1.0.0")
-    end
-
-    it "keeps Kernel#gem private", bundler: "4" do
+    it "keeps Kernel#gem private" do
       install_gemfile <<-G
         source "https://gem.repo1"
         gem "myrack"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We have a setting to enforce this behavior, however, it's disabled by default.

## What is your fix for the problem, implemented in this PR?

This should be the default behavior, and should be no way to opt out.

This is a minor breaking change that I think it's fine to ship with Bundler 2.7.

Closes #8662.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
