### PR TITLE
Workaround for rubygems plugin of `mise`

### DIFF
--- a/bundler/spec/support/hax.rb
+++ b/bundler/spec/support/hax.rb
@@ -66,3 +66,9 @@ module Gem
     Socket.singleton_class.prepend FakeResolv
   end
 end
+
+# mise installed rubygems_plugin.rb to system wide `site_ruby` directory.
+# This empty module avoid to call `mise` command.
+module ReshimInstaller
+  def self.reshim; end
+end

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1578,3 +1578,9 @@ class Object
 end
 
 require_relative "utilities"
+
+# mise installed rubygems_plugin.rb to system wide `site_ruby` directory.
+# This empty module avoid to call `mise` command.
+module ReshimInstaller
+  def self.reshim; end
+end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This PR is another approach of https://github.com/rubygems/rubygems/pull/8856

## What is your fix for the problem, implemented in this PR?

I added `ReshimInstaller` module to `mise` at https://github.com/jdx/mise/pull/5676 and https://github.com/jdx/mise/pull/5678. We can override and make no-op that after this version.

This PR defined `ReshimInstaller` and empty `reshim` method for that.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
