### PR TITLE
Improve documentation of `bundle doctor`, `bundle plugin`, and `bundle config`

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -520,11 +520,11 @@ module Bundler
         Viz requires the ruby-graphviz gem (and its dependencies).
         The associated gems must also be installed via 'bundle install'.
       D
-      method_option :file, type: :string, default: "gem_graph", aliases: "-f", desc: "The name to use for the generated file. see format option"
-      method_option :format, type: :string, default: "png", aliases: "-F", desc: "This is output format option. Supported format is png, jpg, svg, dot ..."
-      method_option :requirements, type: :boolean, default: false, aliases: "-R", desc: "Set to show the version of each required dependency."
-      method_option :version, type: :boolean, default: false, aliases: "-v", desc: "Set to show each gem version."
-      method_option :without, type: :array, default: [], aliases: "-W", banner: "GROUP[ GROUP...]", desc: "Exclude gems that are part of the specified named group."
+      method_option :file, type: :string, default: "gem_graph", aliases: "-f", banner: "The name to use for the generated file. see format option"
+      method_option :format, type: :string, default: "png", aliases: "-F", banner: "This is output format option. Supported format is png, jpg, svg, dot ..."
+      method_option :requirements, type: :boolean, default: false, aliases: "-R", banner: "Set to show the version of each required dependency."
+      method_option :version, type: :boolean, default: false, aliases: "-v", banner: "Set to show each gem version."
+      method_option :without, type: :array, default: [], aliases: "-W", banner: "Exclude gems that are part of the specified named group."
       def viz
         SharedHelpers.major_deprecation 2, "The `viz` command has been renamed to `graph` and moved to a plugin. See https://github.com/rubygems/bundler-graph"
         require_relative "cli/viz"
@@ -533,19 +533,19 @@ module Bundler
     end
 
     desc "gem NAME [OPTIONS]", "Creates a skeleton for creating a rubygem"
-    method_option :exe, type: :boolean, default: false, aliases: ["--bin", "-b"], desc: "Generate a binary executable for your library."
-    method_option :coc, type: :boolean, desc: "Generate a code of conduct file. Set a default with `bundle config set --global gem.coc true`."
-    method_option :edit, type: :string, aliases: "-e", required: false, banner: "EDITOR", lazy_default: [ENV["BUNDLER_EDITOR"], ENV["VISUAL"], ENV["EDITOR"]].find {|e| !e.nil? && !e.empty? }, desc: "Open generated gemspec in the specified editor (defaults to $EDITOR or $BUNDLER_EDITOR)"
-    method_option :ext, type: :string, desc: "Generate the boilerplate for C extension code.", enum: EXTENSIONS
-    method_option :git, type: :boolean, default: true, desc: "Initialize a git repo inside your library."
-    method_option :mit, type: :boolean, desc: "Generate an MIT license file. Set a default with `bundle config set --global gem.mit true`."
-    method_option :rubocop, type: :boolean, desc: "Add rubocop to the generated Rakefile and gemspec. Set a default with `bundle config set --global gem.rubocop true`."
-    method_option :changelog, type: :boolean, desc: "Generate changelog file. Set a default with `bundle config set --global gem.changelog true`."
+    method_option :exe, type: :boolean, default: false, aliases: ["--bin", "-b"], banner: "Generate a binary executable for your library."
+    method_option :coc, type: :boolean, banner: "Generate a code of conduct file. Set a default with `bundle config set --global gem.coc true`."
+    method_option :edit, type: :string, aliases: "-e", required: false, lazy_default: [ENV["BUNDLER_EDITOR"], ENV["VISUAL"], ENV["EDITOR"]].find {|e| !e.nil? && !e.empty? }, banner: "Open generated gemspec in the specified editor (defaults to $EDITOR or $BUNDLER_EDITOR)"
+    method_option :ext, type: :string, banner: "Generate the boilerplate for C extension code.", enum: EXTENSIONS
+    method_option :git, type: :boolean, default: true, banner: "Initialize a git repo inside your library."
+    method_option :mit, type: :boolean, banner: "Generate an MIT license file. Set a default with `bundle config set --global gem.mit true`."
+    method_option :rubocop, type: :boolean, banner: "Add rubocop to the generated Rakefile and gemspec. Set a default with `bundle config set --global gem.rubocop true`."
+    method_option :changelog, type: :boolean, banner: "Generate changelog file. Set a default with `bundle config set --global gem.changelog true`."
     method_option :test, type: :string, lazy_default: Bundler.settings["gem.test"] || "", aliases: "-t", banner: "Use the specified test framework for your library", enum: %w[rspec minitest test-unit], desc: "Generate a test directory for your library, either rspec, minitest or test-unit. Set a default with `bundle config set --global gem.test (rspec|minitest|test-unit)`."
