### PR TITLE
Deprecate `bundle cache --frozen` and `bundle cache --no-prune`

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -415,6 +415,10 @@ module Bundler
       print_remembered_flag_deprecation("--all", "cache_all", "true") if ARGV.include?("--all")
       print_remembered_flag_deprecation("--no-all", "cache_all", "false") if ARGV.include?("--no-all")
 
+      %w[frozen no-prune].each do |option|
+        remembered_flag_deprecation(option)
+      end
+
       if flag_passed?("--path")
         message =
           "The `--path` flag is deprecated because its semantics are unclear. " \

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -42,8 +42,6 @@ module Bundler
                                  "before deploying."
         end
 
-        options[:local] = true if Bundler.app_cache.exist?
-
         Bundler.settings.set_command_option :deployment, true if options[:deployment]
         Bundler.settings.set_command_option :frozen, true if options[:frozen]
       end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -189,12 +189,14 @@ module Bundler
     def setup_domain!(options = {})
       prefer_local! if options[:"prefer-local"]
 
+      sources.cached!
+
       if options[:add_checksums] || (!options[:local] && install_needed?)
-        remotely!
+        sources.remote!
         true
       else
         Bundler.settings.set_command_option(:jobs, 1) unless install_needed? # to avoid the overhead of Bundler::Worker
-        with_cache!
+        sources.local!
         false
       end
     end

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -311,23 +311,22 @@ RSpec.describe "bundle cache" do
         BUNDLED WITH
            #{Bundler::VERSION}
       L
+      bundle "config set --local frozen true"
     end
 
     it "tries to install with frozen" do
-      bundle "config set deployment true"
       gemfile <<-G
         source "https://gem.repo1"
         gem "myrack"
         gem "myrack-obama"
       G
-      bundle "config set --local frozen true"
       bundle :cache, raise_on_error: false
       expect(exitstatus).to eq(16)
       expect(err).to include("frozen mode")
       expect(err).to include("You have added to the Gemfile")
       expect(err).to include("* myrack-obama")
       bundle "env"
-      expect(out).to include("frozen").or include("deployment")
+      expect(out).to include("frozen")
     end
   end
 

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -299,11 +299,6 @@ RSpec.describe "bundle cache" do
       bundle "install"
     end
 
-    subject do
-      bundle "config set --local frozen true"
-      bundle :cache, raise_on_error: false
-    end
-
     it "tries to install with frozen" do
       bundle "config set deployment true"
       gemfile <<-G
@@ -311,7 +306,8 @@ RSpec.describe "bundle cache" do
         gem "myrack"
         gem "myrack-obama"
       G
-      subject
+      bundle "config set --local frozen true"
+      bundle :cache, raise_on_error: false
       expect(exitstatus).to eq(16)
       expect(err).to include("frozen mode")
       expect(err).to include("You have added to the Gemfile")

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -296,7 +296,21 @@ RSpec.describe "bundle cache" do
         source "https://gem.repo1"
         gem "myrack"
       G
-      bundle "install"
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo1/
+          specs:
+            myrack (1.0.0)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          myrack
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
     end
 
     it "tries to install with frozen" do

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -290,6 +290,39 @@ RSpec.describe "bundle cache" do
     end
   end
 
+  it "enforces frozen mode when --frozen is passed" do
+    gemfile <<-G
+      source "https://gem.repo1"
+      gem "myrack"
+      gem "myrack-obama"
+    G
+
+    lockfile <<-L
+      GEM
+        remote: https://gem.repo1/
+        specs:
+          myrack (1.0.0)
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        myrack
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    bundle "cache --frozen", raise_on_error: false
+
+    expect(exitstatus).to eq(16)
+    expect(err).to include("frozen mode")
+    expect(err).to include("You have added to the Gemfile")
+    expect(err).to include("* myrack-obama")
+    bundle "env"
+    expect(out).to include("frozen")
+  end
+
   context "with frozen configured" do
     before do
       gemfile <<-G

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -328,6 +328,16 @@ RSpec.describe "bundle cache" do
       bundle "env"
       expect(out).to include("frozen")
     end
+
+    it "caches gems without installing even if vendor/cache directory is initially empty" do
+      app_cache = bundled_app("vendor/cache")
+      FileUtils.mkdir_p app_cache
+
+      bundle "cache --no-install"
+      expect(out).not_to include("Installing myrack 1.0.0")
+      expect(out).to include("Fetching myrack 1.0.0")
+      expect(app_cache.join("myrack-1.0.0.gem")).to exist
+    end
   end
 
   context "with gems with extensions" do

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -399,6 +399,22 @@ RSpec.describe "bundle install with gem sources" do
       expect(the_bundle).to include_gems "myrack 1.0.0"
     end
 
+    it "does not hit the remote at all in non frozen mode either" do
+      build_repo2
+      install_gemfile <<-G
+        source "https://gem.repo2"
+        gem "myrack"
+      G
+
+      bundle :cache
+      pristine_system_gems
+      FileUtils.rm_r gem_repo2
+
+      bundle "config set --local path vendor/bundle"
+      bundle :install
+      expect(the_bundle).to include_gems "myrack 1.0.0"
+    end
+
     it "does not hit the remote at all when cache_all_platforms configured" do
       build_repo2
       install_gemfile <<-G

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -265,6 +265,50 @@ RSpec.describe "major deprecations" do
     pending "fails with a helpful error", bundler: "4"
   end
 
+  context "bundle cache --frozen" do
+    before do
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        gem "myrack"
+      G
+
+      bundle "cache --frozen", raise_on_error: false
+    end
+
+    it "should print a deprecation warning" do
+      expect(deprecations).to include(
+        "The `--frozen` flag is deprecated because it relies on being " \
+        "remembered across bundler invocations, which bundler will no " \
+        "longer do in future versions. Instead please use `bundle config set " \
+        "frozen true`, and stop using this flag"
+      )
+    end
+
+    pending "fails with a helpful error", bundler: "4"
+  end
+
+  context "bundle cache --no-prune" do
+    before do
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        gem "myrack"
+      G
+
+      bundle "cache --no-prune", raise_on_error: false
+    end
+
+    it "should print a deprecation warning" do
+      expect(deprecations).to include(
+        "The `--no-prune` flag is deprecated because it relies on being " \
+        "remembered across bundler invocations, which bundler will no " \
+        "longer do in future versions. Instead please use `bundle config set " \
+        "no_prune true`, and stop using this flag"
+      )
+    end
+
+    pending "fails with a helpful error", bundler: "4"
+  end
+
   describe "bundle config" do
     describe "old list interface" do
       before do

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -39,7 +39,7 @@ module Spec
     end
 
     def deprecations
-      err.split("\n").select {|l| l =~ MAJOR_DEPRECATION }.join("\n").split(MAJOR_DEPRECATION)
+      err.split("\n").filter_map {|l| l.sub(MAJOR_DEPRECATION, "") if l.match?(MAJOR_DEPRECATION) }
     end
 
     def run(cmd, *args)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

While working on #8853, I noticed that, while these flags are rememebered, they were not printing deprecation warnings.

## What is your fix for the problem, implemented in this PR?

Add the missing deprecation warnings.

Built on top of #8925 for convenience.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
