### PR TITLE
Restore parsing "--" as an unknown platform rather than crashing

### DIFF
--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -90,7 +90,7 @@ class Gem::Platform
     when String then
       cpu, os = arch.sub(/-+$/, "").split("-", 2)
 
-      @cpu = if cpu.match?(/i\d86/)
+      @cpu = if cpu&.match?(/i\d86/)
         "x86"
       else
         cpu

--- a/test/rubygems/test_gem_platform.rb
+++ b/test/rubygems/test_gem_platform.rb
@@ -162,6 +162,8 @@ class TestGemPlatform < Gem::TestCase
       "x86_64-dotnetx86" => ["x86_64", "dotnet", nil],
       "x86_64-dalvik0" => ["x86_64", "dalvik", "0"],
       "x86_64-dotnet1." => ["x86_64", "dotnet", "1"],
+
+      "--" => [nil, "unknown", nil],
     }
 
     test_cases.each do |arch, expected|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We found that some incorrectly implemented `/info/<names>` endpoints in a gem source, where the preamble is preceded by spaces, like `  ---`, may cause Bundler to try to instantiate "--" as a platform.

This previously was properly parsed as an unknown platform, but after https://github.com/rubygems/rubygems/pull/8584, it crashes.

## What is your fix for the problem, implemented in this PR?

We could considered somehow handling these ill-defined compact index implementations, but I figured we could restore how `Gem::Platform#initialize` previously worked, just in case, namely, treat it as an unknown platform, rather than crashing when trying to parse it.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