-    method_option :ci, type: :string, lazy_default: Bundler.settings["gem.ci"] || "", enum: %w[github gitlab circle], desc: "Generate CI configuration, either GitHub Actions, GitLab CI or CircleCI. Set a default with `bundle config set --global gem.ci (github|gitlab|circle)`"
-    method_option :linter, type: :string, lazy_default: Bundler.settings["gem.linter"] || "", enum: %w[rubocop standard], desc: "Add a linter and code formatter, either RuboCop or Standard. Set a default with `bundle config set --global gem.linter (rubocop|standard)`"
+    method_option :ci, type: :string, lazy_default: Bundler.settings["gem.ci"] || "", enum: %w[github gitlab circle], banner: "Generate CI configuration, either GitHub Actions, GitLab CI or CircleCI. Set a default with `bundle config set --global gem.ci (github|gitlab|circle)`"
+    method_option :linter, type: :string, lazy_default: Bundler.settings["gem.linter"] || "", enum: %w[rubocop standard], banner: "Add a linter and code formatter, either RuboCop or Standard. Set a default with `bundle config set --global gem.linter (rubocop|standard)`"
     method_option :github_username, type: :string, default: Bundler.settings["gem.github_username"], banner: "Set your username on GitHub", desc: "Fill in GitHub username on README so that you don't have to do it manually. Set a default with `bundle config set --global gem.github_username <your_username>`."
-    method_option :bundle, type: :boolean, default: Bundler.settings["gem.bundle"], desc: "Automatically run `bundle install` after creation. Set a default with `bundle config set --global gem.bundle true`"
+    method_option :bundle, type: :boolean, default: Bundler.settings["gem.bundle"], banner: "Automatically run `bundle install` after creation. Set a default with `bundle config set --global gem.bundle true`"
 
     def gem(name)
       require_relative "cli/gem"

--- a/bundler/lib/bundler/man/bundle-add.1
+++ b/bundler/lib/bundler/man/bundle-add.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-ADD" "1" "July 2025" ""
+.TH "BUNDLE\-ADD" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-add\fR \- Add gem to the Gemfile and run bundle install
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-binstubs.1
+++ b/bundler/lib/bundler/man/bundle-binstubs.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-BINSTUBS" "1" "July 2025" ""
+.TH "BUNDLE\-BINSTUBS" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-binstubs\fR \- Install the binstubs of the listed gems
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-cache.1
+++ b/bundler/lib/bundler/man/bundle-cache.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-CACHE" "1" "July 2025" ""
+.TH "BUNDLE\-CACHE" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-cache\fR \- Package your needed \fB\.gem\fR files into your application
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-check.1
+++ b/bundler/lib/bundler/man/bundle-check.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-CHECK" "1" "July 2025" ""
+.TH "BUNDLE\-CHECK" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-check\fR \- Verifies if dependencies are satisfied by installed gems
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-clean.1
+++ b/bundler/lib/bundler/man/bundle-clean.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-CLEAN" "1" "July 2025" ""
+.TH "BUNDLE\-CLEAN" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-clean\fR \- Cleans up unused gems in your bundler directory
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -1,16 +1,16 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-CONFIG" "1" "July 2025" ""
+.TH "BUNDLE\-CONFIG" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-config\fR \- Set bundler configuration options
 .SH "SYNOPSIS"
-\fBbundle config\fR list
+\fBbundle config\fR [list]
 .br
-\fBbundle config\fR [get] NAME
+\fBbundle config\fR [get [\-\-local|\-\-global]] NAME
 .br
-\fBbundle config\fR [set] NAME VALUE
+\fBbundle config\fR [set [\-\-local|\-\-global]] NAME VALUE
 .br
-\fBbundle config\fR unset NAME
+\fBbundle config\fR unset [\-\-local|\-\-global] NAME
 .SH "DESCRIPTION"
 This command allows you to interact with Bundler's configuration system\.
 .P
@@ -25,23 +25,40 @@ Global config (\fB~/\.bundle/config\fR)
 Bundler default config
 .IP "" 0
 .P
+Executing \fBbundle\fR with the \fBBUNDLE_IGNORE_CONFIG\fR environment variable set will cause it to ignore all configuration\.
+.SH "SUB\-COMMANDS"
+.SS "list (default command)"
 Executing \fBbundle config list\fR will print a list of all bundler configuration for the current bundle, and where that configuration was set\.
+.SS "get"
+Executing \fBbundle config get <name>\fR will print the value of that configuration setting, and all locations where it was set\.
 .P
-Executing \fBbundle config get <name>\fR will print the value of that configuration setting, and where it was set\.
+\fBOPTIONS\fR
+.TP
+\fB\-\-local\fR
+Get configuration from configuration file for the local application, namely, \fB<project_root>/\.bundle/config\fR, or \fB$BUNDLE_APP_CONFIG/config\fR if \fBBUNDLE_APP_CONFIG\fR is set\.
+.TP
+\fB\-\-global\fR
+Get configuration from configuration file global to all bundles executed as the current user, namely, from \fB~/\.bundle/config\fR\.
+.SS "set"
+Executing \fBbundle config set <name> <value>\fR defaults to setting \fBlocal\fR configuration if executing from within a local application, otherwise it will set \fBglobal\fR configuration\.
 .P
