### PR TITLE
Add missing liking to `irb` repo in DEBUGGING.md

### DIFF
--- a/doc/bundler/development/DEBUGGING.md
+++ b/doc/bundler/development/DEBUGGING.md
@@ -28,7 +28,7 @@ With REPL you can look at the values of objects and variables, the stack trace, 
 
 To use REPL, place a `binding.irb` wherever you'd like to take a look around. An interactive `irb` console will open when your code gets to your breakpoint.
 
-To learn more about using IRB, [TODO: link to doc]
+To learn more about using IRB, see [https://github.com/ruby/irb](https://github.com/ruby/irb).
 
 ## Interactive debugging
 


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Replacing a TODO link to doc, with an actual link to the docs.

## What is your fix for the problem, implemented in this PR?

Replacing a TODO link to doc, with an actual link to the docs.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
