### PR TITLE
Make `bundle remove --install` raise an error

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -187,12 +187,11 @@ module Bundler
     long_desc <<-D
       Removes the given gems from the Gemfile while ensuring that the resulting Gemfile is still valid. If the gem is not found, Bundler prints a error message and if gem could not be removed due to any reason Bundler will display a warning.
     D
-    method_option "install", type: :boolean, banner: "Runs 'bundle install' after removing the gems from the Gemfile"
+    method_option "install", type: :boolean, banner: "Runs 'bundle install' after removing the gems from the Gemfile (removed)"
     def remove(*gems)
       if ARGV.include?("--install")
-        message = "The `--install` flag has been deprecated. `bundle install` is triggered by default."
         removed_message = "The `--install` flag has been removed. `bundle install` is triggered by default."
-        SharedHelpers.major_deprecation(2, message, removed_message: removed_message)
+        raise InvalidOption, removed_message
       end
 
       require_relative "cli/remove"

--- a/bundler/lib/bundler/man/bundle-remove.1
+++ b/bundler/lib/bundler/man/bundle-remove.1
@@ -4,18 +4,12 @@
 .SH "NAME"
 \fBbundle\-remove\fR \- Removes gems from the Gemfile
 .SH "SYNOPSIS"
-\fBbundle remove [GEM [GEM \|\.\|\.\|\.]] [\-\-install]\fR
+`bundle remove [GEM [GEM \|\.\|\.\|\.]]
 .SH "DESCRIPTION"
 Removes the given gems from the Gemfile while ensuring that the resulting Gemfile is still valid\. If a gem cannot be removed, a warning is printed\. If a gem is already absent from the Gemfile, and error is raised\.
-.SH "OPTIONS"
-.TP
-\fB\-\-install\fR
-Runs \fBbundle install\fR after the given gems have been removed from the Gemfile, which ensures that both the lockfile and the installed gems on disk are also updated to remove the given gem(s)\.
 .P
 Example:
 .P
 bundle remove rails
 .P
 bundle remove rails rack
-.P
-bundle remove rails rack \-\-install

--- a/bundler/lib/bundler/man/bundle-remove.1.ronn
+++ b/bundler/lib/bundler/man/bundle-remove.1.ronn
@@ -3,21 +3,14 @@ bundle-remove(1) -- Removes gems from the Gemfile
 
 ## SYNOPSIS
 
-`bundle remove [GEM [GEM ...]] [--install]`
+`bundle remove [GEM [GEM ...]]
 
 ## DESCRIPTION
 
 Removes the given gems from the Gemfile while ensuring that the resulting Gemfile is still valid. If a gem cannot be removed, a warning is printed. If a gem is already absent from the Gemfile, and error is raised.
-
-## OPTIONS
-
-* `--install`:
-  Runs `bundle install` after the given gems have been removed from the Gemfile, which ensures that both the lockfile and the installed gems on disk are also updated to remove the given gem(s).
 
 Example:
 
 bundle remove rails
 
 bundle remove rails rack
-
-bundle remove rails rack --install

--- a/bundler/spec/commands/remove_spec.rb
+++ b/bundler/spec/commands/remove_spec.rb
@@ -43,21 +43,6 @@ RSpec.describe "bundle remove" do
     end
   end
 
-  context "when --install flag is specified" do
-    it "removes gems from .bundle" do
-      gemfile <<-G
-        source "https://gem.repo1"
-
-        gem "myrack"
-      G
-
-      bundle "remove myrack --install"
-
-      expect(out).to include("myrack was removed.")
-      expect(the_bundle).to_not include_gems "myrack"
-    end
-  end
-
   describe "remove single gem from gemfile" do
     context "when gem is present in gemfile" do
       it "shows success for removed gem" do

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -669,13 +669,11 @@ RSpec.describe "major deprecations" do
     end
 
     context "with --install" do
-      it "shows a deprecation warning" do
-        bundle "remove myrack --install"
+      it "fails with a helpful message" do
+        bundle "remove myrack --install", raise_on_error: false
 
-        expect(err).to include "[DEPRECATED] The `--install` flag has been deprecated. `bundle install` is triggered by default."
+        expect(err).to include "The `--install` flag has been removed. `bundle install` is triggered by default."
       end
-
-      pending "fails with a helpful message", bundler: "4"
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This flag is deprecated and set to be removed in Bundler 4.

## What is your fix for the problem, implemented in this PR?

Remove it and let it raise an error.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
