### PR TITLE
Minor improvements in Bundler specs

### DIFF
--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -1432,7 +1432,7 @@ RSpec.describe "bundle install with specific platforms" do
     end
   end
 
-  it "does not fail when a platform variant is incompatible with the current ruby and another equivalent platform specific variant is part of the resolution", rubygems: ">= 3.3.21" do
+  it "does not fail when a platform variant is incompatible with the current ruby and another equivalent platform specific variant is part of the resolution" do
     build_repo4 do
       build_gem "nokogiri", "1.15.5"
 
@@ -1578,7 +1578,7 @@ RSpec.describe "bundle install with specific platforms" do
     end
   end
 
-  it "adds current musl platform, when there are also gnu variants", rubygems: ">= 3.3.21" do
+  it "adds current musl platform, when there are also gnu variants" do
     build_repo4 do
       build_gem "rcee_precompiled", "0.5.0" do |s|
         s.platform = "x86_64-linux-gnu"

--- a/bundler/spec/resolver/platform_spec.rb
+++ b/bundler/spec/resolver/platform_spec.rb
@@ -387,7 +387,7 @@ RSpec.describe "Resolving platform craziness" do
       should_resolve_as %w[thin-1.2.7-x64-mingw-ucrt]
     end
 
-    it "finds universal-mingw gems on x64-mingw-ucrt", rubygems: ">= 3.3.18" do
+    it "finds universal-mingw gems on x64-mingw-ucrt" do
       platform "x64-mingw-ucrt"
       dep "win32-api"
       should_resolve_as %w[win32-api-1.5.1-universal-mingw32]

--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -595,7 +595,7 @@ RSpec.describe "bundler/inline#gemfile" do
     skip "timeout isn't a default gem" if default_timeout_version.empty?
 
     # This only works on RubyGems 3.5.0 or higher
-    ruby "require 'rubygems/timeout'", raise_on_error: false
+    ruby "require 'rubygems/vendored_timeout'", raise_on_error: false
     skip "rubygems under test does not yet vendor timeout" unless last_command.success?
 
     build_repo4 do

--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -590,13 +590,9 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(err).to be_empty
   end
 
-  it "does not load default timeout" do
+  it "does not load default timeout", rubygems: ">= 3.5.0" do
     default_timeout_version = ruby "gem 'timeout', '< 999999'; require 'timeout'; puts Timeout::VERSION", raise_on_error: false
     skip "timeout isn't a default gem" if default_timeout_version.empty?
-
-    # This only works on RubyGems 3.5.0 or higher
-    ruby "require 'rubygems/vendored_timeout'", raise_on_error: false
-    skip "rubygems under test does not yet vendor timeout" unless last_command.success?
 
     build_repo4 do
       build_gem "timeout", "999"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Not much, just noticed some unnecessary `:rubygems` filter and found one spec that stopped being run since fd5685c42f8f3fe71c65f693d5755bf7223d83d6.

## What is your fix for the problem, implemented in this PR?

Remove the unnecessary filters and make sure the spec runs again.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
