### PR TITLE
Remove unnecessary endless loop detection

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -645,20 +645,12 @@ module Bundler
     end
 
     def materialize(dependencies)
-      # Tracks potential endless loops trying to re-resolve.
-      # TODO: Remove as dead code if not reports are received in a while
-      incorrect_spec = nil
-
       specs = begin
         resolve.materialize(dependencies)
       rescue IncorrectLockfileDependencies => e
         raise if Bundler.frozen_bundle?
 
-        spec = e.spec
-        raise "Infinite loop while fixing lockfile dependencies" if incorrect_spec == spec
-
-        incorrect_spec = spec
-        reresolve_without([spec])
+        reresolve_without([e.spec])
         retry
       end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We have a TODO to remove some code if no reports have been issued in a while.

## What is your fix for the problem, implemented in this PR?

Remove the code, since no reports have been filed for a while.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
