### PR TITLE
Update CoC email to conduct@rubygems.org

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-team@bundler.io.
+conduct@rubygems.org.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The code of conduct file contained a defunct email address, team@bundler.io.

## What is your fix for the problem, implemented in this PR?

Updated the code of conduct to reference the current email address, conduct@rubygems.org.