### PR TITLE
Remove `allow_offline_install` setting

### DIFF
--- a/bundler/lib/bundler/feature_flag.rb
+++ b/bundler/lib/bundler/feature_flag.rb
@@ -27,7 +27,6 @@ module Bundler
 
     (1..10).each {|v| define_method("bundler_#{v}_mode?") { @major_version >= v } }
 
-    settings_flag(:allow_offline_install) { bundler_4_mode? }
     settings_flag(:cache_all) { bundler_4_mode? }
     settings_flag(:global_gem_cache) { bundler_5_mode? }
     settings_flag(:lockfile_checksums) { bundler_4_mode? }

--- a/bundler/lib/bundler/fetcher/compact_index.rb
+++ b/bundler/lib/bundler/fetcher/compact_index.rb
@@ -110,7 +110,7 @@ module Bundler
         def call(path, headers)
           fetcher.downloader.fetch(fetcher.fetch_uri + path, headers)
         rescue NetworkDownError => e
-          raise unless Bundler.feature_flag.allow_offline_install? && headers["If-None-Match"]
+          raise unless headers["If-None-Match"]
           ui.warn "Using the cached data for the new index because of a network error: #{e}"
           Gem::Net::HTTPNotModified.new(nil, nil, nil)
         end

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -70,9 +70,6 @@ Any periods in the configuration keys must be replaced with two underscores when
 .SH "LIST OF AVAILABLE KEYS"
 The following is a list of all configuration keys and their purpose\. You can learn more about their operation in bundle install(1) \fIbundle\-install\.1\.html\fR\.
 .TP
-\fBallow_offline_install\fR (\fBBUNDLE_ALLOW_OFFLINE_INSTALL\fR)
-Allow Bundler to use cached data when installing without network access\.
-.TP
 \fBauto_install\fR (\fBBUNDLE_AUTO_INSTALL\fR)
 Automatically run \fBbundle install\fR when gems are missing\.
 .TP

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -106,8 +106,6 @@ the environment variable `BUNDLE_LOCAL__RACK`.
 The following is a list of all configuration keys and their purpose. You can
 learn more about their operation in [bundle install(1)](bundle-install.1.html).
 
-* `allow_offline_install` (`BUNDLE_ALLOW_OFFLINE_INSTALL`):
-   Allow Bundler to use cached data when installing without network access.
 * `auto_install` (`BUNDLE_AUTO_INSTALL`):
    Automatically run `bundle install` when gems are missing.
 * `bin` (`BUNDLE_BIN`):

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -7,7 +7,6 @@ module Bundler
     autoload :Validator, File.expand_path("settings/validator", __dir__)
 
     BOOL_KEYS = %w[
-      allow_offline_install
       auto_install
       cache_all
       cache_all_platforms

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -416,7 +416,6 @@ module Bundler
       def fetch
         git_proxy.checkout
       rescue GitError => e
-        raise unless Bundler.feature_flag.allow_offline_install?
         Bundler.ui.warn "Using cached git data because of network errors:\n#{e}"
       end
 

--- a/bundler/spec/install/allow_offline_install_spec.rb
+++ b/bundler/spec/install/allow_offline_install_spec.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "bundle install with :allow_offline_install" do
-  before do
-    bundle "config set allow_offline_install true"
-  end
-
+RSpec.describe "bundle install allows offline install" do
   context "with no cached data locally" do
     it "still installs" do
       install_gemfile <<-G, artifice: "compact_index"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We need to enable the behavior under the `allow_offline_install` setting by default, since its default is scheduled to change in Bundler 4.

## What is your fix for the problem, implemented in this PR?

Completely remove the setting and let the behavior be enabled without a way to opt-out, because I'm not sure why we'd want this to be disabled.

Extracted from #8887.

Closes #8934.
Closes #8654.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
