### PR TITLE
Completely remove `--rubocop` flag to `bundle gem`, and related configuration

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -525,7 +525,7 @@ module Bundler
     method_option :ext, type: :string, banner: "Generate the boilerplate for C extension code.", enum: EXTENSIONS
     method_option :git, type: :boolean, default: true, banner: "Initialize a git repo inside your library."
     method_option :mit, type: :boolean, banner: "Generate an MIT license file. Set a default with `bundle config set --global gem.mit true`."
-    method_option :rubocop, type: :boolean, banner: "Add rubocop to the generated Rakefile and gemspec. Set a default with `bundle config set --global gem.rubocop true`."
+    method_option :rubocop, type: :boolean, banner: "Add rubocop to the generated Rakefile and gemspec. Set a default with `bundle config set --global gem.rubocop true` (removed)."
     method_option :changelog, type: :boolean, banner: "Generate changelog file. Set a default with `bundle config set --global gem.changelog true`."
     method_option :test, type: :string, lazy_default: Bundler.settings["gem.test"] || "", aliases: "-t", banner: "Use the specified test framework for your library", enum: %w[rspec minitest test-unit], desc: "Generate a test directory for your library, either rspec, minitest or test-unit. Set a default with `bundle config set --global gem.test (rspec|minitest|test-unit)`."
     method_option :ci, type: :string, lazy_default: Bundler.settings["gem.ci"] || "", enum: %w[github gitlab circle], banner: "Generate CI configuration, either GitHub Actions, GitLab CI or CircleCI. Set a default with `bundle config set --global gem.ci (github|gitlab|circle)`"
@@ -535,6 +535,10 @@ module Bundler
 
     def gem(name)
       require_relative "cli/gem"
+
+      raise InvalidOption, "--rubocop has been removed, use --linter=rubocop" if ARGV.include?("--rubocop")
+      raise InvalidOption, "--no-rubocop has been removed, use --no-linter" if ARGV.include?("--no-rubocop")
+
       cmd_args = args + [self]
       cmd_args.unshift(options)
 

--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -382,7 +382,6 @@ module Bundler
     def ask_and_set_linter
       return if skip?(:linter)
       linter_template = options[:linter] || Bundler.settings["gem.linter"]
-      linter_template = deprecated_rubocop_option if linter_template.nil?
 
       if linter_template.to_s.empty?
         Bundler.ui.info "\nDo you want to add a code linter and formatter to your gem? " \
@@ -413,27 +412,6 @@ module Bundler
       end
 
       linter_template
-    end
-
-    def deprecated_rubocop_option
-      if !options[:rubocop].nil?
-        if options[:rubocop]
-          Bundler::SharedHelpers.major_deprecation 2,
-            "--rubocop is deprecated, use --linter=rubocop",
-            removed_message: "--rubocop has been removed, use --linter=rubocop"
-          "rubocop"
-        else
-          Bundler::SharedHelpers.major_deprecation 2,
-            "--no-rubocop is deprecated, use --no-linter",
-            removed_message: "--no-rubocop has been removed, use --no-linter"
-          false
-        end
-      elsif !Bundler.settings["gem.rubocop"].nil?
-        Bundler::SharedHelpers.major_deprecation 2,
-          "config gem.rubocop is deprecated; we've updated your config to use gem.linter instead",
-          removed_message: "config gem.rubocop has been removed; use gem.linter instead"
-        Bundler.settings["gem.rubocop"] ? "rubocop" : false
-      end
     end
 
     def bundler_dependency_version

--- a/bundler/lib/bundler/man/bundle-gem.1
+++ b/bundler/lib/bundler/man/bundle-gem.1
@@ -92,9 +92,6 @@ When Bundler is unconfigured, an interactive prompt will be displayed and the an
 \fB\-\-no\-linter\fR
 Do not add a linter (overrides \fB\-\-linter\fR specified in the global config)\.
 .TP
