### PR TITLE
Pass a file size to `IO.copy_stream`

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -267,7 +267,7 @@ class Gem::Package
 
       tar.add_file_simple file, stat.mode, stat.size do |dst_io|
         File.open file, "rb" do |src_io|
-          copy_stream(src_io, dst_io)
+          copy_stream(src_io, dst_io, stat.size)
         end
       end
     end
@@ -452,7 +452,7 @@ EOM
 
         if entry.file?
           File.open(destination, "wb") do |out|
-            copy_stream(entry, out)
+            copy_stream(entry, out, entry.size)
             # Flush needs to happen before chmod because there could be data
             # in the IO buffer that needs to be written, and that could be
             # written after the chmod (on close) which would mess up the perms
@@ -721,12 +721,12 @@ EOM
   end
 
   if RUBY_ENGINE == "truffleruby"
-    def copy_stream(src, dst) # :nodoc:
-      dst.write src.read
+    def copy_stream(src, dst, size) # :nodoc:
+      dst.write src.read(size)
     end
   else
-    def copy_stream(src, dst) # :nodoc:
-      IO.copy_stream(src, dst)
+    def copy_stream(src, dst, size) # :nodoc:
+      IO.copy_stream(src, dst, size)
     end
   end
 


### PR DESCRIPTION
When extracting tar files, the tar header actually knows the exact size of the file we need to extract.  Before this commit, we would read the file from the tar file until it returned `nil`. We can be a little more efficient when copying by passing the size to copy_stream

## What was the end-user or developer problem that led to this PR?

Installing gems isn't as fast as I would like it to be, so I'm trying to speed it up.

## What is your fix for the problem, implemented in this PR?

This is continuing the process of upstreaming the changes I mentioned in #8965.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
