### PR TITLE
Add a root CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# How to contribute
+
+## Contributing to RubyGems
+
+Check [RubyGems contribution guidelines](doc/rubygems/CONTRIBUTING.md).
+
+## Contributing to Bundler
+
+Check [Bundler contribution guidelines](doc/bundler/contributing/README.md).

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -1,5 +1,6 @@
 CHANGELOG.md
 CODE_OF_CONDUCT.md
+CONTRIBUTING.md
 LICENSE.txt
 MIT.txt
 Manifest.txt


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

GitHub has some functionality that gets enabled when there's a root CONTRIBUTING.md file, like linking to it when first opening a PR.

We don't have a root CONTRIBUTING.md file though, because our docs are split between Bundler and RubyGems.

## What is your fix for the problem, implemented in this PR?

We should try to gradually unify things, but for now having a root file that links to contribution instructions for both RubyGems and Bundler seems like a good initial step.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
