### PR TITLE
Postpone to remove legacy mingw platform

### DIFF
--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -142,7 +142,7 @@ module Bundler
       end
 
       if @platforms.include?(Gem::Platform::X64_MINGW_LEGACY)
-        SharedHelpers.feature_removed!("Found x64-mingw32 in lockfile, which is no longer supported as of Bundler 4.0.")
+        SharedHelpers.feature_deprecated!("Found x64-mingw32 in lockfile, which is deprecated and will be removed in the future.")
       end
 
       @most_specific_locked_platform = @platforms.min_by do |bundle_platform|

--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -601,7 +601,7 @@ RSpec.describe "major deprecations" do
     it "raises a helpful error" do
       bundle "install", raise_on_error: false
 
-      expect(err).to include("Found x64-mingw32 in lockfile, which is no longer supported as of Bundler 4.0.")
+      expect(err).to include("Found x64-mingw32 in lockfile, which is deprecated and will be removed in the future.")
     end
   end
 


### PR DESCRIPTION
`x64-mingw32` is widely available now and break it.

Like https://github.com/nobu/zlib/actions/runs/18590095777/job/53002928494#step:5:25

We update that to `x64-mingw-ucrt` automatically and save it. After that we can remove it at 4.1.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
