### PR TITLE
Fix spacing in bundle gem newgem.gemspec.tt

### DIFF
--- a/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
   spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "<%= config[:source_code_uri] %>"
-  <%- if config[:changelog] -%>
-    spec.metadata["changelog_uri"] = "<%= config[:changelog_uri] %>"
-  <%- end -%>
+<%- if config[:changelog] -%>
+  spec.metadata["changelog_uri"] = "<%= config[:changelog_uri] %>"
+<%- end -%>
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION

## What was the end-user or developer problem that led to this PR?

The changelog line was generating indented more than it should.

## What is your fix for the problem, implemented in this PR?

Indent in the same way the rest of the file is indented.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
