### PR TITLE
Delay default path and global cache changes to Bundler 5 

### DIFF
--- a/bundler/lib/bundler/cli/common.rb
+++ b/bundler/lib/bundler/cli/common.rb
@@ -130,7 +130,7 @@ module Bundler
     def self.clean_after_install?
       clean = Bundler.settings[:clean]
       return clean unless clean.nil?
-      clean ||= Bundler.feature_flag.bundler_4_mode? && Bundler.settings[:path].nil?
+      clean ||= Bundler.feature_flag.bundler_5_mode? && Bundler.settings[:path].nil?
       clean &&= !Bundler.use_system_gems?
       clean
     end

--- a/bundler/lib/bundler/feature_flag.rb
+++ b/bundler/lib/bundler/feature_flag.rb
@@ -30,7 +30,7 @@ module Bundler
     settings_flag(:allow_offline_install) { bundler_4_mode? }
     settings_flag(:cache_all) { bundler_4_mode? }
     settings_flag(:forget_cli_options) { bundler_4_mode? }
-    settings_flag(:global_gem_cache) { bundler_4_mode? }
+    settings_flag(:global_gem_cache) { bundler_5_mode? }
     settings_flag(:lockfile_checksums) { bundler_4_mode? }
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }
     settings_flag(:update_requires_all_flag) { bundler_5_mode? }

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -272,7 +272,7 @@ module Bundler
       def use_system_gems?
         return true if system_path
         return false if explicit_path
-        !Bundler.feature_flag.bundler_4_mode?
+        !Bundler.feature_flag.bundler_5_mode?
       end
 
       def base_path

--- a/bundler/spec/commands/clean_spec.rb
+++ b/bundler/spec/commands/clean_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe "bundle clean" do
     bundle :clean
 
     digest = Digest(:SHA1).hexdigest(git_path.to_s)
-    cache_path = Bundler.feature_flag.global_gem_cache? ? home(".bundle/cache/git/foo-1.0-#{digest}") : vendored_gems("cache/bundler/git/foo-1.0-#{digest}")
+    cache_path = vendored_gems("cache/bundler/git/foo-1.0-#{digest}")
     expect(cache_path).to exist
   end
 

--- a/bundler/spec/commands/clean_spec.rb
+++ b/bundler/spec/commands/clean_spec.rb
@@ -427,7 +427,7 @@ RSpec.describe "bundle clean" do
     should_not_have_gems "foo-1.0"
   end
 
-  it "automatically cleans when path has not been set", bundler: "4" do
+  it "automatically cleans when path has not been set", bundler: "5" do
     build_repo2
 
     install_gemfile <<-G

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -30,22 +30,20 @@ RSpec.describe "bundle install with gem sources" do
     end
 
     it "does not create ./.bundle by default" do
-      gemfile <<-G
+      install_gemfile <<-G
         source "https://gem.repo1"
         gem "myrack"
       G
 
-      bundle :install # can't use install_gemfile since it sets retry
       expect(bundled_app(".bundle")).not_to exist
     end
 
     it "does not create ./.bundle by default when installing to system gems" do
-      gemfile <<-G
+      install_gemfile <<-G, env: { "BUNDLE_PATH__SYSTEM" => "true" }
         source "https://gem.repo1"
         gem "myrack"
       G
 
-      bundle :install, env: { "BUNDLE_PATH__SYSTEM" => "true" } # can't use install_gemfile since it sets retry
       expect(bundled_app(".bundle")).not_to exist
     end
 

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -38,6 +38,15 @@ RSpec.describe "bundle install with gem sources" do
       expect(bundled_app(".bundle")).not_to exist
     end
 
+    it "will create a ./.bundle by default", bundler: "5" do
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        gem "myrack"
+      G
+
+      expect(bundled_app(".bundle")).to exist
+    end
+
     it "does not create ./.bundle by default when installing to system gems" do
       install_gemfile <<-G, env: { "BUNDLE_PATH__SYSTEM" => "true" }
         source "https://gem.repo1"

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -1010,11 +1010,7 @@ RSpec.describe "compact index api" do
         gem "myrack"
       G
 
-      gem_path = if Bundler.feature_flag.global_gem_cache?
-        default_cache_path.dirname.join("cache", "gems", "localgemserver.test.80.dd34752a738ee965a2a4298dc16db6c5", "myrack-1.0.0.gem")
-      else
-        default_cache_path.dirname.join("myrack-1.0.0.gem")
-      end
+      gem_path = default_cache_path.dirname.join("myrack-1.0.0.gem")
 
       expect(exitstatus).to eq(37)
       expect(err).to eq <<~E.strip

--- a/bundler/spec/support/filters.rb
+++ b/bundler/spec/support/filters.rb
@@ -32,7 +32,7 @@ RSpec.configure do |config|
 
   config.filter_run_when_matching :focus unless ENV["CI"]
 
-  config.before(:each, bundler: "4") do
-    bundle "config simulate_version 4"
+  config.before(:each, :bundler) do |example|
+    bundle "config simulate_version #{example.metadata[:bundler]}"
   end
 end

--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -136,19 +136,11 @@ module Spec
     end
 
     def default_bundle_path(*path)
-      if Bundler.feature_flag.bundler_4_mode?
-        local_gem_path(*path)
-      else
-        system_gem_path(*path)
-      end
+      system_gem_path(*path)
     end
 
     def default_cache_path(*path)
-      if Bundler.feature_flag.global_gem_cache?
-        home(".bundle/cache", *path)
-      else
-        default_bundle_path("cache/bundler", *path)
-      end
+      default_bundle_path("cache/bundler", *path)
     end
 
     def compact_index_cache_path

--- a/doc/bundler/UPGRADING.md
+++ b/doc/bundler/UPGRADING.md
@@ -28,28 +28,6 @@ existing default by configuring
 bundle config default_cli_command install
 ```
 
-### Bundler will install to a `.bundle` folder relative to the Gemfile location by default
-
-We're making this change to improve isolation. It will install gems to a
-`.bundle` folder relative to the Gemfile location, instead of a global system folder.
-
-The previous default of installing to system changes can be kept with `bundle
-config path.system true`.
-
-Related to this change, and to alleviate potential bad consequences from it,
-we're also shipping some related changes:
-
-* To keep disk usage under control, Bundler will cleanup unused gems when
-  installing gems per application using the new default. This new behavior can
-  be disabled by toggling back installing to system gems as explained before, or
-  by configuring `bundle config clean false`.
-
-* To avoid duplicate downloads of `.gem` packages and recompilation of
-  extensions, Bundler will keep a global cache of gem packages and compiled
-  extensions. This new behaviour can be disabled with `bundle config
-  global_gem_cache false`, or by toggling back installing to system gems as
-  explained before.
-
 ### Flags passed to `bundle install` that relied on being remembered across invocations will be removed
 
 In particular, the `--clean`, `--deployment`, `--frozen`, `--no-prune`,


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Main issues people are finding with Bundler 4 are related to these changes in defaults. In particular, the new global cache of compiled extensions is creating several problems. I'm still thinking about how to address those issues, but I want to keep our main branch in a releasable state without outstanding blockers in the mean time.

## What is your fix for the problem, implemented in this PR?

Delay global cache changes to Bundler 5. Since global cache changes are a prerrequiste for changing the default to install to a local `.bundle` folder by default, since that's what prevents degrading default performance of `bundle install` due to extension recompilation, delay that change too. 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