-Executing \fBbundle config set <name> <value>\fR defaults to setting \fBlocal\fR configuration if executing from within a local application, otherwise it will set \fBglobal\fR configuration\. See \fB\-\-local\fR and \fB\-\-global\fR options below\.
-.P
+\fBOPTIONS\fR
+.TP
+\fB\-\-local\fR
 Executing \fBbundle config set \-\-local <name> <value>\fR will set that configuration in the directory for the local application\. The configuration will be stored in \fB<project_root>/\.bundle/config\fR\. If \fBBUNDLE_APP_CONFIG\fR is set, the configuration will be stored in \fB$BUNDLE_APP_CONFIG/config\fR\.
-.P
+.TP
+\fB\-\-global\fR
 Executing \fBbundle config set \-\-global <name> <value>\fR will set that configuration to the value specified for all bundles executed as the current user\. The configuration will be stored in \fB~/\.bundle/config\fR\. If \fIname\fR already is set, \fIname\fR will be overridden and user will be warned\.
-.P
+.SS "unset"
 Executing \fBbundle config unset <name>\fR will delete the configuration in both local and global sources\.
 .P
-Executing \fBbundle config unset \-\-global <name>\fR will delete the configuration only from the user configuration\.
-.P
+\fBOPTIONS\fR
+.TP
+\fB\-\-local\fR
 Executing \fBbundle config unset \-\-local <name>\fR will delete the configuration only from the local application\.
-.P
-Executing bundle with the \fBBUNDLE_IGNORE_CONFIG\fR environment variable set will cause it to ignore all configuration\.
+.TP
+\fB\-\-global\fR
+Executing \fBbundle config unset \-\-global <name>\fR will delete the configuration only from the user configuration\.
 .SH "CONFIGURATION KEYS"
 Configuration keys in bundler have two forms: the canonical form and the environment variable form\.
 .P

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -3,10 +3,10 @@ bundle-config(1) -- Set bundler configuration options
 
 ## SYNOPSIS
 
-`bundle config` list<br>
-`bundle config` [get] NAME<br>
-`bundle config` [set] NAME VALUE<br>
-`bundle config` unset NAME
+`bundle config` [list]<br>
+`bundle config` [get [--local|--global]] NAME<br>
+`bundle config` [set [--local|--global]] NAME VALUE<br>
+`bundle config` unset [--local|--global] NAME
 
 ## DESCRIPTION
 
@@ -19,38 +19,67 @@ Bundler loads configuration settings in this order:
 3. Global config (`~/.bundle/config`)
 4. Bundler default config
 
+Executing `bundle` with the `BUNDLE_IGNORE_CONFIG` environment variable set will
+cause it to ignore all configuration.
+
+## SUB-COMMANDS
+
+### list (default command)
+
 Executing `bundle config list` will print a list of all bundler
 configuration for the current bundle, and where that configuration
 was set.
 
+### get
+
 Executing `bundle config get <name>` will print the value of that configuration
-setting, and where it was set.
+setting, and all locations where it was set.
+
+**OPTIONS**
+
+* `--local`:
+  Get configuration from configuration file for the local application, namely,
+  `<project_root>/.bundle/config`, or `$BUNDLE_APP_CONFIG/config` if
+  `BUNDLE_APP_CONFIG` is set.
+
+* `--global`:
+  Get configuration from configuration file global to all bundles executed as
+  the current user, namely, from `~/.bundle/config`.
+
+### set
 
 Executing `bundle config set <name> <value>` defaults to setting `local`
 configuration if executing from within a local application, otherwise it will
-set `global` configuration. See `--local` and `--global` options below.
+set `global` configuration.
 
-Executing `bundle config set --local <name> <value>` will set that configuration
-in the directory for the local application. The configuration will be stored in
-`<project_root>/.bundle/config`. If `BUNDLE_APP_CONFIG` is set, the configuration
-will be stored in `$BUNDLE_APP_CONFIG/config`.
+**OPTIONS**
 
-Executing `bundle config set --global <name> <value>` will set that
-configuration to the value specified for all bundles executed as the current
-user. The configuration will be stored in `~/.bundle/config`. If <name> already
-is set, <name> will be overridden and user will be warned.
+* `--local`:
+  Executing `bundle config set --local <name> <value>` will set that configuration
+  in the directory for the local application. The configuration will be stored in
+  `<project_root>/.bundle/config`. If `BUNDLE_APP_CONFIG` is set, the configuration
+  will be stored in `$BUNDLE_APP_CONFIG/config`.
+
+* `--global`:
+  Executing `bundle config set --global <name> <value>` will set that
+  configuration to the value specified for all bundles executed as the current
+  user. The configuration will be stored in `~/.bundle/config`. If <name> already
+  is set, <name> will be overridden and user will be warned.
+
+### unset
 
 Executing `bundle config unset <name>` will delete the configuration in both
 local and global sources.
 
