### PR TITLE
Allow cached `compact_index` to be refreshed when it has invalid UTF-8

### DIFF
--- a/bundler/lib/bundler/compact_index_client/updater.rb
+++ b/bundler/lib/bundler/compact_index_client/updater.rb
@@ -24,7 +24,7 @@ module Bundler
       private
 
       def append(remote_path, local_path, etag_path)
-        return false unless local_path.file? && local_path.size.nonzero?
+        return false unless local_path.file? && local_path.size.nonzero? && local_path.read.valid_encoding?
 
         CacheFile.copy(local_path) do |file|
           etag = etag_path.read.tap(&:chomp!) if etag_path.file?
@@ -49,7 +49,7 @@ module Bundler
 
       # request without range header to get the full file or a 304 Not Modified
       def replace(remote_path, local_path, etag_path)
-        etag = etag_path.read.tap(&:chomp!) if etag_path.file?
+        etag = etag_path.read.tap(&:chomp!) if etag_path.file? && local_path.read.valid_encoding?
         response = @fetcher.call(remote_path, request_headers(etag))
         return true if response.is_a?(Gem::Net::HTTPNotModified)
         CacheFile.write(local_path, response.body, parse_digests(response))


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Sometimes our internal JFrog's Artifactory mirror serves a compact index file that is not UTF-8 valid.
I'm not sure how it gets into this state, but the versions file becomes a binary.

## What is your fix for the problem, implemented in this PR?

My fix is to prevent this file from being vended as cached, when it's not readable (`valid_encoding?`).
This should force a full replacement of the file when it gets into this state.

Currently, it's hard to get out of this state, because both the `append` and `replace` method will early exit when the `eTag` is passed to remote, and we get back `Gem::Net::HTTPNotModified`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
