### PR TITLE
[tech debt] ffi-compiler supports default install extension in lib set to false 

### DIFF
--- a/lib/rubygems/ext/cargo_builder.rb
+++ b/lib/rubygems/ext/cargo_builder.rb
@@ -54,6 +54,9 @@ class Gem::Ext::CargoBuilder < Gem::Ext::Builder
         nested_lib_dir = File.join(lib_dir, nesting)
         FileUtils.mkdir_p nested_lib_dir
         FileUtils.cp_r dlext_path, nested_lib_dir, remove_destination: true
+        
+        # Create wrapper files for backwards compatibility
+        create_wrapper_files(nested_lib_dir, nested_dest_path, [dlext_path], gem_name)
       end
 
       # move to final destination
@@ -346,5 +349,74 @@ EOF
         #{files}
       MSG
     end
+  end
+
+  def self.detect_gem_name_from_path(cargo_dir)
+    # Try to detect gem name from the cargo directory path
+    # Look for patterns like /path/to/gem_name/ext/extension_name
+    path_parts = cargo_dir.split(File::SEPARATOR)
+    
+    # Find the gem name by looking for the parent of 'ext' directory
+    ext_index = path_parts.rindex('ext')
+    return nil unless ext_index && ext_index > 0
+    
+    gem_name = path_parts[ext_index - 1]
+    return nil if gem_name.nil? || gem_name.empty?
+    
+    gem_name
+  end
+  
+  def self.create_wrapper_files(lib_dir, dest_path, entries, gem_name)
+    return unless gem_name
+    
+    # Find native extensions in the entries
+    native_extensions = entries.select do |entry|
+      File.file?(entry) && native_extension?(entry)
+    end
+    
+    native_extensions.each do |extension_path|
+      extension_name = File.basename(extension_path)
+      wrapper_path = File.join(lib_dir, "#{extension_name}.rb")
+      
+      # Create wrapper file that loads from ext/ and shows deprecation warning
+      create_wrapper_file(wrapper_path, extension_name, gem_name)
+    end
+  end
+  
+  def self.native_extension?(file_path)
+    # Check if file is a native extension based on platform
+    case RbConfig::CONFIG["host_os"]
+    when /darwin|mac os/
+      File.extname(file_path) == ".bundle"
+    when /mswin|mingw|cygwin/
+      File.extname(file_path) == ".dll"
+    else
+      File.extname(file_path) == ".so"
+    end
+  end
+  
+  # Creates a wrapper file that loads the extension from ext/ and shows deprecation warning
+  # it can be removed when ffi-compiler is updated to use the new path
+  def self.create_wrapper_file(wrapper_path, extension_name, gem_name)
+    wrapper_content = <<~RUBY
+      # frozen_string_literal: true
+      
+      # DEPRECATED: This extension is loaded from lib/ directory
+      # The extension has been moved to ext/ directory for better organization
+      # 
+      # To fix this deprecation warning, update your code to load from ext/:
+      #   require_relative '../ext/#{extension_name}'
+      # 
+      # Or set install_extension_in_lib: true in your .gemrc to maintain current behavior
+      
+      warn "DEPRECATED: Gem '#{gem_name}' is loading native extension '#{extension_name}' from lib/ directory. " \
+           "Consider updating your code to load from ext/ directory instead. " \
+           "Set install_extension_in_lib: true in your .gemrc to maintain current behavior."
+      
+      # Load the actual extension from ext/ directory
+      require_relative "../ext/#{extension_name}"
+    RUBY
+    
+    File.write(wrapper_path, wrapper_content)
   end
 end

--- a/test/rubygems/test_gem_ext_ext_conf_builder.rb
+++ b/test/rubygems/test_gem_ext_ext_conf_builder.rb
@@ -220,4 +220,166 @@ end
       RbConfig::CONFIG.delete "configure_args"
     end
   end
