### PR TITLE
Fix regression in presence of RVM gems

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -204,6 +204,40 @@ jobs:
 
     timeout-minutes: 20
 
+  check_rvm_integration:
+    name: Handling gems shipped by default with RVM
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - { name: "3.2", value: 3.2.8 }
+          - { name: "3.3", value: 3.3.8 }
+          - { name: "3.4", value: 3.4.4 }
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Setup ruby
+        uses: ruby/setup-ruby@472790540115ce5bd69d399a020189a8c87d641f # v1.247.0
+        with:
+          ruby-version: ${{ matrix.ruby.value }}
+          bundler: none
+      - name: Install rubygems
+        run: ruby setup.rb
+      - name: Install RVM gems
+        run: gem install rubygems-bundler
+      - name: Check binstubs can run
+        run: |
+          gem install rake
+          RUBYOPT=-Ibundler/lib rake -T
+      - name: Check binstubs can handle nested bundle exec
+        run: |
+          echo "source 'https://rubygems.org'" > Gemfile
+          gem install bundler:2.5.22
+          bundle _2.5.22_ exec ruby -e 'system("bundle", "exec", "ruby", "-e1")' 2>&1 | grep -v LoadError
+
   all-pass:
     name: All install-rubygems jobs pass
 
@@ -213,6 +247,7 @@ jobs:
       - install_rubygems_ubuntu
       - install_rubygems_windows
       - shared_gem_home
+      - check_rvm_integration
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Install & Check Dependencies
         run: bin/rake dev:frozen_deps
       - name: Misc checks
-        run: bin/rake check_rvm_integration man:check vendor:check version:check check_rubygems_integration
+        run: bin/rake man:check vendor:check version:check check_rubygems_integration
         if: matrix.ruby.name != 'jruby'
     timeout-minutes: 15
 

--- a/Rakefile
+++ b/Rakefile
@@ -563,14 +563,6 @@ namespace :spec do
   end
 end
 
-desc "Check RVM integration"
-task :check_rvm_integration do
-  # The rubygems-bundler gem is installed by RVM by default and it could easily
-  # break when we change bundler. Make sure that binstubs still run with it
-  # installed.
-  sh("RUBYOPT=-Ilib gem install rubygems-bundler rake && RUBYOPT=-Ibundler/lib rake -T")
-end
-
 desc "Check RubyGems integration"
 task :check_rubygems_integration do
   # Bundler monkeypatches RubyGems in some ways that could potentially break gem activation.

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -298,6 +298,13 @@ module Gem
     spec = find_and_activate_spec_for_exe name, exec_name, requirements
 
     if spec.name == "bundler"
+      # Old versions of Bundler need a workaround to support nested `bundle
+      # exec` invocations by overriding `Gem.activate_bin_path`. However,
+      # RubyGems now uses this new `Gem.activate_and_load_bin_path` helper in
+      # binstubs, which is of course not overridden in Bundler since it didn't
+      # exist at the time. So, include the override here to workaround that.
+      load ENV["BUNDLE_BIN_PATH"] if ENV["BUNDLE_BIN_PATH"] && spec.version <= "2.5.22"
+
       # Make sure there's no version of Bundler in `$LOAD_PATH` that's different
       # from the version we just activated. If that was the case (it happens
       # when testing Bundler from ruby/ruby), we would load Bundler extensions


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Introducing `Gem.activate_and_load_bin_path` in RubyGems 3.7.0 caused an issue when using RVM and versions of Bundler older that 2.5.23, where nested `bundle exec` invocations will fail.

Versions of Bundler not including https://github.com/rubygems/rubygems/commit/f530f8686d7114a21ff59e953336b7c3798e95f1 (Bundler < 2.5.23) needed to override `Gem.activate_bin_path` in order to support nested `bundle exec` invocations. However, since RubyGems 3.7.0 now uses a new `Gem.load_and_activate_bin_path` helper, those workarounds no longer work.

## What is your fix for the problem, implemented in this PR?

Include the same workaround in RubyGems itself, when the version of Bundler being activated suffers from the problem.

Closes #8845.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
