### PR TITLE
Remove out of date TODO

### DIFF
--- a/bundler/lib/bundler/cli/cache.rb
+++ b/bundler/lib/bundler/cli/cache.rb
@@ -16,7 +16,6 @@ module Bundler
       setup_cache_all
       install
 
-      # TODO: move cache contents here now that all bundles are locked
       custom_path = Bundler.settings[:path] if options[:path]
 
       Bundler.settings.temporary(cache_all_platforms: options["all-platforms"]) do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

A seemingly AI-generated PR is trying to "fix" this TODO. However, I don't think there's anything to fix here. As per https://github.com/rubygems/rubygems/commit/f13f8fb0427c375ae6cc7271f36dbac72ed8a1c1, I suspect this TODO was meant to move forward unifying `bundle cache` and `bundle package` commands, which already happened a long time ago. 

## What is your fix for the problem, implemented in this PR?

Remove the TODO.

Closes #8863.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
