### PR TITLE
Fix incorrect UPGRADING link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To upgrade to the latest RubyGems, run:
 
     $ gem update --system
 
-See [UPGRADING](doc/bundler/UPGRADING.md) for more details and alternative instructions.
+See [UPGRADING](doc/rubygems/UPGRADING.md) for more details and alternative instructions.
 
 ## Release policy
 


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

I clicked on UPGRADING in the README.md and was taken to the bundler doc instead of the rubygems doc.

## What is your fix for the problem, implemented in this PR?

Fixes the link.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
