### PR TITLE
Use spaces around optional parameter values

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -11,3 +11,5 @@ cf58bc4b1ee83b2697fbdbcc76ced09515525141
 ff426fdbc1bde3582b6e1d5137abd21d74c38f87
 # [RuboCop] Use modern hashes consistently in Bundler
 bb66253f2ceddee527b82971423348d8bbc1b606
+# [RuboCop] Enable Layout/SpaceAroundEqualsInParameterDefault
+cf085f1d11e729732657991baa2de010a51f4378

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,15 +1,13 @@
 # .git-blame-ignore-revs
-# RubyGems
-# Enable Style/StringLiterals cop
+# [RuboCop] Enable Style/StringLiterals in RubyGems
 dca5fa728437383428a593644f537aaa1020ee63
-# enable Style/MethodDefParentheses in Rubocop
+# [RuboCop] Enable Style/MethodDefParentheses in RubyGems
 79e6bafd945e358480ac2253995e82e229bb4f5c
-# Bundler
-# [RuboCop] Enable Style/StringLiterals
+# [RuboCop] Enable Style/StringLiterals in Bundler
 b0d532adb80521271fbde4d3955c252f2ee09a5c
-# [RuboCop] Enable Style/SymbolProc
+# [RuboCop] Enable Style/SymbolProc in Bundler
 cf58bc4b1ee83b2697fbdbcc76ced09515525141
-# [RuboCop] Enable Style/EmptyLines
+# [RuboCop] Enable Style/EmptyLines in Bundler
 ff426fdbc1bde3582b6e1d5137abd21d74c38f87
-# Use modern hashes consistently
+# [RuboCop] Use modern hashes consistently in Bundler
 bb66253f2ceddee527b82971423348d8bbc1b606

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -290,6 +290,9 @@ Layout/AssignmentIndentation:
 Layout/EmptyLinesAroundExceptionHandlingKeywords:
   Enabled: true
 
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: true
+
 Layout/SpaceInsideArrayLiteralBrackets:
   Enabled: true
 

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -165,7 +165,7 @@ module Bundler
       PubGrub::VersionConstraint.new(package, range: range)
     end
 
-    def versions_for(package, range=VersionRange.any)
+    def versions_for(package, range = VersionRange.any)
       range.select_versions(@sorted_versions[package])
     end
 

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -417,7 +417,7 @@ module Gem
     unless Gem::NameTuple.new("a", Gem::Version.new("1"), Gem::Platform.new("x86_64-linux")).platform.is_a?(String)
       alias_method :initialize_with_platform, :initialize
 
-      def initialize(name, version, platform=Gem::Platform::RUBY)
+      def initialize(name, version, platform = Gem::Platform::RUBY)
         if Gem::Platform === platform
           initialize_with_platform(name, version, platform.to_s)
         else

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -224,7 +224,7 @@ module Gem
     finish_resolve rs
   end
 
-  def self.finish_resolve(request_set=Gem::RequestSet.new)
+  def self.finish_resolve(request_set = Gem::RequestSet.new)
     request_set.import Gem::Specification.unresolved_deps.values
     request_set.import Gem.loaded_specs.values.map {|s| Gem::Dependency.new(s.name, s.version) }
 
@@ -341,7 +341,7 @@ module Gem
   ##
   # The path where gem executables are to be installed.
 
-  def self.bindir(install_dir=Gem.dir)
+  def self.bindir(install_dir = Gem.dir)
     return File.join install_dir, "bin" unless
       install_dir.to_s == Gem.default_dir.to_s
     Gem.default_bindir
@@ -350,7 +350,7 @@ module Gem
   ##
   # The path were rubygems plugins are to be installed.
 
-  def self.plugindir(install_dir=Gem.dir)
+  def self.plugindir(install_dir = Gem.dir)
     File.join install_dir, "plugins"
   end
 
@@ -534,7 +534,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   # Note that find_files will return all files even if they are from different
   # versions of the same gem.  See also find_latest_files
 
-  def self.find_files(glob, check_load_path=true)
+  def self.find_files(glob, check_load_path = true)
     files = []
 
     files = find_files_from_load_path glob if check_load_path
@@ -571,7 +571,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   # Unlike find_files, find_latest_files will return only files from the
   # latest version of a gem.
 
-  def self.find_latest_files(glob, check_load_path=true)
+  def self.find_latest_files(glob, check_load_path = true)
     files = []
 
     files = find_files_from_load_path glob if check_load_path

