### PR TITLE
Use `IO.copy_stream` with IO object directly

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -452,7 +452,7 @@ EOM
 
         if entry.file?
           File.open(destination, "wb") do |out|
-            copy_stream(entry, out, entry.size)
+            copy_stream(tar.io, out, entry.size)
             # Flush needs to happen before chmod because there could be data
             # in the IO buffer that needs to be written, and that could be
             # written after the chmod (on close) which would mess up the perms

--- a/lib/rubygems/package/tar_reader.rb
+++ b/lib/rubygems/package/tar_reader.rb
@@ -30,6 +30,8 @@ class Gem::Package::TarReader
     nil
   end
 
+  attr_reader :io # :nodoc:
+
   ##
   # Creates a new tar file reader on +io+ which needs to respond to #pos,
   # #eof?, #read, #getc and #pos=


### PR DESCRIPTION
Before this patch we would use `IO.copy_stream` with the tar entry object rather than just straight to the IO.  That means every time copy_stream wanted data, we would have to proxy the call.

The reason we did this is because every tar entry object _shares_ the same IO object, and previous to 8927533b0a4751340442702237db801c43cbf5c1 we would call `IO.copy_stream` _without_ a size.  Without passing a size, copy_stream will just read until there is nothing left to read, so these proxy object emulate finding "the end of the file" (where "end of file" means "end of tar chunk").  Without emulating this "end of file" behavior, copy_stream would just keep reading past the end of the tar chunk.

However, now that we're passing the size to copy_stream, we can bypass the proxy object overhead and just use the IO object directly because copy_stream knows exactly the number of bytes it needs to read and will stop when it reaches the goal.

## What was the end-user or developer problem that led to this PR?

Installing gems isn't as fast as I would like it to be, so I'm trying to speed it up.

## What is your fix for the problem, implemented in this PR?

This is continuing the process of upstreaming the changes I mentioned in #8965.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)

I referenced a commit sha in the commit message. Hopefully that is acceptable 😅