### PR TITLE
Fix "did you mean" suggestions for unknown commands

### DIFF
--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           repository: ruby/ruby
           path: ruby/ruby
-          ref: 2cce628721728409a26c2d4732f63419785c7fd8 # TODO: Point to v3_4_5 once released
+          ref: v3_4_5
           persist-credentials: false
       - name: Install libraries
         run: |

--- a/lib/rubygems/exceptions.rb
+++ b/lib/rubygems/exceptions.rb
@@ -23,15 +23,8 @@ class Gem::UnknownCommandError < Gem::Exception
   def self.attach_correctable
     return if defined?(@attached)
 
-    if defined?(DidYouMean::SPELL_CHECKERS) && defined?(DidYouMean::Correctable)
-      if DidYouMean.respond_to?(:correct_error)
-        DidYouMean.correct_error(Gem::UnknownCommandError, Gem::UnknownCommandSpellChecker)
-      else
-        DidYouMean::SPELL_CHECKERS["Gem::UnknownCommandError"] =
-          Gem::UnknownCommandSpellChecker
-
-        prepend DidYouMean::Correctable
-      end
+    if defined?(DidYouMean) && DidYouMean.respond_to?(:correct_error)
+      DidYouMean.correct_error(Gem::UnknownCommandError, Gem::UnknownCommandSpellChecker)
     end
 
     @attached = true

--- a/test/rubygems/test_gem_command_manager.rb
+++ b/test/rubygems/test_gem_command_manager.rb
@@ -78,7 +78,7 @@ class TestGemCommandManager < Gem::TestCase
 
     message = "Unknown command pish".dup
 
-    if defined?(DidYouMean::SPELL_CHECKERS) && defined?(DidYouMean::Correctable)
+    if defined?(DidYouMean)
       message << "\nDid you mean?  \"push\""
     end
 


### PR DESCRIPTION

## What was the end-user or developer problem that led to this PR?

Since Ruby 3.4.5, which ships with did_you_mean-2.0.0, RubyGems no longer gives "did you mean" suggestions for unknown commands.

This is because did_you_mean-2.0.0 completely removed the SPELL_CHECKERS constant, and attaching "did you mean" to `Gem::UnknownCommandError` errors required this constant to be defined.

## What is your fix for the problem, implemented in this PR?

The fix is to remove conditions on the `SPELL_CHECKERS` constant.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
