### PR TITLE
Remove JRuby workaround

### DIFF
--- a/bundler/lib/bundler/source/path.rb
+++ b/bundler/lib/bundler/source/path.rb
@@ -124,11 +124,7 @@ module Bundler
       end
 
       def expand(somepath)
-        if Bundler.current_ruby.jruby? # TODO: Unify when https://github.com/rubygems/bundler/issues/7598 fixed upstream and all supported jrubies include the fix
-          somepath.expand_path(root_path).expand_path
-        else
-          somepath.expand_path(root_path)
-        end
+        somepath.expand_path(root_path)
       rescue ArgumentError => e
         Bundler.ui.debug(e)
         raise PathError, "There was an error while trying to use the path " \


### PR DESCRIPTION


## What was the end-user or developer problem that led to this PR?

We have a TODO to remind us to remove a workaround once JRuby versions without a JRuby fix are no longer supported. 

## What is your fix for the problem, implemented in this PR?

For JRuby, we generally support only the latest version. The fix for this problem was shipped with JRuby 9.3.0.0, which is pretty old now. So it seems fine to remove the workaround.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
