### PR TITLE
Fix `bundle cache --no-all` not printing a deprecation warning

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -412,6 +412,7 @@ module Bundler
     D
     def cache
       print_remembered_flag_deprecation("--all", "cache_all", "true") if ARGV.include?("--all")
+      print_remembered_flag_deprecation("--no-all", "cache_all", "false") if ARGV.include?("--no-all")
 
       if flag_passed?("--path")
         message =

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -199,6 +199,28 @@ RSpec.describe "major deprecations" do
     pending "fails with a helpful error", bundler: "4"
   end
 
+  context "bundle cache --no-all" do
+    before do
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        gem "myrack"
+      G
+
+      bundle "cache --no-all", raise_on_error: false
+    end
+
+    it "should print a deprecation warning" do
+      expect(deprecations).to include(
+        "The `--no-all` flag is deprecated because it relies on being " \
+        "remembered across bundler invocations, which bundler will no " \
+        "longer do in future versions. Instead please use `bundle config set " \
+        "cache_all false`, and stop using this flag"
+      )
+    end
+
+    pending "fails with a helpful error", bundler: "4"
+  end
+
   context "bundle cache --path" do
     before do
       install_gemfile <<-G


### PR DESCRIPTION
Like others, it's a remembered option which we are deprecating in favor of configuration.

## What was the end-user or developer problem that led to this PR?

Like in #8844, I found one more missing deprecation warning.

## What is your fix for the problem, implemented in this PR?

Make sure `bundle cache --no-all` shows a deprecation warning. Like others, it's a remembered option which we are deprecating in favor of configuration.
## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
