### PR TITLE
Reset tmp directories before spec suite

### DIFF
--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -103,7 +103,7 @@ RSpec.configure do |config|
 
     build_repo1
 
-    reset_paths!
+    reset!
   end
 
   config.around :each do |example|

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -24,10 +24,6 @@ module Spec
       end
       FileUtils.mkdir_p(home)
       FileUtils.mkdir_p(tmpdir)
-      reset_paths!
-    end
-
-    def reset_paths!
       Bundler.reset!
       Gem.clear_paths
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If you abort running test suite with a quick double Ctrl-C, tmp files will be left around, and they will interfere with the next test run.

## What is your fix for the problem, implemented in this PR?

Clear them once at the beginning of the test suite.

### Before

```
$ bin/parallel_rspec
16 processes for 175 specs, ~ 11 specs per process
.............................................................................................^C^C

Finished in 19.45 seconds (files took 0.42722 seconds to load)
94 examples, 0 failures

(... turbo tests backtrace ...)

$ bin/parallel_rspec
16 processes for 175 specs, ~ 11 specs per process
.F....F....F...F......^C

Failures:

(... failures' details ...)
```

### After

```
$ bin/parallel_rspec
16 processes for 175 specs, ~ 11 specs per process
.................................................................................^C^C

Finished in 18.18 seconds (files took 0.4383 seconds to load)
82 examples, 0 failures

(... turbo tests backtrace ...)

$ bin/parallel_rspec
16 processes for 175 specs, ~ 11 specs per process
................................................................................^C^C

Finished in 8.79 seconds (files took 0.45187 seconds to load)
80 examples, 0 failures

(... turbo tests backtrace ...)
```
## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