--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -117,7 +117,7 @@ class Gem::Command
   # Unhandled arguments (gem names, files, etc.) are left in
   # <tt>options[:args]</tt>.
 
-  def initialize(command, summary=nil, defaults={})
+  def initialize(command, summary = nil, defaults = {})
     @command = command
     @summary = summary
     @program_name = "gem #{command}"

--- a/lib/rubygems/command_manager.rb
+++ b/lib/rubygems/command_manager.rb
@@ -118,7 +118,7 @@ class Gem::CommandManager
   ##
   # Register the Symbol +command+ as a gem command.
 
-  def register_command(command, obj=false)
+  def register_command(command, obj = false)
     @commands[command] = obj
   end
 
@@ -148,7 +148,7 @@ class Gem::CommandManager
   ##
   # Run the command specified by +args+.
 
-  def run(args, build_args=nil)
+  def run(args, build_args = nil)
     process_args(args, build_args)
   rescue StandardError, Gem::Timeout::Error => ex
     if ex.respond_to?(:detailed_message)
@@ -165,7 +165,7 @@ class Gem::CommandManager
     terminate_interaction(1)
   end
 
-  def process_args(args, build_args=nil)
+  def process_args(args, build_args = nil)
     if args.empty?
       say Gem::Command::HELP
       terminate_interaction 1

--- a/lib/rubygems/dependency.rb
+++ b/lib/rubygems/dependency.rb
@@ -217,7 +217,7 @@ class Gem::Dependency
   # NOTE:  Unlike #matches_spec? this method does not return true when the
   # version is a prerelease version unless this is a prerelease dependency.
 
-  def match?(obj, version=nil, allow_prerelease=false)
+  def match?(obj, version = nil, allow_prerelease = false)
     if !version
       name = obj.name
       version = obj.version

--- a/lib/rubygems/dependency_installer.rb
+++ b/lib/rubygems/dependency_installer.rb
@@ -127,7 +127,7 @@ class Gem::DependencyInstaller
   # sources.  Gems are sorted with newer gems preferred over older gems, and
   # local gems preferred over remote gems.
 
-  def find_gems_with_sources(dep, best_only=false) # :nodoc:
+  def find_gems_with_sources(dep, best_only = false) # :nodoc:
     set = Gem::AvailableSet.new
 
     if consider_local?

--- a/lib/rubygems/dependency_list.rb
+++ b/lib/rubygems/dependency_list.rb
@@ -140,7 +140,7 @@ class Gem::DependencyList
   # If removing the gemspec creates breaks a currently ok dependency, then it
   # is NOT ok to remove the gemspec.
 
-  def ok_to_remove?(full_name, check_dev=true)
+  def ok_to_remove?(full_name, check_dev = true)
     gem_to_remove = find_name full_name
 
     # If the state is inconsistent, at least don't crash

--- a/lib/rubygems/deprecate.rb
+++ b/lib/rubygems/deprecate.rb
@@ -126,7 +126,7 @@ module Gem
     # telling the user of +repl+ (unless +repl+ is :none) and the
     # Rubygems version that it is planned to go away.
 
-    def rubygems_deprecate(name, replacement=:none, version=nil)
+    def rubygems_deprecate(name, replacement = :none, version = nil)
       class_eval do
         old = "_deprecated_#{name}"
         alias_method old, name

--- a/lib/rubygems/errors.rb
+++ b/lib/rubygems/errors.rb
@@ -26,7 +26,7 @@ module Gem
   # system.  Instead of rescuing from this class, make sure to rescue from the
   # superclass Gem::LoadError to catch all types of load errors.
   class MissingSpecError < Gem::LoadError
-    def initialize(name, requirement, extra_message=nil)
+    def initialize(name, requirement, extra_message = nil)
       @name        = name
       @requirement = requirement
       @extra_message = extra_message

--- a/lib/rubygems/exceptions.rb
+++ b/lib/rubygems/exceptions.rb
@@ -110,7 +110,7 @@ class Gem::SpecificGemNotFoundException < Gem::GemNotFoundException
   # and +version+.  Any +errors+ encountered when attempting to find the gem
   # are also stored.
 
-  def initialize(name, version, errors=nil)
+  def initialize(name, version, errors = nil)
     super "Could not find a valid gem '#{name}' (#{version}) locally or in a repository"
 
     @name = name
@@ -261,7 +261,7 @@ class Gem::UnsatisfiableDependencyError < Gem::DependencyError
   # Creates a new UnsatisfiableDependencyError for the unsatisfiable
   # Gem::Resolver::DependencyRequest +dep+
 
