### PR TITLE
Remove Ruby 3.1 specific workaround from CI workflow

### DIFF
--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -47,8 +47,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby.value }}
           bundler: none
-      - name: Update RBS # https://github.com/ruby/rbs/pull/1612
-        run: ruby -e 'begin; require "rbs"; rescue LoadError; exit; end; exec(*%w{gem install --version 3.4.0 rbs}) if Gem::Requirement.new([">= 1.6", "< 3.1.1"]).satisfied_by?(Gem::Version.new(RBS::VERSION))'
       - name: Install Dependencies
         run: bin/rake setup
       - name: Run Test


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

None, just noticed this is no longer necessary.

## What is your fix for the problem, implemented in this PR?

Remove the unnecessary workaround.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
