### PR TITLE
Deprecate `Gem::Specification#datadir`

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -199,6 +199,9 @@ class Gem::BasicSpecification
     File.expand_path(File.join(gems_dir, full_name, "data", name))
   end
 
+  extend Gem::Deprecate
+  rubygems_deprecate :datadir, :none, "4.1"
+
   ##
   # Full path of the target library file.
   # If the file is not in this gem, return nil.

--- a/lib/rubygems/deprecate.rb
+++ b/lib/rubygems/deprecate.rb
@@ -126,13 +126,14 @@ module Gem
     # telling the user of +repl+ (unless +repl+ is :none) and the
     # Rubygems version that it is planned to go away.
 
-    def rubygems_deprecate(name, replacement=:none, version=Gem::Deprecate.next_rubygems_major_version)
+    def rubygems_deprecate(name, replacement=:none, version=nil)
       class_eval do
         old = "_deprecated_#{name}"
         alias_method old, name
         define_method name do |*args, &block|
           klass = is_a? Module
           target = klass ? "#{self}." : "#{self.class}#"
+          version ||= Gem::Deprecate.next_rubygems_major_version
           msg = [
             "NOTE: #{target}#{name} is deprecated",
             replacement == :none ? " with no replacement" : "; use #{replacement} instead",
@@ -147,13 +148,14 @@ module Gem
     end
 
     # Deprecation method to deprecate Rubygems commands
-    def rubygems_deprecate_command(version = Gem::Deprecate.next_rubygems_major_version)
+    def rubygems_deprecate_command(version = nil)
       class_eval do
         define_method "deprecated?" do
           true
         end
 
         define_method "deprecation_warning" do
+          version ||= Gem::Deprecate.next_rubygems_major_version
           msg = [
             "#{command} command is deprecated",
             ". It will be removed in Rubygems #{version}.\n",

--- a/lib/rubygems/deprecate.rb
+++ b/lib/rubygems/deprecate.rb
@@ -126,7 +126,7 @@ module Gem
     # telling the user of +repl+ (unless +repl+ is :none) and the
     # Rubygems version that it is planned to go away.
 
-    def rubygems_deprecate(name, replacement=:none)
+    def rubygems_deprecate(name, replacement=:none, version=Gem::Deprecate.next_rubygems_major_version)
       class_eval do
         old = "_deprecated_#{name}"
         alias_method old, name
@@ -136,7 +136,7 @@ module Gem
           msg = [
             "NOTE: #{target}#{name} is deprecated",
             replacement == :none ? " with no replacement" : "; use #{replacement} instead",
-            ". It will be removed in Rubygems #{Gem::Deprecate.next_rubygems_major_version}",
+            ". It will be removed in Rubygems #{version}",
             "\n#{target}#{name} called from #{Gem.location_of_caller.join(":")}",
           ]
           warn "#{msg.join}." unless Gem::Deprecate.skip

--- a/test/rubygems/test_config.rb
+++ b/test/rubygems/test_config.rb
@@ -5,13 +5,6 @@ require "rubygems"
 require "shellwords"
 
 class TestGemConfig < Gem::TestCase
-  def test_datadir
-    util_make_gems
-    spec = Gem::Specification.find_by_name("a")
-    spec.activate
-    assert_equal "#{spec.full_gem_path}/data/a", spec.datadir
-  end
-
   def test_good_rake_path_is_escaped
     path = Gem::TestCase.class_variable_get(:@@good_rake)
     ruby, rake = path.shellsplit

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -527,35 +527,6 @@ class TestGem < Gem::TestCase
     assert_equal expected, Gem.configuration
   end
 
-  def test_self_datadir
-    foo = nil
-
-    Dir.chdir @tempdir do
-      FileUtils.mkdir_p "data"
-      File.open File.join("data", "foo.txt"), "w" do |fp|
-        fp.puts "blah"
-      end
-
-      foo = util_spec "foo" do |s|
-        s.files = %w[data/foo.txt]
-      end
-
-      install_gem foo
-    end
-
-    gem "foo"
-
-    expected = File.join @gemhome, "gems", foo.full_name, "data", "foo"
-
-    assert_equal expected, Gem::Specification.find_by_name("foo").datadir
-  end
-
-  def test_self_datadir_nonexistent_package
-    assert_raise(Gem::MissingSpecError) do
-      Gem::Specification.find_by_name("xyzzy").datadir
-    end
-  end
-
   def test_self_default_exec_format
     ruby_install_name "ruby" do
       assert_equal "%s", Gem.default_exec_format


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

from https://github.com/rubygems/rubygems/issues/6464#issuecomment-1466125025

We already removed `Gem.datadir` at https://github.com/rubygems/rubygems/pull/6469

`Gem::Specification#datadir` is also no longer used. we should deprecate and remove it.

## What is your fix for the problem, implemented in this PR?

Mark to deprecate that.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
