### PR TITLE
Switch `cache_all` to be `true` by default

### DIFF
--- a/bundler/lib/bundler/feature_flag.rb
+++ b/bundler/lib/bundler/feature_flag.rb
@@ -27,7 +27,6 @@ module Bundler
 
     (1..10).each {|v| define_method("bundler_#{v}_mode?") { @major_version >= v } }
 
-    settings_flag(:cache_all) { bundler_4_mode? }
     settings_flag(:global_gem_cache) { bundler_5_mode? }
     settings_flag(:plugins) { @bundler_version >= Gem::Version.new("1.14") }
     settings_flag(:update_requires_all_flag) { bundler_5_mode? }

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -82,6 +82,7 @@ module Bundler
       "BUNDLE_TIMEOUT" => 10,
       "BUNDLE_VERSION" => "lockfile",
       "BUNDLE_LOCKFILE_CHECKSUMS" => true,
+      "BUNDLE_CACHE_ALL" => true,
     }.freeze
 
     def initialize(root = nil)

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -268,7 +268,7 @@ module Bundler
       private
 
       def cache_to(custom_path, try_migrate: false)
-        return unless Bundler.feature_flag.cache_all?
+        return unless Bundler.settings[:cache_all]
 
         app_cache_path = app_cache_path(custom_path)
 

--- a/bundler/lib/bundler/source/path.rb
+++ b/bundler/lib/bundler/source/path.rb
@@ -83,7 +83,7 @@ module Bundler
 
       def cache(spec, custom_path = nil)
         app_cache_path = app_cache_path(custom_path)
-        return unless Bundler.feature_flag.cache_all?
+        return unless Bundler.settings[:cache_all]
         return if expand(@original_path).to_s.index(root_path.to_s + "/") == 0
 
         unless @original_path.exist?

--- a/bundler/spec/cache/git_spec.rb
+++ b/bundler/spec/cache/git_spec.rb
@@ -13,6 +13,22 @@ RSpec.describe "git base name" do
 end
 
 RSpec.describe "bundle cache with git" do
+  it "does not copy repository to vendor cache when cache_all set to false" do
+    git = build_git "foo"
+    ref = git.ref_for("main", 11)
+
+    install_gemfile <<-G
+      source "https://gem.repo1"
+      gem "foo", :git => '#{lib_path("foo-1.0")}'
+    G
+
+    bundle "config cache_all false"
+    bundle :cache
+    expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).not_to exist
+
+    expect(the_bundle).to include_gems "foo 1.0"
+  end
+
   it "copies repository to vendor cache and uses it" do
     git = build_git "foo"
     ref = git.ref_for("main", 11)
@@ -22,7 +38,6 @@ RSpec.describe "bundle cache with git" do
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
 
-    bundle "config set cache_all true"
     bundle :cache
     expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist
     expect(bundled_app("vendor/cache/foo-1.0-#{ref}/.git")).not_to exist
@@ -43,7 +58,6 @@ RSpec.describe "bundle cache with git" do
 
     bundle "config set --local path vendor/bundle"
     bundle "install"
-    bundle "config set cache_all true"
     bundle :cache
 
     expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist
@@ -61,7 +75,6 @@ RSpec.describe "bundle cache with git" do
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
 
-    bundle "config set cache_all true"
     bundle :cache
     bundle :cache
 
@@ -79,7 +92,6 @@ RSpec.describe "bundle cache with git" do
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
 
-    bundle "config set cache_all true"
     bundle :cache
 
     update_git "foo" do |s|
@@ -109,7 +121,6 @@ RSpec.describe "bundle cache with git" do
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
 
-    bundle "config set cache_all true"
     bundle :cache
 
     update_git "foo" do |s|
