### PR TITLE
Make `bundle show --outdated` raise an error

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -283,12 +283,11 @@ module Bundler
       Calling show with [GEM] will list the exact location of that gem on your machine.
     D
     method_option "paths", type: :boolean, banner: "List the paths of all gems that are required by your Gemfile."
-    method_option "outdated", type: :boolean, banner: "Show verbose output including whether gems are outdated."
+    method_option "outdated", type: :boolean, banner: "Show verbose output including whether gems are outdated (removed)."
     def show(gem_name = nil)
       if ARGV.include?("--outdated")
-        message = "the `--outdated` flag to `bundle show` will be removed in favor of `bundle show --verbose`"
         removed_message = "the `--outdated` flag to `bundle show` has been removed in favor of `bundle show --verbose`"
-        SharedHelpers.major_deprecation(2, message, removed_message: removed_message)
+        raise InvalidOption, removed_message
       end
       require_relative "cli/show"
       Show.new(options, gem_name).run

--- a/bundler/lib/bundler/cli/show.rb
+++ b/bundler/lib/bundler/cli/show.rb
@@ -6,7 +6,7 @@ module Bundler
     def initialize(options, gem_name)
       @options = options
       @gem_name = gem_name
-      @verbose = options[:verbose] || options[:outdated]
+      @verbose = options[:verbose]
       @latest_specs = fetch_latest_specs if @verbose
     end
 

--- a/bundler/lib/bundler/man/bundle-show.1
+++ b/bundler/lib/bundler/man/bundle-show.1
@@ -4,7 +4,7 @@
 .SH "NAME"
 \fBbundle\-show\fR \- Shows all the gems in your bundle, or the path to a gem
 .SH "SYNOPSIS"
-\fBbundle show\fR [GEM] [\-\-paths] [\-\-outdated]
+\fBbundle show\fR [GEM] [\-\-paths]
 .SH "DESCRIPTION"
 Without the [GEM] option, \fBshow\fR will print a list of the names and versions of all gems that are required by your [\fBGemfile(5)\fR][Gemfile(5)], sorted by name\.
 .P
@@ -13,7 +13,4 @@ Calling show with [GEM] will list the exact location of that gem on your machine
 .TP
 \fB\-\-paths\fR
 List the paths of all gems that are required by your [\fBGemfile(5)\fR][Gemfile(5)], sorted by gem name\.
-.TP
-\fB\-\-outdated\fR
-Show verbose output including whether gems are outdated\.
 

--- a/bundler/lib/bundler/man/bundle-show.1.ronn
+++ b/bundler/lib/bundler/man/bundle-show.1.ronn
@@ -5,7 +5,6 @@ bundle-show(1) -- Shows all the gems in your bundle, or the path to a gem
 
 `bundle show` [GEM]
               [--paths]
-              [--outdated]
 
 ## DESCRIPTION
 
@@ -20,6 +19,3 @@ machine.
 * `--paths`:
   List the paths of all gems that are required by your [`Gemfile(5)`][Gemfile(5)],
   sorted by gem name.
-
-* `--outdated`:
-  Show verbose output including whether gems are outdated.

--- a/bundler/spec/commands/show_spec.rb
+++ b/bundler/spec/commands/show_spec.rb
@@ -210,33 +210,6 @@ RSpec.describe "bundle show" do
       expect(err).to include("Could not find gem '#{invalid_regexp}'.")
     end
   end
-
-  context "--outdated option" do
-    # Regression test for https://github.com/rubygems/bundler/issues/5375
-    before do
-      build_repo2
-    end
-
-    it "doesn't update gems to newer versions" do
-      install_gemfile <<-G
-        source "https://gem.repo2"
-        gem "rails"
-      G
-
-      expect(the_bundle).to include_gem("rails 2.3.2")
-
-      update_repo2 do
-        build_gem "rails", "3.0.0" do |s|
-          s.executables = "rails"
-        end
-      end
-
-      bundle "show --outdated"
-
-      bundle "install"
-      expect(the_bundle).to include_gem("rails 2.3.2")
-    end
-  end
 end
 
 RSpec.describe "bundle show", bundler: "5" do

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -649,14 +649,12 @@ RSpec.describe "major deprecations" do
 
     context "with --outdated flag" do
       before do
-        bundle "show --outdated"
+        bundle "show --outdated", raise_on_error: false
       end
 
-      it "prints a deprecation warning informing about its removal" do
-        expect(deprecations).to include("the `--outdated` flag to `bundle show` will be removed in favor of `bundle show --verbose`")
+      it "fails with a helpful message" do
+        expect(err).to include("the `--outdated` flag to `bundle show` has been removed in favor of `bundle show --verbose`")
       end
-
-      pending "fails with a helpful message", bundler: "4"
     end
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This flag is deprecated and set to be removed in Bundler 4.

## What is your fix for the problem, implemented in this PR?

Remove it and let it raise an error.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
