### PR TITLE
Consolidate removal of `Bundler::SpecSet#-` and `Bundler::SpecSet#<<`

### DIFF
--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -179,9 +179,7 @@ module Bundler
     end
 
     def -(other)
-      SharedHelpers.major_deprecation 2, "SpecSet#- has been removed with no replacement"
-
-      SpecSet.new(to_a - other.to_a)
+      SharedHelpers.feature_removed! "SpecSet#- has been removed with no replacement"
     end
 
     def find_by_name_and_platform(name, platform)
@@ -212,9 +210,7 @@ module Bundler
     end
 
     def <<(spec)
-      SharedHelpers.major_deprecation 2, "SpecSet#<< has been removed with no replacement"
-
-      @specs << spec
+      SharedHelpers.feature_removed! "SpecSet#<< has been removed with no replacement"
     end
 
     def length


### PR DESCRIPTION
## What is your fix for the problem, implemented in this PR?

from https://github.com/rubygems/rubygems/pull/8986

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
