### PR TITLE
Restrict what schemes are acceptable in the remote fetcher

### DIFF
--- a/lib/rubygems/remote_fetcher.rb
+++ b/lib/rubygems/remote_fetcher.rb
@@ -245,11 +245,14 @@ class Gem::RemoteFetcher
   def fetch_path(uri, mtime = nil, head = false)
     uri = Gem::Uri.new uri
 
-    unless uri.scheme
-      raise ArgumentError, "uri scheme is invalid: #{uri.scheme.inspect}"
-    end
+    method = {
+      "http" => "fetch_http",
+      "https" => "fetch_http",
+      "s3" => "fetch_s3",
+      "file" => "fetch_file",
+    }.fetch(uri.scheme) { raise ArgumentError, "uri scheme is invalid: #{uri.scheme.inspect}" }
 
-    data = send "fetch_#{uri.scheme}", uri, mtime, head
+    data = send method, uri, mtime, head
 
     if data && !head && uri.to_s.end_with?(".gz")
       begin


### PR DESCRIPTION
The remote fetcher only works with certain schemes (`http`, `https`, `s3`, and `file`).  It's possible for other schemes to show up in this code and it can cause bugs.

Before this patch, doing `gem install path:///hello` would result in an infinite loop because this function would do `send "fetch_path"`, calling itself forever.  Now we see an exception.

I think we should validate gem names earlier, but it's really best practice to restrict the possible strings passed to `send`.