### PR TITLE
Make `bundle install --binstubs` raise an error

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -209,7 +209,7 @@ module Bundler
 
       If the bundle has already been installed, bundler will tell you so and then exit.
     D
-    method_option "binstubs", type: :string, lazy_default: "bin", banner: "Generate bin stubs for bundled gems to ./bin"
+    method_option "binstubs", type: :string, lazy_default: "bin", banner: "Generate bin stubs for bundled gems to ./bin (removed)"
     method_option "clean", type: :boolean, banner: "Run bundle clean automatically after install (removed)"
     method_option "deployment", type: :boolean, banner: "Install using defaults tuned for deployment environments (removed)"
     method_option "frozen", type: :boolean, banner: "Do not allow the Gemfile.lock to be updated after this install (removed)"
@@ -240,9 +240,8 @@ module Bundler
       remembered_flag_deprecation("deployment", negative: true)
 
       if ARGV.include?("--binstubs")
-        message = "The --binstubs option will be removed in favor of `bundle binstubs --all`"
         removed_message = "The --binstubs option has been removed in favor of `bundle binstubs --all`"
-        SharedHelpers.major_deprecation(2, message, removed_message: removed_message)
+        raise InvalidOption, removed_message
       end
 
       require_relative "cli/install"

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -239,6 +239,12 @@ module Bundler
 
       remembered_flag_deprecation("deployment", negative: true)
 
+      if ARGV.include?("--binstubs")
+        message = "The --binstubs option will be removed in favor of `bundle binstubs --all`"
+        removed_message = "The --binstubs option have been removed in favor of `bundle binstubs --all`"
+        SharedHelpers.major_deprecation(2, message, removed_message: removed_message)
+      end
+
       require_relative "cli/install"
       Bundler.settings.temporary(no_install: false) do
         Install.new(options.dup).run

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -241,7 +241,7 @@ module Bundler
 
       if ARGV.include?("--binstubs")
         message = "The --binstubs option will be removed in favor of `bundle binstubs --all`"
-        removed_message = "The --binstubs option have been removed in favor of `bundle binstubs --all`"
+        removed_message = "The --binstubs option has been removed in favor of `bundle binstubs --all`"
         SharedHelpers.major_deprecation(2, message, removed_message: removed_message)
       end
 

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -38,12 +38,6 @@ module Bundler
 
       Bundler::Fetcher.disable_endpoint = options["full-index"]
 
-      if options["binstubs"]
-        Bundler::SharedHelpers.major_deprecation 2,
-          "The --binstubs option will be removed in favor of `bundle binstubs --all`",
-          removed_message: "The --binstubs option have been removed in favor of `bundle binstubs --all`"
-      end
-
       Plugin.gemfile_install(Bundler.default_gemfile) if Bundler.feature_flag.plugins?
 
       # For install we want to enable strict validation

--- a/bundler/lib/bundler/man/bundle-install.1
+++ b/bundler/lib/bundler/man/bundle-install.1
@@ -13,11 +13,6 @@ If a \fBGemfile\.lock\fR does exist, and you have not updated your Gemfile(5), B
 If a \fBGemfile\.lock\fR does exist, and you have updated your Gemfile(5), Bundler will use the dependencies in the \fBGemfile\.lock\fR for all gems that you did not update, but will re\-resolve the dependencies of gems that you did update\. You can find more information about this update process below under \fICONSERVATIVE UPDATING\fR\.
 .SH "OPTIONS"
 .TP
-\fB\-\-binstubs[=BINSTUBS]\fR
-Binstubs are scripts that wrap around executables\. Bundler creates a small Ruby file (a binstub) that loads Bundler, runs the command, and puts it in \fBbin/\fR\. This lets you link the binstub inside of an application to the exact gem version the application needs\.
-.IP
-Creates a directory (defaults to \fB~/bin\fR when the option is used without a value, or to the given \fB<BINSTUBS>\fR directory otherwise) and places any executables from the gem there\. These executables run in Bundler's context\. If used, you might add this directory to your environment's \fBPATH\fR variable\. For instance, if the \fBrails\fR gem comes with a \fBrails\fR executable, this flag will create a \fBbin/rails\fR executable that ensures that all referred dependencies will be resolved using the bundled gems\.
-.TP
 \fB\-\-force\fR, \fB\-\-redownload\fR
 Force reinstalling every gem, even if already installed\.
 .TP

--- a/bundler/lib/bundler/man/bundle-install.1.ronn
+++ b/bundler/lib/bundler/man/bundle-install.1.ronn
@@ -35,20 +35,6 @@ update process below under [CONSERVATIVE UPDATING][].
 
 ## OPTIONS
 
-* `--binstubs[=BINSTUBS]`:
-  Binstubs are scripts that wrap around executables. Bundler creates a small Ruby
-  file (a binstub) that loads Bundler, runs the command, and puts it in `bin/`.
-  This lets you link the binstub inside of an application to the exact gem
-  version the application needs.
-
-  Creates a directory (defaults to `~/bin` when the option is used without a
-  value, or to the given `<BINSTUBS>` directory otherwise) and places any
-  executables from the gem there. These executables run in Bundler's context. If
-  used, you might add this directory to your environment's `PATH` variable. For
-  instance, if the `rails` gem comes with a `rails` executable, this flag will
-  create a `bin/rails` executable that ensures that all referred dependencies
-  will be resolved using the bundled gems.
-
 * `--force`, `--redownload`:
   Force reinstalling every gem, even if already installed.
 

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -398,17 +398,15 @@ RSpec.describe "major deprecations" do
 
   describe "bundle install --binstubs" do
     before do
-      install_gemfile <<-G, binstubs: true
+      install_gemfile <<-G, binstubs: true, raise_on_error: false
         source "https://gem.repo1"
         gem "myrack"
       G
     end
 
-    it "should output a deprecation warning" do
-      expect(deprecations).to include("The --binstubs option will be removed in favor of `bundle binstubs --all`")
+    it "fails with a helpful error" do
+      expect(err).to include("The --binstubs option has been removed in favor of `bundle binstubs --all`")
     end
-
-    pending "fails with a helpful error", bundler: "4"
   end
 
   context "bundle install with both gems.rb and Gemfile present" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This flag is deprecated and set to be removed in Bundler 4.

## What is your fix for the problem, implemented in this PR?

Remove it and let it raise an error.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
