### PR TITLE
Consolidate removal of `Bundler.rubygems.all_specs`

### DIFF
--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -416,11 +416,7 @@ module Bundler
     end
 
     def all_specs
-      SharedHelpers.major_deprecation 2, "Bundler.rubygems.all_specs has been removed in favor of Bundler.rubygems.installed_specs"
-
-      Gem::Specification.stubs.map do |stub|
-        StubSpecification.from_stub(stub)
-      end
+      SharedHelpers.feature_removed! "Bundler.rubygems.all_specs has been removed in favor of Bundler.rubygems.installed_specs"
     end
 
     def installed_specs


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We generally don't consider removing methods like this as breaking changes since they are internal. However, in this case I believe we detected it was used somewhere in the wild and decided to be extra careful.

## What is your fix for the problem, implemented in this PR?

Consolidate the deprecation by removing the implementation and raising an error.
 
## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
