### PR TITLE
Document that `global_gem_cache` also caches compiled extensions

### DIFF
--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -114,7 +114,7 @@ Sets the \fB\-\-key\fR parameter for \fBgem push\fR when using the \fBrake relea
 The name of the file that bundler should use as the \fBGemfile\fR\. This location of this file also sets the root of the project, which is used to resolve relative paths in the \fBGemfile\fR, among other things\. By default, bundler will search up from the current working directory until it finds a \fBGemfile\fR\.
 .TP
 \fBglobal_gem_cache\fR (\fBBUNDLE_GLOBAL_GEM_CACHE\fR)
-Whether Bundler should cache all gems globally, rather than locally to the configured installation path\.
+Whether Bundler should cache all gems and compiled extensions globally, rather than locally to the configured installation path\.
 .TP
 \fBignore_funding_requests\fR (\fBBUNDLE_IGNORE_FUNDING_REQUESTS\fR)
 When set, no funding requests will be printed\.

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -140,8 +140,8 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    will search up from the current working directory until it finds a
    `Gemfile`.
 * `global_gem_cache` (`BUNDLE_GLOBAL_GEM_CACHE`):
-   Whether Bundler should cache all gems globally, rather than locally to the
-   configured installation path.
+   Whether Bundler should cache all gems and compiled extensions globally,
+   rather than locally to the configured installation path.
 * `ignore_funding_requests` (`BUNDLE_IGNORE_FUNDING_REQUESTS`):
    When set, no funding requests will be printed.
 * `ignore_messages` (`BUNDLE_IGNORE_MESSAGES`):


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Up until not so long, I did not know that this setting also controls caching compiled extensions.

## What is your fix for the problem, implemented in this PR?

Document it so people are aware.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
