### PR TITLE
Cancel deprecation of `bundle show --outdated`

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -286,11 +286,6 @@ module Bundler
     method_option "paths", type: :boolean, banner: "List the paths of all gems that are required by your Gemfile."
     method_option "outdated", type: :boolean, banner: "Show verbose output including whether gems are outdated."
     def show(gem_name = nil)
-      if ARGV.include?("--outdated")
-        message = "the `--outdated` flag to `bundle show` was undocumented and will be removed without replacement"
-        removed_message = "the `--outdated` flag to `bundle show` was undocumented and has been removed without replacement"
-        SharedHelpers.major_deprecation(2, message, removed_message: removed_message)
-      end
       require_relative "cli/show"
       Show.new(options, gem_name).run
     end

--- a/bundler/spec/commands/show_spec.rb
+++ b/bundler/spec/commands/show_spec.rb
@@ -218,7 +218,3 @@ RSpec.describe "bundle show" do
     end
   end
 end
-
-RSpec.describe "bundle show", bundler: "4" do
-  pending "shows a friendly error about the command removal"
-end

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -578,27 +578,6 @@ RSpec.describe "major deprecations" do
     pending "fails with a helpful error", bundler: "4"
   end
 
-  context "bundle show" do
-    before do
-      install_gemfile <<-G
-        source "https://gem.repo1"
-        gem "myrack"
-      G
-    end
-
-    context "with --outdated flag" do
-      before do
-        bundle "show --outdated"
-      end
-
-      it "prints a deprecation warning informing about its removal" do
-        expect(deprecations).to include("the `--outdated` flag to `bundle show` was undocumented and will be removed without replacement")
-      end
-
-      pending "fails with a helpful message", bundler: "4"
-    end
-  end
-
   context "bundle remove" do
     before do
       gemfile <<-G


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I found two reasons for not removing it:

* We claim "it's undocumented" as the reason for deprecating it, however, we've inadvertently added documentation for it, recently.
* `bundle show --verbose` does the same thing, and we are not deprecating it.

## What is your fix for the problem, implemented in this PR?

I feel it's simpler to not deprecate it, there are way more important changes that we'll be doing in Bundler 4.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
