### PR TITLE
Load RubyGems extensions in the first place

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "bundler/rubygems_ext"
 require_relative "bundler/vendored_fileutils"
 require "pathname"
 require "rbconfig"
@@ -7,7 +8,6 @@ require "rbconfig"
 require_relative "bundler/errors"
 require_relative "bundler/environment_preserver"
 require_relative "bundler/plugin"
-require_relative "bundler/rubygems_ext"
 require_relative "bundler/rubygems_integration"
 require_relative "bundler/version"
 require_relative "bundler/current_ruby"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This is not currently causing any issues, but I think the most correct thing to do is that Bundler loads the extensions to RubyGems in the first place, so that they are available from the beginning.

## What is your fix for the problem, implemented in this PR?

Move `require_relative "bundler/rubygems_ext"` to the top of the `bundler.rb` file.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
