### PR TITLE
Bump up to test version for 4.0.0.dev

### DIFF
--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -1571,12 +1571,12 @@ RSpec.describe "bundle update --bundler" do
   end
 
   it "does not claim to update to Bundler version to a wrong version when cached gems are present" do
-    pristine_system_gems "bundler-2.99.0"
+    pristine_system_gems "bundler-4.99.0"
 
     build_repo4 do
       build_gem "myrack", "3.0.9.1"
 
-      build_bundler "2.99.0"
+      build_bundler "4.99.0"
     end
 
     gemfile <<~G


### PR DESCRIPTION
## What is your fix for the problem, implemented in this PR?

If we use ruby-dev version, that has `bundler-4.0.0.dev` and failed `update_spec.rb` because stub is lower version than system version.

We need to bump up to > 4.0.0.dev.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
