### PR TITLE
[feature] Allows command to run when cache path is empty

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -404,6 +404,7 @@ module Bundler
     method_option "path", type: :string, banner: "Specify a different path than the system default ($BUNDLE_PATH or $GEM_HOME).#{" Bundler will remember this value for future installs on this machine" unless Bundler.feature_flag.forget_cli_options?}"
     method_option "quiet", type: :boolean, banner: "Only output warnings and errors."
     method_option "frozen", type: :boolean, banner: "Do not allow the Gemfile.lock to be updated after this bundle cache operation's install"
+    method_option "no-fail-on-empty-cache-path", type: :boolean, banner: "Runs even when the cache directory exists but is empty"
     long_desc <<-D
       The cache command will copy the .gem files for every gem in the bundle into the
       directory ./vendor/cache. If you then check that directory into your source

--- a/bundler/lib/bundler/man/bundle-cache.1.ronn
+++ b/bundler/lib/bundler/man/bundle-cache.1.ronn
@@ -42,6 +42,12 @@ use the gems in the cache in preference to the ones on `rubygems.org`.
 * `--frozen`:
   Do not allow the Gemfile.lock to be updated after this bundle cache operation's install.
 
+* `--no-fail-on-empty-cache-path`:
+  Runs even when the cache directory exists but is empty.
+  This is useful in Docker multi-stage builds where the cache directory may be
+  created by a mount but is initially empty and it will be copied from existing
+  directory to avoid 
+
 ## GIT AND PATH GEMS
 
 The `bundle cache` command can also package `:git` and `:path` dependencies


### PR DESCRIPTION
Adding new option for bypassing cache paths validations, in this case explicitly ignore the fact folders are empty

## What was the end-user or developer problem that led to this PR?

[CLOSES#8853](https://github.com/rubygems/rubygems/issues/8853) 

Basically user want to make bundler pre-cache gems in a build stage, and then reuse it to avoid re-downloading gems in subsequent stages.

Currently bundler will raise an exception because there is no way to skip this validation, it is worth to add it to support docker recipes using this setup.

The existing flags don't solve this because:
`--no-install` still fails when cache is empty
`--frozen still` fails when cache is empty
`--local` would fail real nasty

The Docker multi-stage build scenario is common as i think many developers use Docker with volume mounts for caching.

## What is your fix for the problem, implemented in this PR?

Introducing new flag, or option so the user or developer can tell bundler to skip or bypass this validation

Benefits:
- The flag is explicitly opt-in - users must consciously choose this behavior
- It's scoped to a specific scenario (empty cache directory)
- It provides clear warnings about what's happening
- It's documented with the specific use case