### PR TITLE
Fix `bundle install` when the Gemfile contains "install_if" git gems:

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -282,10 +282,15 @@ module Bundler
     end
 
     def filter_relevant(dependencies)
-      platforms_array = [Bundler.generic_local_platform].freeze
       dependencies.select do |d|
-        d.should_include? && !d.gem_platforms(platforms_array).empty?
+        relevant_deps?(d)
       end
+    end
+
+    def relevant_deps?(dep)
+      platforms_array = [Bundler.generic_local_platform].freeze
+
+      dep.should_include? && !dep.gem_platforms(platforms_array).empty?
     end
 
     def locked_dependencies
@@ -973,10 +978,11 @@ module Bundler
       @missing_lockfile_dep = nil
       @changed_dependencies = []
 
-      current_dependencies.each do |dep|
+      @dependencies.each do |dep|
         if dep.source
           dep.source = sources.get(dep.source)
         end
+        next unless relevant_deps?(dep)
 
         name = dep.name
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Fix #8985

TL;DR If you have a Gemfile that contains a `install_if` git gem, it will be impossible to add other gems in the Gemfile and run `bundle install`, you'll get a "The git source [...] is not yet checked out".

The change that modified this behaviour was in abbea0cc94dd8ad74e52fff17aacf5f175ba0cff, and the issue is about the call to `current_dependencies`. This call filters out irrelevant dependencies such as the one that get condtionnally installed. By doing so, we skip over setting the source based of the lockfile for that dependency https://github.com/rubygems/rubygems/blob/ade324bdc8ea77b342f203cb7f3929a456d725ed/bundler/lib/bundler/definition.rb#L978

Ultimately, because of this, the dependency source doesn't have any additional information such as the `revision`. Down the line, when we end up to converge the spec, Bundler will attempt to get the revision for that spec but won't be able to because the git source isn't configured to allow running git operations.

## What is your fix for the problem, implemented in this PR?

Filter out the irrelevant only spec only after we have set its source.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
