### PR TITLE
Fixup example title for mingw-legacy deprecation

### DIFF
--- a/bundler/spec/other/major_deprecation_spec.rb
+++ b/bundler/spec/other/major_deprecation_spec.rb
@@ -598,7 +598,7 @@ RSpec.describe "major deprecations" do
       L
     end
 
-    it "raises a helpful error" do
+    it "warns a helpful error" do
       bundle "install", raise_on_error: false
 
       expect(err).to include("Found x64-mingw32 in lockfile, which is deprecated and will be removed in the future.")


### PR DESCRIPTION
I forgot to update example title of 9b3a5a8ae9cd8bc3666185d5c09c9fea403c80c6