### PR TITLE
Fix outdated lockfile during `bundle lock` when source changes

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -1051,6 +1051,7 @@ module Bundler
 
         # Replace the locked dependency's source with the equivalent source from the Gemfile
         s.source = replacement_source || default_source
+        next if s.source_changed?
 
         source = s.source
         next if @sources_to_unlock.include?(source.name)
@@ -1138,7 +1139,7 @@ module Bundler
     def additional_base_requirements_to_prevent_downgrades(resolution_base)
       return resolution_base unless @locked_gems && !sources.expired_sources?(@locked_gems.sources)
       @originally_locked_specs.each do |locked_spec|
-        next if locked_spec.source.is_a?(Source::Path)
+        next if locked_spec.source.is_a?(Source::Path) || locked_spec.source_changed?
 
         name = locked_spec.name
         next if @changed_dependencies.include?(name)

--- a/bundler/spec/lock/git_spec.rb
+++ b/bundler/spec/lock/git_spec.rb
@@ -220,4 +220,39 @@ RSpec.describe "bundle lock with git gems" do
 
     expect(lockfile).to include("securerandom (0.3.2)")
   end
+
+  it "does not lock versions that don't exist in the repository when changing a GIT direct dep to a GEM direct dep" do
+    build_repo4 do
+      build_gem "ruby-lsp", "0.16.1"
+    end
+
+    path = lib_path("ruby-lsp")
+    revision = build_git("ruby-lsp", "0.16.2", path: path).ref_for("HEAD")
+
+    lockfile <<~L
+      GIT
+        remote: #{path}
+        revision: #{revision}
+        specs:
+          ruby-lsp (0.16.2)
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        ruby-lsp!
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    gemfile <<~G
+      source "https://gem.repo4"
+      gem "ruby-lsp"
+    G
+
+    bundle "lock"
+
+    expect(lockfile).to include("ruby-lsp (0.16.1)")
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Closes #8961

When the source used to be git and switches back to rubygems, it is possible that the git source contains a version that ruybgems doesn't know about yet.

## What is your fix for the problem, implemented in this PR?

Since different sources are not guaranteed to contain the same information , it seems ok to simply re-resolve the dependency in such cases.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
