### PR TITLE
Clarify documentation about new default gem installation directory in Bundler 4

### DIFF
--- a/doc/bundler/UPGRADING.md
+++ b/doc/bundler/UPGRADING.md
@@ -28,9 +28,10 @@ existing default by configuring
 bundle config default_cli_command install
 ```
 
-### Bundler will install to a `.bundle` folder relative to repository root by default
+### Bundler will install to a `.bundle` folder relative to the Gemfile location by default
 
-We're making this change to improve isolation.
+We're making this change to improve isolation. It will install gems to a
+`.bundle` folder relative to the Gemfile location, instead of a global system folder.
 
 The previous default of installing to system changes can be kept with `bundle
 config path.system true`.


### PR DESCRIPTION
This documentation change does two things:

1. Explains what the `.bundle` folder relative install change is, as a one liner.

2. Identifies the location as being relative to the `Gemfile`, not the "repository root".

In the case of a multiproject monorepo, you may have many Gemfiles.

```
project_a
- Gemfile
project_b
- Gemfile
```

Running `cd project_a && BUNDLE_SIMULATE_VERSION=4 bundle install` puts the new `.config` folder in `project_a`. The documentation describes it as going in the "repository root" which would be one above.