-  def initialize(dep, platform_mismatch=nil)
+  def initialize(dep, platform_mismatch = nil)
     if platform_mismatch && !platform_mismatch.empty?
       plats = platform_mismatch.map {|x| x.platform.to_s }.sort.uniq
       super "Unable to resolve dependency: No match for '#{dep}' on this platform. Found: #{plats.join(", ")}"

--- a/lib/rubygems/ext/cargo_builder.rb
+++ b/lib/rubygems/ext/cargo_builder.rb
@@ -15,7 +15,7 @@ class Gem::Ext::CargoBuilder < Gem::Ext::Builder
   end
 
   def build(extension, dest_path, results, args = [], lib_dir = nil, cargo_dir = Dir.pwd,
-    target_rbconfig=Gem.target_rbconfig)
+    target_rbconfig = Gem.target_rbconfig)
     require "tempfile"
     require "fileutils"
 

--- a/lib/rubygems/ext/cmake_builder.rb
+++ b/lib/rubygems/ext/cmake_builder.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Gem::Ext::CmakeBuilder < Gem::Ext::Builder
-  def self.build(extension, dest_path, results, args=[], lib_dir=nil, cmake_dir=Dir.pwd,
-    target_rbconfig=Gem.target_rbconfig)
+  def self.build(extension, dest_path, results, args = [], lib_dir = nil, cmake_dir = Dir.pwd,
+    target_rbconfig = Gem.target_rbconfig)
     if target_rbconfig.path
       warn "--target-rbconfig is not yet supported for CMake extensions. Ignoring"
     end

--- a/lib/rubygems/ext/configure_builder.rb
+++ b/lib/rubygems/ext/configure_builder.rb
@@ -7,8 +7,8 @@
 #++
 
 class Gem::Ext::ConfigureBuilder < Gem::Ext::Builder
-  def self.build(extension, dest_path, results, args=[], lib_dir=nil, configure_dir=Dir.pwd,
-    target_rbconfig=Gem.target_rbconfig)
+  def self.build(extension, dest_path, results, args = [], lib_dir = nil, configure_dir = Dir.pwd,
+    target_rbconfig = Gem.target_rbconfig)
     if target_rbconfig.path
       warn "--target-rbconfig is not yet supported for configure-based extensions. Ignoring"
     end

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -7,8 +7,8 @@
 #++
 
 class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
-  def self.build(extension, dest_path, results, args=[], lib_dir=nil, extension_dir=Dir.pwd,
-    target_rbconfig=Gem.target_rbconfig)
+  def self.build(extension, dest_path, results, args = [], lib_dir = nil, extension_dir = Dir.pwd,
+    target_rbconfig = Gem.target_rbconfig)
     require "fileutils"
     require "tempfile"
 

--- a/lib/rubygems/ext/rake_builder.rb
+++ b/lib/rubygems/ext/rake_builder.rb
@@ -7,8 +7,8 @@
 #++
 
 class Gem::Ext::RakeBuilder < Gem::Ext::Builder
-  def self.build(extension, dest_path, results, args=[], lib_dir=nil, extension_dir=Dir.pwd,
-    target_rbconfig=Gem.target_rbconfig)
+  def self.build(extension, dest_path, results, args = [], lib_dir = nil, extension_dir = Dir.pwd,
+    target_rbconfig = Gem.target_rbconfig)
     if target_rbconfig.path
       warn "--target-rbconfig is not yet supported for Rake extensions. Ignoring"
     end

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -153,7 +153,7 @@ class Gem::Installer
   #               process. If not set, then Gem::Command.build_args is used
   # :post_install_message:: Print gem post install message if true
 
-  def initialize(package, options={})
+  def initialize(package, options = {})
     require "fileutils"
 
     @options = options

--- a/lib/rubygems/name_tuple.rb
+++ b/lib/rubygems/name_tuple.rb
@@ -6,7 +6,7 @@
 # wrap the data returned from the indexes.
 
 class Gem::NameTuple
-  def initialize(name, version, platform=Gem::Platform::RUBY)
+  def initialize(name, version, platform = Gem::Platform::RUBY)
     @name = name
     @version = version
 

--- a/lib/rubygems/package/tar_writer.rb
+++ b/lib/rubygems/package/tar_writer.rb
@@ -99,7 +99,7 @@ class Gem::Package::TarWriter
   # Gem.source_date_epoch if not specified), and yields an IO for
   # writing the file to
 
-  def add_file(name, mode, mtime=nil) # :yields: io
+  def add_file(name, mode, mtime = nil) # :yields: io
     check_closed
 
     name, prefix = split_name name

