### PR TITLE
Avoid openssl bug in test_verify_certificate_extra_message

### DIFF
--- a/test/rubygems/test_gem_request.rb
+++ b/test/rubygems/test_gem_request.rb
@@ -363,19 +363,19 @@ class TestGemRequest < Gem::TestCase
   def test_verify_certificate_extra_message
     pend if Gem.java_platform?
 
-    error_number = OpenSSL::X509::V_ERR_INVALID_CA
+    error_number = OpenSSL::X509::V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY
 
     store = OpenSSL::X509::Store.new
-    context = OpenSSL::X509::StoreContext.new store
-    context.error = error_number
+    context = OpenSSL::X509::StoreContext.new store, CHILD_CERT
+    context.verify
 
     use_ui @ui do
       Gem::Request.verify_certificate context
     end
 
     expected = <<-ERROR
-ERROR:  SSL verification error at depth 0: invalid CA certificate (#{error_number})
-ERROR:  Certificate  is an invalid CA certificate
+ERROR:  SSL verification error at depth 0: unable to get local issuer certificate (#{error_number})
+ERROR:  You must add #{CHILD_CERT.issuer} to your local trusted store
     ERROR
 
     assert_equal expected, @ui.error


### PR DESCRIPTION



<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

`OpenSSL::X509::StoreContext#current_cert` returns an empty and invalid `OpenSSL::X509::Certificate` instance if it is called before starting a certificate verification.
https://github.com/ruby/openssl/pull/919 will change it to return nil instead in such a case, which I consider a bug fix.

Merging the ruby/openssl change will break RubyGems tests. Only tests will be affected.
<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

Adjust `test_verify_certificate_extra_message` to actually complete `OpenSSL::X509::StoreContext#verify` so that it will not rely on this behavior.
<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