-Executing `bundle config unset --global <name>` will delete the configuration
-only from the user configuration.
+**OPTIONS**
 
-Executing `bundle config unset --local <name>` will delete the configuration
-only from the local application.
+* `--local`:
+  Executing `bundle config unset --local <name>` will delete the configuration
+  only from the local application.
 
-Executing bundle with the `BUNDLE_IGNORE_CONFIG` environment variable set will
-cause it to ignore all configuration.
+* `--global`:
+  Executing `bundle config unset --global <name>` will delete the configuration
+  only from the user configuration.
 
 ## CONFIGURATION KEYS
 

--- a/bundler/lib/bundler/man/bundle-console.1
+++ b/bundler/lib/bundler/man/bundle-console.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-CONSOLE" "1" "July 2025" ""
+.TH "BUNDLE\-CONSOLE" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-console\fR \- Open an IRB session with the bundle pre\-loaded
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-doctor.1
+++ b/bundler/lib/bundler/man/bundle-doctor.1
@@ -6,7 +6,7 @@
 .SH "SYNOPSIS"
 \fBbundle doctor [diagnose]\fR [\-\-quiet] [\-\-gemfile=GEMFILE] [\-\-ssl]
 .br
-\fBbundle doctor ssl\fR [\-\-host=HOST] [\-\-tls\-version=VERSION] [\-\-verify\-mode=MODE]
+\fBbundle doctor ssl\fR [\-\-host=HOST] [\-\-tls\-version=TLS\-VERSION] [\-\-verify\-mode=VERIFY\-MODE]
 .br
 \fBbundle doctor\fR help [COMMAND]
 .SH "DESCRIPTION"
@@ -57,12 +57,12 @@ Open a TLS connection and verify the outcome\.
 \fB\-\-host=HOST\fR
 Perform the diagnostic on HOST\. Defaults to \fBrubygems\.org\fR\.
 .TP
-\fB\-\-tls\-version=VERSION\fR
+\fB\-\-tls\-version=TLS\-VERSION\fR
 Specify the TLS version when opening the connection to HOST\.
 .IP
 Accepted values are: \fB1\.1\fR or \fB1\.2\fR\.
 .TP
-\fB\-\-verify\-mode=MODE\fR
+\fB\-\-verify\-mode=VERIFY\-MODE\fR
 Specify the TLS verify mode when opening the connection to HOST\. Defaults to \fBSSL_VERIFY_PEER\fR\.
 .IP
 Accepted values are: \fBCLIENT_ONCE\fR, \fBFAIL_IF_NO_PEER_CERT\fR, \fBNONE\fR, \fBPEER\fR\.

--- a/bundler/lib/bundler/man/bundle-doctor.1
+++ b/bundler/lib/bundler/man/bundle-doctor.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-DOCTOR" "1" "July 2025" ""
+.TH "BUNDLE\-DOCTOR" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-doctor\fR \- Checks the bundle for common problems
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-doctor.1.ronn
+++ b/bundler/lib/bundler/man/bundle-doctor.1.ronn
@@ -7,8 +7,8 @@ bundle-doctor(1) -- Checks the bundle for common problems
                            [--gemfile=GEMFILE]
                            [--ssl]<br>
 `bundle doctor ssl` [--host=HOST]
-                    [--tls-version=VERSION]
-                    [--verify-mode=MODE]<br>
+                    [--tls-version=TLS-VERSION]
+                    [--verify-mode=VERIFY-MODE]<br>
 `bundle doctor` help [COMMAND]
 
 ## DESCRIPTION
@@ -65,12 +65,12 @@ The diagnostic will perform a few checks such as:
 * `--host=HOST`:
   Perform the diagnostic on HOST. Defaults to `rubygems.org`.
 
-* `--tls-version=VERSION`:
+* `--tls-version=TLS-VERSION`:
   Specify the TLS version when opening the connection to HOST.
 
   Accepted values are: `1.1` or `1.2`.
 
-* `--verify-mode=MODE`:
+* `--verify-mode=VERIFY-MODE`:
   Specify the TLS verify mode when opening the connection to HOST.
   Defaults to `SSL_VERIFY_PEER`.
 

