### PR TITLE
Fix Unsafe shell command constructed from library input

### DIFF
--- a/bundler/lib/bundler/vendor/thor/lib/thor/shell/basic.rb
+++ b/bundler/lib/bundler/vendor/thor/lib/thor/shell/basic.rb
@@ -314,10 +314,12 @@ class Bundler::Thor
         diff_cmd = ENV["THOR_DIFF"] || ENV["RAILS_DIFF"] || "diff -u"
 
         require "tempfile"
+        require "shellwords"
         Tempfile.open(File.basename(destination), File.dirname(destination), binmode: true) do |temp|
           temp.write content
           temp.rewind
-          system %(#{diff_cmd} "#{destination}" "#{temp.path}")
+          cmd_ary = Shellwords.split(diff_cmd) + [destination, temp.path]
+          system(*cmd_ary)
         end
       end
 


### PR DESCRIPTION
https://github.com/rubygems/rubygems/blob/76abc01487175b3aa9a30b4425501de39ea115f8/bundler/lib/bundler/vendor/thor/lib/thor/shell/basic.rb#L320-L320

fix this problem, we should avoid passing a single string to `system`, which invokes the shell, and instead pass the command and its arguments as separate parameters. This way, Ruby will invoke the command directly without using the shell, and the arguments will not be interpreted as shell code. Specifically, we should split `diff_cmd` into the command and its arguments, and pass `destination` and `temp.path` as additional arguments. If `diff_cmd` is a simple command (like `"diff -u"`), we can use `Shellwords.split` to safely split it into an array of arguments. We will need to require the `shellwords` library for this. The change should be made in the `show_diff` method in `bundler/lib/bundler/vendor/thor/lib/thor/shell/basic.rb`.



## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