--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -72,7 +72,7 @@ class Gem::RemoteFetcher
   # +headers+: A set of additional HTTP headers to be sent to the server when
   #            fetching the gem.
 
-  def initialize(proxy=nil, dns=nil, headers={})
+  def initialize(proxy = nil, dns = nil, headers = {})
     require_relative "core_ext/tcpsocket_init" if Gem.configuration.ipv4_fallback_enabled
     require_relative "vendored_net_http"
     require_relative "vendor/uri/lib/uri"

--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -144,7 +144,7 @@ class Gem::Resolver
     [spec, activation_request]
   end
 
-  def requests(s, act, reqs=[]) # :nodoc:
+  def requests(s, act, reqs = []) # :nodoc:
     return reqs if @ignore_dependencies
 
     s.fetch_development_dependencies if @development

--- a/lib/rubygems/resolver/conflict.rb
+++ b/lib/rubygems/resolver/conflict.rb
@@ -21,7 +21,7 @@ class Gem::Resolver::Conflict
   # Creates a new resolver conflict when +dependency+ is in conflict with an
   # already +activated+ specification.
 
-  def initialize(dependency, activated, failed_dep=dependency)
+  def initialize(dependency, activated, failed_dep = dependency)
     @dependency = dependency
     @activated = activated
     @failed_dep = failed_dep

--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -190,7 +190,7 @@ class Gem::Source
   # Downloads +spec+ and writes it to +dir+.  See also
   # Gem::RemoteFetcher#download.
 
-  def download(spec, dir=Dir.pwd)
+  def download(spec, dir = Dir.pwd)
     fetcher = Gem::RemoteFetcher.fetcher
     fetcher.download spec, uri.to_s, dir
   end
@@ -210,7 +210,7 @@ class Gem::Source
     end
   end
 
-  def typo_squatting?(host, distance_threshold=4)
+  def typo_squatting?(host, distance_threshold = 4)
     return if @uri.host.nil?
     levenshtein_distance(@uri.host, host).between? 1, distance_threshold
   end

--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -83,7 +83,7 @@ class Gem::SpecFetcher
   #
   # If +matching_platform+ is false, gems for all platforms are returned.
 
-  def search_for_dependency(dependency, matching_platform=true)
+  def search_for_dependency(dependency, matching_platform = true)
     found = {}
 
     rejected_specs = {}
@@ -130,7 +130,7 @@ class Gem::SpecFetcher
   ##
   # Return all gem name tuples who's names match +obj+
 
-  def detect(type=:complete)
+  def detect(type = :complete)
     tuples = []
 
     list, _ = available_specs(type)
@@ -150,7 +150,7 @@ class Gem::SpecFetcher
   #
   # If +matching_platform+ is false, gems for all platforms are returned.
 
-  def spec_for_dependency(dependency, matching_platform=true)
+  def spec_for_dependency(dependency, matching_platform = true)
     tuples, errors = search_for_dependency(dependency, matching_platform)
 
     specs = []
@@ -280,7 +280,7 @@ class Gem::SpecFetcher
   # Retrieves NameTuples from +source+ of the given +type+ (:prerelease,
   # etc.).  If +gracefully_ignore+ is true, errors are ignored.
 
-  def tuples_for(source, type, gracefully_ignore=false) # :nodoc:
+  def tuples_for(source, type, gracefully_ignore = false) # :nodoc:
     @caches[type][source.uri] ||=
       source.load_specs(type).sort_by(&:name)
   rescue Gem::RemoteFetcher::FetchError

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1757,7 +1757,7 @@ class Gem::Specification < Gem::BasicSpecification
   #
   #   [depending_gem, dependency, [list_of_gems_that_satisfy_dependency]]
 
-  def dependent_gems(check_dev=true)
+  def dependent_gems(check_dev = true)
     out = []
     Gem::Specification.each do |spec|
       deps = check_dev ? spec.dependencies : spec.runtime_dependencies

--- a/lib/rubygems/text.rb
+++ b/lib/rubygems/text.rb
@@ -21,7 +21,7 @@ module Gem::Text
   # Wraps +text+ to +wrap+ characters and optionally indents by +indent+
   # characters
 
-  def format_text(text, wrap, indent=0)
+  def format_text(text, wrap, indent = 0)
     result = []
     work = clean_text(text)
 

--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -193,7 +193,7 @@ class Gem::StreamUI
   # then special operations (like asking for passwords) will use the TTY
   # commands to disable character echo.
 
