### PR TITLE
Replaced Bundler::SharedHelpers.major_deprecation to feature_removed! or feature_deprecated!

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -447,9 +447,8 @@ module Bundler
     D
     def exec(*args)
       if ARGV.include?("--no-keep-file-descriptors")
-        message = "The `--no-keep-file-descriptors` has been deprecated. `bundle exec` no longer mess with your file descriptors. Close them in the exec'd script if you need to"
         removed_message = "The `--no-keep-file-descriptors` has been removed. `bundle exec` no longer mess with your file descriptors. Close them in the exec'd script if you need to"
-        SharedHelpers.major_deprecation(2, message, removed_message: removed_message)
+        raise InvalidOption, removed_message
       end
 
       require_relative "cli/exec"

--- a/bundler/lib/bundler/cli/config.rb
+++ b/bundler/lib/bundler/cli/config.rb
@@ -26,8 +26,7 @@ module Bundler
         end
 
       message = "Using the `config` command without a subcommand [list, get, set, unset] is deprecated and will be removed in the future. Use `bundle #{new_args.join(" ")}` instead."
-      removed_message = "Using the `config` command without a subcommand [list, get, set, unset] has been removed. Use `bundle #{new_args.join(" ")}` instead."
-      SharedHelpers.major_deprecation 4, message, removed_message: removed_message
+      SharedHelpers.feature_deprecated! message
 
       Base.new(options, name, value, self).run
     end

--- a/bundler/lib/bundler/cli/update.rb
+++ b/bundler/lib/bundler/cli/update.rb
@@ -26,7 +26,7 @@ module Bundler
         if Bundler.settings[:update_requires_all_flag]
           raise InvalidOption, "To update everything, pass the `--all` flag."
         end
-        SharedHelpers.major_deprecation 4, "Pass --all to `bundle update` to update everything"
+        SharedHelpers.feature_deprecated! "Pass --all to `bundle update` to update everything"
       elsif !full_update && options[:all]
         raise InvalidOption, "Cannot specify --all along with specific options."
       end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -372,7 +372,7 @@ module Bundler
 
         msg = "`Definition#lock` was passed a target file argument. #{suggestion}"
 
-        Bundler::SharedHelpers.major_deprecation 2, msg
+        Bundler::SharedHelpers.feature_removed! msg
       end
 
       write_lock(target_lockfile, preserve_unknown_sections)

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -483,14 +483,10 @@ module Bundler
     def normalize_source(source)
       case source
       when :gemcutter, :rubygems, :rubyforge
-        message =
-          "The source :#{source} is deprecated because HTTP requests are insecure.\n" \
-          "Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not."
         removed_message =
           "The source :#{source} is disallowed because HTTP requests are insecure.\n" \
           "Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not."
-        Bundler::SharedHelpers.major_deprecation 2, message, removed_message: removed_message
-        "http://rubygems.org"
+        Bundler::SharedHelpers.feature_removed! removed_message
       when String
         source
       else
@@ -509,7 +505,7 @@ module Bundler
               "      gem 'rails'\n" \
               "    end\n\n"
 
-      SharedHelpers.major_deprecation(2, msg.strip)
+      SharedHelpers.feature_removed! msg.strip
     end
 
     def check_rubygems_source_safety

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -125,28 +125,13 @@ module Bundler
       raise GenericSystemCallError.new(e, "There was an error #{[:create, :write].include?(action) ? "creating" : "accessing"} `#{path}`.")
     end
 
-    def major_deprecation(major_version, message, removed_message: nil, print_caller_location: false)
-      if print_caller_location
-        caller_location = caller_locations(2, 2).first
-        suffix = " (called at #{caller_location.path}:#{caller_location.lineno})"
-        message += suffix
-      end
+    def feature_deprecated!(message)
+      return unless prints_major_deprecations?
 
-      require_relative "../bundler"
-
-      feature_flag = Bundler.feature_flag
-
-      if feature_flag.removed_major?(major_version)
-        feature_removed!(removed_message || message)
-      end
-
-      return unless feature_flag.deprecated_major?(major_version) && prints_major_deprecations?
       Bundler.ui.warn("[DEPRECATED] #{message}")
     end
 
     def feature_removed!(message)
-      require_relative "../bundler"
-
       require_relative "errors"
       raise RemovedError, "[REMOVED] #{message}"
     end

--- a/bundler/spec/bundler/shared_helpers_spec.rb
+++ b/bundler/spec/bundler/shared_helpers_spec.rb
@@ -515,34 +515,4 @@ RSpec.describe Bundler::SharedHelpers do
       end
     end
   end
-
-  describe "#major_deprecation" do
-    before { allow(Bundler).to receive(:feature_flag).and_return(Bundler::FeatureFlag.new(37)) }
-    before { allow(Bundler.ui).to receive(:warn) }
-
-    it "prints and raises nothing below the deprecated major version" do
-      subject.major_deprecation(38, "Message")
-      subject.major_deprecation(39, "Message", removed_message: "Removal", print_caller_location: true)
-      expect(Bundler.ui).not_to have_received(:warn)
-    end
-
-    it "prints but does not raise _at_ the deprecated major version" do
-      subject.major_deprecation(37, "Message")
-      subject.major_deprecation(37, "Message", removed_message: "Removal")
-      expect(Bundler.ui).to have_received(:warn).with("[DEPRECATED] Message").twice
-
-      subject.major_deprecation(37, "Message", print_caller_location: true)
-      expect(Bundler.ui).to have_received(:warn).
-        with(a_string_matching(/^\[DEPRECATED\] Message \(called at .*:\d+\)$/))
-    end
-
-    it "raises the appropriate errors when _past_ the deprecated major version" do
-      expect { subject.major_deprecation(36, "Message") }.
-        to raise_error(Bundler::RemovedError, "[REMOVED] Message")
-      expect { subject.major_deprecation(36, "Message", removed_message: "Removal") }.
-        to raise_error(Bundler::RemovedError, "[REMOVED] Removal")
-      expect { subject.major_deprecation(35, "Message", removed_message: "Removal", print_caller_location: true) }.
-        to raise_error(Bundler::RemovedError, "[REMOVED] Removal")
-    end
-  end
 end


### PR DESCRIPTION
## What is your fix for the problem, implemented in this PR?

From https://github.com/rubygems/rubygems/pull/8887/

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
