### PR TITLE
Fix `bundle update foo` unable to update foo in an edge case

### DIFF
--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -445,6 +445,49 @@ RSpec.describe "bundle update" do
       expect(out).to include("Installing sneakers 2.11.0").and include("Installing rake 13.0.6")
     end
 
+    it "downgrades indirect dependencies if required to fulfill an explicit upgrade request" do
+      build_repo4 do
+        build_gem "rbs", "3.6.1"
+        build_gem "rbs", "3.9.4"
+
+        build_gem "solargraph", "0.56.0" do |s|
+          s.add_dependency "rbs", "~> 3.3"
+        end
+
+        build_gem "solargraph", "0.56.2" do |s|
+          s.add_dependency "rbs", "~> 3.6.1"
+        end
+      end
+
+      gemfile <<~G
+        source "https://gem.repo4"
+
+        gem 'solargraph', '~> 0.56.0'
+      G
+
+      lockfile <<~L
+        GEM
+          remote: https://gem.repo4/
+          specs:
+            rbs (3.9.4)
+            solargraph (0.56.0)
+              rbs (~> 3.3)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          solargraph (~> 0.56.0)
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "lock --update solargraph"
+
+      expect(lockfile).to include("solargraph (0.56.2)")
+    end
+
     it "does not downgrade direct dependencies unnecessarily" do
       build_repo4 do
         build_gem "redis", "4.8.1"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If a user is explicitly requesting an upgrade of gem `foo`, through `bundle update foo`, and the latest version of `foo` is resolvable through `bundle install` without a lockfile, Bundler should be able to upgrade it, even if it requires downgrading an indirect dependency.

## What is your fix for the problem, implemented in this PR?

The problem is that when calculating the latest resolvable version of foo, Bundler was still adding lower bound requirements on the locked versions of all dependencies to avoid downgrades, effectively pinning foo to a version older than the latest.

To fix this, instead of creating a second "unlocked" definition to figure out the latest resolvable version, create a second unlocked resolver, and DO NOT add lower bound requirements to it.

Closes #8893.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
