### PR TITLE
`gem sources --prepend` and `--append` allow finer grained control of sources

### DIFF
--- a/lib/rubygems/source_list.rb
+++ b/lib/rubygems/source_list.rb
@@ -60,6 +60,42 @@ class Gem::SourceList
   end
 
   ##
+  # Prepends +obj+ to the beginning of the source list which may be a Gem::Source, Gem::URI or URI
+  # Moves +obj+ to the beginning of the list if already present.
+  # String.
+
+  def prepend(obj)
+    src = case obj
+          when Gem::Source
+            obj
+          else
+            Gem::Source.new(obj)
+    end
+
+    @sources.delete(src) if @sources.include?(src)
+    @sources.unshift(src)
+    src
+  end
+
+  ##
+  # Appends +obj+ to the end of the source list, moving it if already present.
+  # +obj+ may be a Gem::Source, Gem::URI or URI String.
+  # Moves +obj+ to the end of the list if already present.
+
+  def append(obj)
+    src = case obj
+          when Gem::Source
+            obj
+          else
+            Gem::Source.new(obj)
+    end
+
+    @sources.delete(src) if @sources.include?(src)
+    @sources << src
+    src
+  end
+
+  ##
   # Replaces this SourceList with the sources in +other+  See #<< for
   # acceptable items in +other+.
 

--- a/test/rubygems/test_gem_source_list.rb
+++ b/test/rubygems/test_gem_source_list.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require "rubygems"
-require "rubygems/source_list"
 require_relative "helper"
+require "rubygems/source_list"
 
 class TestGemSourceList < Gem::TestCase
   def setup
@@ -115,5 +114,129 @@ class TestGemSourceList < Gem::TestCase
   def test_delete_a_source
     @sl.delete Gem::Source.new(@uri)
     assert_equal @sl.sources, []
+  end
+
+  def test_prepend_new_source
+    uri2 = "http://example2"
+    source2 = Gem::Source.new(uri2)
+
+    result = @sl.prepend(uri2)
+
+    assert_kind_of Gem::Source, result
+    assert_kind_of Gem::URI, result.uri
+    assert_equal uri2, result.uri.to_s
+    assert_equal [source2, @source], @sl.sources
+  end
+
+  def test_prepend_existing_source
+    uri2 = "http://example2"
+    source2 = Gem::Source.new(uri2)
+    @sl << uri2
+
+    assert_equal [@source, source2], @sl.sources
+
+    result = @sl.prepend(uri2)
+
+    assert_kind_of Gem::Source, result
+    assert_kind_of Gem::URI, result.uri
+    assert_equal uri2, result.uri.to_s
+    assert_equal [source2, @source], @sl.sources
+  end
+
+  def test_prepend_alias_behaves_like_unshift
+    sl = Gem::SourceList.new
+
+    uri1 = "http://one"
+    uri2 = "http://two"
+
+    source1 = sl << uri1
+    source2 = sl << uri2
+
+    # move existing to front
+    result = sl.prepend(uri2)
+
+    assert_kind_of Gem::Source, result
+    assert_equal [source2, source1], sl.sources
+
+    # and again with the other
+    result = sl.prepend(uri1)
+    assert_equal [source1, source2], sl.sources
+  end
+
+  def test_append_method_new_source
+    sl = Gem::SourceList.new
+
+    uri1 = "http://example1"
+
+    result = sl.append(uri1)
+
+    assert_kind_of Gem::Source, result
+    assert_kind_of Gem::URI, result.uri
+    assert_equal uri1, result.uri.to_s
+    assert_equal [result], sl.sources
+  end
+
+  def test_append_method_existing_moves_to_end
+    sl = Gem::SourceList.new
+
+    uri1 = "http://example1"
+    uri2 = "http://example2"
+
+    s1 = sl << uri1
+    s2 = sl << uri2
+
+    # list is [s1, s2]; appending s1 should move it to end => [s2, s1]
+    result = sl.append(uri1)
+
+    assert_equal s1, result
+    assert_equal [s2, s1], sl.sources
+  end
+
+  def test_prepend_with_gem_source_object
+    sl = Gem::SourceList.new
+
+    uri1 = "http://example1"
+    uri2 = "http://example2"
+    source1 = Gem::Source.new(uri1)
+    source2 = Gem::Source.new(uri2)
+
+    # Add first source
+    sl << source1
+
+    # Prepend with Gem::Source object
+    result = sl.prepend(source2)
+
+    assert_equal source2, result
+    assert_equal [source2, source1], sl.sources
+
+    # Prepend existing source - should move to front
+    result = sl.prepend(source1)
+
+    assert_equal source1, result
+    assert_equal [source1, source2], sl.sources
+  end
+
+  def test_append_with_gem_source_object
+    sl = Gem::SourceList.new
+
+    uri1 = "http://example1"
+    uri2 = "http://example2"
+    source1 = Gem::Source.new(uri1)
+    source2 = Gem::Source.new(uri2)
+
+    # Add first source
+    sl << source1
+
+    # Append with Gem::Source object
+    result = sl.append(source2)
+
+    assert_equal source2, result
+    assert_equal [source1, source2], sl.sources
+
+    # Append existing source - should move to end
+    result = sl.append(source1)
+
+    assert_equal source1, result
+    assert_equal [source2, source1], sl.sources
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I need a way to programmatically and idempotently add a source to the top of the sources list. 

Previously, sources could only be appended using the `gem sources --add` command since rubygems.org was always re-added as the first source when there were no other sources.

## What is your fix for the problem, implemented in this PR?

This improves the ability to add sources programmatically by enabling sources to be added in front of rubygems.org.
It also renames the primary command line options to `--append` and `--prepend` and allows you to use the flag multiple times (in which case it behaves as if the command was called multiple time with each flag).

One edgecase I didn't fix: if you `--append` and `--prepend` the same source, the order is indeterminate. I hope that's just not a thing people do, because fixing it seemed like unnecessary complexity. 

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