--- a/bundler/lib/bundler/man/bundle-env.1
+++ b/bundler/lib/bundler/man/bundle-env.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-ENV" "1" "July 2025" ""
+.TH "BUNDLE\-ENV" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-env\fR \- Print information about the environment Bundler is running under
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-exec.1
+++ b/bundler/lib/bundler/man/bundle-exec.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-EXEC" "1" "July 2025" ""
+.TH "BUNDLE\-EXEC" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-exec\fR \- Execute a command in the context of the bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-fund.1
+++ b/bundler/lib/bundler/man/bundle-fund.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-FUND" "1" "July 2025" ""
+.TH "BUNDLE\-FUND" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-fund\fR \- Lists information about gems seeking funding assistance
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-gem.1
+++ b/bundler/lib/bundler/man/bundle-gem.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-GEM" "1" "July 2025" ""
+.TH "BUNDLE\-GEM" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-gem\fR \- Generate a project skeleton for creating a rubygem
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-help.1
+++ b/bundler/lib/bundler/man/bundle-help.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-HELP" "1" "July 2025" ""
+.TH "BUNDLE\-HELP" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-help\fR \- Displays detailed help for each subcommand
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-info.1
+++ b/bundler/lib/bundler/man/bundle-info.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-INFO" "1" "July 2025" ""
+.TH "BUNDLE\-INFO" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-info\fR \- Show information for the given gem in your bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-init.1
+++ b/bundler/lib/bundler/man/bundle-init.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-INIT" "1" "July 2025" ""
+.TH "BUNDLE\-INIT" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-init\fR \- Generates a Gemfile into the current working directory
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-inject.1
+++ b/bundler/lib/bundler/man/bundle-inject.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-INJECT" "1" "July 2025" ""
+.TH "BUNDLE\-INJECT" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-inject\fR \- Add named gem(s) with version requirements to Gemfile
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-install.1
+++ b/bundler/lib/bundler/man/bundle-install.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-INSTALL" "1" "July 2025" ""
+.TH "BUNDLE\-INSTALL" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-install\fR \- Install the dependencies specified in your Gemfile
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-issue.1
+++ b/bundler/lib/bundler/man/bundle-issue.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-ISSUE" "1" "July 2025" ""
+.TH "BUNDLE\-ISSUE" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-issue\fR \- Get help reporting Bundler issues
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-licenses.1
+++ b/bundler/lib/bundler/man/bundle-licenses.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-LICENSES" "1" "July 2025" ""
+.TH "BUNDLE\-LICENSES" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-licenses\fR \- Print the license of all gems in the bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-list.1
+++ b/bundler/lib/bundler/man/bundle-list.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-LIST" "1" "July 2025" ""
+.TH "BUNDLE\-LIST" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-list\fR \- List all the gems in the bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-lock.1
+++ b/bundler/lib/bundler/man/bundle-lock.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-LOCK" "1" "July 2025" ""
+.TH "BUNDLE\-LOCK" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-lock\fR \- Creates / Updates a lockfile without installing
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-open.1
+++ b/bundler/lib/bundler/man/bundle-open.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-OPEN" "1" "July 2025" ""
+.TH "BUNDLE\-OPEN" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-open\fR \- Opens the source directory for a gem in your bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-outdated.1
+++ b/bundler/lib/bundler/man/bundle-outdated.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-OUTDATED" "1" "July 2025" ""
+.TH "BUNDLE\-OUTDATED" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-outdated\fR \- List installed gems with newer versions available
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-platform.1
+++ b/bundler/lib/bundler/man/bundle-platform.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-PLATFORM" "1" "July 2025" ""
+.TH "BUNDLE\-PLATFORM" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-platform\fR \- Displays platform compatibility information
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-plugin.1
+++ b/bundler/lib/bundler/man/bundle-plugin.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-PLUGIN" "1" "July 2025" ""
+.TH "BUNDLE\-PLUGIN" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-plugin\fR \- Manage Bundler plugins
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-plugin.1
+++ b/bundler/lib/bundler/man/bundle-plugin.1
@@ -4,7 +4,7 @@
 .SH "NAME"
 \fBbundle\-plugin\fR \- Manage Bundler plugins
 .SH "SYNOPSIS"
-\fBbundle plugin\fR install PLUGINS [\-\-source=\fISOURCE\fR] [\-\-version=\fIversion\fR] [\-\-git=\fIgit\-url\fR] [\-\-branch=\fIbranch\fR|\-\-ref=\fIrev\fR] [\-\-path=\fIpath\fR]
+\fBbundle plugin\fR install PLUGINS [\-\-source=SOURCE] [\-\-version=VERSION] [\-\-git=GIT] [\-\-branch=BRANCH|\-\-ref=REF] [\-\-local\-git=LOCAL_GIT] [\-\-path=PATH]
 .br
 \fBbundle plugin\fR uninstall PLUGINS [\-\-all]
 .br
@@ -16,18 +16,23 @@ You can install, uninstall, and list plugin(s) with this command to extend funct
 .SH "SUB\-COMMANDS"
 .SS "install"
 Install the given plugin(s)\.
+.P
+For example, \fBbundle plugin install bundler\-graph\fR will install bundler\-graph gem from globally configured sources (defaults to RubyGems\.org)\. Note that the global source specified in Gemfile is ignored\.
+.P
+\fBOPTIONS\fR
 .TP
-\fBbundle plugin install bundler\-graph\fR
-Install bundler\-graph gem from globally configured sources (defaults to RubyGems\.org)\. The global source, specified in source in Gemfile is ignored\.
+\fB\-\-source=SOURCE\fR
+Install the plugin gem from a specific source, rather than from globally configured sources\.
+.IP
+Example: \fBbundle plugin install bundler\-graph \-\-source https://example\.com\fR
 .TP
