### PR TITLE
[feature] Updating default value for global_gem_cache

### DIFF
--- a/bundler/lib/bundler/feature_flag.rb
+++ b/bundler/lib/bundler/feature_flag.rb
@@ -30,7 +30,7 @@ module Bundler
     settings_flag(:allow_offline_install) { bundler_4_mode? }
     settings_flag(:cache_all) { bundler_4_mode? }
     settings_flag(:forget_cli_options) { bundler_4_mode? }
-    settings_flag(:global_gem_cache) { bundler_5_mode? }
+    settings_flag(:global_gem_cache) { true }
     settings_flag(:lockfile_checksums) { bundler_4_mode? }
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }
     settings_flag(:update_requires_all_flag) { bundler_5_mode? }

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -117,7 +117,7 @@ Sets the \fB\-\-key\fR parameter for \fBgem push\fR when using the \fBrake relea
 The name of the file that bundler should use as the \fBGemfile\fR\. This location of this file also sets the root of the project, which is used to resolve relative paths in the \fBGemfile\fR, among other things\. By default, bundler will search up from the current working directory until it finds a \fBGemfile\fR\.
 .TP
 \fBglobal_gem_cache\fR (\fBBUNDLE_GLOBAL_GEM_CACHE\fR)
-Whether Bundler should cache all gems and compiled extensions globally, rather than locally to the configured installation path\.
+Whether Bundler should cache all gems and compiled extensions globally, rather than locally to the configured installation path\. Enabled by default\.
 .TP
 \fBignore_funding_requests\fR (\fBBUNDLE_IGNORE_FUNDING_REQUESTS\fR)
 When set, no funding requests will be printed\.

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -145,7 +145,7 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    `Gemfile`.
 * `global_gem_cache` (`BUNDLE_GLOBAL_GEM_CACHE`):
    Whether Bundler should cache all gems and compiled extensions globally,
-   rather than locally to the configured installation path.
+   rather than locally to the configured installation path. Enabled by default.
 * `ignore_funding_requests` (`BUNDLE_IGNORE_FUNDING_REQUESTS`):
    When set, no funding requests will be printed.
 * `ignore_messages` (`BUNDLE_IGNORE_MESSAGES`):


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

[Closes](https://github.com/rubygems/rubygems/issues/8658)

## What is your fix for the problem, implemented in this PR?

Setting default feature flag value to true, for `global_gem_cache`

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
