### PR TITLE
Added x64-mswin64-140 to lockfiles

### DIFF
--- a/tool/bundler/dev_gems.rb.lock
+++ b/tool/bundler/dev_gems.rb.lock
@@ -69,6 +69,7 @@ PLATFORMS
   ruby
   universal-java
   x64-mingw-ucrt
+  x64-mswin64-140
   x86-linux
   x86_64-darwin
   x86_64-linux

--- a/tool/bundler/lint_gems.rb.lock
+++ b/tool/bundler/lint_gems.rb.lock
@@ -74,6 +74,7 @@ PLATFORMS
   ruby
   universal-java
   x64-mingw-ucrt
+  x64-mswin64-140
   x86_64-darwin
   x86_64-linux
 

--- a/tool/bundler/rubocop_gems.rb.lock
+++ b/tool/bundler/rubocop_gems.rb.lock
@@ -88,6 +88,7 @@ PLATFORMS
   ruby
   universal-java
   x64-mingw-ucrt
+  x64-mswin64-140
   x86_64-darwin
   x86_64-linux
 

--- a/tool/bundler/standard_gems.rb.lock
+++ b/tool/bundler/standard_gems.rb.lock
@@ -104,6 +104,7 @@ PLATFORMS
   ruby
   universal-java
   x64-mingw-ucrt
+  x64-mswin64-140
   x86_64-darwin
   x86_64-linux
 

--- a/tool/bundler/test_gems.rb.lock
+++ b/tool/bundler/test_gems.rb.lock
@@ -55,6 +55,7 @@ PLATFORMS
   ruby
   universal-java
   x64-mingw-ucrt
+  x64-mswin64-140
   x86_64-darwin
   x86_64-linux
 

--- a/tool/bundler/vendor_gems.rb.lock
+++ b/tool/bundler/vendor_gems.rb.lock
@@ -47,6 +47,7 @@ PLATFORMS
   ruby
   universal-java
   x64-mingw-ucrt
+  x64-mswin64-140
   x86_64-darwin
   x86_64-linux
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I'm working to improve compatibility with `mswin` platform. I always revert `x64-mswin64-140` from platform section after working time.

I would like to add `x64-mswin64-140` permanently in this repo.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
