### PR TITLE
Fix Bundler printing more flags than actually passed in verbose mode

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -713,7 +713,12 @@ module Bundler
       command_name = cmd.name
       return if PARSEABLE_COMMANDS.include?(command_name)
       command = ["bundle", command_name] + args
-      command << Thor::Options.to_switches(options.sort_by(&:first)).strip
+      options_to_print = options.dup
+      options_to_print.delete_if do |k, v|
+        next unless o = cmd.options[k]
+        o.default == v
+      end
+      command << Thor::Options.to_switches(options_to_print.sort_by(&:first)).strip
       command.reject!(&:empty?)
       Bundler.ui.info "Running `#{command * " "}` with bundler #{Bundler.verbose_version}"
     end

--- a/bundler/spec/commands/list_spec.rb
+++ b/bundler/spec/commands/list_spec.rb
@@ -1,6 +1,18 @@
 # frozen_string_literal: true
 
 RSpec.describe "bundle list" do
+  context "in verbose mode" do
+    it "logs the actual flags passed to the command" do
+      install_gemfile <<-G
+        source "https://gem.repo1"
+      G
+
+      bundle "list --verbose"
+
+      expect(out).to include("Running `bundle list --verbose`")
+    end
+  end
+
   context "with name-only and paths option" do
     it "raises an error" do
       bundle "list --name-only --paths", raise_on_error: false


### PR DESCRIPTION

## What was the end-user or developer problem that led to this PR?

I introduced a regression in bea87eab0b17d73798353bb15d8ea4130c1359bf, where bundler in verbose mode now logs the command being run, printing more flags than actually passed.

For example,

```
$ dbundle list --verbose
Running `bundle list --only-group  --verbose --without-group` with bundler 2.8.0.dev
Found no changes, using resolution from the lockfile
(...)
```

## What is your fix for the problem, implemented in this PR?

This reverts commit bea87eab0b17d73798353bb15d8ea4130c1359bf and adds a regression spec for it.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