-\fBbundle plugin install bundler\-graph \-\-source https://example\.com\fR
-Install bundler\-graph gem from example\.com\. The global source, specified in source in Gemfile is not considered\.
+\fB\-\-version=VERSION\fR
+Specify a version of the plugin gem to install via \fB\-\-version\fR\.
+.IP
+Example: \fBbundle plugin install bundler\-graph \-\-version 0\.2\.1\fR
 .TP
-\fBbundle plugin install bundler\-graph \-\-version 0\.2\.1\fR
-You can specify the version of the gem via \fB\-\-version\fR\.
-.TP
-\fBbundle plugin install bundler\-graph \-\-git https://github\.com/rubygems/bundler\-graph\fR
-Install bundler\-graph gem from Git repository\. You can use standard Git URLs like:
+\fB\-\-git=GIT\fR
+Install the plugin gem from a Git repository\. You can use standard Git URLs like:
 .IP
 \fBssh://[user@]host\.xz[:port]/path/to/repo\.git\fR
 .br
@@ -37,12 +42,24 @@ Install bundler\-graph gem from Git repository\. You can use standard Git URLs l
 .br
 \fBfile:///path/to/repo\fR
 .IP
-When you specify \fB\-\-git\fR, you can use \fB\-\-branch\fR or \fB\-\-ref\fR to specify any branch, tag, or commit hash (revision) to use\.
+Example: \fBbundle plugin install bundler\-graph \-\-git https://github\.com/rubygems/bundler\-graph\fR
 .TP
-\fBbundle plugin install bundler\-graph \-\-path \.\./bundler\-graph\fR
-Install bundler\-graph gem from a local path\.
+\fB\-\-branch=BRANCH\fR
+When you specify \fB\-\-git\fR, you can use \fB\-\-branch\fR to use\.
 .TP
-\fBbundle plugin install bundler\-graph \-\-local\-git \.\./bundler\-graph\fR
+\fB\-\-ref=REF\fR
+When you specify \fB\-\-git\fR, you can use \fB\-\-ref\fR to specify any tag, or commit hash (revision) to use\.
+.TP
+\fB\-\-path=PATH\fR
+Install the plugin gem from a local path\.
+.IP
+Example: \fBbundle plugin install bundler\-graph \-\-path \.\./bundler\-graph\fR
+.TP
+\fB\-\-local\-git=LOCAL_GIT\fR
+Install the plugin gem from a local Git repository\.
+.IP
+Example: \fBbundle plugin install bundler\-graph \-\-local\-git \.\./bundler\-graph\fR\.
+.IP
 This option is deprecated in favor of \fB\-\-git\fR\.
 .SS "uninstall"
 Uninstall the plugin(s) specified in PLUGINS\.

--- a/bundler/lib/bundler/man/bundle-plugin.1.ronn
+++ b/bundler/lib/bundler/man/bundle-plugin.1.ronn
@@ -3,9 +3,10 @@ bundle-plugin(1) -- Manage Bundler plugins
 
 ## SYNOPSIS
 
-`bundle plugin` install PLUGINS [--source=<SOURCE>] [--version=<version>]
-                              [--git=<git-url>] [--branch=<branch>|--ref=<rev>]
-                              [--path=<path>]<br>
+`bundle plugin` install PLUGINS [--source=SOURCE] [--version=VERSION]
+                              [--git=GIT] [--branch=BRANCH|--ref=REF]
+                              [--local-git=LOCAL_GIT]
+                              [--path=PATH]<br>
 `bundle plugin` uninstall PLUGINS [--all]<br>
 `bundle plugin` list<br>
 `bundle plugin` help [COMMAND]
@@ -20,29 +21,49 @@ You can install, uninstall, and list plugin(s) with this command to extend funct
 
 Install the given plugin(s).
 
-* `bundle plugin install bundler-graph`:
-  Install bundler-graph gem from globally configured sources (defaults to RubyGems.org). The global source, specified in source in Gemfile is ignored.
+For example, `bundle plugin install bundler-graph` will install bundler-graph
+gem from globally configured sources (defaults to RubyGems.org). Note that the
+global source specified in Gemfile is ignored.
 
-* `bundle plugin install bundler-graph --source https://example.com`:
-  Install bundler-graph gem from example.com. The global source, specified in source in Gemfile is not considered.
+**OPTIONS**
 
-* `bundle plugin install bundler-graph --version 0.2.1`:
-  You can specify the version of the gem via `--version`.
+* `--source=SOURCE`:
+  Install the plugin gem from a specific source, rather than from globally configured sources.
 
-* `bundle plugin install bundler-graph --git https://github.com/rubygems/bundler-graph`:
-  Install bundler-graph gem from Git repository. You can use standard Git URLs like:
+  Example: `bundle plugin install bundler-graph --source https://example.com`
+
+* `--version=VERSION`:
+  Specify a version of the plugin gem to install via `--version`.
+
+  Example: `bundle plugin install bundler-graph --version 0.2.1`
+
+* `--git=GIT`:
+  Install the plugin gem from a Git repository. You can use standard Git URLs like:
 
   `ssh://[user@]host.xz[:port]/path/to/repo.git`<br>
   `http[s]://host.xz[:port]/path/to/repo.git`<br>
   `/path/to/repo`<br>
   `file:///path/to/repo`
 
