### PR TITLE
Add bin/setup to help with setup discovery

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+exec File.expand_path("rake", __dir__), "setup"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I keep forgetting the command to setup the rubygems repo. 

## What is your fix for the problem, implemented in this PR?

bin/setup is common enough, adding it here seems like it couldn't hurt. I know this is a really small change, but thought it might help someone else too.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
