### PR TITLE
Removed legacy_check option from SpecSet#for

### DIFF
--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -11,16 +11,11 @@ module Bundler
       @specs = specs
     end
 
-    def for(dependencies, platforms_or_legacy_check = [nil], legacy_platforms = [nil], skips: [])
-      platforms = if [true, false].include?(platforms_or_legacy_check)
-        Bundler::SharedHelpers.major_deprecation 2,
+    def for(dependencies, platforms = [nil], legacy_platforms = [nil], skips: [])
+      if [true, false].include?(platforms)
+        Bundler::SharedHelpers.feature_removed! \
           "SpecSet#for received a `check` parameter, but that's no longer used and deprecated. " \
-          "SpecSet#for always implicitly performs validation. Please remove this parameter",
-          print_caller_location: true
-
-        legacy_platforms
-      else
-        platforms_or_legacy_check
+          "SpecSet#for always implicitly performs validation. Please remove this parameter"
       end
 
       materialize_dependencies(dependencies, platforms, skips: skips)


### PR DESCRIPTION
## What is your fix for the problem, implemented in this PR?

From https://github.com/rubygems/rubygems/pull/8887/

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
