### PR TITLE
Update Magnus version in Rust extension gem template

### DIFF
--- a/bundler/lib/bundler/templates/newgem/ext/newgem/Cargo.toml.tt
+++ b/bundler/lib/bundler/templates/newgem/ext/newgem/Cargo.toml.tt
@@ -12,4 +12,4 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-magnus = { version = "0.6.2" }
+magnus = { version = "0.8.2" }


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

The gem skeleton generated by `bundle gem --ext=rust` uses an older version (0.6.2) of the Magnus Rust library that will not build with Ruby 3.5. It would be nice to have the version of bundler that ships with Ruby 3.5 generate a gem skeleton that works with that Ruby version.

## What is your fix for the problem, implemented in this PR?

I've updated the template to the latest release of Magnus (0.8.2), which is tested against Ruby head and is currently working fine with Ruby 3.5-dev. Additionally as the maintainer of Magnus I plan to support version 0.8 through the release of Ruby 3.5. I will not be doing new releases of Magnus 0.6.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
