### PR TITLE
Keep fixture Gemfiles in sync when bumping version

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,7 @@ namespace :version do
     stdout = Spec::Rubygems.dev_bundle "--version"
     version = stdout.split(" ").last
 
-    Dir.glob("tool/bundler/*_gems.rb").each do |file|
+    Dir.glob("{tool/bundler/*_gems.rb,bundler/spec/realworld/fixtures/*/Gemfile}").each do |file|
       Spec::Rubygems.dev_bundle("update", "--bundler", version, gemfile: file)
     end
   end

--- a/bundler/spec/realworld/fixtures/tapioca/Gemfile.lock
+++ b/bundler/spec/realworld/fixtures/tapioca/Gemfile.lock
@@ -46,4 +46,4 @@ DEPENDENCIES
   tapioca
 
 BUNDLED WITH
-   2.7.0.dev
+   2.8.0.dev

--- a/bundler/spec/realworld/fixtures/warbler/Gemfile.lock
+++ b/bundler/spec/realworld/fixtures/warbler/Gemfile.lock
@@ -36,4 +36,4 @@ DEPENDENCIES
   warbler!
 
 BUNDLED WITH
-   2.7.0.dev
+   2.8.0.dev


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Not much, it just seems nice that all lockfiles in our repo lock the current development version of Bundler.

## What is your fix for the problem, implemented in this PR?

Include fixture lockfiles in the task that bumps locked version of Bundler.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