-  def initialize(in_stream, out_stream, err_stream=$stderr, usetty=true)
+  def initialize(in_stream, out_stream, err_stream = $stderr, usetty = true)
     @ins = in_stream
     @outs = out_stream
     @errs = err_stream
@@ -246,7 +246,7 @@ class Gem::StreamUI
   # to a tty, raises an exception if default is nil, otherwise returns
   # default.
 
-  def ask_yes_no(question, default=nil)
+  def ask_yes_no(question, default = nil)
     unless tty?
       if default.nil?
         raise Gem::OperationNotSupportedError,
@@ -325,14 +325,14 @@ class Gem::StreamUI
   ##
   # Display a statement.
 
-  def say(statement="")
+  def say(statement = "")
     @outs.puts statement
   end
 
   ##
   # Display an informational alert.  Will ask +question+ if it is not nil.
 
-  def alert(statement, question=nil)
+  def alert(statement, question = nil)
     @outs.puts "INFO:  #{statement}"
     ask(question) if question
   end
@@ -340,7 +340,7 @@ class Gem::StreamUI
   ##
   # Display a warning on stderr.  Will ask +question+ if it is not nil.
 
-  def alert_warning(statement, question=nil)
+  def alert_warning(statement, question = nil)
     @errs.puts "WARNING:  #{statement}"
     ask(question) if question
   end
@@ -349,7 +349,7 @@ class Gem::StreamUI
   # Display an error message in a location expected to get error messages.
   # Will ask +question+ if it is not nil.
 
-  def alert_error(statement, question=nil)
+  def alert_error(statement, question = nil)
     @errs.puts "ERROR:  #{statement}"
     ask(question) if question
   end

--- a/lib/rubygems/validator.rb
+++ b/lib/rubygems/validator.rb
@@ -59,7 +59,7 @@ class Gem::Validator
   #--
   # TODO needs further cleanup
 
-  def alien(gems=[])
+  def alien(gems = [])
     errors = Hash.new {|h,k| h[k] = {} }
 
     Gem::Specification.each do |spec|

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -724,7 +724,7 @@ class Gem::TestCase < Test::Unit::TestCase
   #
   # Use this with #write_file to build an installed gem.
 
-  def quick_gem(name, version="2")
+  def quick_gem(name, version = "2")
     require "rubygems/specification"
 
     spec = Gem::Specification.new do |s|
@@ -1033,7 +1033,7 @@ Also, a list:
   # Add +spec+ to +@fetcher+ serving the data in the file +path+.
   # +repo+ indicates which repo to make +spec+ appear to be in.
 
-  def add_to_fetcher(spec, path=nil, repo=@gem_repo)
+  def add_to_fetcher(spec, path = nil, repo = @gem_repo)
     path ||= spec.cache_file
     @fetcher.data["#{@gem_repo}gems/#{spec.file_name}"] = read_binary(path)
   end
@@ -1206,7 +1206,7 @@ Also, a list:
   ##
   # Allows the proper version of +rake+ to be used for the test.
 
-  def build_rake_in(good=true)
+  def build_rake_in(good = true)
     gem_ruby = Gem.ruby
     Gem.ruby = self.class.rubybin
     env_rake = ENV["rake"]

--- a/test/rubygems/installer_test_case.rb
+++ b/test/rubygems/installer_test_case.rb
@@ -215,7 +215,7 @@ class Gem::InstallerTestCase < Gem::TestCase
   ##
   # Creates an installer for +spec+ that will install into +gem_home+.
 
-  def util_installer(spec, gem_home, force=true)
+  def util_installer(spec, gem_home, force = true)
     Gem::Installer.at(spec.cache_file,
                        install_dir: gem_home,
                        force: force)

--- a/test/rubygems/mock_gem_ui.rb
+++ b/test/rubygems/mock_gem_ui.rb
@@ -77,7 +77,7 @@ class Gem::MockGemUi < Gem::StreamUI
     @terminated
   end
 
-  def terminate_interaction(status=0)
+  def terminate_interaction(status = 0)
     @terminated = true
 
     raise TermError, status if status != 0

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -592,7 +592,7 @@ class TestGemRemoteFetcher < Gem::TestCase
     end
   end
 
-  def assert_error(exception_class=Exception)
+  def assert_error(exception_class = Exception)
     got_exception = false
 
     begin


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Reviewing https://github.com/rubygems/rubygems/pull/8753 I'm seeing some unrelated style changes. I'd like to enforce a consistent style to get more focused PR diffs.

## What is your fix for the problem, implemented in this PR?

Consistently use spaces around optional parameter values.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
