### PR TITLE
Fix bundler failing to install sorbet-static in truffleruby when there's no lockfile

### DIFF
--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -35,7 +35,7 @@ jobs:
           - ruby: { name: jruby, value: jruby-10.0.0.1 }
             os: { name: Ubuntu, value: ubuntu-24.04 }
 
-          - ruby: { name: truffleruby, value: truffleruby-24.2.0 }
+          - ruby: { name: truffleruby, value: truffleruby-24.2.1 }
             os: { name: Ubuntu, value: ubuntu-24.04 }
 
     steps:

--- a/.github/workflows/truffleruby-bundler.yml
+++ b/.github/workflows/truffleruby-bundler.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@472790540115ce5bd69d399a020189a8c87d641f # v1.247.0
         with:
-          ruby-version: truffleruby-24.2.0
+          ruby-version: truffleruby-24.2.1
           bundler: none
       - name: Prepare dependencies
         run: |

--- a/.github/workflows/truffleruby-bundler.yml
+++ b/.github/workflows/truffleruby-bundler.yml
@@ -37,7 +37,7 @@ jobs:
           bin/rake dev:deps
       - name: Run Test
         run: |
-          bin/parallel_rspec --tag truffleruby_only --tag truffleruby
+          bin/rspec --tag truffleruby_only --tag truffleruby
         working-directory: ./bundler
     timeout-minutes: 20
 

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -67,7 +67,7 @@ jobs:
         ruby:
           - { name: ruby, value: 3.4.4 }
           - { name: jruby, value: jruby-10.0.0.1 }
-          - { name: truffleruby, value: truffleruby-24.2.0 }
+          - { name: truffleruby, value: truffleruby-24.2.1 }
     env:
       RUBYOPT: -Ilib
     steps:

--- a/Rakefile
+++ b/Rakefile
@@ -41,7 +41,7 @@ namespace :version do
   desc "Check locked bundler version is up to date"
   task check: :update_locked_bundler do
     Spec::Rubygems.check_source_control_changes(
-      success_message: "Locked bundler version is out of sync",
+      success_message: "Locked bundler version is in sync",
       error_message: "Please run `rake version:update_locked_bundler` and commit the result."
     )
   end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -740,7 +740,6 @@ module Bundler
     def start_resolution
       local_platform_needed_for_resolvability = @most_specific_non_local_locked_platform && !@platforms.include?(Bundler.local_platform)
       @platforms << Bundler.local_platform if local_platform_needed_for_resolvability
-      add_platform(Gem::Platform::RUBY) if RUBY_ENGINE == "truffleruby"
 
       result = SpecSet.new(resolver.start)
 

--- a/bundler/lib/bundler/resolver/package.rb
+++ b/bundler/lib/bundler/resolver/package.rb
@@ -21,6 +21,7 @@ module Bundler
         @locked_version = locked_specs.version_for(name)
         @unlock = unlock
         @dependency = dependency || Dependency.new(name, @locked_version)
+        @platforms |= [Gem::Platform::RUBY] if @dependency.default_force_ruby_platform
         @top_level = !dependency.nil?
         @prerelease = @dependency.prerelease? || @locked_version&.prerelease? || prerelease ? :consider_first : :ignore
         @prefer_local = prefer_local

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -2237,7 +2237,6 @@ RSpec.describe "bundle lock" do
               nokogiri (1.14.2-x86_64-linux)
 
           PLATFORMS
-            ruby
             x86_64-linux
 
           DEPENDENCIES

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -392,7 +392,23 @@ RSpec.describe "bundle install with specific platforms" do
     end
   end
 
-  it "installs sorbet-static, which does not provide a pure ruby variant, just fine", :truffleruby do
+  it "installs sorbet-static, which does not provide a pure ruby variant, in absence of a lockfile, just fine", :truffleruby do
+    skip "does not apply to Windows" if Gem.win_platform?
+
+    build_repo2 do
+      build_gem("sorbet-static", "0.5.6403") {|s| s.platform = Bundler.local_platform }
+    end
+
+    gemfile <<~G
+      source "https://gem.repo2"
+
+      gem "sorbet-static", "0.5.6403"
+    G
+
+    bundle "install --verbose"
+  end
+
+  it "installs sorbet-static, which does not provide a pure ruby variant, in presence of a lockfile, just fine", :truffleruby do
     skip "does not apply to Windows" if Gem.win_platform?
 
     build_repo2 do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This is a regression of https://github.com/rubygems/rubygems/pull/7795.

Since that PR, the generic Ruby platform was getting unconditionally added in truffleruby, preventing resolution in situations where there's no generic ruby version (sorbet-static). 

## What is your fix for the problem, implemented in this PR?

Consider the generic platform per dependency, not globally, so that when gems actually support platform specific gems in truffleruby like sorbet-static, that's actually respected.
 
## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
