### PR TITLE
Improve `gem sources --remove` output

### DIFF
--- a/lib/rubygems/commands/sources_command.rb
+++ b/lib/rubygems/commands/sources_command.rb
@@ -208,7 +208,11 @@ To remove a source use the --remove argument:
       Gem.sources.delete source
       Gem.configuration.write
 
-      say "#{source_uri} removed from sources"
+      if default_sources.include?(source) && configured_sources.one?
+        alert_warning "Removing a default source when it is the only source has no effect. Add a different source to #{config_file_name} if you want to stop using it as a source."
+      else
+        say "#{source_uri} removed from sources"
+      end
     elsif configured_sources
       say "source #{source_uri} cannot be removed because it's not present in #{config_file_name}"
     else
@@ -238,6 +242,10 @@ To remove a source use the --remove argument:
   end
 
   private
+
+  def default_sources
+    Gem::SourceList.from(Gem.default_sources)
+  end
 
   def configured_sources
     return @configured_sources if defined?(@configured_sources)

--- a/test/rubygems/test_gem_commands_sources_command.rb
+++ b/test/rubygems/test_gem_commands_sources_command.rb
@@ -455,6 +455,40 @@ beta-gems.example.com is not a URI
     assert_equal "", @ui.error
   end
 
+  def test_remove_default_also_present_in_configuration
+    Gem.configuration.sources = [@gem_repo]
+
+    @cmd.handle_options %W[--remove #{@gem_repo}]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    expected = "WARNING:  Removing a default source when it is the only source has no effect. Add a different source to #{Gem.configuration.config_file_name} if you want to stop using it as a source.\n"
+
+    assert_equal "", @ui.output
+    assert_equal expected, @ui.error
+  ensure
+    Gem.configuration.sources = nil
+  end
+
+  def test_remove_default_also_present_in_configuration_when_there_are_more_configured_sources
+    Gem.configuration.sources = [@gem_repo, "https://other.repo"]
+
+    @cmd.handle_options %W[--remove #{@gem_repo}]
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    expected = "#{@gem_repo} removed from sources\n"
+
+    assert_equal expected, @ui.output
+    assert_equal "", @ui.error
+  ensure
+    Gem.configuration.sources = nil
+  end
+
   def test_execute_remove_redundant_source_trailing_slash
     repo_with_slash = "http://sample.repo/"
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Several issues with `gem sources` command.

## What is your fix for the problem, implemented in this PR?

* ~Make it clear in `gem sources` output, when it's listing sources explicitly configured and when it's listing default sources.~ Extracted to #8938.
* ~Fix `gem sources --remove` getting confused by trailing slashes. Similar to https://github.com/rubygems/rubygems/pull/1883, but for `gem sources --remove`.~ Extracted to #8939.
* Improve `gem sources --remove` output to be explain more accurately when why fails to remove the source when that happens.
* Improve `gem sources --remove` output when you try to remove the default source. In particular, don't say the default source has been removed since default sources cannot be removed. This fixes #8344.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
