### PR TITLE
Make `--local-git` flag to `bundle plugin install` raise an error

### DIFF
--- a/bundler/lib/bundler/cli/plugin.rb
+++ b/bundler/lib/bundler/cli/plugin.rb
@@ -10,7 +10,7 @@ module Bundler
     method_option "source", type: :string, default: nil, banner: "URL of the RubyGems source to fetch the plugin from"
     method_option "version", type: :string, default: nil, banner: "The version of the plugin to fetch"
     method_option "git", type: :string, default: nil, banner: "URL of the git repo to fetch from"
-    method_option "local_git", type: :string, default: nil, banner: "Path of the local git repo to fetch from (deprecated)"
+    method_option "local_git", type: :string, default: nil, banner: "Path of the local git repo to fetch from (removed)"
     method_option "branch", type: :string, default: nil, banner: "The git branch to checkout"
     method_option "ref", type: :string, default: nil, banner: "The git revision to check out"
     method_option "path", type: :string, default: nil, banner: "Path of a local gem to directly use"

--- a/bundler/lib/bundler/cli/plugin.rb
+++ b/bundler/lib/bundler/cli/plugin.rb
@@ -15,6 +15,10 @@ module Bundler
     method_option "ref", type: :string, default: nil, banner: "The git revision to check out"
     method_option "path", type: :string, default: nil, banner: "Path of a local gem to directly use"
     def install(*plugins)
+      if options.key?(:local_git)
+        raise InvalidOption, "--local_git has been removed, use --git"
+      end
+
       Bundler::Plugin.install(plugins, options)
     end
 

--- a/bundler/lib/bundler/man/bundle-plugin.1
+++ b/bundler/lib/bundler/man/bundle-plugin.1
@@ -4,7 +4,7 @@
 .SH "NAME"
 \fBbundle\-plugin\fR \- Manage Bundler plugins
 .SH "SYNOPSIS"
-\fBbundle plugin\fR install PLUGINS [\-\-source=SOURCE] [\-\-version=VERSION] [\-\-git=GIT] [\-\-branch=BRANCH|\-\-ref=REF] [\-\-local\-git=LOCAL_GIT] [\-\-path=PATH]
+\fBbundle plugin\fR install PLUGINS [\-\-source=SOURCE] [\-\-version=VERSION] [\-\-git=GIT] [\-\-branch=BRANCH|\-\-ref=REF] [\-\-path=PATH]
 .br
 \fBbundle plugin\fR uninstall PLUGINS [\-\-all]
 .br
@@ -54,13 +54,6 @@ When you specify \fB\-\-git\fR, you can use \fB\-\-ref\fR to specify any tag, or
 Install the plugin gem from a local path\.
 .IP
 Example: \fBbundle plugin install bundler\-graph \-\-path \.\./bundler\-graph\fR
-.TP
-\fB\-\-local\-git=LOCAL_GIT\fR
-Install the plugin gem from a local Git repository\.
-.IP
-Example: \fBbundle plugin install bundler\-graph \-\-local\-git \.\./bundler\-graph\fR\.
-.IP
-This option is deprecated in favor of \fB\-\-git\fR\.
 .SS "uninstall"
 Uninstall the plugin(s) specified in PLUGINS\.
 .P

--- a/bundler/lib/bundler/man/bundle-plugin.1.ronn
+++ b/bundler/lib/bundler/man/bundle-plugin.1.ronn
@@ -5,7 +5,6 @@ bundle-plugin(1) -- Manage Bundler plugins
 
 `bundle plugin` install PLUGINS [--source=SOURCE] [--version=VERSION]
                               [--git=GIT] [--branch=BRANCH|--ref=REF]
-                              [--local-git=LOCAL_GIT]
                               [--path=PATH]<br>
 `bundle plugin` uninstall PLUGINS [--all]<br>
 `bundle plugin` list<br>
@@ -58,13 +57,6 @@ global source specified in Gemfile is ignored.
   Install the plugin gem from a local path.
 
   Example: `bundle plugin install bundler-graph --path ../bundler-graph`
-
-* `--local-git=LOCAL_GIT`:
-  Install the plugin gem from a local Git repository.
-
-  Example: `bundle plugin install bundler-graph --local-git ../bundler-graph`.
-
-  This option is deprecated in favor of `--git`.
 
 ### uninstall
 

--- a/bundler/lib/bundler/plugin/installer.rb
+++ b/bundler/lib/bundler/plugin/installer.rb
@@ -43,14 +43,8 @@ module Bundler
       private
 
       def check_sources_consistency!(options)
-        if options.key?(:git) && options.key?(:local_git)
-          raise InvalidOption, "Remote and local plugin git sources can't be both specified"
-        end
-
-        # back-compat; local_git is an alias for git
         if options.key?(:local_git)
-          Bundler::SharedHelpers.major_deprecation(2, "--local_git is deprecated, use --git")
-          options[:git] = options.delete(:local_git)
+          raise InvalidOption, "--local_git has been removed, use --git"
         end
 
         if (options.keys & [:source, :git, :path]).length > 1

--- a/bundler/lib/bundler/plugin/installer.rb
+++ b/bundler/lib/bundler/plugin/installer.rb
@@ -43,10 +43,6 @@ module Bundler
       private
 
       def check_sources_consistency!(options)
-        if options.key?(:local_git)
-          raise InvalidOption, "--local_git has been removed, use --git"
-        end
-
         if (options.keys & [:source, :git, :path]).length > 1
           raise InvalidOption, "Only one of --source, --git, or --path may be specified"
         end

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -704,14 +704,11 @@ RSpec.describe "major deprecations" do
       end
     end
 
-    it "prints a deprecation warning" do
-      bundle "plugin install foo --local_git #{lib_path("foo-1.0")}"
+    it "fails with a helpful message" do
+      bundle "plugin install foo --local_git #{lib_path("foo-1.0")}", raise_on_error: false
 
-      expect(out).to include("Installed plugin foo")
-      expect(deprecations).to include "--local_git is deprecated, use --git"
+      expect(err).to include "--local_git has been removed, use --git"
     end
-
-    pending "fails with a helpful message", bundler: "4"
   end
 
   describe "removing rubocop" do

--- a/bundler/spec/plugins/install_spec.rb
+++ b/bundler/spec/plugins/install_spec.rb
@@ -203,13 +203,6 @@ RSpec.describe "bundler plugin install" do
       expect(out).to include("Installed plugin foo")
       plugin_should_be_installed("foo")
     end
-
-    it "raises an error when both git and local git sources are specified" do
-      bundle "plugin install foo --git /phony/path/project --local_git git@gitphony.com:/repo/project", raise_on_error: false
-
-      expect(exitstatus).not_to eq(0)
-      expect(err).to eq("Remote and local plugin git sources can't be both specified")
-    end
   end
 
   context "path plugins" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This flag is deprecated and set to be removed in Bundler 4.

## What is your fix for the problem, implemented in this PR?

Remove it and let it raise an error.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