-\fB\-\-rubocop\fR
-Add rubocop to the generated Rakefile and gemspec\. Set a default with \fBbundle config set \-\-global gem\.rubocop true\fR\.
-.TP
 \fB\-\-edit=EDIT\fR, \fB\-e=EDIT\fR
 Open the resulting GEM_NAME\.gemspec in EDIT, or the default editor if not specified\. The default is \fB$BUNDLER_EDITOR\fR, \fB$VISUAL\fR, or \fB$EDITOR\fR\.
 .TP

--- a/bundler/lib/bundler/man/bundle-gem.1.ronn
+++ b/bundler/lib/bundler/man/bundle-gem.1.ronn
@@ -135,9 +135,6 @@ configuration file using the following names:
 * `--no-linter`:
   Do not add a linter (overrides `--linter` specified in the global config).
 
-* `--rubocop`:
-  Add rubocop to the generated Rakefile and gemspec. Set a default with `bundle config set --global gem.rubocop true`.
-
 * `--edit=EDIT`, `-e=EDIT`:
   Open the resulting GEM_NAME.gemspec in EDIT, or the default editor if not
   specified. The default is `$BUNDLER_EDITOR`, `$VISUAL`, or `$EDITOR`.

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -175,75 +175,6 @@ RSpec.describe "bundle gem" do
     end
   end
 
-  shared_examples_for "--rubocop flag" do
-    context "is deprecated" do
-      before do
-        global_config "BUNDLE_GEM__LINTER" => nil
-        bundle "gem #{gem_name} --rubocop"
-      end
-
-      it "generates a gem skeleton with rubocop" do
-        gem_skeleton_assertions
-        expect(bundled_app("#{gem_name}/Rakefile")).to read_as(
-          include("# frozen_string_literal: true").
-          and(include('require "rubocop/rake_task"').
-          and(include("RuboCop::RakeTask.new").
-          and(match(/default:.+:rubocop/))))
-        )
-      end
-
-      it "includes rubocop in generated Gemfile" do
-        allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
-        builder = Bundler::Dsl.new
-        builder.eval_gemfile(bundled_app("#{gem_name}/Gemfile"))
-        builder.dependencies
-        rubocop_dep = builder.dependencies.find {|d| d.name == "rubocop" }
-        expect(rubocop_dep).not_to be_nil
-      end
-
-      it "generates a default .rubocop.yml" do
-        expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
-      end
-
-      it "includes .rubocop.yml into ignore list" do
-        expect(ignore_paths).to include(".rubocop.yml")
-      end
-    end
-  end
-
-  shared_examples_for "--no-rubocop flag" do
-    context "is deprecated" do
-      define_negated_matcher :exclude, :include
-
-      before do
-        bundle "gem #{gem_name} --no-rubocop"
-      end
-
-      it "generates a gem skeleton without rubocop" do
-        gem_skeleton_assertions
-        expect(bundled_app("#{gem_name}/Rakefile")).to read_as(exclude("rubocop"))
-        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec")).to read_as(exclude("rubocop"))
-      end
-
-      it "does not include rubocop in generated Gemfile" do
-        allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
-        builder = Bundler::Dsl.new
-        builder.eval_gemfile(bundled_app("#{gem_name}/Gemfile"))
-        builder.dependencies
-        rubocop_dep = builder.dependencies.find {|d| d.name == "rubocop" }
-        expect(rubocop_dep).to be_nil
-      end
-
-      it "doesn't generate a default .rubocop.yml" do
-        expect(bundled_app("#{gem_name}/.rubocop.yml")).to_not exist
-      end
-
-      it "does not add .rubocop.yml into ignore list" do
-        expect(ignore_paths).not_to include(".rubocop.yml")
-      end
-    end
-  end
-
   shared_examples_for "--linter=rubocop flag" do
     before do
       bundle "gem #{gem_name} --linter=rubocop"
@@ -1335,32 +1266,6 @@ RSpec.describe "bundle gem" do
     end
   end
 