-  When you specify `--git`, you can use `--branch` or `--ref` to specify any branch, tag, or commit hash (revision) to use.
+  Example: `bundle plugin install bundler-graph --git https://github.com/rubygems/bundler-graph`
 
-* `bundle plugin install bundler-graph --path ../bundler-graph`:
-  Install bundler-graph gem from a local path.
+* `--branch=BRANCH`:
+  When you specify `--git`, you can use `--branch`  to use.
 
-* `bundle plugin install bundler-graph --local-git ../bundler-graph`:
+* `--ref=REF`:
+  When you specify `--git`, you can use `--ref` to specify any tag, or commit
+  hash (revision) to use.
+
+* `--path=PATH`:
+  Install the plugin gem from a local path.
+
+  Example: `bundle plugin install bundler-graph --path ../bundler-graph`
+
+* `--local-git=LOCAL_GIT`:
+  Install the plugin gem from a local Git repository.
+
+  Example: `bundle plugin install bundler-graph --local-git ../bundler-graph`.
+
   This option is deprecated in favor of `--git`.
 
 ### uninstall

--- a/bundler/lib/bundler/man/bundle-pristine.1
+++ b/bundler/lib/bundler/man/bundle-pristine.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-PRISTINE" "1" "July 2025" ""
+.TH "BUNDLE\-PRISTINE" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-pristine\fR \- Restores installed gems to their pristine condition
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-remove.1
+++ b/bundler/lib/bundler/man/bundle-remove.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-REMOVE" "1" "July 2025" ""
+.TH "BUNDLE\-REMOVE" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-remove\fR \- Removes gems from the Gemfile
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-show.1
+++ b/bundler/lib/bundler/man/bundle-show.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-SHOW" "1" "July 2025" ""
+.TH "BUNDLE\-SHOW" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-show\fR \- Shows all the gems in your bundle, or the path to a gem
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-update.1
+++ b/bundler/lib/bundler/man/bundle-update.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-UPDATE" "1" "July 2025" ""
+.TH "BUNDLE\-UPDATE" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-update\fR \- Update your gems to the latest available versions
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-version.1
+++ b/bundler/lib/bundler/man/bundle-version.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-VERSION" "1" "July 2025" ""
+.TH "BUNDLE\-VERSION" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-version\fR \- Prints Bundler version information
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-viz.1
+++ b/bundler/lib/bundler/man/bundle-viz.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-VIZ" "1" "July 2025" ""
+.TH "BUNDLE\-VIZ" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\-viz\fR \- Generates a visual dependency graph for your Gemfile
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle.1
+++ b/bundler/lib/bundler/man/bundle.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE" "1" "July 2025" ""
+.TH "BUNDLE" "1" "August 2025" ""
 .SH "NAME"
 \fBbundle\fR \- Ruby Dependency Management
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/gemfile.5
+++ b/bundler/lib/bundler/man/gemfile.5
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "GEMFILE" "5" "July 2025" ""
+.TH "GEMFILE" "5" "August 2025" ""
 .SH "NAME"
 \fBGemfile\fR \- A format for describing gem dependencies for Ruby programs
 .SH "SYNOPSIS"

--- a/bundler/spec/other/cli_man_pages_spec.rb
+++ b/bundler/spec/other/cli_man_pages_spec.rb
@@ -1,49 +1,72 @@
 # frozen_string_literal: true
 
 RSpec.describe "bundle commands" do
-  it "expects all commands to have a man page" do
-    Bundler::CLI.all_commands.each_key do |command_name|
-      next if command_name == "cli_help"
+  it "expects all commands to have all options and subcommands documented" do
+    check_commands!(Bundler::CLI)
 
-      expect(man_page(command_name)).to exist
-    end
-  end
-
-  it "expects all commands to have all options documented" do
-    Bundler::CLI.all_commands.each do |command_name, command|
-      next if command_name == "cli_help"
-
-      man_page_content = man_page(command_name).read
-
-      command.options.each do |_, option|
-        aliases = option.aliases
-        formatted_aliases = aliases.sort.map {|name| "`#{name}`" }.join(", ") if aliases
-
-        help = if option.type == :boolean
-          "* #{append_aliases("`#{option.switch_name}`", formatted_aliases)}:"
-        elsif option.enum
-          formatted_aliases = "`#{option.switch_name}`" if aliases.empty? && option.lazy_default
-          "* #{prepend_aliases(option.enum.sort.map {|enum| "`#{option.switch_name}=#{enum}`" }.join(", "), formatted_aliases)}:"
-        else
-          names = [option.switch_name, *aliases]
-          value =
-            case option.type
-            when :array then "<list>"
-            when :numeric then "<number>"
-            else option.name.upcase
-            end
-
-          value = option.type != :numeric && option.lazy_default ? "[=#{value}]" : "=#{value}"
-
-          "* #{names.map {|name| "`#{name}#{value}`" }.join(", ")}:"
-        end
-
-        expect(man_page_content).to include(help)
-      end
+    Bundler::CLI.subcommand_classes.each_value do |klass|
+      check_commands!(klass)
     end
   end
 
   private
