### PR TITLE
Raise an error in frozen mode if some registry gems have empty checksums

### DIFF
--- a/bundler/lib/bundler/checksum.rb
+++ b/bundler/lib/bundler/checksum.rb
@@ -205,6 +205,12 @@ module Bundler
         @store[spec.lock_name].nil?
       end
 
+      def empty?(spec)
+        return false unless spec.source.is_a?(Bundler::Source::Rubygems)
+
+        @store[spec.lock_name].empty?
+      end
+
       def register(spec, checksum)
         register_checksum(spec.lock_name, checksum)
       end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -531,7 +531,7 @@ module Bundler
 
       return unless added.any? || deleted.any? || changed.any? || resolve_needed?
 
-      msg = String.new("#{change_reason.capitalize.strip}, but ")
+      msg = String.new("#{change_reason[0].upcase}#{change_reason[1..-1].strip}, but ")
       msg << "the lockfile " unless msg.start_with?("Your lockfile")
       msg << "can't be updated because #{update_refused_reason}"
       msg << "\n\nYou have added to the Gemfile:\n" << added.join("\n") if added.any?

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -557,6 +557,7 @@ module Bundler
         @missing_lockfile_dep ||
         @unlocking_bundler ||
         @locked_spec_with_missing_checksums ||
+        @locked_spec_with_empty_checksums ||
         @locked_spec_with_missing_deps ||
         @locked_spec_with_invalid_deps
     end
@@ -836,6 +837,7 @@ module Bundler
         [@missing_lockfile_dep, "your lockfile is missing \"#{@missing_lockfile_dep}\""],
         [@unlocking_bundler, "an update to the version of Bundler itself was requested"],
         [@locked_spec_with_missing_checksums, "your lockfile is missing a CHECKSUMS entry for \"#{@locked_spec_with_missing_checksums}\""],
+        [@locked_spec_with_empty_checksums, "your lockfile has an empty CHECKSUMS entry for \"#{@locked_spec_with_empty_checksums}\""],
         [@locked_spec_with_missing_deps, "your lockfile includes \"#{@locked_spec_with_missing_deps}\" but not some of its dependencies"],
         [@locked_spec_with_invalid_deps, "your lockfile does not satisfy dependencies of \"#{@locked_spec_with_invalid_deps}\""],
       ].select(&:first).map(&:last).join(", ")
@@ -895,13 +897,23 @@ module Bundler
       @locked_spec_with_invalid_deps = nil
       @locked_spec_with_missing_deps = nil
       @locked_spec_with_missing_checksums = nil
+      @locked_spec_with_empty_checksums = nil
 
       missing_deps = []
       missing_checksums = []
+      empty_checksums = []
       invalid = []
 
       @locked_specs.each do |s|
-        missing_checksums << s if @locked_checksums && s.source.checksum_store.missing?(s)
+        if @locked_checksums
+          checksum_store = s.source.checksum_store
+
+          if checksum_store.missing?(s)
+            missing_checksums << s
+          elsif checksum_store.empty?(s)
+            empty_checksums << s
+          end
+        end
 
         validation = @locked_specs.validate_deps(s)
 
@@ -910,6 +922,7 @@ module Bundler
       end
 
       @locked_spec_with_missing_checksums = missing_checksums.first.name if missing_checksums.any?
+      @locked_spec_with_empty_checksums = empty_checksums.first.name if empty_checksums.any?
 
       if missing_deps.any?
         @locked_specs.delete(missing_deps)

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -1852,7 +1852,7 @@ RSpec.describe "bundle update --bundler" do
     system_gems "bundler-9.9.9", path: local_gem_path
 
     bundle "update --bundler=9.9.9", env: { "BUNDLE_FROZEN" => "true" }, raise_on_error: false
-    expect(err).to include("An update to the version of bundler itself was requested, but the lockfile can't be updated because frozen mode is set")
+    expect(err).to include("An update to the version of Bundler itself was requested, but the lockfile can't be updated because frozen mode is set")
   end
 end
 

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "bundle install with git sources" do
   describe "when floating on main" do
-    before :each do
+    let(:install_base_gemfile) do
       build_git "foo" do |s|
         s.executables = "foobar"
       end
@@ -16,6 +16,7 @@ RSpec.describe "bundle install with git sources" do
     end
 
     it "fetches gems" do
+      install_base_gemfile
       expect(the_bundle).to include_gems("foo 1.0")
 
       run <<-RUBY
