### PR TITLE
[tech-debt] Updating bundler cache command adding new centralized method for loading cache

### DIFF
--- a/bundler/lib/bundler/cli/add.rb
+++ b/bundler/lib/bundler/cli/add.rb
@@ -23,7 +23,8 @@ module Bundler
 
     def perform_bundle_install
       Installer.install(Bundler.root, Bundler.definition)
-      Bundler.load.cache if Bundler.app_cache.exist?
+      require_relative "cache"
+      CLI::Cache.load_cache if Bundler.app_cache.exist?
     end
 
     def inject_dependencies

--- a/bundler/lib/bundler/cli/update.rb
+++ b/bundler/lib/bundler/cli/update.rb
@@ -77,7 +77,8 @@ module Bundler
       end
 
       installer = Installer.install Bundler.root, Bundler.definition, opts
-      Bundler.load.cache if Bundler.app_cache.exist?
+      require_relative "cache"
+      CLI::Cache.load_cache if Bundler.app_cache.exist?
 
       if CLI::Common.clean_after_install?
         require_relative "clean"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

There was a `TODO` in the bundler cache command [line#19](https://github.com/rubygems/rubygems/blob/b1f5024e3d989f863dce5a197fb1f49d7e356427/bundler/lib/bundler/cli/cache.rb#L19) asking to move cache operations or function in within the `cache.rb` and a way to standardise or centralize loading cache method

## What is your fix for the problem, implemented in this PR?
We are basically introducing a new static method int he Cache command that can be use for the other commands.

Benefits:
Single source of truth for cache operations
Consistent behavior across all commands
Easier maintenance - cache logic is in one place
Better testability - shared method can be tested independently
Follows Ruby conventions - DRY principle, clear separation of concerns

## Code was fully tested running the following rspec commands

Tests Passed with the following results:

✅ `spec/commands/cache_spec.rb` - 25 examples, 0 failures
✅ `spec/commands/add_spec.rb`- 44 examples, 0 failures
✅ `spec/commands/update_spec.rb` - 82 examples, 0 failures
