### PR TITLE
Add a quality spec to ensure man pages are up to date:

### DIFF
--- a/bundler/lib/bundler/man/bundle-plugin.1
+++ b/bundler/lib/bundler/man/bundle-plugin.1
@@ -6,7 +6,7 @@
 .SH "SYNOPSIS"
 \fBbundle plugin\fR install PLUGINS [\-\-source=\fISOURCE\fR] [\-\-version=\fIversion\fR] [\-\-git=\fIgit\-url\fR] [\-\-branch=\fIbranch\fR|\-\-ref=\fIrev\fR] [\-\-path=\fIpath\fR]
 .br
-\fBbundle plugin\fR uninstall PLUGINS
+\fBbundle plugin\fR uninstall PLUGINS [\-\-all]
 .br
 \fBbundle plugin\fR list
 .br
@@ -41,8 +41,16 @@ When you specify \fB\-\-git\fR, you can use \fB\-\-branch\fR or \fB\-\-ref\fR to
 .TP
 \fBbundle plugin install bundler\-graph \-\-path \.\./bundler\-graph\fR
 Install bundler\-graph gem from a local path\.
+.TP
+\fBbundle plugin install bundler\-graph \-\-local\-git \.\./bundler\-graph\fR
+This option is deprecated in favor of \fB\-\-git\fR\.
 .SS "uninstall"
 Uninstall the plugin(s) specified in PLUGINS\.
+.P
+\fBOPTIONS\fR
+.TP
+\fB\-\-all\fR
+Uninstall all the installed plugins\. If no plugin is installed, then it does nothing\.
 .SS "list"
 List the installed plugins and available commands\.
 .P

--- a/bundler/lib/bundler/man/bundle-plugin.1.ronn
+++ b/bundler/lib/bundler/man/bundle-plugin.1.ronn
@@ -6,7 +6,7 @@ bundle-plugin(1) -- Manage Bundler plugins
 `bundle plugin` install PLUGINS [--source=<SOURCE>] [--version=<version>]
                               [--git=<git-url>] [--branch=<branch>|--ref=<rev>]
                               [--path=<path>]<br>
-`bundle plugin` uninstall PLUGINS<br>
+`bundle plugin` uninstall PLUGINS [--all]<br>
 `bundle plugin` list<br>
 `bundle plugin` help [COMMAND]
 
@@ -42,9 +42,17 @@ Install the given plugin(s).
 * `bundle plugin install bundler-graph --path ../bundler-graph`:
   Install bundler-graph gem from a local path.
 
+* `bundle plugin install bundler-graph --local-git ../bundler-graph`:
+  This option is deprecated in favor of `--git`.
+
 ### uninstall
 
 Uninstall the plugin(s) specified in PLUGINS.
+
+**OPTIONS**
+
+* `--all`:
+  Uninstall all the installed plugins. If no plugin is installed, then it does nothing.
 
 ### list
 

--- a/bundler/spec/quality_spec.rb
+++ b/bundler/spec/quality_spec.rb
@@ -288,8 +288,6 @@ RSpec.describe "The library itself" do
   end
 
   def cli_and_man_pages_in_sync!(commands)
-    undocumented_options = ["--all", "--local-git"]
-
     commands.each do |command_name, opts|
       man_page_path = man_tracked_files.find {|f| File.basename(f) == "bundle-#{command_name}.1.ronn" }
       expect(man_page_path).to_not be_nil, "The command #{command_name} has no associated man page."
@@ -298,8 +296,6 @@ RSpec.describe "The library itself" do
 
       man_page_content = File.read(man_page_path)
       opts.each do |option_name|
-        next if undocumented_options.include?(option_name.to_s)
-
         error_msg = <<~EOM
           The command #{command_name} has no mention of the option or subcommand `#{option_name}` in its man page.
           Document the `#{option_name}` in the man page to discard this error.

--- a/bundler/spec/quality_spec.rb
+++ b/bundler/spec/quality_spec.rb
@@ -251,9 +251,62 @@ RSpec.describe "The library itself" do
     expect(lib_code).to eq(spec_code)
   end
 
+  it "documents all cli command options in their associated man pages" do
+    commands = normalize_commands_and_options(Bundler::CLI)
+    cli_and_man_pages_in_sync!(commands)
+
+    Bundler::CLI.subcommand_classes.each do |_, klass|
+      subcommands = normalize_commands_and_options(klass)
+
+      cli_and_man_pages_in_sync!(subcommands)
+    end
+  end
+
   private
 
   def each_line(filename, &block)
     File.readlines(filename, encoding: "UTF-8").each_with_index(&block)
+  end
+
+  def normalize_commands_and_options(command_class)
+    commands = {}
+
+    command_class.commands.each do |command_name, command|
+      next if command.is_a?(Bundler::Thor::HiddenCommand)
+
+      key = command.ancestor_name || command_name
+      commands[key] ||= []
+      # Verify that all subcommands are documented in the main command's man page.
+      commands[key] << command_name unless command_class == Bundler::CLI
+
+      command.options.each do |_, option|
+        commands[key] << option.switch_name
+      end
+    end
+
+    commands
+  end
+
+  def cli_and_man_pages_in_sync!(commands)
+    undocumented_options = ["--all", "--local-git"]
+
+    commands.each do |command_name, opts|
+      man_page_path = man_tracked_files.find {|f| File.basename(f) == "bundle-#{command_name}.1.ronn" }
+      expect(man_page_path).to_not be_nil, "The command #{command_name} has no associated man page."
+
+      next if opts.empty?
+
+      man_page_content = File.read(man_page_path)
+      opts.each do |option_name|
+        next if undocumented_options.include?(option_name.to_s)
+
+        error_msg = <<~EOM
+          The command #{command_name} has no mention of the option or subcommand `#{option_name}` in its man page.
+          Document the `#{option_name}` in the man page to discard this error.
+        EOM
+
+        expect(man_page_content).to match(option_name), error_msg
+      end
+    end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Whenever a bundler command options is added, we want to make sure that the associated command man page is updated to reflect the new option (e.g. this mistake was made in #8624)

## What is your fix for the problem, implemented in this PR?

In #8802 we discussed a bit on the implementation which would rely on parsing ronn files and introduce some conventions on how options documented in man pages should be written.

I figured I would try a simpler approach by just checking if the man page of a command list options using a simple regex.

Pros:

- Simpler as we don't have to parse ronn files.
- No need to modify all existing man pages.

Cons:

- We can only verify one way (CLI options -> man pages). If a CLI option get removed, we won't be able to warn that the existing document man page option needs to be removed.

cc/ @deivid-rodriguez , let me know if this an acceptable approach!

## Verify that this PR works

You can verify the spec works by adding or modifying command options in Bundler::CLI or any other subcommand (e.g. Bundler::CLI::Plugin).

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
