### PR TITLE
[Feature] Bundler supports key value pairs prefixing the commands with ENV vars

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -432,13 +432,16 @@ module Bundler
 
     map aliases_for("cache")
 
-    desc "exec [OPTIONS]", "Run the command in context of the bundle"
+    desc "exec [OPTIONS] [KEY=VALUE...] COMMAND", "Run the command in context of the bundle"
     method_option :keep_file_descriptors, type: :boolean, default: true, banner: "Passes all file descriptors to the new processes. Default is true, and setting it to false is deprecated"
     method_option :gemfile, type: :string, required: false, banner: "Use the specified gemfile instead of Gemfile"
     long_desc <<-D
       Exec runs a command, providing it access to the gems in the bundle. While using
       bundle exec you can require and call the bundled gems as if they were installed
       into the system wide RubyGems repository.
+      
+      You can also set environment variables for the commands by prefixing with KEY=VALUE pairs.
+      e.g.: bundle exec RUBYOPT=-rlogger ruby script.rb
     D
     def exec(*args)
       if ARGV.include?("--no-keep-file-descriptors")

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -192,6 +192,16 @@ RSpec.describe "bundle exec" do
     expect(out).to eq("1.0.0")
   end
 
+  it "sets environment variables only for the child process" do
+    install_gemfile <<-G
+      source "https://gem.repo1"
+      gem "myrack"
+    G
+    ruby_script = "puts ENV['RUBYOPT'] || 'none'"    
+    bundle "exec RUBYOPT=foo ruby -e \"#{ruby_script}\""
+    expect(out).to include("foo")
+  end
+
   context "with default gems" do
     # TODO: Switch to ERB::VERSION once Ruby 3.4 support is dropped, so all
     # supported rubies include an `erb` gem version where `ERB::VERSION` is


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?
[Closes #8824](https://github.com/rubygems/rubygems/issues/8824)

## Summary of the Problem:

`RUBYOPT=-rlogger bundle exec ruby` ... sets `RUBYOPT` for both `Bundler` and the child, which can break Bundler.
You want `bundle exec RUBYOPT=-rlogger ruby` ... to set `RUBYOPT` *only for the child process*.
The workaround (`bundle exec sh -c 'RUBYOPT=... exec ruby ...'`) is not cross-platform, it will fail for Windows operative system as stated and probed by the reporter.

This is how most POSIX shells work, but Ruby’s `bundle exec` currently does not support this natively.

## What is your fix for the problem, implemented in this PR?

Allow users to specify environment variables that are set **only for the child process** launched by `bundle exec`, not for Bundler itself.

## Syntax
- **Preferred:**
  ```sh
  bundle exec RUBYOPT=-rlogger ruby ...
  ```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
