### PR TITLE
Fix `bundle cache --no-install` with empty initial cache in frozen mode

### DIFF
--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -42,8 +42,6 @@ module Bundler
                                  "before deploying."
         end
 
-        options[:local] = true if Bundler.app_cache.exist?
-
         Bundler.settings.set_command_option :deployment, true if options[:deployment]
         Bundler.settings.set_command_option :frozen, true if options[:frozen]
       end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -189,12 +189,14 @@ module Bundler
     def setup_domain!(options = {})
       prefer_local! if options[:"prefer-local"]
 
+      sources.cached!
+
       if options[:add_checksums] || (!options[:local] && install_needed?)
-        remotely!
+        sources.remote!
         true
       else
         Bundler.settings.set_command_option(:jobs, 1) unless install_needed? # to avoid the overhead of Bundler::Worker
-        with_cache!
+        sources.local!
         false
       end
     end

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -311,23 +311,22 @@ RSpec.describe "bundle cache" do
         BUNDLED WITH
            #{Bundler::VERSION}
       L
+      bundle "config set --local frozen true"
     end
 
     it "tries to install with frozen" do
-      bundle "config set deployment true"
       gemfile <<-G
         source "https://gem.repo1"
         gem "myrack"
         gem "myrack-obama"
       G
-      bundle "config set --local frozen true"
       bundle :cache, raise_on_error: false
       expect(exitstatus).to eq(16)
       expect(err).to include("frozen mode")
       expect(err).to include("You have added to the Gemfile")
       expect(err).to include("* myrack-obama")
       bundle "env"
-      expect(out).to include("frozen").or include("deployment")
+      expect(out).to include("frozen")
     end
   end
 

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -299,11 +299,6 @@ RSpec.describe "bundle cache" do
       bundle "install"
     end
 
-    subject do
-      bundle "config set --local frozen true"
-      bundle :cache, raise_on_error: false
-    end
-
     it "tries to install with frozen" do
       bundle "config set deployment true"
       gemfile <<-G
@@ -311,7 +306,8 @@ RSpec.describe "bundle cache" do
         gem "myrack"
         gem "myrack-obama"
       G
-      subject
+      bundle "config set --local frozen true"
+      bundle :cache, raise_on_error: false
       expect(exitstatus).to eq(16)
       expect(err).to include("frozen mode")
       expect(err).to include("You have added to the Gemfile")

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -296,7 +296,21 @@ RSpec.describe "bundle cache" do
         source "https://gem.repo1"
         gem "myrack"
       G
-      bundle "install"
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo1/
+          specs:
+            myrack (1.0.0)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          myrack
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
     end
 
     it "tries to install with frozen" do

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -328,6 +328,16 @@ RSpec.describe "bundle cache" do
       bundle "env"
       expect(out).to include("frozen")
     end
+
+    it "caches gems without installing even if vendor/cache directory is initially empty" do
+      app_cache = bundled_app("vendor/cache")
+      FileUtils.mkdir_p app_cache
+
+      bundle "cache --no-install"
+      expect(out).not_to include("Installing myrack 1.0.0")
+      expect(out).to include("Fetching myrack 1.0.0")
+      expect(app_cache.join("myrack-1.0.0.gem")).to exist
+    end
   end
 
   context "with gems with extensions" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

It was reported that running `bundle cache --no-install` in frozen mode with an empty initial cache would fail to fetch any remote gems.

## What is your fix for the problem, implemented in this PR?

Apparently frozen mode forces local mode, which does not make a lot of sense to me. Local mode should be set either when explicitly requested by `--frozen`, or when fetching remote gems is not necessary. But in this case it's necessary. So remove that  and make sure further checks when we set local or remote mode consider cached gems.

Fixes #8853.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
