### PR TITLE
Fixed owner name for sync ruby workflow

### DIFF
--- a/.github/workflows/sync-ruby.yml
+++ b/.github/workflows/sync-ruby.yml
@@ -6,7 +6,7 @@ jobs:
   sync:
     name: Sync ruby
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'ruby' }}
+    if: ${{ github.repository_owner == 'rubygems' }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:


### PR DESCRIPTION
## What is your fix for the problem, implemented in this PR?

We need to use `rubygems` owner instead of `ruby`.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