+
+  def test_install_extension_in_lib_with_wrapper_file_when_enabled
+    skip "Wrapper functionality not available" unless Gem.respond_to?(:install_extension_in_lib)
+    
+    # Mock the install_extension_in_lib setting
+    Gem.stub(:install_extension_in_lib, true) do
+      # Create a mock extension file
+      extension_file = File.join(@ext, "test_extension.#{RbConfig::CONFIG["DLEXT"]}")
+      File.write(extension_file, "fake extension content")
+      
+      # Mock the build method to test wrapper creation
+      lib_dir = File.join(@dest_path, "lib")
+      FileUtils.mkdir_p(lib_dir)
+      
+      # Test the wrapper file creation
+      entries = [extension_file]
+      gem_name = "test_gem"
+      
+      Gem::Ext::ExtConfBuilder.create_wrapper_files(lib_dir, @dest_path, entries, gem_name)
+      
+      # Verify wrapper file was created
+      wrapper_path = File.join(lib_dir, "test_extension.#{RbConfig::CONFIG["DLEXT"]}.rb")
+      assert_path_exist wrapper_path
+      
+      # Verify wrapper content
+      wrapper_content = File.read(wrapper_path)
+      assert_includes wrapper_content, "DEPRECATED: Gem 'test_gem'"
+      assert_includes wrapper_content, "require_relative \"../ext/test_extension.#{RbConfig::CONFIG["DLEXT"]}\""
+    end
+  end
+
+  def test_install_extension_in_lib_with_wrapper_file_without_gem_name
+    skip "Wrapper functionality not available" unless Gem.respond_to?(:install_extension_in_lib)
+    
+    lib_dir = File.join(@dest_path, "lib")
+    FileUtils.mkdir_p(lib_dir)
+    
+    # Test that no wrapper is created when gem_name is nil
+    extension_file = File.join(@ext, "test_extension.#{RbConfig::CONFIG["DLEXT"]}")
+    File.write(extension_file, "fake extension content")
+    
+    entries = [extension_file]
+    
+    Gem::Ext::ExtConfBuilder.create_wrapper_files(lib_dir, @dest_path, entries, nil)
+    
+    # Verify no wrapper file was created
+    wrapper_path = File.join(lib_dir, "test_extension.#{RbConfig::CONFIG["DLEXT"]}.rb")
+    refute_path_exist wrapper_path
+  end
+
+  def test_install_extension_in_lib_detection_os
+    skip "Wrapper functionality not available" unless Gem.respond_to?(:install_extension_in_lib)
+    
+    # Test different operative system extensions
+    case RbConfig::CONFIG["host_os"]
+    when /darwin|mac os/
+      assert Gem::Ext::ExtConfBuilder.native_extension?("test.bundle")
+      refute Gem::Ext::ExtConfBuilder.native_extension?("test.so")
+    when /mswin|mingw|cygwin/
+      assert Gem::Ext::ExtConfBuilder.native_extension?("test.dll")
+      refute Gem::Ext::ExtConfBuilder.native_extension?("test.so")
+    else
+      assert Gem::Ext::ExtConfBuilder.native_extension?("test.so")
+      refute Gem::Ext::ExtConfBuilder.native_extension?("test.dll")
+    end
+    
+    # Test non-extension files
+    refute Gem::Ext::ExtConfBuilder.native_extension?("test.rb")
+    refute Gem::Ext::ExtConfBuilder.native_extension?("test.txt")
+  end
+
+  def test_install_extension_in_lib_with_wrapper_file_detects_gem_name_from_path
+    skip "Wrapper functionality not available" unless Gem.respond_to?(:install_extension_in_lib)
+    
+    # Test path detection
+    path = "/path/to/gem_name/ext/extension_name"
+    gem_name = Gem::Ext::ExtConfBuilder.detect_gem_name_from_path(path)
+    assert_equal "gem_name", gem_name
+    
+    # Test path without ext directory
+    path = "/path/to/gem_name/lib/extension_name"
+    gem_name = Gem::Ext::ExtConfBuilder.detect_gem_name_from_path(path)
+    assert_nil gem_name
+    
+    # Test path with multiple ext directories
+    path = "/path/to/gem_name/ext/subdir/ext/extension_name"
+    gem_name = Gem::Ext::ExtConfBuilder.detect_gem_name_from_path(path)
+    assert_equal "subdir", gem_name
+  end
+
+  def test_extension_in_lib_with_wrapper_file_content_file_structure
+    skip "Wrapper functionality not available" unless Gem.respond_to?(:install_extension_in_lib)
+    
+    lib_dir = File.join(@dest_path, "lib")
+    FileUtils.mkdir_p(lib_dir)
+    
+    extension_name = "test_extension.#{RbConfig::CONFIG["DLEXT"]}"
+    gem_name = "test_gem"
+    wrapper_path = File.join(lib_dir, "#{extension_name}.rb")
+    
+    Gem::Ext::ExtConfBuilder.create_wrapper_file(wrapper_path, extension_name, gem_name)
+    
+    # Verify wrapper file exists
+    assert_path_exist wrapper_path
+    
+    # Verify content structure
+    content = File.read(wrapper_path)
+    assert_includes content, "# frozen_string_literal: true"
+    assert_includes content, "# DEPRECATED: This extension is loaded from lib/ directory"
+    assert_includes content, "warn \"DEPRECATED: Gem 'test_gem'"
+    assert_includes content, "require_relative \"../ext/#{extension_name}\""
+    assert_includes content, "This wrapper will be removed in a future RubyGems version"
+  end
+
+  def test_extension_in_lib_wont_wrap_non_native_extensions
+    skip "Wrapper functionality not available" unless Gem.respond_to?(:install_extension_in_lib)
+    
+    lib_dir = File.join(@dest_path, "lib")
+    FileUtils.mkdir_p(lib_dir)
+    
+    # Create non-native extension files
+    ruby_file = File.join(@ext, "test_helper.rb")
+    File.write(ruby_file, "class TestHelper; end")
+    
+    text_file = File.join(@ext, "README.txt")
+    File.write(text_file, "Read me")
+    
+    entries = [ruby_file, text_file]
+    gem_name = "test_gem"
+    
+    Gem::Ext::ExtConfBuilder.create_wrapper_files(lib_dir, @dest_path, entries, gem_name)
+    
+    # Verify no wrapper files were created
+    refute_path_exist File.join(lib_dir, "test_helper.rb.rb")
+    refute_path_exist File.join(lib_dir, "README.txt.rb")
+  end
+
+  def test_extension_in_lib_will_wrap_native_extensions_only
+    skip "Wrapper functionality not available" unless Gem.respond_to?(:install_extension_in_lib)
+    
+    lib_dir = File.join(@dest_path, "lib")
+    FileUtils.mkdir_p(lib_dir)
+    
+    # Create mixed content: native extension + Ruby file
+    extension_file = File.join(@ext, "test_extension.#{RbConfig::CONFIG["DLEXT"]}")
+    File.write(extension_file, "fake extension content")
+    
+    ruby_file = File.join(@ext, "test_wrapper.rb")
+    File.write(ruby_file, "class TestWrapper; end")
+    
+    entries = [extension_file, ruby_file]
+    gem_name = "test_gem"
+    
+    Gem::Ext::ExtConfBuilder.create_wrapper_files(lib_dir, @dest_path, entries, gem_name)
+    
+    # Verify wrapper file was created only for native extension
+    wrapper_path = File.join(lib_dir, "test_extension.#{RbConfig::CONFIG["DLEXT"]}.rb")
+    assert_path_exist wrapper_path
+    
+    # Verify no wrapper for Ruby file
+    refute_path_exist File.join(lib_dir, "test_helper.rb.rb")
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

[Closes](https://github.com/rubygems/rubygems/pull/8889)

It was premature to deprecate `Gem.install_extension_in_lib == true` when we have not even yet changed libraries that could break when the path changes to ext/

@deivid-rodriguez suggestion was
"While I think explicit deprecation of Gem.install_extension_in_lib == true is great, I believe the issue is more that some gems actually rely on the compiled extension being placed in the lib folder to work, so once we toggle the default, they will break. If I recall correctly, the problem was gems using ffi-compiler.

So my idea was to:

Figure out what ffi-compiler should be doing instead to play nice with RubyGems.
Propose that change to ffi-compiler.
Figure out how to warn other cases we may be missing, and cases where an old version of ffi-compiler not including our fix is used.
One potential idea I just had is to temporarily keep installing a wrapper file into lib that warns and then loads the extension from the proper location."

This PR includes the work related to this part in specific.
"One potential idea I just had is to temporarily keep installing a wrapper file into lib that warns and then loads the extension from the proper location."

## What is your fix for the problem, implemented in this PR?

install with `extension_in_lib` option will add ruby wrapper file including `ext/` folder path

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
