### PR TITLE
Stop trying to remove every file on extraction

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -436,8 +436,6 @@ EOM
           symlinks << [full_name, link_target, destination, real_destination]
         end
 
-        FileUtils.rm_rf destination
-
         mkdir =
           if entry.directory?
             destination


### PR DESCRIPTION
When we're extracting a gem, it should be extracted to an empty directory.  Trying to remove every file before extracting the file greatly slows the tar extraction process.

This change increases tar extraction speed by about 10%:

Master branch:

```
aaron@tc ~/g/tartest (main)> ruby -I../rubygems/lib:../vernier/lib test.rb
{MEAN: 0.6701955500058829}
{stddev: 0.029875687861609046}
{"mib/s": 20.88942548167786}
```

This commit:

```
aaron@tc ~/g/tartest (main)> ruby -I../rubygems/lib:../vernier/lib test.rb {MEAN: 0.6002237499691546}
{stddev: 0.03722422666707127}
{"mib/s": 23.324635189326408}
```

We go from 20 mib/s to 23 mib/s.

I think this PR might be a little more controversial than the previous performance related PRs I've sent.  For context, before this change the tar extraction code would [try to rm_rf every single file destination before writing out the new file](https://github.com/rubygems/rubygems/blob/a3d3df0bd9503afeb5c61e42140ee5ade317a1be/lib/rubygems/package.rb#L439).  This is extremely expensive (over 10% of our time is spent trying to `FileUtils.rm_rf` files).

I'm not sure _why_ the code did this (digging through git history wasn't helpful), and it doesn't seem we have any tests to enforce this behavior (at least `bin/rake test` is green here).  IMO, the caller of this method should ensure the target directory is empty and or writable before calling this method.

Alternatively, if there is a reason we need to do this, maybe we could rm_rf the destination directory at the top of the method, that way we're not trying to do it on every file.  My personal preference is the implementation in _this_ PR though (ask that the callers of the method prepare the destination directory).

## What was the end-user or developer problem that led to this PR?

Installing gems isn't as fast as I would like it to be, so I'm trying to speed it up.

## What is your fix for the problem, implemented in this PR?

This is continuing the process of upstreaming the changes I mentioned in https://github.com/rubygems/rubygems/pull/8965.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
