### PR TITLE
Restore Windows test times prior to D: drive removal

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -48,6 +48,7 @@ jobs:
     env:
       RGV: ..
       RUBYOPT: --disable-gems
+      WORKSPACE: ${{ github.workspace }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -66,18 +67,25 @@ jobs:
       - name: Install graphviz (Ubuntu)
         run: sudo apt-get install graphviz -y
         if: matrix.os.name == 'Ubuntu'
+      - uses: samypr100/setup-dev-drive@750bec535eb7e4833d6a4c86c5738751f9887575 # v3.4.2
+        with:
+          workspace-copy: true
+          env-mapping: |
+            WORKSPACE,{{ DEV_DRIVE_WORKSPACE }}
+        if: matrix.os.name == 'Windows'
       - name: Prepare dependencies
         run: |
           bin/rake dev:deps
+        working-directory: ${{ env.WORKSPACE }}
       - name: Run Test (CRuby)
         run: |
           bin/parallel_rspec
-        working-directory: ./bundler
+        working-directory: ${{ env.WORKSPACE }}/bundler
         if: matrix.ruby.name != 'jruby'
       - name: Run Test (JRuby)
         run: |
           bin/parallel_rspec --tag jruby_only --tag jruby
-        working-directory: ./bundler
+        working-directory: ${{ env.WORKSPACE }}/bundler
         if: matrix.ruby.name == 'jruby' && matrix.os.name == 'Ubuntu'
       - name: Run a warbler project
         run: |
@@ -87,6 +95,7 @@ jobs:
           bundle exec warble
           java -jar warbler.jar
         if: matrix.ruby.name == 'jruby' && matrix.os.name == 'Ubuntu'
+        working-directory: ${{ env.WORKSPACE }}
 
     timeout-minutes: ${{ matrix.timeout || 60 }}
 


### PR DESCRIPTION

## What was the end-user or developer problem that led to this PR?

Recently Windows jobs got even slower. I found that it seems due to some runner upgrade and I reported it at https://github.com/actions/runner-images/issues/12647.

## What is your fix for the problem, implemented in this PR?

Using samypr100/setup-dev-drive to setup a Windows Dev Drive at D: seems to restore previous test times.

This is an alternative to https://github.com/rubygems/rubygems/pull/8866 that allows us to keep using windows-2025.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