+
+  def check_commands!(command_class)
+    command_class.commands.each do |command_name, command|
+      next if command.is_a?(Bundler::Thor::HiddenCommand)
+
+      if command_class == Bundler::CLI
+        man_page = man_page(command_name)
+        expect(man_page).to exist
+
+        check_options!(command, man_page)
+      else
+        man_page = man_page(command.ancestor_name)
+        expect(man_page).to exist
+
+        check_options!(command, man_page)
+        check_subcommand!(command_name, man_page)
+      end
+    end
+  end
+
+  def check_options!(command, man_page)
+    command.options.each do |_, option|
+      check_option!(option, man_page)
+    end
+  end
+
+  def check_option!(option, man_page)
+    man_page_content = man_page.read
+
+    aliases = option.aliases
+    formatted_aliases = aliases.sort.map {|name| "`#{name}`" }.join(", ") if aliases
+
+    help = if option.type == :boolean
+      "* #{append_aliases("`#{option.switch_name}`", formatted_aliases)}:"
+    elsif option.enum
+      formatted_aliases = "`#{option.switch_name}`" if aliases.empty? && option.lazy_default
+      "* #{prepend_aliases(option.enum.sort.map {|enum| "`#{option.switch_name}=#{enum}`" }.join(", "), formatted_aliases)}:"
+    else
+      names = [option.switch_name, *aliases]
+      value =
+        case option.type
+        when :array then "<list>"
+        when :numeric then "<number>"
+        else option.name.upcase
+        end
+
+      value = option.type != :numeric && option.lazy_default ? "[=#{value}]" : "=#{value}"
+
+      "* #{names.map {|name| "`#{name}#{value}`" }.join(", ")}:"
+    end
+
+    expect(man_page_content).to include(help)
+  end
+
+  def check_subcommand!(name, man_page)
+    expect(man_page.read).to match(name)
+  end
 
   def append_aliases(text, aliases)
     return text if aliases.empty?
@@ -55,6 +78,10 @@ RSpec.describe "bundle commands" do
     return text if aliases.empty?
 
     "#{aliases}, #{text}"
+  end
+
+  def man_page_content(command_name)
+    man_page(command_name).read
   end
 
   def man_page(command_name)

--- a/bundler/spec/quality_spec.rb
+++ b/bundler/spec/quality_spec.rb
@@ -251,58 +251,9 @@ RSpec.describe "The library itself" do
     expect(lib_code).to eq(spec_code)
   end
 
-  it "documents all cli command options in their associated man pages" do
-    commands = normalize_commands_and_options(Bundler::CLI)
-    cli_and_man_pages_in_sync!(commands)
-
-    Bundler::CLI.subcommand_classes.each do |_, klass|
-      subcommands = normalize_commands_and_options(klass)
-
-      cli_and_man_pages_in_sync!(subcommands)
-    end
-  end
-
   private
 
   def each_line(filename, &block)
     File.readlines(filename, encoding: "UTF-8").each_with_index(&block)
-  end
-
-  def normalize_commands_and_options(command_class)
-    commands = {}
-
-    command_class.commands.each do |command_name, command|
-      next if command.is_a?(Bundler::Thor::HiddenCommand)
-
-      key = command.ancestor_name || command_name
-      commands[key] ||= []
-      # Verify that all subcommands are documented in the main command's man page.
-      commands[key] << command_name unless command_class == Bundler::CLI
-
-      command.options.each do |_, option|
-        commands[key] << option.switch_name
-      end
-    end
-
-    commands
-  end
-
-  def cli_and_man_pages_in_sync!(commands)
-    commands.each do |command_name, opts|
-      man_page_path = man_tracked_files.find {|f| File.basename(f) == "bundle-#{command_name}.1.ronn" }
-      expect(man_page_path).to_not be_nil, "The command #{command_name} has no associated man page."
-
-      next if opts.empty?
-
-      man_page_content = File.read(man_page_path)
-      opts.each do |option_name|
-        error_msg = <<~EOM
-          The command #{command_name} has no mention of the option or subcommand `#{option_name}` in its man page.
-          Document the `#{option_name}` in the man page to discard this error.
-        EOM
-
-        expect(man_page_content).to match(option_name), error_msg
-      end
-    end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We had two duplicated specs checking essentially the same thing: that all subcommands and their flags are documented.

## What is your fix for the problem, implemented in this PR?

This PR merges the specs to keep the best of each, and make sure all our commands pass them, resulting in more standard documentation for commands with subcommands (`bundle config`, `bundle plugin`, and `bundle doctor`).

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)