### PR TITLE
Fix trailing slashes not considered by `gem sources --remove`

### DIFF
--- a/lib/rubygems/commands/sources_command.rb
+++ b/lib/rubygems/commands/sources_command.rb
@@ -202,8 +202,10 @@ To remove a source use the --remove argument:
   end
 
   def remove_source(source_uri) # :nodoc:
-    if Gem.sources.include? source_uri
-      Gem.sources.delete source_uri
+    source = Gem::Source.new source_uri
+
+    if Gem.sources.include? source
+      Gem.sources.delete source
       Gem.configuration.write
 
       say "#{source_uri} removed from sources"

--- a/test/rubygems/test_gem_commands_sources_command.rb
+++ b/test/rubygems/test_gem_commands_sources_command.rb
@@ -428,6 +428,32 @@ beta-gems.example.com is not a URI
     assert_equal "", @ui.error
   end
 
+  def test_execute_remove_redundant_source_trailing_slash
+    repo_with_slash = "http://sample.repo/"
+
+    Gem.configuration.sources = [repo_with_slash]
+
+    setup_fake_source(repo_with_slash)
+
+    repo_without_slash = repo_with_slash.delete_suffix("/")
+
+    @cmd.handle_options %W[--remove #{repo_without_slash}]
+    use_ui @ui do
+      @cmd.execute
+    end
+    source = Gem::Source.new repo_without_slash
+    assert_equal false, Gem.sources.include?(source)
+
+    expected = <<-EOF
+#{repo_without_slash} removed from sources
+    EOF
+
+    assert_equal expected, @ui.output
+    assert_equal "", @ui.error
+  ensure
+    Gem.configuration.sources = nil
+  end
+
   def test_execute_update
     @cmd.handle_options %w[--update]
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`gem sources --remove` does not consider sources with or without trailing slash as the same source.

## What is your fix for the problem, implemented in this PR?

Handle the edge case in the same way `gem sources --add` handles it.

Extracted from #8909.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
