### PR TITLE
[tech debt] default install extension in lib set to false

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -47,8 +47,8 @@ class Gem::ConfigFile
   DEFAULT_CONCURRENT_DOWNLOADS = 8
   DEFAULT_CERT_EXPIRATION_LENGTH_DAYS = 365
   DEFAULT_IPV4_FALLBACK_ENABLED = false
-  # TODO: Use false as default value for this option in RubyGems 4.0
-  DEFAULT_INSTALL_EXTENSION_IN_LIB = true
+  # Changed from true to false in RubyGems 4.0 for better gem organization
+  DEFAULT_INSTALL_EXTENSION_IN_LIB = false
 
   ##
   # For Ruby packagers to set configuration defaults.  Set in
@@ -229,6 +229,11 @@ class Gem::ConfigFile
     # TODO: We should handle concurrent_downloads same as other options
     @cert_expiration_length_days = @hash[:cert_expiration_length_days] if @hash.key? :cert_expiration_length_days
     @install_extension_in_lib    = @hash[:install_extension_in_lib]    if @hash.key? :install_extension_in_lib
+    # Issue deprecation warning if install_extension_in_lib is set to true
+    if @hash.key?(:install_extension_in_lib) && @hash[:install_extension_in_lib] == true
+      warn  "The default value has changed to false in RubyGems 4.0 for better gem organization. " \
+           "Extensions will now be installed in ext/ by default. "
+    end
     @ipv4_fallback_enabled       = @hash[:ipv4_fallback_enabled]       if @hash.key? :ipv4_fallback_enabled
 
     @home                        = @hash[:gemhome]                     if @hash.key? :gemhome

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -529,6 +529,26 @@ if you believe they were disclosed to a third party.
     assert_equal(false, @cfg.install_extension_in_lib)
   end
 
+  def test_install_extension_in_lib_deprecation_warning
+    File.open @temp_conf, "w" do |fp|
+      fp.puts ":install_extension_in_lib: true"
+    end
+    
+    # Capture the warning using stderr
+    require "stringio"
+    stderr = StringIO.new
+    $stderr = stderr
+    
+    util_config_file
+    
+    # Restore stderr
+    $stderr = STDERR
+    
+    assert_equal(true, @cfg.install_extension_in_lib)
+    warning_output = stderr.string
+    assert_includes warning_output, "The default value has changed to false in RubyGems 4.0"
+  end
+
   def test_disable_default_gem_server
     File.open @temp_conf, "w" do |fp|
       fp.puts ":disable_default_gem_server: true"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

There is a comment asking for this change to take place specially because we already missed to do it for previous versions.

[Closes issue mentioned here](https://github.com/rubygems/rubygems/issues/8650#issuecomment-3090136669)

## What is your fix for the problem, implemented in this PR?

just changing the default value to `false` as requested, i also added deprecation warning nmessage for people using the previous versions to know the default value should not be `true` any longer (not sure if that is too overkill though)

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
