### PR TITLE
[feature] Enable lockfile_checksums by default

### DIFF
--- a/bundler/lib/bundler/feature_flag.rb
+++ b/bundler/lib/bundler/feature_flag.rb
@@ -31,7 +31,7 @@ module Bundler
     settings_flag(:cache_all) { bundler_4_mode? }
     settings_flag(:forget_cli_options) { bundler_4_mode? }
     settings_flag(:global_gem_cache) { bundler_5_mode? }
-    settings_flag(:lockfile_checksums) { bundler_4_mode? }
+    settings_flag(:lockfile_checksums) { true }
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }
     settings_flag(:update_requires_all_flag) { bundler_5_mode? }
 

--- a/bundler/lib/bundler/feature_flag.rb
+++ b/bundler/lib/bundler/feature_flag.rb
@@ -31,7 +31,7 @@ module Bundler
     settings_flag(:cache_all) { bundler_4_mode? }
     settings_flag(:forget_cli_options) { bundler_4_mode? }
     settings_flag(:global_gem_cache) { bundler_5_mode? }
-    settings_flag(:lockfile_checksums) { true }
+    settings_flag(:lockfile_checksums) { bundler_4_mode? }
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }
     settings_flag(:update_requires_all_flag) { bundler_5_mode? }
 

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -132,7 +132,7 @@ Generate a \fBgems\.rb\fR instead of a \fBGemfile\fR when running \fBbundle init
 The number of gems Bundler can install in parallel\. Defaults to the number of available processors\.
 .TP
 \fBlockfile_checksums\fR (\fBBUNDLE_LOCKFILE_CHECKSUMS\fR)
-Whether Bundler should include a checksums section in new lockfiles, to protect from compromised gem sources\. Enabled by default.
+Whether Bundler should include a checksums section in new lockfiles, to protect from compromised gem sources.  Defaults to true\.
 .TP
 \fBno_install\fR (\fBBUNDLE_NO_INSTALL\fR)
 Whether \fBbundle package\fR should skip installing gems\.

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -132,7 +132,7 @@ Generate a \fBgems\.rb\fR instead of a \fBGemfile\fR when running \fBbundle init
 The number of gems Bundler can install in parallel\. Defaults to the number of available processors\.
 .TP
 \fBlockfile_checksums\fR (\fBBUNDLE_LOCKFILE_CHECKSUMS\fR)
-Whether Bundler should include a checksums section in new lockfiles, to protect from compromised gem sources\.
+Whether Bundler should include a checksums section in new lockfiles, to protect from compromised gem sources\. Enabled by default.
 .TP
 \fBno_install\fR (\fBBUNDLE_NO_INSTALL\fR)
 Whether \fBbundle package\fR should skip installing gems\.

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -157,7 +157,7 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    The number of gems Bundler can install in parallel. Defaults to the number of
    available processors.
 * `lockfile_checksums` (`BUNDLE_LOCKFILE_CHECKSUMS`):
-   Whether Bundler should include a checksums section in new lockfiles, to protect from compromised gem sources. Enabled by default.
+   Whether Bundler should include a checksums section in new lockfiles, to protect from compromised gem sources. Defaults to true.
 * `no_install` (`BUNDLE_NO_INSTALL`):
    Whether `bundle package` should skip installing gems.
 * `no_prune` (`BUNDLE_NO_PRUNE`):

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -157,7 +157,7 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    The number of gems Bundler can install in parallel. Defaults to the number of
    available processors.
 * `lockfile_checksums` (`BUNDLE_LOCKFILE_CHECKSUMS`):
-   Whether Bundler should include a checksums section in new lockfiles, to protect from compromised gem sources.
+   Whether Bundler should include a checksums section in new lockfiles, to protect from compromised gem sources. Enabled by default.
 * `no_install` (`BUNDLE_NO_INSTALL`):
    Whether `bundle package` should skip installing gems.
 * `no_prune` (`BUNDLE_NO_PRUNE`):

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -2059,15 +2059,13 @@ RSpec.describe "bundle lock" do
     L
   end
 
-  it "generates checksums by default if configured to do so" do
+  it "generates checksums by default" do
     build_repo4 do
       build_gem "nokogiri", "1.14.2"
       build_gem "nokogiri", "1.14.2" do |s|
         s.platform = "x86_64-linux"
       end
     end
-
-    bundle "config lockfile_checksums true"
 
     simulate_platform "x86_64-linux" do
       install_gemfile <<-G
@@ -2096,6 +2094,42 @@ RSpec.describe "bundle lock" do
       DEPENDENCIES
         nokogiri
       #{checksums}
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+  end
+
+  it "disables checksums if configured to do so" do
+    build_repo4 do
+      build_gem "nokogiri", "1.14.2"
+      build_gem "nokogiri", "1.14.2" do |s|
+        s.platform = "x86_64-linux"
+      end
+    end
+
+    bundle "config lockfile_checksums false"
+
+    simulate_platform "x86_64-linux" do
+      install_gemfile <<-G
+        source "https://gem.repo4"
+
+        gem "nokogiri"
+      G
+    end
+
+    expect(lockfile).to eq <<~L
+      GEM
+        remote: https://gem.repo4/
+        specs:
+          nokogiri (1.14.2)
+          nokogiri (1.14.2-x86_64-linux)
+
+      PLATFORMS
+        ruby
+        x86_64-linux
+
+      DEPENDENCIES
+        nokogiri
       BUNDLED WITH
          #{Bundler::VERSION}
     L


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

[Closes #8659]

## What is your fix for the problem, implemented in this PR?

Includes checksums in lockfiles by default.

Team member mentioned It's a recent feature, so seems fine to enable by default and make it more visible, but needs decision on whether keep disabling them as a option (seems probably the smoothest way).

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