@@ -27,16 +28,19 @@ RSpec.describe "bundle install with git sources" do
     end
 
     it "caches the git repo" do
+      install_base_gemfile
       expect(Dir["#{default_bundle_path}/cache/bundler/git/foo-1.0-*"]).to have_attributes size: 1
     end
 
     it "does not write to cache on bundler/setup" do
+      install_base_gemfile
       FileUtils.rm_r(default_cache_path)
       ruby "require 'bundler/setup'"
       expect(default_cache_path).not_to exist
     end
 
     it "caches the git repo globally and properly uses the cached repo on the next invocation" do
+      install_base_gemfile
       pristine_system_gems
       bundle "config set global_gem_cache true"
       bundle :install
@@ -48,6 +52,7 @@ RSpec.describe "bundle install with git sources" do
     end
 
     it "caches the evaluated gemspec" do
+      install_base_gemfile
       git = update_git "foo" do |s|
         s.executables = ["foobar"] # we added this the first time, so keep it now
         s.files = ["bin/foobar"] # updating git nukes the files list
@@ -66,6 +71,7 @@ RSpec.describe "bundle install with git sources" do
     end
 
     it "does not update the git source implicitly" do
+      install_base_gemfile
       update_git "foo"
 
       install_gemfile bundled_app2("Gemfile"), <<-G, dir: bundled_app2
@@ -84,6 +90,7 @@ RSpec.describe "bundle install with git sources" do
     end
 
     it "sets up git gem executables on the path" do
+      install_base_gemfile
       bundle "exec foobar"
       expect(out).to eq("1.0")
     end
@@ -136,7 +143,7 @@ RSpec.describe "bundle install with git sources" do
 
     it "still works after moving the application directory" do
       bundle "config set --local path vendor/bundle"
-      bundle "install"
+      install_base_gemfile
 
       FileUtils.mv bundled_app, tmp("bundled_app.bck")
 
@@ -145,7 +152,7 @@ RSpec.describe "bundle install with git sources" do
 
     it "can still install after moving the application directory" do
       bundle "config set --local path vendor/bundle"
-      bundle "install"
+      install_base_gemfile
 
       FileUtils.mv bundled_app, tmp("bundled_app.bck")
 

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -1638,7 +1638,7 @@ RSpec.describe "the lockfile format" do
     G
 
     expect(err).to eq <<~L.strip
-      Your lockfile is missing a checksums entry for \"myrack_middleware\", but can't be updated because frozen mode is set
+      Your lockfile is missing a CHECKSUMS entry for \"myrack_middleware\", but can't be updated because frozen mode is set
 
       Run `bundle install` elsewhere and add the updated Gemfile.lock to version control.
     L

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -1646,6 +1646,40 @@ RSpec.describe "the lockfile format" do
     expect(the_bundle).not_to include_gems "myrack_middleware 1.0"
   end
 
+  it "raises a clear error when frozen mode is set and lockfile has empty checksums in CHECKSUMS section, and does not install any gems" do
+    lockfile <<-L
+      GEM
+        remote: https://gem.repo2/
+        specs:
+          myrack (0.9.1)
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        myrack
+
+      CHECKSUMS
+        myrack (0.9.1)
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    install_gemfile <<-G, env: { "BUNDLE_FROZEN" => "true" }, raise_on_error: false
+      source "https://gem.repo2"
+      gem "myrack"
+    G
+
+    expect(err).to eq <<~L.strip
+      Your lockfile has an empty CHECKSUMS entry for \"myrack\", but can't be updated because frozen mode is set
+
+      Run `bundle install` elsewhere and add the updated Gemfile.lock to version control.
+    L
+
+    expect(the_bundle).not_to include_gems "myrack 0.9.1"
+  end
+
   it "automatically fixes the lockfile when it's missing deps, they conflict with other locked deps, but conflicts are fixable" do
     build_repo4 do
       build_gem "other_dep", "0.9"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler is not able to detect missing checksums for registry gems. If `frozen` mode is enabled, lockfile checksums are enabled, and a registry gem does not have a lockfile checksum, Bundler should refuse to install that gem.

## What is your fix for the problem, implemented in this PR?

It's a bit tricky because Bundler does not currently generate checksums for `git` or `path` gems, so this strict mode should only apply to registry gems.

This PR adds a `ChecksumStore#empty?` method that we check when validating the lockfile, and makes sure it only applies to registry gems, not to git or path gems.

Fixes #8885.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
