### PR TITLE
Completely forbid passing `--ext` to `bundle gem` without a value

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -24,7 +24,7 @@ module Bundler
     }.freeze
 
     def self.start(*)
-      check_deprecated_ext_option(ARGV) if ARGV.include?("--ext")
+      check_invalid_ext_option(ARGV) if ARGV.include?("--ext")
 
       super
     ensure
@@ -658,18 +658,15 @@ module Bundler
       end
     end
 
-    def self.check_deprecated_ext_option(arguments)
-      # when deprecated version of `--ext` is called
-      # print out deprecation warning and pretend `--ext=c` was provided
-      if deprecated_ext_value?(arguments)
-        message = "Extensions can now be generated using C or Rust, so `--ext` with no arguments has been deprecated. Please select a language, e.g. `--ext=rust` to generate a Rust extension. This gem will now be generated as if `--ext=c` was used."
+    def self.check_invalid_ext_option(arguments)
+      # when invalid version of `--ext` is called
+      if invalid_ext_value?(arguments)
         removed_message = "Extensions can now be generated using C or Rust, so `--ext` with no arguments has been removed. Please select a language, e.g. `--ext=rust` to generate a Rust extension."
-        SharedHelpers.major_deprecation 2, message, removed_message: removed_message
-        arguments[arguments.index("--ext")] = "--ext=c"
+        raise InvalidOption, removed_message
       end
     end
 
-    def self.deprecated_ext_value?(arguments)
+    def self.invalid_ext_value?(arguments)
       index = arguments.index("--ext")
       next_argument = arguments[index + 1]
 
@@ -677,15 +674,15 @@ module Bundler
       # for example `bundle gem hello --ext c`
       return false if EXTENSIONS.include?(next_argument)
 
-      # deprecated call when --ext is called with no value in last position
+      # invalid call when --ext is called with no value in last position
       # for example `bundle gem hello_gem --ext`
       return true if next_argument.nil?
 
-      # deprecated call when --ext is followed by other parameter
+      # invalid call when --ext is followed by other parameter
       # for example `bundle gem --ext --no-ci hello_gem`
       return true if next_argument.start_with?("-")
 
-      # deprecated call when --ext is followed by gem name
+      # invalid call when --ext is followed by gem name
       # for example `bundle gem --ext hello_gem`
       return true if next_argument
 

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -1661,33 +1661,11 @@ RSpec.describe "bundle gem" do
 
     include_examples "paths that depend on gem name"
 
-    context "--ext parameter with no value" do
-      context "is deprecated" do
-        it "prints deprecation when used after gem name" do
-          bundle ["gem", "--ext", gem_name].compact.join(" ")
-          expect(err).to include "[DEPRECATED]"
-          expect(err).to include "`--ext` with no arguments has been deprecated"
-          expect(bundled_app("#{gem_name}/ext/#{gem_name}/#{gem_name}.c")).to exist
-        end
-
-        it "prints deprecation when used before gem name" do
-          bundle ["gem", gem_name, "--ext"].compact.join(" ")
-          expect(err).to include "[DEPRECATED]"
-          expect(err).to include "`--ext` with no arguments has been deprecated"
-          expect(bundled_app("#{gem_name}/ext/#{gem_name}/#{gem_name}.c")).to exist
-        end
-      end
-    end
-
     context "--ext parameter set with C" do
       let(:flags) { "--ext=c" }
 
       before do
         bundle ["gem", gem_name, flags].compact.join(" ")
-      end
-
-      it "is not deprecated" do
-        expect(err).not_to include "[DEPRECATED] Option `--ext` without explicit value is deprecated."
       end
 
       it "builds ext skeleton" do

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -740,4 +740,16 @@ RSpec.describe "major deprecations" do
       end
     end
   end
+
+  context " bundle gem --ext parameter with no value" do
+    it "prints error when used before gem name" do
+      bundle "gem --ext foo", raise_on_error: false
+      expect(err).to include "Extensions can now be generated using C or Rust, so `--ext` with no arguments has been removed. Please select a language, e.g. `--ext=rust` to generate a Rust extension."
+    end
+
+    it "prints error when used after gem name" do
+      bundle "gem foo --ext", raise_on_error: false
+      expect(err).to include "Extensions can now be generated using C or Rust, so `--ext` with no arguments has been removed. Please select a language, e.g. `--ext=rust` to generate a Rust extension."
+    end
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When we added support for `rust` extensions, we deprecated passing just `--ext` and we now prefer specifying either `--ext=c` or `--ext=rust`.

## What is your fix for the problem, implemented in this PR?

Consolidate that breaking change.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
