### PR TITLE
Revert recent "Scorecard tweaks"

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -48,18 +48,8 @@ jobs:
           # - See https://github.com/ossf/scorecard-action#publishing-results.
           publish_results: true
 
-      - name: Filter SARIF to skip irrelevant rules
-        env:
-          SCORECARD_SKIPPED_RULE_IDS: CodeReviewID,FuzzingID,CIIBestPracticesID
-        run: |
-          SCORECARD_SKIPPED_RULE_IDS_IN_JSON=$(echo $SCORECARD_SKIPPED_RULE_IDS | jq -cR 'split(",")')
-          # Trim the SARIF file to remove skipped rule detections
-          cat results.sarif | jq '.runs[].results |= map(select(.ruleId as $id | '$SCORECARD_SKIPPED_RULE_IDS_IN_JSON' | all($id != .)))' > filteredResults.sarif
-          # Print the skipped rule detections
-          cat results.sarif | jq '.runs[].results | map(select(.ruleId as $id | '$SCORECARD_SKIPPED_RULE_IDS_IN_JSON' | any($id == .))) | select(. | length > 0)'
-
       # Upload the results to GitHub's code scanning dashboard.
       - name: Upload to code-scanning
         uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
         with:
-          sarif_file: filteredResults.sarif
+          sarif_file: results.sarif


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I introduced some tweaks in 7cf7082a53599fb31a2f702bc810532f2632a9bf to try revert scorecard checks that we don't currently care about.

However, the workflow has now run and it doesn't work.

The reason is https://github.com/ossf/scorecard-action#workflow-restrictions. When results are pushed, the scorecard API checks that the workflow that pushed it only uses actions from the following list:
 
* "actions/checkout"
* "actions/upload-artifact"
* "github/codeql-action/upload-sarif"
* "ossf/scorecard-action"
* "step-security/harden-runner"

Otherwise detects the workflow as tampered and rejects publication.

## What is your fix for the problem, implemented in this PR?

I have no fix for now, the scorecard API tries very hard to prevent only using a subset of the checks, not sure.

For now I'm reverting the check, but I'd like us to consider removing this workflow altogether because it's too inflexible.
 
## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
