### PR TITLE
Make `gem sources` output more clear

### DIFF
--- a/lib/rubygems/commands/sources_command.rb
+++ b/lib/rubygems/commands/sources_command.rb
@@ -128,7 +128,7 @@ yourself to use your own gem server.
 Without any arguments the sources lists your currently configured sources:
 
   $ gem sources
-  *** CURRENT SOURCES ***
+  *** NO CONFIGURED SOURCES, DEFAULT SOURCES LISTED BELOW ***
 
   https://rubygems.org
 
@@ -164,10 +164,18 @@ To remove a source use the --remove argument:
   end
 
   def list # :nodoc:
-    say "*** CURRENT SOURCES ***"
+    if configured_sources
+      header = "*** CURRENT SOURCES ***"
+      list = configured_sources
+    else
+      header = "*** NO CONFIGURED SOURCES, DEFAULT SOURCES LISTED BELOW ***"
+      list = Gem.sources
+    end
+
+    say header
     say
 
-    Gem.sources.each do |src|
+    list.each do |src|
       say src
     end
   end
@@ -223,5 +231,11 @@ To remove a source use the --remove argument:
     else
       say "*** Unable to remove #{desc} source cache ***"
     end
+  end
+
+  private
+
+  def configured_sources
+    Gem.configuration.sources
   end
 end

--- a/lib/rubygems/defaults.rb
+++ b/lib/rubygems/defaults.rb
@@ -13,7 +13,7 @@ module Gem
   # An Array of the default sources that come with RubyGems
 
   def self.default_sources
-    %w[https://rubygems.org/]
+    @default_sources ||= %w[https://rubygems.org/]
   end
 
   ##

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -400,8 +400,9 @@ class Gem::TestCase < Test::Unit::TestCase
     Gem::RemoteFetcher.fetcher = Gem::FakeFetcher.new
 
     @gem_repo = "http://gems.example.com/"
+    Gem.instance_variable_set :@default_sources, [@gem_repo]
+    Gem.instance_variable_set :@sources, nil
     @uri = Gem::URI.parse @gem_repo
-    Gem.sources.replace [@gem_repo]
 
     Gem.searcher = nil
     Gem::SpecFetcher.fetcher = nil

--- a/test/rubygems/test_gem.rb
+++ b/test/rubygems/test_gem.rb
@@ -586,6 +586,7 @@ class TestGem < Gem::TestCase
   end
 
   def test_self_default_sources
+    Gem.remove_instance_variable :@default_sources
     assert_equal %w[https://rubygems.org/], Gem.default_sources
   end
 
@@ -1198,6 +1199,8 @@ class TestGem < Gem::TestCase
     Gem.sources = nil
     Gem.configuration.sources = %w[http://test.example.com/]
     assert_equal %w[http://test.example.com/], Gem.sources
+  ensure
+    Gem.configuration.sources = nil
   end
 
   def test_try_activate_returns_true_for_activated_specs

--- a/test/rubygems/test_gem_commands_sources_command.rb
+++ b/test/rubygems/test_gem_commands_sources_command.rb
@@ -32,7 +32,7 @@ class TestGemCommandsSourcesCommand < Gem::TestCase
     end
 
     expected = <<-EOF
-*** CURRENT SOURCES ***
+*** NO CONFIGURED SOURCES, DEFAULT SOURCES LISTED BELOW ***
 
 #{@gem_repo}
     EOF
@@ -476,7 +476,7 @@ beta-gems.example.com is not a URI
     end
 
     expected = <<-EOF
-*** CURRENT SOURCES ***
+*** NO CONFIGURED SOURCES, DEFAULT SOURCES LISTED BELOW ***
 
 #{@gem_repo}
     EOF


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I was getting #8909 ready and decided it included too many different fixes & improvements. So I'm splitting out some changes.

## What is your fix for the problem, implemented in this PR?

This PR changes `gem sources` output to distinguish the case when it's display configured sources vs the case where it's displaying the default sources.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
