### PR TITLE
Update vendored resolv to 0.6.2

### DIFF
--- a/tool/bundler/vendor_gems.rb
+++ b/tool/bundler/vendor_gems.rb
@@ -9,7 +9,7 @@ gem "net-http-persistent", github: "hsbt/net-http-persistent", ref: "9b6fbd733cf
 gem "net-protocol", "0.2.2"
 gem "optparse", "0.6.0"
 gem "pub_grub", github: "jhawthorn/pub_grub", ref: "df6add45d1b4d122daff2f959c9bd1ca93d14261"
-gem "resolv", "0.6.0"
+gem "resolv", "0.6.2"
 gem "securerandom", "0.4.1"
 gem "timeout", "0.4.3"
 gem "thor", "1.3.2"

--- a/tool/bundler/vendor_gems.rb.lock
+++ b/tool/bundler/vendor_gems.rb.lock
@@ -35,7 +35,7 @@ GEM
     net-protocol (0.2.2)
       timeout
     optparse (0.6.0)
-    resolv (0.6.0)
+    resolv (0.6.2)
     securerandom (0.4.1)
     thor (1.3.2)
     timeout (0.4.3)
@@ -58,7 +58,7 @@ DEPENDENCIES
   net-protocol (= 0.2.2)
   optparse (= 0.6.0)
   pub_grub!
-  resolv (= 0.6.0)
+  resolv (= 0.6.2)
   securerandom (= 0.4.1)
   thor (= 1.3.2)
   timeout (= 0.4.3)
@@ -74,7 +74,7 @@ CHECKSUMS
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
   optparse (0.6.0) sha256=25e90469c1cd44048a89dc01c1dde9d5f0bdf717851055fb18237780779b068c
   pub_grub (0.5.0)
-  resolv (0.6.0) sha256=b8b73f7734d4102ef9f75bad281d8fd1c434f8588b6aba17832ddc16fe679fab
+  resolv (0.6.2) sha256=61efe545cedddeb1b14f77e51f85c85ca66af5098fdbf567fadf32c34590fb14
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   thor (1.3.2) sha256=eef0293b9e24158ccad7ab383ae83534b7ad4ed99c09f96f1a6b036550abbeda
   timeout (0.4.3) sha256=9509f079b2b55fe4236d79633bd75e34c1c1e7e3fb4b56cb5fda61f80a0fe30e


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Resolved for https://www.ruby-lang.org/en/news/2025/07/08/dos-resolv-cve-2025-24294/

## What is your fix for the problem, implemented in this PR?

Bump up to vendored resolv to 0.6.2 from 0.6.0.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