@@ -140,7 +151,6 @@ RSpec.describe "bundle cache with git" do
 
     bundle %(config set local.foo #{lib_path("foo-1.0")})
     bundle "install"
-    bundle "config set cache_all true"
     bundle :cache
 
     expect(bundled_app("vendor/cache/foo-invalid-#{ref}")).to exist
@@ -179,7 +189,6 @@ RSpec.describe "bundle cache with git" do
       source "https://gem.repo1"
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
-    bundle "config set cache_all true"
     bundle :cache, "all-platforms" => true
 
     pristine_system_gems
@@ -196,7 +205,6 @@ RSpec.describe "bundle cache with git" do
       source "https://gem.repo1"
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
-    bundle "config set cache_all true"
     bundle :cache, "all-platforms" => true
 
     pristine_system_gems
@@ -213,7 +221,6 @@ RSpec.describe "bundle cache with git" do
       source "https://gem.repo1"
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
-    bundle "config set cache_all true"
     bundle :cache, "all-platforms" => true
 
     pristine_system_gems
@@ -242,7 +249,6 @@ RSpec.describe "bundle cache with git" do
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
     bundle "config set global_gem_cache false"
-    bundle "config set cache_all true"
     bundle "config path vendor/bundle"
     bundle :install
 
@@ -274,7 +280,6 @@ RSpec.describe "bundle cache with git" do
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
     bundle "config set global_gem_cache false"
-    bundle "config set cache_all true"
     bundle "config path vendor/bundle"
     bundle :install
 
@@ -304,7 +309,6 @@ RSpec.describe "bundle cache with git" do
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
     bundle "config set global_gem_cache false"
-    bundle "config set cache_all true"
     bundle "config path vendor/bundle"
     bundle :install
 
@@ -342,7 +346,6 @@ RSpec.describe "bundle cache with git" do
     G
 
     ref = git.ref_for("main", 11)
-    bundle "config set cache_all true"
     bundle :cache
 
     expect(bundled_app("vendor/cache/has_submodule-1.0-#{ref}")).to exist
@@ -362,7 +365,6 @@ RSpec.describe "bundle cache with git" do
       source "https://gem.repo1"
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
-    bundle "config set cache_all true"
     bundle :cache
 
     ref = git.ref_for("main", 11)
@@ -377,7 +379,6 @@ RSpec.describe "bundle cache with git" do
       source "https://gem.repo1"
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
-    bundle "config set cache_all true"
     bundle :cache, "all-platforms" => true, :install => false
 
     pristine_system_gems
@@ -436,7 +437,6 @@ RSpec.describe "bundle cache with git" do
       source "https://gem.repo1"
       gem "foo", :git => '#{lib_path("foo-1.0")}'
     G
-    bundle "config set cache_all true"
 
     # The algorithm for the cache location for a git checkout is
     # in Bundle::Source::Git#cache_path
@@ -498,7 +498,6 @@ RSpec.describe "bundle cache with git" do
     end
 
     FileUtils.mkdir_p(bundled_app("vendor/cache"))
-    bundle "config set cache_all all"
 
     install_gemfile <<-G
       source "https://gem.repo1"

--- a/bundler/spec/cache/path_spec.rb
+++ b/bundler/spec/cache/path_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe "bundle cache with path" do
       gem "foo", :path => '#{bundled_app("lib/foo")}'
     G
 
-    bundle "config set cache_all true"
     bundle :cache
     expect(bundled_app("vendor/cache/foo-1.0")).not_to exist
     expect(the_bundle).to include_gems "foo 1.0"
@@ -23,7 +22,6 @@ RSpec.describe "bundle cache with path" do
       gem "foo", :path => '#{lib_path("foo-1.0")}'
     G
 
-    bundle "config set cache_all true"
     bundle :cache
     expect(bundled_app("vendor/cache/foo-1.0")).to exist
     expect(bundled_app("vendor/cache/foo-1.0/.bundlecache")).to be_file
@@ -42,7 +40,6 @@ RSpec.describe "bundle cache with path" do
       gem "#{libname}", :path => '#{libpath}'
     G
 
-    bundle "config set cache_all true"
     bundle :cache
     expect(bundled_app("vendor/cache/#{libname}")).to exist
     expect(bundled_app("vendor/cache/#{libname}/.bundlecache")).to be_file
@@ -58,7 +55,6 @@ RSpec.describe "bundle cache with path" do
       gem "foo", :path => '#{lib_path("foo-1.0")}'
     G
 
-    bundle "config set cache_all true"
     bundle :cache
 
     build_lib "foo" do |s|
@@ -81,7 +77,6 @@ RSpec.describe "bundle cache with path" do
       gem "foo", :path => '#{lib_path("foo-1.0")}'
     G
 
-    bundle "config set cache_all true"
     bundle :cache
 
     expect(bundled_app("vendor/cache/foo-1.0")).to exist
@@ -97,20 +92,21 @@ RSpec.describe "bundle cache with path" do
     expect(bundled_app("vendor/cache/foo-1.0")).not_to exist
   end
 
-  it "does not cache path gems by default" do
+  it "does not cache path gems if cache_all is set to false" do
     build_lib "foo"
 
     install_gemfile <<-G
       source "https://gem.repo1"
       gem "foo", :path => '#{lib_path("foo-1.0")}'
     G
+    bundle "config cache_all false"
 
     bundle :cache
     expect(err).to be_empty
     expect(bundled_app("vendor/cache/foo-1.0")).not_to exist
   end
 
-  it "caches path gems by default", bundler: "4" do
+  it "caches path gems by default" do
     build_lib "foo"
 
     install_gemfile <<-G

--- a/bundler/spec/install/deploy_spec.rb
+++ b/bundler/spec/install/deploy_spec.rb
@@ -474,7 +474,6 @@ RSpec.describe "install in deployment or frozen mode" do
       bundle :install
       expect(the_bundle).to include_gems "foo 1.0"
 
-      bundle "config set cache_all true"
       bundle :cache
       expect(bundled_app("vendor/cache/foo")).to be_directory
 

--- a/bundler/spec/install/gemfile/specific_platform_spec.rb
+++ b/bundler/spec/install/gemfile/specific_platform_spec.rb
@@ -336,7 +336,6 @@ RSpec.describe "bundle install with specific platforms" do
          #{Bundler::VERSION}
     L
 
-    bundle "config set --local cache_all true"
     bundle "cache --all-platforms"
 
     expect(err).to be_empty

--- a/bundler/spec/lock/lockfile_spec.rb
+++ b/bundler/spec/lock/lockfile_spec.rb
@@ -786,7 +786,6 @@ RSpec.describe "the lockfile format" do
       c.no_checksum "foo", "1.0"
     end
 
-    bundle "config set cache_all true"
     bundle :cache
     bundle :install, local: true
 

--- a/bundler/spec/plugins/source/example_spec.rb
+++ b/bundler/spec/plugins/source/example_spec.rb
@@ -124,7 +124,6 @@ RSpec.describe "real source plugins" do
       let(:uri_hash) { Digest(:SHA1).hexdigest(lib_path("a-path-gem-1.0").to_s) }
       it "copies repository to vendor cache and uses it" do
         bundle "install"
-        bundle "config set cache_all true"
         bundle :cache
 
         expect(bundled_app("vendor/cache/a-path-gem-1.0-#{uri_hash}")).to exist
@@ -138,7 +137,6 @@ RSpec.describe "real source plugins" do
       it "copies repository to vendor cache and uses it even when installed with `path` configured" do
         bundle "config set --local path vendor/bundle"
         bundle :install
-        bundle "config set cache_all true"
         bundle :cache
 
         expect(bundled_app("vendor/cache/a-path-gem-1.0-#{uri_hash}")).to exist
@@ -150,7 +148,6 @@ RSpec.describe "real source plugins" do
       it "bundler package copies repository to vendor cache" do
         bundle "config set --local path vendor/bundle"
         bundle :install
-        bundle "config set cache_all true"
         bundle :cache
 
         expect(bundled_app("vendor/cache/a-path-gem-1.0-#{uri_hash}")).to exist
@@ -446,7 +443,6 @@ RSpec.describe "real source plugins" do
           end
         G
 
-        bundle "config set cache_all true"
         bundle :cache
         expect(bundled_app("vendor/cache/foo-1.0-#{ref}")).to exist
         expect(bundled_app("vendor/cache/foo-1.0-#{ref}/.git")).not_to exist


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Make sure to consolidate all setting toggles that we consider breaking changes.

## What is your fix for the problem, implemented in this PR?

I removed the feature flag and made it a setting that's `true` by default. I could've completely removed the setting but I kept it for now just in case the default value of `true` causes any issues, so people can workaround.

Closes #8656.

We could completely remove the setting later if we deem it unnecessary.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
