### PR TITLE
Backport patch for `test/rubygems/test_gem_command_manager.rb`

### DIFF
--- a/lib/rubygems/exceptions.rb
+++ b/lib/rubygems/exceptions.rb
@@ -21,13 +21,11 @@ class Gem::UnknownCommandError < Gem::Exception
   end
 
   def self.attach_correctable
-    return if defined?(@attached)
+    return if method_defined?(:corrections)
 
     if defined?(DidYouMean) && DidYouMean.respond_to?(:correct_error)
       DidYouMean.correct_error(Gem::UnknownCommandError, Gem::UnknownCommandSpellChecker)
     end
-
-    @attached = true
   end
 end
 

--- a/test/rubygems/test_gem_command_manager.rb
+++ b/test/rubygems/test_gem_command_manager.rb
@@ -78,7 +78,7 @@ class TestGemCommandManager < Gem::TestCase
 
     message = "Unknown command pish".dup
 
-    if defined?(DidYouMean)
+    if e.respond_to?(:corrections)
       message << "\nDid you mean?  \"push\""
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`test/rubygems/test_gem_command_manager.rb` failed on the ruby/ruby repository like:

https://ci.rvm.jp/results/trunk@ruby-sp3/5934760

## What is your fix for the problem, implemented in this PR?

I backported https://github.com/ruby/ruby/commit/ac24f70fb0c0cc80d30ec6e96b3369079775d0dc

```
Align the conditions for did_you_mean
Probably due to the testing order, sometimes it looks like that `Gem::UnknownCommandError` happens to be used without registered in `DidYouMean`.
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
