### PR TITLE
Removed to workaround for Bundler 2.2

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -67,23 +67,6 @@ class Gem::Installer
   attr_reader :package
 
   class << self
-    #
-    # Changes in rubygems to lazily loading `rubygems/command` (in order to
-    # lazily load `optparse` as a side effect) affect bundler's custom installer
-    # which uses `Gem::Command` without requiring it (up until bundler 2.2.29).
-    # This hook is to compensate for that missing require.
-    #
-    # TODO: Remove when rubygems no longer supports running on bundler older
-    # than 2.2.29.
-
-    def inherited(klass)
-      if klass.name == "Bundler::RubyGemsGemInstaller"
-        require "rubygems/command"
-      end
-
-      super(klass)
-    end
-
     ##
     # Overrides the executable format.
     #


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The current oldest support Ruby version is 3.2. And Ruby 3.2 bundled Bundler 2.5. It means RG 4.0 can drop to support Bundler 2.2.

## What is your fix for the problem, implemented in this PR?

Removed the workaround for Bundler 2.2.29.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