-  context "gem.rubocop setting set to true" do
-    before do
-      global_config "BUNDLE_GEM__LINTER" => nil
-      bundle "config set gem.rubocop true"
-      bundle "gem #{gem_name}"
-    end
-
-    it "generates rubocop config" do
-      expect(bundled_app("#{gem_name}/.rubocop.yml")).to exist
-    end
-
-    it "includes .rubocop.yml into ignore list" do
-      expect(ignore_paths).to include(".rubocop.yml")
-    end
-
-    it "unsets gem.rubocop" do
-      bundle "config gem.rubocop"
-      expect(out).to include("You have not configured a value for `gem.rubocop`")
-    end
-
-    it "sets gem.linter=rubocop instead" do
-      bundle "config gem.linter"
-      expect(out).to match(/Set for the current user .*: "rubocop"/)
-    end
-  end
-
   context "gem.linter set to rubocop and --linter with no arguments" do
     before do
       bundle "config set gem.linter rubocop"
@@ -1558,8 +1463,6 @@ RSpec.describe "bundle gem" do
     it_behaves_like "--linter=rubocop flag"
     it_behaves_like "--linter=standard flag"
     it_behaves_like "--no-linter flag"
-    it_behaves_like "--rubocop flag"
-    it_behaves_like "--no-rubocop flag"
   end
 
   context "with rubocop option in bundle config settings set to false" do
@@ -1569,8 +1472,6 @@ RSpec.describe "bundle gem" do
     it_behaves_like "--linter=rubocop flag"
     it_behaves_like "--linter=standard flag"
     it_behaves_like "--no-linter flag"
-    it_behaves_like "--rubocop flag"
-    it_behaves_like "--no-rubocop flag"
   end
 
   context "with linter option in bundle config settings set to rubocop" do

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -711,7 +711,7 @@ RSpec.describe "major deprecations" do
     pending "fails with a helpful message", bundler: "4"
   end
 
-  describe "deprecating rubocop" do
+  describe "removing rubocop" do
     before do
       global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false",
                     "BUNDLE_GEM__CI" => "false", "BUNDLE_GEM__CHANGELOG" => "false"
@@ -722,9 +722,9 @@ RSpec.describe "major deprecations" do
         bundle "gem my_new_gem --rubocop", raise_on_error: false
       end
 
-      it "prints a deprecation warning" do
-        expect(deprecations).to include \
-          "--rubocop is deprecated, use --linter=rubocop"
+      it "prints an error" do
+        expect(err).to include \
+          "--rubocop has been removed, use --linter=rubocop"
       end
     end
 
@@ -733,31 +733,9 @@ RSpec.describe "major deprecations" do
         bundle "gem my_new_gem --no-rubocop", raise_on_error: false
       end
 
-      it "prints a deprecation warning" do
-        expect(deprecations).to include \
-          "--no-rubocop is deprecated, use --no-linter"
-      end
-    end
-
-    context "bundle gem with gem.rubocop set to true" do
-      before do
-        bundle "gem my_new_gem", env: { "BUNDLE_GEM__RUBOCOP" => "true" }, raise_on_error: false
-      end
-
-      it "prints a deprecation warning" do
-        expect(deprecations).to include \
-          "config gem.rubocop is deprecated; we've updated your config to use gem.linter instead"
-      end
-    end
-
-    context "bundle gem with gem.rubocop set to false" do
-      before do
-        bundle "gem my_new_gem", env: { "BUNDLE_GEM__RUBOCOP" => "false" }, raise_on_error: false
-      end
-
-      it "prints a deprecation warning" do
-        expect(deprecations).to include \
-          "config gem.rubocop is deprecated; we've updated your config to use gem.linter instead"
+      it "prints an error" do
+        expect(err).to include \
+          "--no-rubocop has been removed, use --no-linter"
       end
     end
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I want to keep landing more breaking changes for Bundler 4.

## What is your fix for the problem, implemented in this PR?

* Completely remove the `--rubocop` flag to `bundle gem`, like we've done for other CLI flags.
* Start ignoring the `rubocop` setting.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
