### PR TITLE
Improve `bundle gem` specs

### DIFF
--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe "bundle gem" do
 
       it "generates a gem skeleton with rubocop" do
         gem_skeleton_assertions
-        expect(bundled_app("test-gem/Rakefile")).to read_as(
+        expect(bundled_app("#{gem_name}/Rakefile")).to read_as(
           include("# frozen_string_literal: true").
           and(include('require "rubocop/rake_task"').
           and(include("RuboCop::RakeTask.new").
@@ -227,8 +227,8 @@ RSpec.describe "bundle gem" do
 
       it "generates a gem skeleton without rubocop" do
         gem_skeleton_assertions
-        expect(bundled_app("test-gem/Rakefile")).to read_as(exclude("rubocop"))
-        expect(bundled_app("test-gem/#{gem_name}.gemspec")).to read_as(exclude("rubocop"))
+        expect(bundled_app("#{gem_name}/Rakefile")).to read_as(exclude("rubocop"))
+        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec")).to read_as(exclude("rubocop"))
       end
 
       it "does not include rubocop in generated Gemfile" do
@@ -257,7 +257,7 @@ RSpec.describe "bundle gem" do
 
     it "generates a gem skeleton with rubocop" do
       gem_skeleton_assertions
-      expect(bundled_app("test-gem/Rakefile")).to read_as(
+      expect(bundled_app("#{gem_name}/Rakefile")).to read_as(
         include("# frozen_string_literal: true").
         and(include('require "rubocop/rake_task"').
         and(include("RuboCop::RakeTask.new").
@@ -290,7 +290,7 @@ RSpec.describe "bundle gem" do
 
     it "generates a gem skeleton with standard" do
       gem_skeleton_assertions
-      expect(bundled_app("test-gem/Rakefile")).to read_as(
+      expect(bundled_app("#{gem_name}/Rakefile")).to read_as(
         include('require "standard/rake"').
         and(match(/default:.+:standard/))
       )
@@ -323,8 +323,8 @@ RSpec.describe "bundle gem" do
 
     it "generates a gem skeleton without rubocop" do
       gem_skeleton_assertions
-      expect(bundled_app("test-gem/Rakefile")).to read_as(exclude("rubocop"))
-      expect(bundled_app("test-gem/#{gem_name}.gemspec")).to read_as(exclude("rubocop"))
+      expect(bundled_app("#{gem_name}/Rakefile")).to read_as(exclude("rubocop"))
+      expect(bundled_app("#{gem_name}/#{gem_name}.gemspec")).to read_as(exclude("rubocop"))
     end
 
     it "does not include rubocop in generated Gemfile" do

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -629,6 +629,543 @@ RSpec.describe "bundle gem" do
     end
   end
 
+  it "includes bin/ into ignore list" do
+    bundle "gem #{gem_name}"
+
+    expect(ignore_paths).to include("bin/")
+  end
+
+  it "includes Gemfile into ignore list" do
+    bundle "gem #{gem_name}"
+
+    expect(ignore_paths).to include("Gemfile")
+  end
+
+  it "includes .gitignore into ignore list" do
+    bundle "gem #{gem_name}"
+
+    expect(ignore_paths).to include(".gitignore")
+  end
+
+  context "git config user.{name,email} is set" do
+    before do
+      bundle "gem #{gem_name}"
+    end
+
+    it "sets gemspec author to git user.name if available" do
+      expect(generated_gemspec.authors.first).to eq("Bundler User")
+    end
+
+    it "sets gemspec email to git user.email if available" do
+      expect(generated_gemspec.email.first).to eq("user@example.com")
+    end
+  end
+
+  context "git config user.{name,email} is not set" do
+    before do
+      git("config --global --unset user.name")
+      git("config --global --unset user.email")
+      bundle "gem #{gem_name}"
+    end
+
+    it "sets gemspec author to default message if git user.name is not set or empty" do
+      expect(generated_gemspec.authors.first).to eq("TODO: Write your name")
+    end
+
+    it "sets gemspec email to default message if git user.email is not set or empty" do
+      expect(generated_gemspec.email.first).to eq("TODO: Write your email address")
+    end
+  end
+
+  it "sets gemspec metadata['allowed_push_host']" do
+    bundle "gem #{gem_name}"
+
+    expect(generated_gemspec.metadata["allowed_push_host"]).
+      to match(/example\.com/)
+  end
+
+  it "sets a minimum ruby version" do
+    bundle "gem #{gem_name}"
+
+    expect(generated_gemspec.required_ruby_version.to_s).to start_with(">=")
+  end
+
+  context "init_gems_rb setting to true" do
+    before do
+      bundle "config set init_gems_rb true"
+      bundle "gem #{gem_name}"
+    end
+
+    it "generates gems.rb instead of Gemfile" do
+      expect(bundled_app("#{gem_name}/gems.rb")).to exist
+      expect(bundled_app("#{gem_name}/Gemfile")).to_not exist
+    end
+
+    it "includes gems.rb and gems.locked into ignore list" do
+      expect(ignore_paths).to include("gems.rb")
+      expect(ignore_paths).to include("gems.locked")
+      expect(ignore_paths).not_to include("Gemfile")
+    end
+  end
+
+  context "init_gems_rb setting to false" do
+    before do
+      bundle "config set init_gems_rb false"
+      bundle "gem #{gem_name}"
+    end
+
+    it "generates Gemfile instead of gems.rb" do
+      expect(bundled_app("#{gem_name}/gems.rb")).to_not exist
+      expect(bundled_app("#{gem_name}/Gemfile")).to exist
+    end
+
+    it "includes Gemfile into ignore list" do
+      expect(ignore_paths).to include("Gemfile")
+      expect(ignore_paths).not_to include("gems.rb")
+      expect(ignore_paths).not_to include("gems.locked")
+    end
+  end
+
+  context "gem.test setting set to minitest" do
+    before do
+      bundle "config set gem.test minitest"
+      bundle "gem #{gem_name}"
+    end
+
+    it "creates a default rake task to run the test suite" do
+      rakefile = <<~RAKEFILE
+        # frozen_string_literal: true
+
+        require "bundler/gem_tasks"
+        require "minitest/test_task"
+
+        Minitest::TestTask.create
+
+        task default: :test
+      RAKEFILE
+
+      expect(bundled_app("#{gem_name}/Rakefile").read).to eq(rakefile)
+    end
+  end
+
+  context "--test parameter set to an invalid value" do
+    before do
+      bundle "gem #{gem_name} --test=foo", raise_on_error: false
+    end
+
+    it "fails loudly" do
+      expect(last_command).to be_failure
+      expect(err).to match(/Expected '--test' to be one of .*; got foo/)
+    end
+  end
+
+  context "gem.test setting set to test-unit" do
+    before do
+      bundle "config set gem.test test-unit"
+      bundle "gem #{gem_name}"
+    end
+
+    it "creates a default rake task to run the test suite" do
+      rakefile = <<~RAKEFILE
+        # frozen_string_literal: true
+
+        require "bundler/gem_tasks"
+        require "rake/testtask"
+
+        Rake::TestTask.new(:test) do |t|
+          t.libs << "test"
+          t.libs << "lib"
+          t.test_files = FileList["test/**/*_test.rb"]
+        end
+
+        task default: :test
+      RAKEFILE
+
+      expect(bundled_app("#{gem_name}/Rakefile").read).to eq(rakefile)
+    end
+  end
+
+  context "--ci with no argument" do
+    before do
+      bundle "gem #{gem_name}"
+    end
+
+    it "does not generate any CI config" do
+      expect(bundled_app("#{gem_name}/.github/workflows/main.yml")).to_not exist
+      expect(bundled_app("#{gem_name}/.gitlab-ci.yml")).to_not exist
+      expect(bundled_app("#{gem_name}/.circleci/config.yml")).to_not exist
+    end
+
+    it "does not add any CI config files into ignore list" do
+      expect(ignore_paths).not_to include(".github/")
+      expect(ignore_paths).not_to include(".gitlab-ci.yml")
+      expect(ignore_paths).not_to include(".circleci/")
+    end
+  end
+
+  context "--ci set to github" do
+    before do
+      bundle "gem #{gem_name} --ci=github"
+    end
+
+    it "generates a GitHub Actions config file" do
+      expect(bundled_app("#{gem_name}/.github/workflows/main.yml")).to exist
+    end
+
+    it "includes .github/ into ignore list" do
+      expect(ignore_paths).to include(".github/")
+    end
+  end
+
+  context "--ci set to gitlab" do
+    before do
+      bundle "gem #{gem_name} --ci=gitlab"
+    end
+
+    it "generates a GitLab CI config file" do
+      expect(bundled_app("#{gem_name}/.gitlab-ci.yml")).to exist
+    end
+
+    it "includes .gitlab-ci.yml into ignore list" do
+      expect(ignore_paths).to include(".gitlab-ci.yml")
+    end
+  end
+
+  context "--ci set to circle" do
+    before do
+      bundle "gem #{gem_name} --ci=circle"
+    end
+
+    it "generates a CircleCI config file" do
+      expect(bundled_app("#{gem_name}/.circleci/config.yml")).to exist
+    end
+
+    it "includes .circleci/ into ignore list" do
+      expect(ignore_paths).to include(".circleci/")
+    end
+  end
+
+  context "--ci set to an invalid value" do
+    before do
+      bundle "gem #{gem_name} --ci=foo", raise_on_error: false
+    end
+
+    it "fails loudly" do
+      expect(last_command).to be_failure
+      expect(err).to match(/Expected '--ci' to be one of .*; got foo/)
+    end
+  end
+
+  context "gem.ci setting set to none" do
+    it "doesn't generate any CI config" do
+      expect(bundled_app("#{gem_name}/.github/workflows/main.yml")).to_not exist
+      expect(bundled_app("#{gem_name}/.gitlab-ci.yml")).to_not exist
+      expect(bundled_app("#{gem_name}/.circleci/config.yml")).to_not exist
+    end
+  end
+
+  context "gem.ci setting set to github" do
+    it "generates a GitHub Actions config file" do
+      bundle "config set gem.ci github"
+      bundle "gem #{gem_name}"
+
+      expect(bundled_app("#{gem_name}/.github/workflows/main.yml")).to exist
+    end
+  end
+
+  context "gem.ci setting set to gitlab" do
+    it "generates a GitLab CI config file" do
+      bundle "config set gem.ci gitlab"
+      bundle "gem #{gem_name}"
+
+      expect(bundled_app("#{gem_name}/.gitlab-ci.yml")).to exist
+    end
+  end
+
+  context "gem.ci setting set to circle" do
+    it "generates a CircleCI config file" do
+      bundle "config set gem.ci circle"
+      bundle "gem #{gem_name}"
+
+      expect(bundled_app("#{gem_name}/.circleci/config.yml")).to exist
+    end
+  end
+
+  context "gem.ci set to github and --ci with no arguments" do
+    before do
+      bundle "config set gem.ci github"
+      bundle "gem #{gem_name} --ci"
+    end
+
+    it "generates a GitHub Actions config file" do
+      expect(bundled_app("#{gem_name}/.github/workflows/main.yml")).to exist
+    end
+
+    it "hints that --ci is already configured" do
+      expect(out).to match("github is already configured, ignoring --ci flag.")
+    end
+  end
+
+  context "gem.ci setting set to false and --ci with no arguments", :readline do
+    before do
+      bundle "config set gem.ci false"
+      bundle "gem #{gem_name} --ci" do |input, _, _|
+        input.puts "github"
+      end
+    end
+
+    it "asks to setup CI" do
+      expect(out).to match("Do you want to set up continuous integration for your gem?")
+    end
+
+    it "hints that the choice will only be applied to the current gem" do
+      expect(out).to match("Your choice will only be applied to this gem.")
+    end
+  end
+
+  context "gem.ci setting not set and --ci with no arguments", :readline do
+    before do
+      global_config "BUNDLE_GEM__CI" => nil
+      bundle "gem #{gem_name} --ci" do |input, _, _|
+        input.puts "github"
+      end
+    end
+
+    it "asks to setup CI" do
+      expect(out).to match("Do you want to set up continuous integration for your gem?")
+    end
+
+    it "hints that the choice will be applied to future bundle gem calls" do
+      hint = "Future `bundle gem` calls will use your choice. " \
+             "This setting can be changed anytime with `bundle config gem.ci`."
+      expect(out).to match(hint)
+    end
+  end
+
+  context "gem.ci setting set to a CI service and --no-ci" do
+    before do
+      bundle "config set gem.ci github"
+      bundle "gem #{gem_name} --no-ci"
+    end
+
+    it "does not generate any CI config" do
+      expect(bundled_app("#{gem_name}/.github/workflows/main.yml")).to_not exist
+      expect(bundled_app("#{gem_name}/.gitlab-ci.yml")).to_not exist
+      expect(bundled_app("#{gem_name}/.circleci/config.yml")).to_not exist
+    end
+  end
+
+  context "--linter with no argument" do
+    before do
+      bundle "gem #{gem_name}"
+    end
+
+    it "does not generate any linter config" do
+      expect(bundled_app("#{gem_name}/.rubocop.yml")).to_not exist
+      expect(bundled_app("#{gem_name}/.standard.yml")).to_not exist
+    end
+
+    it "does not add any linter config files into ignore list" do
+      expect(ignore_paths).not_to include(".rubocop.yml")
+      expect(ignore_paths).not_to include(".standard.yml")
+    end
+  end
+
+  context "--linter set to rubocop" do
+    before do
+      bundle "gem #{gem_name} --linter=rubocop"
+    end
+
+    it "generates a RuboCop config" do
+      expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
+      expect(bundled_app("#{gem_name}/.standard.yml")).to_not exist
+    end
+
+    it "includes .rubocop.yml into ignore list" do
+      expect(ignore_paths).to include(".rubocop.yml")
+      expect(ignore_paths).not_to include(".standard.yml")
+    end
+  end
+
+  context "--linter set to standard" do
+    before do
+      bundle "gem #{gem_name} --linter=standard"
+    end
+
+    it "generates a Standard config" do
+      expect(bundled_app("#{gem_name}/.standard.yml")).to exist
+      expect(bundled_app("#{gem_name}/.rubocop.yml")).to_not exist
+    end
+
+    it "includes .standard.yml into ignore list" do
+      expect(ignore_paths).to include(".standard.yml")
+      expect(ignore_paths).not_to include(".rubocop.yml")
+    end
+  end
+
+  context "--linter set to an invalid value" do
+    before do
+      bundle "gem #{gem_name} --linter=foo", raise_on_error: false
+    end
+
+    it "fails loudly" do
+      expect(last_command).to be_failure
+      expect(err).to match(/Expected '--linter' to be one of .*; got foo/)
+    end
+  end
+
+  context "gem.linter setting set to none" do
+    before do
+      bundle "gem #{gem_name}"
+    end
+
+    it "doesn't generate any linter config" do
+      expect(bundled_app("#{gem_name}/.rubocop.yml")).to_not exist
+      expect(bundled_app("#{gem_name}/.standard.yml")).to_not exist
+    end
+
+    it "does not add any linter config files into ignore list" do
+      expect(ignore_paths).not_to include(".rubocop.yml")
+      expect(ignore_paths).not_to include(".standard.yml")
+    end
+  end
+
+  context "gem.linter setting set to rubocop" do
+    before do
+      bundle "config set gem.linter rubocop"
+      bundle "gem #{gem_name}"
+    end
+
+    it "generates a RuboCop config file" do
+      expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
+    end
+
+    it "includes .rubocop.yml into ignore list" do
+      expect(ignore_paths).to include(".rubocop.yml")
+    end
+  end
+
+  context "gem.linter setting set to standard" do
+    before do
+      bundle "config set gem.linter standard"
+      bundle "gem #{gem_name}"
+    end
+
+    it "generates a Standard config file" do
+      expect(bundled_app("#{gem_name}/.standard.yml")).to exist
+    end
+
+    it "includes .standard.yml into ignore list" do
+      expect(ignore_paths).to include(".standard.yml")
+    end
+  end
+
+  context "gem.rubocop setting set to true" do
+    before do
+      global_config "BUNDLE_GEM__LINTER" => nil
+      bundle "config set gem.rubocop true"
+      bundle "gem #{gem_name}"
+    end
+
+    it "generates rubocop config" do
+      expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
+    end
+
+    it "includes .rubocop.yml into ignore list" do
+      expect(ignore_paths).to include(".rubocop.yml")
+    end
+
+    it "unsets gem.rubocop" do
+      bundle "config gem.rubocop"
+      expect(out).to include("You have not configured a value for `gem.rubocop`")
+    end
+
+    it "sets gem.linter=rubocop instead" do
+      bundle "config gem.linter"
+      expect(out).to match(/Set for the current user .*: "rubocop"/)
+    end
+  end
+
+  context "gem.linter set to rubocop and --linter with no arguments" do
+    before do
+      bundle "config set gem.linter rubocop"
+      bundle "gem #{gem_name} --linter"
+    end
+
+    it "generates a RuboCop config file" do
+      expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
+    end
+
+    it "includes .rubocop.yml into ignore list" do
+      expect(ignore_paths).to include(".rubocop.yml")
+    end
+
+    it "hints that --linter is already configured" do
+      expect(out).to match("rubocop is already configured, ignoring --linter flag.")
+    end
+  end
+
+  context "gem.linter setting set to false and --linter with no arguments", :readline do
+    before do
+      bundle "config set gem.linter false"
+      bundle "gem #{gem_name} --linter" do |input, _, _|
+        input.puts "rubocop"
+      end
+    end
+
+    it "asks to setup a linter" do
+      expect(out).to match("Do you want to add a code linter and formatter to your gem?")
+    end
+
+    it "hints that the choice will only be applied to the current gem" do
+      expect(out).to match("Your choice will only be applied to this gem.")
+    end
+  end
+
+  context "gem.linter setting not set and --linter with no arguments", :readline do
+    before do
+      global_config "BUNDLE_GEM__LINTER" => nil
+      bundle "gem #{gem_name} --linter" do |input, _, _|
+        input.puts "rubocop"
+      end
+    end
+
+    it "asks to setup a linter" do
+      expect(out).to match("Do you want to add a code linter and formatter to your gem?")
+    end
+
+    it "hints that the choice will be applied to future bundle gem calls" do
+      hint = "Future `bundle gem` calls will use your choice. " \
+             "This setting can be changed anytime with `bundle config gem.linter`."
+      expect(out).to match(hint)
+    end
+  end
+
+  context "gem.linter setting set to a linter and --no-linter" do
+    before do
+      bundle "config set gem.linter rubocop"
+      bundle "gem #{gem_name} --no-linter"
+    end
+
+    it "does not generate any linter config" do
+      expect(bundled_app("#{gem_name}/.rubocop.yml")).to_not exist
+      expect(bundled_app("#{gem_name}/.standard.yml")).to_not exist
+    end
+
+    it "does not add any linter config files into ignore list" do
+      expect(ignore_paths).not_to include(".rubocop.yml")
+      expect(ignore_paths).not_to include(".standard.yml")
+    end
+  end
+
+  context "--edit option" do
+    it "opens the generated gemspec in the user's text editor" do
+      output = bundle "gem #{gem_name} --edit=echo"
+      gemspec_path = File.join(bundled_app, gem_name, "#{gem_name}.gemspec")
+      expect(output).to include("echo \"#{gemspec_path}\"")
+    end
+  end
+
   shared_examples_for "generating a gem" do
     it "generates a gem skeleton" do
       bundle "gem #{gem_name}"
@@ -653,24 +1190,6 @@ RSpec.describe "bundle gem" do
       expect(bundled_app("#{gem_name}/bin/console").read).to start_with("#!")
     end
 
-    it "includes bin/ into ignore list" do
-      bundle "gem #{gem_name}"
-
-      expect(ignore_paths).to include("bin/")
-    end
-
-    it "includes Gemfile into ignore list" do
-      bundle "gem #{gem_name}"
-
-      expect(ignore_paths).to include("Gemfile")
-    end
-
-    it "includes .gitignore into ignore list" do
-      bundle "gem #{gem_name}"
-
-      expect(ignore_paths).to include(".gitignore")
-    end
-
     it "starts with version 0.1.0" do
       bundle "gem #{gem_name}"
 
@@ -683,49 +1202,6 @@ RSpec.describe "bundle gem" do
       expect(bundled_app("#{gem_name}/sig/#{require_path}.rbs").read).to match(/VERSION: String/)
     end
 
-    context "git config user.{name,email} is set" do
-      before do
-        bundle "gem #{gem_name}"
-      end
-
-      it "sets gemspec author to git user.name if available" do
-        expect(generated_gemspec.authors.first).to eq("Bundler User")
-      end
-
-      it "sets gemspec email to git user.email if available" do
-        expect(generated_gemspec.email.first).to eq("user@example.com")
-      end
-    end
-
-    context "git config user.{name,email} is not set" do
-      before do
-        git("config --global --unset user.name")
-        git("config --global --unset user.email")
-        bundle "gem #{gem_name}"
-      end
-
-      it "sets gemspec author to default message if git user.name is not set or empty" do
-        expect(generated_gemspec.authors.first).to eq("TODO: Write your name")
-      end
-
-      it "sets gemspec email to default message if git user.email is not set or empty" do
-        expect(generated_gemspec.email.first).to eq("TODO: Write your email address")
-      end
-    end
-
-    it "sets gemspec metadata['allowed_push_host']" do
-      bundle "gem #{gem_name}"
-
-      expect(generated_gemspec.metadata["allowed_push_host"]).
-        to match(/example\.com/)
-    end
-
-    it "sets a minimum ruby version" do
-      bundle "gem #{gem_name}"
-
-      expect(generated_gemspec.required_ruby_version.to_s).to start_with(">=")
-    end
-
     it "requires the version file" do
       bundle "gem #{gem_name}"
 
@@ -736,40 +1212,6 @@ RSpec.describe "bundle gem" do
       bundle "gem #{gem_name}"
 
       expect(bundled_app("#{gem_name}/lib/#{require_path}.rb").read).to match(/class Error < StandardError; end$/)
-    end
-
-    it "does not include the gemspec file in files" do
-      bundle "gem #{gem_name}"
-
-      bundler_gemspec = Bundler::GemHelper.new(bundled_app(gem_name), gem_name).gemspec
-
-      expect(bundler_gemspec.files).not_to include("#{gem_name}.gemspec")
-    end
-
-    it "does not include the Gemfile file in files" do
-      bundle "gem #{gem_name}"
-
-      bundler_gemspec = Bundler::GemHelper.new(bundled_app(gem_name), gem_name).gemspec
-
-      expect(bundler_gemspec.files).not_to include("Gemfile")
-    end
-
-    it "runs rake without problems" do
-      bundle "gem #{gem_name}"
-
-      system_gems ["rake-#{rake_version}"]
-
-      rakefile = <<~RAKEFILE
-        task :default do
-          puts 'SUCCESS'
-        end
-      RAKEFILE
-      File.open(bundled_app("#{gem_name}/Rakefile"), "w") do |file|
-        file.puts rakefile
-      end
-
-      sys_exec(rake, dir: bundled_app(gem_name))
-      expect(out).to include("SUCCESS")
     end
 
     context "--exe parameter set" do
@@ -842,42 +1284,6 @@ RSpec.describe "bundle gem" do
 
       it "creates a default test which fails" do
         expect(bundled_app("#{gem_name}/spec/#{require_path}_spec.rb").read).to include("expect(false).to eq(true)")
-      end
-    end
-
-    context "init_gems_rb setting to true" do
-      before do
-        bundle "config set init_gems_rb true"
-        bundle "gem #{gem_name}"
-      end
-
-      it "generates gems.rb instead of Gemfile" do
-        expect(bundled_app("#{gem_name}/gems.rb")).to exist
-        expect(bundled_app("#{gem_name}/Gemfile")).to_not exist
-      end
-
-      it "includes gems.rb and gems.locked into ignore list" do
-        expect(ignore_paths).to include("gems.rb")
-        expect(ignore_paths).to include("gems.locked")
-        expect(ignore_paths).not_to include("Gemfile")
-      end
-    end
-
-    context "init_gems_rb setting to false" do
-      before do
-        bundle "config set init_gems_rb false"
-        bundle "gem #{gem_name}"
-      end
-
-      it "generates Gemfile instead of gems.rb" do
-        expect(bundled_app("#{gem_name}/gems.rb")).to_not exist
-        expect(bundled_app("#{gem_name}/Gemfile")).to exist
-      end
-
-      it "includes Gemfile into ignore list" do
-        expect(ignore_paths).to include("Gemfile")
-        expect(ignore_paths).not_to include("gems.rb")
-        expect(ignore_paths).not_to include("gems.locked")
       end
     end
 
@@ -955,28 +1361,6 @@ RSpec.describe "bundle gem" do
       end
     end
 
-    context "gem.test setting set to minitest" do
-      before do
-        bundle "config set gem.test minitest"
-        bundle "gem #{gem_name}"
-      end
-
-      it "creates a default rake task to run the test suite" do
-        rakefile = <<~RAKEFILE
-          # frozen_string_literal: true
-
-          require "bundler/gem_tasks"
-          require "minitest/test_task"
-
-          Minitest::TestTask.create
-
-          task default: :test
-        RAKEFILE
-
-        expect(bundled_app("#{gem_name}/Rakefile").read).to eq(rakefile)
-      end
-    end
-
     context "--test parameter set to test-unit" do
       before do
         bundle "gem #{gem_name} --test=test-unit"
@@ -1010,43 +1394,6 @@ RSpec.describe "bundle gem" do
 
       it "creates a default test which fails" do
         expect(bundled_app("#{gem_name}/test/#{require_path}_test.rb").read).to include("assert_equal(\"expected\", \"actual\")")
-      end
-    end
-
-    context "--test parameter set to an invalid value" do
-      before do
-        bundle "gem #{gem_name} --test=foo", raise_on_error: false
-      end
-
-      it "fails loudly" do
-        expect(last_command).to be_failure
-        expect(err).to match(/Expected '--test' to be one of .*; got foo/)
-      end
-    end
-
-    context "gem.test setting set to test-unit" do
-      before do
-        bundle "config set gem.test test-unit"
-        bundle "gem #{gem_name}"
-      end
-
-      it "creates a default rake task to run the test suite" do
-        rakefile = <<~RAKEFILE
-          # frozen_string_literal: true
-
-          require "bundler/gem_tasks"
-          require "rake/testtask"
-
-          Rake::TestTask.new(:test) do |t|
-            t.libs << "test"
-            t.libs << "lib"
-            t.test_files = FileList["test/**/*_test.rb"]
-          end
-
-          task default: :test
-        RAKEFILE
-
-        expect(bundled_app("#{gem_name}/Rakefile").read).to eq(rakefile)
       end
     end
 
@@ -1119,387 +1466,6 @@ RSpec.describe "bundle gem" do
       end
 
       it_behaves_like "test framework is absent"
-    end
-
-    context "--ci with no argument" do
-      before do
-        bundle "gem #{gem_name}"
-      end
-
-      it "does not generate any CI config" do
-        expect(bundled_app("#{gem_name}/.github/workflows/main.yml")).to_not exist
-        expect(bundled_app("#{gem_name}/.gitlab-ci.yml")).to_not exist
-        expect(bundled_app("#{gem_name}/.circleci/config.yml")).to_not exist
-      end
-
-      it "does not add any CI config files into ignore list" do
-        expect(ignore_paths).not_to include(".github/")
-        expect(ignore_paths).not_to include(".gitlab-ci.yml")
-        expect(ignore_paths).not_to include(".circleci/")
-      end
-    end
-
-    context "--ci set to github" do
-      before do
-        bundle "gem #{gem_name} --ci=github"
-      end
-
-      it "generates a GitHub Actions config file" do
-        expect(bundled_app("#{gem_name}/.github/workflows/main.yml")).to exist
-      end
-
-      it "includes .github/ into ignore list" do
-        expect(ignore_paths).to include(".github/")
-      end
-    end
-
-    context "--ci set to gitlab" do
-      before do
-        bundle "gem #{gem_name} --ci=gitlab"
-      end
-
-      it "generates a GitLab CI config file" do
-        expect(bundled_app("#{gem_name}/.gitlab-ci.yml")).to exist
-      end
-
-      it "includes .gitlab-ci.yml into ignore list" do
-        expect(ignore_paths).to include(".gitlab-ci.yml")
-      end
-    end
-
-    context "--ci set to circle" do
-      before do
-        bundle "gem #{gem_name} --ci=circle"
-      end
-
-      it "generates a CircleCI config file" do
-        expect(bundled_app("#{gem_name}/.circleci/config.yml")).to exist
-      end
-
-      it "includes .circleci/ into ignore list" do
-        expect(ignore_paths).to include(".circleci/")
-      end
-    end
-
-    context "--ci set to an invalid value" do
-      before do
-        bundle "gem #{gem_name} --ci=foo", raise_on_error: false
-      end
-
-      it "fails loudly" do
-        expect(last_command).to be_failure
-        expect(err).to match(/Expected '--ci' to be one of .*; got foo/)
-      end
-    end
-
-    context "gem.ci setting set to none" do
-      it "doesn't generate any CI config" do
-        expect(bundled_app("#{gem_name}/.github/workflows/main.yml")).to_not exist
-        expect(bundled_app("#{gem_name}/.gitlab-ci.yml")).to_not exist
-        expect(bundled_app("#{gem_name}/.circleci/config.yml")).to_not exist
-      end
-    end
-
-    context "gem.ci setting set to github" do
-      it "generates a GitHub Actions config file" do
-        bundle "config set gem.ci github"
-        bundle "gem #{gem_name}"
-
-        expect(bundled_app("#{gem_name}/.github/workflows/main.yml")).to exist
-      end
-    end
-
-    context "gem.ci setting set to gitlab" do
-      it "generates a GitLab CI config file" do
-        bundle "config set gem.ci gitlab"
-        bundle "gem #{gem_name}"
-
-        expect(bundled_app("#{gem_name}/.gitlab-ci.yml")).to exist
-      end
-    end
-
-    context "gem.ci setting set to circle" do
-      it "generates a CircleCI config file" do
-        bundle "config set gem.ci circle"
-        bundle "gem #{gem_name}"
-
-        expect(bundled_app("#{gem_name}/.circleci/config.yml")).to exist
-      end
-    end
-
-    context "gem.ci set to github and --ci with no arguments" do
-      before do
-        bundle "config set gem.ci github"
-        bundle "gem #{gem_name} --ci"
-      end
-
-      it "generates a GitHub Actions config file" do
-        expect(bundled_app("#{gem_name}/.github/workflows/main.yml")).to exist
-      end
-
-      it "hints that --ci is already configured" do
-        expect(out).to match("github is already configured, ignoring --ci flag.")
-      end
-    end
-
-    context "gem.ci setting set to false and --ci with no arguments", :readline do
-      before do
-        bundle "config set gem.ci false"
-        bundle "gem #{gem_name} --ci" do |input, _, _|
-          input.puts "github"
-        end
-      end
-
-      it "asks to setup CI" do
-        expect(out).to match("Do you want to set up continuous integration for your gem?")
-      end
-
-      it "hints that the choice will only be applied to the current gem" do
-        expect(out).to match("Your choice will only be applied to this gem.")
-      end
-    end
-
-    context "gem.ci setting not set and --ci with no arguments", :readline do
-      before do
-        global_config "BUNDLE_GEM__CI" => nil
-        bundle "gem #{gem_name} --ci" do |input, _, _|
-          input.puts "github"
-        end
-      end
-
-      it "asks to setup CI" do
-        expect(out).to match("Do you want to set up continuous integration for your gem?")
-      end
-
-      it "hints that the choice will be applied to future bundle gem calls" do
-        hint = "Future `bundle gem` calls will use your choice. " \
-               "This setting can be changed anytime with `bundle config gem.ci`."
-        expect(out).to match(hint)
-      end
-    end
-
-    context "gem.ci setting set to a CI service and --no-ci" do
-      before do
-        bundle "config set gem.ci github"
-        bundle "gem #{gem_name} --no-ci"
-      end
-
-      it "does not generate any CI config" do
-        expect(bundled_app("#{gem_name}/.github/workflows/main.yml")).to_not exist
-        expect(bundled_app("#{gem_name}/.gitlab-ci.yml")).to_not exist
-        expect(bundled_app("#{gem_name}/.circleci/config.yml")).to_not exist
-      end
-    end
-
-    context "--linter with no argument" do
-      before do
-        bundle "gem #{gem_name}"
-      end
-
-      it "does not generate any linter config" do
-        expect(bundled_app("#{gem_name}/.rubocop.yml")).to_not exist
-        expect(bundled_app("#{gem_name}/.standard.yml")).to_not exist
-      end
-
-      it "does not add any linter config files into ignore list" do
-        expect(ignore_paths).not_to include(".rubocop.yml")
-        expect(ignore_paths).not_to include(".standard.yml")
-      end
-    end
-
-    context "--linter set to rubocop" do
-      before do
-        bundle "gem #{gem_name} --linter=rubocop"
-      end
-
-      it "generates a RuboCop config" do
-        expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
-        expect(bundled_app("#{gem_name}/.standard.yml")).to_not exist
-      end
-
-      it "includes .rubocop.yml into ignore list" do
-        expect(ignore_paths).to include(".rubocop.yml")
-        expect(ignore_paths).not_to include(".standard.yml")
-      end
-    end
-
-    context "--linter set to standard" do
-      before do
-        bundle "gem #{gem_name} --linter=standard"
-      end
-
-      it "generates a Standard config" do
-        expect(bundled_app("#{gem_name}/.standard.yml")).to exist
-        expect(bundled_app("#{gem_name}/.rubocop.yml")).to_not exist
-      end
-
-      it "includes .standard.yml into ignore list" do
-        expect(ignore_paths).to include(".standard.yml")
-        expect(ignore_paths).not_to include(".rubocop.yml")
-      end
-    end
-
-    context "--linter set to an invalid value" do
-      before do
-        bundle "gem #{gem_name} --linter=foo", raise_on_error: false
-      end
-
-      it "fails loudly" do
-        expect(last_command).to be_failure
-        expect(err).to match(/Expected '--linter' to be one of .*; got foo/)
-      end
-    end
-
-    context "gem.linter setting set to none" do
-      before do
-        bundle "gem #{gem_name}"
-      end
-
-      it "doesn't generate any linter config" do
-        expect(bundled_app("#{gem_name}/.rubocop.yml")).to_not exist
-        expect(bundled_app("#{gem_name}/.standard.yml")).to_not exist
-      end
-
-      it "does not add any linter config files into ignore list" do
-        expect(ignore_paths).not_to include(".rubocop.yml")
-        expect(ignore_paths).not_to include(".standard.yml")
-      end
-    end
-
-    context "gem.linter setting set to rubocop" do
-      before do
-        bundle "config set gem.linter rubocop"
-        bundle "gem #{gem_name}"
-      end
-
-      it "generates a RuboCop config file" do
-        expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
-      end
-
-      it "includes .rubocop.yml into ignore list" do
-        expect(ignore_paths).to include(".rubocop.yml")
-      end
-    end
-
-    context "gem.linter setting set to standard" do
-      before do
-        bundle "config set gem.linter standard"
-        bundle "gem #{gem_name}"
-      end
-
-      it "generates a Standard config file" do
-        expect(bundled_app("#{gem_name}/.standard.yml")).to exist
-      end
-
-      it "includes .standard.yml into ignore list" do
-        expect(ignore_paths).to include(".standard.yml")
-      end
-    end
-
-    context "gem.rubocop setting set to true" do
-      before do
-        global_config "BUNDLE_GEM__LINTER" => nil
-        bundle "config set gem.rubocop true"
-        bundle "gem #{gem_name}"
-      end
-
-      it "generates rubocop config" do
-        expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
-      end
-
-      it "includes .rubocop.yml into ignore list" do
-        expect(ignore_paths).to include(".rubocop.yml")
-      end
-
-      it "unsets gem.rubocop" do
-        bundle "config gem.rubocop"
-        expect(out).to include("You have not configured a value for `gem.rubocop`")
-      end
-
-      it "sets gem.linter=rubocop instead" do
-        bundle "config gem.linter"
-        expect(out).to match(/Set for the current user .*: "rubocop"/)
-      end
-    end
-
-    context "gem.linter set to rubocop and --linter with no arguments" do
-      before do
-        bundle "config set gem.linter rubocop"
-        bundle "gem #{gem_name} --linter"
-      end
-
-      it "generates a RuboCop config file" do
-        expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
-      end
-
-      it "includes .rubocop.yml into ignore list" do
-        expect(ignore_paths).to include(".rubocop.yml")
-      end
-
-      it "hints that --linter is already configured" do
-        expect(out).to match("rubocop is already configured, ignoring --linter flag.")
-      end
-    end
-
-    context "gem.linter setting set to false and --linter with no arguments", :readline do
-      before do
-        bundle "config set gem.linter false"
-        bundle "gem #{gem_name} --linter" do |input, _, _|
-          input.puts "rubocop"
-        end
-      end
-
-      it "asks to setup a linter" do
-        expect(out).to match("Do you want to add a code linter and formatter to your gem?")
-      end
-
-      it "hints that the choice will only be applied to the current gem" do
-        expect(out).to match("Your choice will only be applied to this gem.")
-      end
-    end
-
-    context "gem.linter setting not set and --linter with no arguments", :readline do
-      before do
-        global_config "BUNDLE_GEM__LINTER" => nil
-        bundle "gem #{gem_name} --linter" do |input, _, _|
-          input.puts "rubocop"
-        end
-      end
-
-      it "asks to setup a linter" do
-        expect(out).to match("Do you want to add a code linter and formatter to your gem?")
-      end
-
-      it "hints that the choice will be applied to future bundle gem calls" do
-        hint = "Future `bundle gem` calls will use your choice. " \
-               "This setting can be changed anytime with `bundle config gem.linter`."
-        expect(out).to match(hint)
-      end
-    end
-
-    context "gem.linter setting set to a linter and --no-linter" do
-      before do
-        bundle "config set gem.linter rubocop"
-        bundle "gem #{gem_name} --no-linter"
-      end
-
-      it "does not generate any linter config" do
-        expect(bundled_app("#{gem_name}/.rubocop.yml")).to_not exist
-        expect(bundled_app("#{gem_name}/.standard.yml")).to_not exist
-      end
-
-      it "does not add any linter config files into ignore list" do
-        expect(ignore_paths).not_to include(".rubocop.yml")
-        expect(ignore_paths).not_to include(".standard.yml")
-      end
-    end
-
-    context "--edit option" do
-      it "opens the generated gemspec in the user's text editor" do
-        output = bundle "gem #{gem_name} --edit=echo"
-        gemspec_path = File.join(bundled_app, gem_name, "#{gem_name}.gemspec")
-        expect(output).to include("echo \"#{gemspec_path}\"")
-      end
     end
   end
 

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -1505,185 +1505,165 @@ RSpec.describe "bundle gem" do
 
   include_examples "generating a gem"
 
-  context "testing --mit and --coc options against bundle config settings" do
-    let(:gem_name) { "test-gem" }
-
-    let(:require_path) { "test/gem" }
-
-    context "with mit option in bundle config settings set to true" do
-      before do
-        global_config "BUNDLE_GEM__MIT" => "true"
-      end
-      it_behaves_like "--mit flag"
-      it_behaves_like "--no-mit flag"
+  context "with mit option in bundle config settings set to true" do
+    before do
+      global_config "BUNDLE_GEM__MIT" => "true"
     end
+    it_behaves_like "--mit flag"
+    it_behaves_like "--no-mit flag"
+  end
 
-    context "with mit option in bundle config settings set to false" do
-      before do
-        global_config "BUNDLE_GEM__MIT" => "false"
-      end
-      it_behaves_like "--mit flag"
-      it_behaves_like "--no-mit flag"
+  context "with mit option in bundle config settings set to false" do
+    before do
+      global_config "BUNDLE_GEM__MIT" => "false"
     end
+    it_behaves_like "--mit flag"
+    it_behaves_like "--no-mit flag"
+  end
 
-    context "with coc option in bundle config settings set to true" do
-      before do
-        global_config "BUNDLE_GEM__COC" => "true"
-      end
-      it_behaves_like "--coc flag"
-      it_behaves_like "--no-coc flag"
+  context "with coc option in bundle config settings set to true" do
+    before do
+      global_config "BUNDLE_GEM__COC" => "true"
     end
+    it_behaves_like "--coc flag"
+    it_behaves_like "--no-coc flag"
+  end
 
-    context "with coc option in bundle config settings set to false" do
-      before do
-        global_config "BUNDLE_GEM__COC" => "false"
-      end
-      it_behaves_like "--coc flag"
-      it_behaves_like "--no-coc flag"
+  context "with coc option in bundle config settings set to false" do
+    before do
+      global_config "BUNDLE_GEM__COC" => "false"
     end
+    it_behaves_like "--coc flag"
+    it_behaves_like "--no-coc flag"
+  end
 
-    context "with rubocop option in bundle config settings set to true" do
-      before do
-        global_config "BUNDLE_GEM__RUBOCOP" => "true"
-      end
-      it_behaves_like "--linter=rubocop flag"
-      it_behaves_like "--linter=standard flag"
-      it_behaves_like "--no-linter flag"
-      it_behaves_like "--rubocop flag"
-      it_behaves_like "--no-rubocop flag"
+  context "with rubocop option in bundle config settings set to true" do
+    before do
+      global_config "BUNDLE_GEM__RUBOCOP" => "true"
     end
+    it_behaves_like "--linter=rubocop flag"
+    it_behaves_like "--linter=standard flag"
+    it_behaves_like "--no-linter flag"
+    it_behaves_like "--rubocop flag"
+    it_behaves_like "--no-rubocop flag"
+  end
 
-    context "with rubocop option in bundle config settings set to false" do
-      before do
-        global_config "BUNDLE_GEM__RUBOCOP" => "false"
-      end
-      it_behaves_like "--linter=rubocop flag"
-      it_behaves_like "--linter=standard flag"
-      it_behaves_like "--no-linter flag"
-      it_behaves_like "--rubocop flag"
-      it_behaves_like "--no-rubocop flag"
+  context "with rubocop option in bundle config settings set to false" do
+    before do
+      global_config "BUNDLE_GEM__RUBOCOP" => "false"
     end
+    it_behaves_like "--linter=rubocop flag"
+    it_behaves_like "--linter=standard flag"
+    it_behaves_like "--no-linter flag"
+    it_behaves_like "--rubocop flag"
+    it_behaves_like "--no-rubocop flag"
+  end
 
-    context "with linter option in bundle config settings set to rubocop" do
-      before do
-        global_config "BUNDLE_GEM__LINTER" => "rubocop"
-      end
-      it_behaves_like "--linter=rubocop flag"
-      it_behaves_like "--linter=standard flag"
-      it_behaves_like "--no-linter flag"
+  context "with linter option in bundle config settings set to rubocop" do
+    before do
+      global_config "BUNDLE_GEM__LINTER" => "rubocop"
     end
+    it_behaves_like "--linter=rubocop flag"
+    it_behaves_like "--linter=standard flag"
+    it_behaves_like "--no-linter flag"
+  end
 
-    context "with linter option in bundle config settings set to standard" do
-      before do
-        global_config "BUNDLE_GEM__LINTER" => "standard"
-      end
-      it_behaves_like "--linter=rubocop flag"
-      it_behaves_like "--linter=standard flag"
-      it_behaves_like "--no-linter flag"
+  context "with linter option in bundle config settings set to standard" do
+    before do
+      global_config "BUNDLE_GEM__LINTER" => "standard"
     end
+    it_behaves_like "--linter=rubocop flag"
+    it_behaves_like "--linter=standard flag"
+    it_behaves_like "--no-linter flag"
+  end
 
-    context "with linter option in bundle config settings set to false" do
-      before do
-        global_config "BUNDLE_GEM__LINTER" => "false"
-      end
-      it_behaves_like "--linter=rubocop flag"
-      it_behaves_like "--linter=standard flag"
-      it_behaves_like "--no-linter flag"
+  context "with linter option in bundle config settings set to false" do
+    before do
+      global_config "BUNDLE_GEM__LINTER" => "false"
     end
+    it_behaves_like "--linter=rubocop flag"
+    it_behaves_like "--linter=standard flag"
+    it_behaves_like "--no-linter flag"
+  end
 
-    context "with changelog option in bundle config settings set to true" do
-      before do
-        global_config "BUNDLE_GEM__CHANGELOG" => "true"
-      end
-      it_behaves_like "--changelog flag"
-      it_behaves_like "--no-changelog flag"
+  context "with changelog option in bundle config settings set to true" do
+    before do
+      global_config "BUNDLE_GEM__CHANGELOG" => "true"
     end
+    it_behaves_like "--changelog flag"
+    it_behaves_like "--no-changelog flag"
+  end
 
-    context "with changelog option in bundle config settings set to false" do
-      before do
-        global_config "BUNDLE_GEM__CHANGELOG" => "false"
-      end
-      it_behaves_like "--changelog flag"
-      it_behaves_like "--no-changelog flag"
+  context "with changelog option in bundle config settings set to false" do
+    before do
+      global_config "BUNDLE_GEM__CHANGELOG" => "false"
+    end
+    it_behaves_like "--changelog flag"
+    it_behaves_like "--no-changelog flag"
+  end
+
+  context "with bundle option in bundle config settings set to true" do
+    before do
+      global_config "BUNDLE_GEM__BUNDLE" => "true"
+    end
+    it_behaves_like "--bundle flag"
+    it_behaves_like "--no-bundle flag"
+
+    it "runs bundle install" do
+      bundle "gem #{gem_name}"
+      expect(out).to include("Running bundle install in the new gem directory.")
     end
   end
 
-  context "testing --bundle option against git and bundle config settings" do
-    context "with bundle option in bundle config settings set to true" do
-      before do
-        global_config "BUNDLE_GEM__BUNDLE" => "true"
-      end
-      it_behaves_like "--bundle flag"
-      it_behaves_like "--no-bundle flag"
-
-      it "runs bundle install" do
-        bundle "gem #{gem_name}"
-        expect(out).to include("Running bundle install in the new gem directory.")
-      end
+  context "with bundle option in bundle config settings set to false" do
+    before do
+      global_config "BUNDLE_GEM__BUNDLE" => "false"
     end
+    it_behaves_like "--bundle flag"
+    it_behaves_like "--no-bundle flag"
 
-    context "with bundle option in bundle config settings set to false" do
-      before do
-        global_config "BUNDLE_GEM__BUNDLE" => "false"
-      end
-      it_behaves_like "--bundle flag"
-      it_behaves_like "--no-bundle flag"
-
-      it "does not run bundle install" do
-        bundle "gem #{gem_name}"
-        expect(out).to_not include("Running bundle install in the new gem directory.")
-      end
+    it "does not run bundle install" do
+      bundle "gem #{gem_name}"
+      expect(out).to_not include("Running bundle install in the new gem directory.")
     end
   end
 
-  context "testing --github-username option against git and bundle config settings" do
-    context "without git config set" do
+  context "without git config set" do
+    before do
+      git("config --global --unset github.user")
+    end
+    context "with github-username option in bundle config settings set to some value" do
       before do
-        git("config --global --unset github.user")
+        global_config "BUNDLE_GEM__GITHUB_USERNAME" => "different_username"
       end
-      context "with github-username option in bundle config settings set to some value" do
-        before do
-          global_config "BUNDLE_GEM__GITHUB_USERNAME" => "different_username"
-        end
-        it_behaves_like "--github-username option", "gh_user"
-      end
-
-      context "with github-username option in bundle config settings set to false" do
-        before do
-          global_config "BUNDLE_GEM__GITHUB_USERNAME" => "false"
-        end
-        it_behaves_like "--github-username option", "gh_user"
-      end
+      it_behaves_like "--github-username option", "gh_user"
     end
 
-    context "with git config set" do
-      context "with github-username option in bundle config settings set to some value" do
-        before do
-          global_config "BUNDLE_GEM__GITHUB_USERNAME" => "different_username"
-        end
-        it_behaves_like "--github-username option", "gh_user"
-      end
+    it_behaves_like "github_username configuration"
 
-      context "with github-username option in bundle config settings set to false" do
-        before do
-          global_config "BUNDLE_GEM__GITHUB_USERNAME" => "false"
-        end
-        it_behaves_like "--github-username option", "gh_user"
+    context "with github-username option in bundle config settings set to false" do
+      before do
+        global_config "BUNDLE_GEM__GITHUB_USERNAME" => "false"
       end
+      it_behaves_like "--github-username option", "gh_user"
     end
   end
 
-  context "testing github_username bundle config against git config settings" do
-    context "without git config set" do
+  context "with git config set" do
+    context "with github-username option in bundle config settings set to some value" do
       before do
-        git("config --global --unset github.user")
+        global_config "BUNDLE_GEM__GITHUB_USERNAME" => "different_username"
       end
-
-      it_behaves_like "github_username configuration"
+      it_behaves_like "--github-username option", "gh_user"
     end
 
-    context "with git config set" do
-      it_behaves_like "github_username configuration"
+    it_behaves_like "github_username configuration"
+
+    context "with github-username option in bundle config settings set to false" do
+      before do
+        global_config "BUNDLE_GEM__GITHUB_USERNAME" => "false"
+      end
+      it_behaves_like "--github-username option", "gh_user"
     end
   end
 

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "bundle gem" do
     expect(bundled_app("#{gem_name}/README.md")).to exist
     expect(bundled_app("#{gem_name}/Gemfile")).to exist
     expect(bundled_app("#{gem_name}/Rakefile")).to exist
-    expect(bundled_app("#{gem_name}/lib/#{require_path}.rb")).to exist
-    expect(bundled_app("#{gem_name}/lib/#{require_path}/version.rb")).to exist
+    expect(bundled_app("#{gem_name}/lib/#{gem_name}.rb")).to exist
+    expect(bundled_app("#{gem_name}/lib/#{gem_name}/version.rb")).to exist
 
     expect(ignore_paths).to include("bin/")
     expect(ignore_paths).to include("Gemfile")
@@ -34,14 +34,6 @@ RSpec.describe "bundle gem" do
   let(:generated_gemspec) { Bundler.load_gemspec_uncached(bundled_app(gem_name).join("#{gem_name}.gemspec")) }
 
   let(:gem_name) { "mygem" }
-
-  let(:require_path) { "mygem" }
-
-  let(:require_relative_path) { "mygem" }
-
-  let(:minitest_test_file_path) { "test/test_mygem.rb" }
-
-  let(:minitest_test_class_name) { "class TestMygem < Minitest::Test" }
 
   before do
     git("config --global user.name 'Bundler User'")
@@ -449,9 +441,9 @@ RSpec.describe "bundle gem" do
   shared_examples_for "test framework is absent" do
     it "does not create any test framework files" do
       expect(bundled_app("#{gem_name}/.rspec")).to_not exist
-      expect(bundled_app("#{gem_name}/spec/#{require_path}_spec.rb")).to_not exist
+      expect(bundled_app("#{gem_name}/spec/#{gem_name}_spec.rb")).to_not exist
       expect(bundled_app("#{gem_name}/spec/spec_helper.rb")).to_not exist
-      expect(bundled_app("#{gem_name}/test/#{require_path}.rb")).to_not exist
+      expect(bundled_app("#{gem_name}/test/#{gem_name}.rb")).to_not exist
       expect(bundled_app("#{gem_name}/test/test_helper.rb")).to_not exist
     end
 
@@ -629,6 +621,29 @@ RSpec.describe "bundle gem" do
     end
   end
 
+  it "generates a gem skeleton" do
+    bundle "gem #{gem_name}"
+
+    expect(bundled_app("#{gem_name}/#{gem_name}.gemspec")).to exist
+    expect(bundled_app("#{gem_name}/Gemfile")).to exist
+    expect(bundled_app("#{gem_name}/Rakefile")).to exist
+    expect(bundled_app("#{gem_name}/lib/#{gem_name}.rb")).to exist
+    expect(bundled_app("#{gem_name}/lib/#{gem_name}/version.rb")).to exist
+    expect(bundled_app("#{gem_name}/sig/#{gem_name}.rbs")).to exist
+    expect(bundled_app("#{gem_name}/.gitignore")).to exist
+
+    expect(bundled_app("#{gem_name}/bin/setup")).to exist
+    expect(bundled_app("#{gem_name}/bin/console")).to exist
+
+    unless Gem.win_platform?
+      expect(bundled_app("#{gem_name}/bin/setup")).to be_executable
+      expect(bundled_app("#{gem_name}/bin/console")).to be_executable
+    end
+
+    expect(bundled_app("#{gem_name}/bin/setup").read).to start_with("#!")
+    expect(bundled_app("#{gem_name}/bin/console").read).to start_with("#!")
+  end
+
   it "includes bin/ into ignore list" do
     bundle "gem #{gem_name}"
 
@@ -645,6 +660,18 @@ RSpec.describe "bundle gem" do
     bundle "gem #{gem_name}"
 
     expect(ignore_paths).to include(".gitignore")
+  end
+
+  it "starts with version 0.1.0" do
+    bundle "gem #{gem_name}"
+
+    expect(bundled_app("#{gem_name}/lib/#{gem_name}/version.rb").read).to match(/VERSION = "0.1.0"/)
+  end
+
+  it "declare String type for VERSION constant" do
+    bundle "gem #{gem_name}"
+
+    expect(bundled_app("#{gem_name}/sig/#{gem_name}.rbs").read).to match(/VERSION: String/)
   end
 
   context "git config user.{name,email} is set" do
@@ -690,6 +717,97 @@ RSpec.describe "bundle gem" do
     expect(generated_gemspec.required_ruby_version.to_s).to start_with(">=")
   end
 
+  it "does not include the gemspec file in files" do
+    bundle "gem #{gem_name}"
+
+    bundler_gemspec = Bundler::GemHelper.new(bundled_app(gem_name), gem_name).gemspec
+
+    expect(bundler_gemspec.files).not_to include("#{gem_name}.gemspec")
+  end
+
+  it "does not include the Gemfile file in files" do
+    bundle "gem #{gem_name}"
+
+    bundler_gemspec = Bundler::GemHelper.new(bundled_app(gem_name), gem_name).gemspec
+
+    expect(bundler_gemspec.files).not_to include("Gemfile")
+  end
+
+  it "runs rake without problems" do
+    bundle "gem #{gem_name}"
+
+    system_gems ["rake-#{rake_version}"]
+
+    rakefile = <<~RAKEFILE
+      task :default do
+        puts 'SUCCESS'
+      end
+    RAKEFILE
+    File.open(bundled_app("#{gem_name}/Rakefile"), "w") do |file|
+      file.puts rakefile
+    end
+
+    sys_exec(rake, dir: bundled_app(gem_name))
+    expect(out).to include("SUCCESS")
+  end
+
+  context "--exe parameter set" do
+    before do
+      bundle "gem #{gem_name} --exe"
+    end
+
+    it "builds exe skeleton" do
+      expect(bundled_app("#{gem_name}/exe/#{gem_name}")).to exist
+      unless Gem.win_platform?
+        expect(bundled_app("#{gem_name}/exe/#{gem_name}")).to be_executable
+      end
+    end
+  end
+
+  context "--bin parameter set" do
+    before do
+      bundle "gem #{gem_name} --bin"
+    end
+
+    it "builds exe skeleton" do
+      expect(bundled_app("#{gem_name}/exe/#{gem_name}")).to exist
+    end
+  end
+
+  context "no --test parameter" do
+    before do
+      bundle "gem #{gem_name}"
+    end
+
+    it_behaves_like "test framework is absent"
+  end
+
+  context "--test parameter set to rspec" do
+    before do
+      bundle "gem #{gem_name} --test=rspec"
+    end
+
+    it "builds spec skeleton" do
+      expect(bundled_app("#{gem_name}/.rspec")).to exist
+      expect(bundled_app("#{gem_name}/spec/#{gem_name}_spec.rb")).to exist
+      expect(bundled_app("#{gem_name}/spec/spec_helper.rb")).to exist
+    end
+
+    it "includes .rspec and spec/ into ignore list" do
+      expect(ignore_paths).to include(".rspec")
+      expect(ignore_paths).to include("spec/")
+    end
+
+    it "depends on a specific version of rspec in generated Gemfile" do
+      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+      builder = Bundler::Dsl.new
+      builder.eval_gemfile(bundled_app("#{gem_name}/Gemfile"))
+      builder.dependencies
+      rspec_dep = builder.dependencies.find {|d| d.name == "rspec" }
+      expect(rspec_dep).to be_specific
+    end
+  end
+
   context "init_gems_rb setting to true" do
     before do
       bundle "config set init_gems_rb true"
@@ -726,6 +844,79 @@ RSpec.describe "bundle gem" do
     end
   end
 
+  context "gem.test setting set to rspec" do
+    before do
+      bundle "config set gem.test rspec"
+      bundle "gem #{gem_name}"
+    end
+
+    it "builds spec skeleton" do
+      expect(bundled_app("#{gem_name}/.rspec")).to exist
+      expect(bundled_app("#{gem_name}/spec/#{gem_name}_spec.rb")).to exist
+      expect(bundled_app("#{gem_name}/spec/spec_helper.rb")).to exist
+    end
+
+    it "includes .rspec and spec/ into ignore list" do
+      expect(ignore_paths).to include(".rspec")
+      expect(ignore_paths).to include("spec/")
+    end
+  end
+
+  context "gem.test setting set to rspec and --test is set to minitest" do
+    before do
+      bundle "config set gem.test rspec"
+      bundle "gem #{gem_name} --test=minitest"
+    end
+
+    it "builds spec skeleton" do
+      expect(bundled_app("#{gem_name}/test/test_#{gem_name}.rb")).to exist
+      expect(bundled_app("#{gem_name}/test/test_helper.rb")).to exist
+    end
+
+    it "includes test/ into ignore list" do
+      expect(ignore_paths).to include("test/")
+    end
+  end
+
+  context "--test parameter set to minitest" do
+    before do
+      bundle "gem #{gem_name} --test=minitest"
+    end
+
+    it "depends on a specific version of minitest" do
+      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+      builder = Bundler::Dsl.new
+      builder.eval_gemfile(bundled_app("#{gem_name}/Gemfile"))
+      builder.dependencies
+      minitest_dep = builder.dependencies.find {|d| d.name == "minitest" }
+      expect(minitest_dep).to be_specific
+    end
+
+    it "builds spec skeleton" do
+      expect(bundled_app("#{gem_name}/test/test_#{gem_name}.rb")).to exist
+      expect(bundled_app("#{gem_name}/test/test_helper.rb")).to exist
+    end
+
+    it "includes test/ into ignore list" do
+      expect(ignore_paths).to include("test/")
+    end
+
+    it "creates a default rake task to run the test suite" do
+      rakefile = <<~RAKEFILE
+        # frozen_string_literal: true
+
+        require "bundler/gem_tasks"
+        require "minitest/test_task"
+
+        Minitest::TestTask.create
+
+        task default: :test
+      RAKEFILE
+
+      expect(bundled_app("#{gem_name}/Rakefile").read).to eq(rakefile)
+    end
+  end
+
   context "gem.test setting set to minitest" do
     before do
       bundle "config set gem.test minitest"
@@ -748,21 +939,27 @@ RSpec.describe "bundle gem" do
     end
   end
 
-  context "--test parameter set to an invalid value" do
+  context "--test parameter set to test-unit" do
     before do
-      bundle "gem #{gem_name} --test=foo", raise_on_error: false
+      bundle "gem #{gem_name} --test=test-unit"
     end
 
-    it "fails loudly" do
-      expect(last_command).to be_failure
-      expect(err).to match(/Expected '--test' to be one of .*; got foo/)
+    it "depends on a specific version of test-unit" do
+      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+      builder = Bundler::Dsl.new
+      builder.eval_gemfile(bundled_app("#{gem_name}/Gemfile"))
+      builder.dependencies
+      test_unit_dep = builder.dependencies.find {|d| d.name == "test-unit" }
+      expect(test_unit_dep).to be_specific
     end
-  end
 
-  context "gem.test setting set to test-unit" do
-    before do
-      bundle "config set gem.test test-unit"
-      bundle "gem #{gem_name}"
+    it "builds spec skeleton" do
+      expect(bundled_app("#{gem_name}/test/#{gem_name}_test.rb")).to exist
+      expect(bundled_app("#{gem_name}/test/test_helper.rb")).to exist
+    end
+
+    it "includes test/ into ignore list" do
+      expect(ignore_paths).to include("test/")
     end
 
     it "creates a default rake task to run the test suite" do
@@ -783,6 +980,88 @@ RSpec.describe "bundle gem" do
 
       expect(bundled_app("#{gem_name}/Rakefile").read).to eq(rakefile)
     end
+  end
+
+  context "--test parameter set to an invalid value" do
+    before do
+      bundle "gem #{gem_name} --test=foo", raise_on_error: false
+    end
+
+    it "fails loudly" do
+      expect(last_command).to be_failure
+      expect(err).to match(/Expected '--test' to be one of .*; got foo/)
+    end
+  end
+
+  context "gem.test set to rspec and --test with no arguments" do
+    before do
+      bundle "config set gem.test rspec"
+      bundle "gem #{gem_name} --test"
+    end
+
+    it "builds spec skeleton" do
+      expect(bundled_app("#{gem_name}/.rspec")).to exist
+      expect(bundled_app("#{gem_name}/spec/#{gem_name}_spec.rb")).to exist
+      expect(bundled_app("#{gem_name}/spec/spec_helper.rb")).to exist
+    end
+
+    it "includes .rspec and spec/ into ignore list" do
+      expect(ignore_paths).to include(".rspec")
+      expect(ignore_paths).to include("spec/")
+    end
+
+    it "hints that --test is already configured" do
+      expect(out).to match("rspec is already configured, ignoring --test flag.")
+    end
+  end
+
+  context "gem.test setting set to false and --test with no arguments", :readline do
+    before do
+      bundle "config set gem.test false"
+      bundle "gem #{gem_name} --test" do |input, _, _|
+        input.puts
+      end
+    end
+
+    it "asks to generate test files" do
+      expect(out).to match("Do you want to generate tests with your gem?")
+    end
+
+    it "hints that the choice will only be applied to the current gem" do
+      expect(out).to match("Your choice will only be applied to this gem.")
+    end
+
+    it_behaves_like "test framework is absent"
+  end
+
+  context "gem.test setting not set and --test with no arguments", :readline do
+    before do
+      global_config "BUNDLE_GEM__TEST" => nil
+      bundle "gem #{gem_name} --test" do |input, _, _|
+        input.puts
+      end
+    end
+
+    it "asks to generate test files" do
+      expect(out).to match("Do you want to generate tests with your gem?")
+    end
+
+    it "hints that the choice will be applied to future bundle gem calls" do
+      hint = "Future `bundle gem` calls will use your choice. " \
+             "This setting can be changed anytime with `bundle config gem.test`."
+      expect(out).to match(hint)
+    end
+
+    it_behaves_like "test framework is absent"
+  end
+
+  context "gem.test setting set to a test framework and --no-test" do
+    before do
+      bundle "config set gem.test rspec"
+      bundle "gem #{gem_name} --no-test"
+    end
+
+    it_behaves_like "test framework is absent"
   end
 
   context "--ci with no argument" do
@@ -1166,52 +1445,16 @@ RSpec.describe "bundle gem" do
     end
   end
 
-  shared_examples_for "generating a gem" do
-    it "generates a gem skeleton" do
+  shared_examples_for "paths that depend on gem name" do
+    it "generates entrypoint, version file and signatures file at the proper path, with the proper content" do
       bundle "gem #{gem_name}"
 
-      expect(bundled_app("#{gem_name}/#{gem_name}.gemspec")).to exist
-      expect(bundled_app("#{gem_name}/Gemfile")).to exist
-      expect(bundled_app("#{gem_name}/Rakefile")).to exist
       expect(bundled_app("#{gem_name}/lib/#{require_path}.rb")).to exist
+      expect(bundled_app("#{gem_name}/lib/#{require_path}.rb").read).to match(%r{require_relative "#{require_relative_path}/version"})
+      expect(bundled_app("#{gem_name}/lib/#{require_path}.rb").read).to match(/class Error < StandardError; end$/)
+
       expect(bundled_app("#{gem_name}/lib/#{require_path}/version.rb")).to exist
       expect(bundled_app("#{gem_name}/sig/#{require_path}.rbs")).to exist
-      expect(bundled_app("#{gem_name}/.gitignore")).to exist
-
-      expect(bundled_app("#{gem_name}/bin/setup")).to exist
-      expect(bundled_app("#{gem_name}/bin/console")).to exist
-
-      unless Gem.win_platform?
-        expect(bundled_app("#{gem_name}/bin/setup")).to be_executable
-        expect(bundled_app("#{gem_name}/bin/console")).to be_executable
-      end
-
-      expect(bundled_app("#{gem_name}/bin/setup").read).to start_with("#!")
-      expect(bundled_app("#{gem_name}/bin/console").read).to start_with("#!")
-    end
-
-    it "starts with version 0.1.0" do
-      bundle "gem #{gem_name}"
-
-      expect(bundled_app("#{gem_name}/lib/#{require_path}/version.rb").read).to match(/VERSION = "0.1.0"/)
-    end
-
-    it "declare String type for VERSION constant" do
-      bundle "gem #{gem_name}"
-
-      expect(bundled_app("#{gem_name}/sig/#{require_path}.rbs").read).to match(/VERSION: String/)
-    end
-
-    it "requires the version file" do
-      bundle "gem #{gem_name}"
-
-      expect(bundled_app("#{gem_name}/lib/#{require_path}.rb").read).to match(%r{require_relative "#{require_relative_path}/version"})
-    end
-
-    it "creates a base error class" do
-      bundle "gem #{gem_name}"
-
-      expect(bundled_app("#{gem_name}/lib/#{require_path}.rb").read).to match(/class Error < StandardError; end$/)
     end
 
     context "--exe parameter set" do
@@ -1219,14 +1462,8 @@ RSpec.describe "bundle gem" do
         bundle "gem #{gem_name} --exe"
       end
 
-      it "builds exe skeleton" do
+      it "builds an exe file that requires the proper entrypoint" do
         expect(bundled_app("#{gem_name}/exe/#{gem_name}")).to exist
-        unless Gem.win_platform?
-          expect(bundled_app("#{gem_name}/exe/#{gem_name}")).to be_executable
-        end
-      end
-
-      it "requires the main file" do
         expect(bundled_app("#{gem_name}/exe/#{gem_name}").read).to match(/require "#{require_path}"/)
       end
     end
@@ -1236,21 +1473,10 @@ RSpec.describe "bundle gem" do
         bundle "gem #{gem_name} --bin"
       end
 
-      it "builds exe skeleton" do
+      it "builds an exe file that requires the proper entrypoint" do
         expect(bundled_app("#{gem_name}/exe/#{gem_name}")).to exist
-      end
-
-      it "requires the main file" do
         expect(bundled_app("#{gem_name}/exe/#{gem_name}").read).to match(/require "#{require_path}"/)
       end
-    end
-
-    context "no --test parameter" do
-      before do
-        bundle "gem #{gem_name}"
-      end
-
-      it_behaves_like "test framework is absent"
     end
 
     context "--test parameter set to rspec" do
@@ -1258,66 +1484,11 @@ RSpec.describe "bundle gem" do
         bundle "gem #{gem_name} --test=rspec"
       end
 
-      it "builds spec skeleton" do
-        expect(bundled_app("#{gem_name}/.rspec")).to exist
-        expect(bundled_app("#{gem_name}/spec/#{require_path}_spec.rb")).to exist
+      it "builds a spec helper that requires the proper entrypoint, and a default test in the proper path which fails" do
         expect(bundled_app("#{gem_name}/spec/spec_helper.rb")).to exist
-      end
-
-      it "includes .rspec and spec/ into ignore list" do
-        expect(ignore_paths).to include(".rspec")
-        expect(ignore_paths).to include("spec/")
-      end
-
-      it "depends on a specific version of rspec in generated Gemfile" do
-        allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
-        builder = Bundler::Dsl.new
-        builder.eval_gemfile(bundled_app("#{gem_name}/Gemfile"))
-        builder.dependencies
-        rspec_dep = builder.dependencies.find {|d| d.name == "rspec" }
-        expect(rspec_dep).to be_specific
-      end
-
-      it "requires the main file" do
         expect(bundled_app("#{gem_name}/spec/spec_helper.rb").read).to include(%(require "#{require_path}"))
-      end
-
-      it "creates a default test which fails" do
-        expect(bundled_app("#{gem_name}/spec/#{require_path}_spec.rb").read).to include("expect(false).to eq(true)")
-      end
-    end
-
-    context "gem.test setting set to rspec" do
-      before do
-        bundle "config set gem.test rspec"
-        bundle "gem #{gem_name}"
-      end
-
-      it "builds spec skeleton" do
-        expect(bundled_app("#{gem_name}/.rspec")).to exist
         expect(bundled_app("#{gem_name}/spec/#{require_path}_spec.rb")).to exist
-        expect(bundled_app("#{gem_name}/spec/spec_helper.rb")).to exist
-      end
-
-      it "includes .rspec and spec/ into ignore list" do
-        expect(ignore_paths).to include(".rspec")
-        expect(ignore_paths).to include("spec/")
-      end
-    end
-
-    context "gem.test setting set to rspec and --test is set to minitest" do
-      before do
-        bundle "config set gem.test rspec"
-        bundle "gem #{gem_name} --test=minitest"
-      end
-
-      it "builds spec skeleton" do
-        expect(bundled_app("#{gem_name}/#{minitest_test_file_path}")).to exist
-        expect(bundled_app("#{gem_name}/test/test_helper.rb")).to exist
-      end
-
-      it "includes test/ into ignore list" do
-        expect(ignore_paths).to include("test/")
+        expect(bundled_app("#{gem_name}/spec/#{require_path}_spec.rb").read).to include("expect(false).to eq(true)")
       end
     end
 
@@ -1326,37 +1497,13 @@ RSpec.describe "bundle gem" do
         bundle "gem #{gem_name} --test=minitest"
       end
 
-      it "depends on a specific version of minitest" do
-        allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
-        builder = Bundler::Dsl.new
-        builder.eval_gemfile(bundled_app("#{gem_name}/Gemfile"))
-        builder.dependencies
-        minitest_dep = builder.dependencies.find {|d| d.name == "minitest" }
-        expect(minitest_dep).to be_specific
-      end
-
-      it "builds spec skeleton" do
-        expect(bundled_app("#{gem_name}/#{minitest_test_file_path}")).to exist
+      it "builds a test helper that requires the proper entrypoint, and default test file in the proper path that defines the proper test class name, requires helper, and fails" do
         expect(bundled_app("#{gem_name}/test/test_helper.rb")).to exist
-      end
-
-      it "includes test/ into ignore list" do
-        expect(ignore_paths).to include("test/")
-      end
-
-      it "requires the main file" do
         expect(bundled_app("#{gem_name}/test/test_helper.rb").read).to include(%(require "#{require_path}"))
-      end
 
-      it "requires 'test_helper'" do
-        expect(bundled_app("#{gem_name}/#{minitest_test_file_path}").read).to include(%(require "test_helper"))
-      end
-
-      it "defines valid test class name" do
+        expect(bundled_app("#{gem_name}/#{minitest_test_file_path}")).to exist
         expect(bundled_app("#{gem_name}/#{minitest_test_file_path}").read).to include(minitest_test_class_name)
-      end
-
-      it "creates a default test which fails" do
+        expect(bundled_app("#{gem_name}/#{minitest_test_file_path}").read).to include(%(require "test_helper"))
         expect(bundled_app("#{gem_name}/#{minitest_test_file_path}").read).to include("assert false")
       end
     end
@@ -1366,110 +1513,15 @@ RSpec.describe "bundle gem" do
         bundle "gem #{gem_name} --test=test-unit"
       end
 
-      it "depends on a specific version of test-unit" do
-        allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
-        builder = Bundler::Dsl.new
-        builder.eval_gemfile(bundled_app("#{gem_name}/Gemfile"))
-        builder.dependencies
-        test_unit_dep = builder.dependencies.find {|d| d.name == "test-unit" }
-        expect(test_unit_dep).to be_specific
-      end
-
-      it "builds spec skeleton" do
-        expect(bundled_app("#{gem_name}/test/#{require_path}_test.rb")).to exist
+      it "builds a test helper that requires the proper entrypoint, and default test file in the proper path which requires helper and fails" do
         expect(bundled_app("#{gem_name}/test/test_helper.rb")).to exist
-      end
-
-      it "includes test/ into ignore list" do
-        expect(ignore_paths).to include("test/")
-      end
-
-      it "requires the main file" do
         expect(bundled_app("#{gem_name}/test/test_helper.rb").read).to include(%(require "#{require_path}"))
-      end
-
-      it "requires 'test_helper'" do
+        expect(bundled_app("#{gem_name}/test/#{require_path}_test.rb")).to exist
         expect(bundled_app("#{gem_name}/test/#{require_path}_test.rb").read).to include(%(require "test_helper"))
-      end
-
-      it "creates a default test which fails" do
         expect(bundled_app("#{gem_name}/test/#{require_path}_test.rb").read).to include("assert_equal(\"expected\", \"actual\")")
       end
     end
-
-    context "gem.test set to rspec and --test with no arguments" do
-      before do
-        bundle "config set gem.test rspec"
-        bundle "gem #{gem_name} --test"
-      end
-
-      it "builds spec skeleton" do
-        expect(bundled_app("#{gem_name}/.rspec")).to exist
-        expect(bundled_app("#{gem_name}/spec/#{require_path}_spec.rb")).to exist
-        expect(bundled_app("#{gem_name}/spec/spec_helper.rb")).to exist
-      end
-
-      it "includes .rspec and spec/ into ignore list" do
-        expect(ignore_paths).to include(".rspec")
-        expect(ignore_paths).to include("spec/")
-      end
-
-      it "hints that --test is already configured" do
-        expect(out).to match("rspec is already configured, ignoring --test flag.")
-      end
-    end
-
-    context "gem.test setting set to false and --test with no arguments", :readline do
-      before do
-        bundle "config set gem.test false"
-        bundle "gem #{gem_name} --test" do |input, _, _|
-          input.puts
-        end
-      end
-
-      it "asks to generate test files" do
-        expect(out).to match("Do you want to generate tests with your gem?")
-      end
-
-      it "hints that the choice will only be applied to the current gem" do
-        expect(out).to match("Your choice will only be applied to this gem.")
-      end
-
-      it_behaves_like "test framework is absent"
-    end
-
-    context "gem.test setting not set and --test with no arguments", :readline do
-      before do
-        global_config "BUNDLE_GEM__TEST" => nil
-        bundle "gem #{gem_name} --test" do |input, _, _|
-          input.puts
-        end
-      end
-
-      it "asks to generate test files" do
-        expect(out).to match("Do you want to generate tests with your gem?")
-      end
-
-      it "hints that the choice will be applied to future bundle gem calls" do
-        hint = "Future `bundle gem` calls will use your choice. " \
-               "This setting can be changed anytime with `bundle config gem.test`."
-        expect(out).to match(hint)
-      end
-
-      it_behaves_like "test framework is absent"
-    end
-
-    context "gem.test setting set to a test framework and --no-test" do
-      before do
-        bundle "config set gem.test rspec"
-        bundle "gem #{gem_name} --no-test"
-      end
-
-      it_behaves_like "test framework is absent"
-    end
   end
-
-  include_examples "generating a gem"
 
   context "with mit option in bundle config settings set to true" do
     before do
@@ -1633,6 +1685,18 @@ RSpec.describe "bundle gem" do
     end
   end
 
+  context "standard gem naming" do
+    let(:require_path) { gem_name }
+
+    let(:require_relative_path) { gem_name }
+
+    let(:minitest_test_file_path) { "test/test_#{gem_name}.rb" }
+
+    let(:minitest_test_class_name) { "class TestMygem < Minitest::Test" }
+
+    include_examples "paths that depend on gem name"
+  end
+
   context "gem naming with underscore" do
     let(:gem_name) { "test_gem" }
 
@@ -1652,7 +1716,7 @@ RSpec.describe "bundle gem" do
       expect(bundled_app("#{gem_name}/lib/#{require_path}.rb").read).to match(/module TestGem/)
     end
 
-    include_examples "generating a gem"
+    include_examples "paths that depend on gem name"
 
     context "--ext parameter with no value" do
       context "is deprecated" do
@@ -1782,7 +1846,7 @@ RSpec.describe "bundle gem" do
       expect(bundled_app("#{gem_name}/lib/#{require_path}.rb").read).to match(/module Test\n  module Gem/)
     end
 
-    include_examples "generating a gem"
+    include_examples "paths that depend on gem name"
   end
 
   describe "uncommon gem names" do

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe "bundle gem" do
 
   let(:require_path) { "mygem" }
 
+  let(:require_relative_path) { "mygem" }
+
   let(:minitest_test_file_path) { "test/test_mygem.rb" }
 
   let(:minitest_test_class_name) { "class TestMygem < Minitest::Test" }
@@ -1500,6 +1502,8 @@ RSpec.describe "bundle gem" do
       end
     end
   end
+
+  include_examples "generating a gem"
 
   context "testing --mit and --coc options against bundle config settings" do
     let(:gem_name) { "test-gem" }


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

They are currently quite hard to work with. For example, #8622 was essentially ready, yet it was hard to figure out why specs were hanging on Windows.
 
## What is your fix for the problem, implemented in this PR?

This is not a definitive fix, just some iterative improvements. The main change is that I discovered that there was a huge `shared_examples_for "generating a gem"` block that was running for two edge case gem names (hyphenated, and underscored), but not for the more standard gem name.

My improvement is to reduce that block to only the specs whole result depend on the gem name, and only run that for the different gem name cases. The rest of the specs are moved, unnested, to the main body of the spec.

In addition to improving readability, this reduces runtime of this file from ~1m40s to ~1m10s on my laptop.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
