### PR TITLE
Raise error on missing version file

### DIFF
--- a/bundler/lib/bundler/ruby_dsl.rb
+++ b/bundler/lib/bundler/ruby_dsl.rb
@@ -57,6 +57,8 @@ module Bundler
       else
         file_content.strip
       end
+    rescue Errno::ENOENT
+      raise GemfileError, "Could not find version file #{filename}"
     end
   end
 end

--- a/bundler/spec/bundler/ruby_dsl_spec.rb
+++ b/bundler/spec/bundler/ruby_dsl_spec.rb
@@ -210,6 +210,16 @@ RSpec.describe Bundler::RubyDsl do
           it_behaves_like "it stores the ruby version"
         end
       end
+
+      context "when the file does not exist" do
+        let(:ruby_version_file_path) { nil }
+        let(:ruby_version_arg) { nil }
+        let(:file) { "nonexistent.txt" }
+
+        it "raises an error" do
+          expect { subject }.to raise_error(Bundler::GemfileError, /Could not find version file nonexistent.txt/)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If a Gemfile has a ruby version specified like `ruby file: '.some-file'` but that file doesn't exist, bundler is aborting with a generic Errno::ENOENT error currently.

## What is your fix for the problem, implemented in this PR?

If the file option is given but the file not found, raise a GemfileError with a message indicating the file was not found.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
