### PR TITLE
Remove open-ended and prerelease dependency warnings when building gems

### DIFF
--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -190,9 +190,6 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
 
   ##
   # Checks that the gem does not depend on itself.
-  # Checks that dependencies use requirements as we recommend.  Warnings are
-  # issued when dependencies are open-ended or overly strict for semantic
-  # versioning.
 
   def validate_dependencies # :nodoc:
     warning_messages = []
@@ -200,39 +197,6 @@ duplicate dependency on #{dep}, (#{prev.requirement}) use:
       if dep.name == @specification.name # warn on self reference
         warning_messages << "Self referencing dependency is unnecessary and strongly discouraged."
       end
-
-      prerelease_dep = dep.requirements_list.any? do |req|
-        Gem::Requirement.new(req).prerelease?
-      end
-
-      warning_messages << "prerelease dependency on #{dep} is not recommended" if
-          prerelease_dep && !@specification.version.prerelease?
-
-      open_ended = dep.requirement.requirements.all? do |op, version|
-        !version.prerelease? && [">", ">="].include?(op)
-      end
-
-      next unless open_ended
-      op, dep_version = dep.requirement.requirements.first
-
-      segments = dep_version.segments
-
-      base = segments.first 2
-
-      recommendation = if [">", ">="].include?(op) && segments == [0]
-        "  use a bounded requirement, such as \"~> x.y\""
-      else
-        bugfix = if op == ">"
-          ", \"> #{dep_version}\""
-        elsif op == ">=" && base != segments
-          ", \">= #{dep_version}\""
-        end
-
-        "  if #{dep.name} is semantically versioned, use:\n" \
-        "    add_#{dep.type}_dependency \"#{dep.name}\", \"~> #{base.join "."}\"#{bugfix}"
-      end
-
-      warning_messages << ["open-ended dependency on #{dep} is not recommended", recommendation].join("\n") + "\n"
     end
     if warning_messages.any?
       warning_messages.each {|warning_message| warning warning_message }

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -2671,27 +2671,7 @@ end
         @a1.validate
       end
 
-      expected = <<-EXPECTED
-#{w}:  prerelease dependency on b (>= 1.0.rc1) is not recommended
-#{w}:  prerelease dependency on c (>= 2.0.rc2, development) is not recommended
-#{w}:  open-ended dependency on i (>= 1.2) is not recommended
-  if i is semantically versioned, use:
-    add_runtime_dependency "i", "~> 1.2"
-#{w}:  open-ended dependency on j (>= 1.2.3) is not recommended
-  if j is semantically versioned, use:
-    add_runtime_dependency "j", "~> 1.2", ">= 1.2.3"
-#{w}:  open-ended dependency on k (> 1.2) is not recommended
-  if k is semantically versioned, use:
-    add_runtime_dependency "k", "~> 1.2", "> 1.2"
-#{w}:  open-ended dependency on l (> 1.2.3) is not recommended
-  if l is semantically versioned, use:
-    add_runtime_dependency "l", "~> 1.2", "> 1.2.3"
-#{w}:  open-ended dependency on o (>= 0) is not recommended
-  use a bounded requirement, such as "~> x.y"
-#{w}:  See https://guides.rubygems.org/specification-reference/ for help
-      EXPECTED
-
-      assert_equal expected, @ui.error, "warning"
+      assert_equal "", @ui.error, "warning"
     end
   end
 


### PR DESCRIPTION
In general, rubygems should provide mechanism and not policy.

Pessimistic versioning is not universally better, and in many cases, it can cause more problems than it solves. Rubygems should not be warning against open-ended versioning when building gems. The majority of the default gems with dependencies do not use pessimistic versioning, which indicates that Ruby itself recognizes that open-ended versioning is generally better.

In some cases, depending on a prerelease gem is the only choice other than not releasing a gem. If you are building an extension gem for a feature in a prerelease version of another gem, then depending on the prerelease version is the only way to ensure a compatible dependency is installed.

## What was the end-user or developer problem that led to this PR?

Spurious and unnecessary warnings when building gems, such as:

```
WARNING:  open-ended dependency on bigdecimal (>= 0) is not recommended
  use a bounded requirement, such as "~> x.y"
```

## What is your fix for the problem, implemented in this PR?

Remove open-ended dependency warning. While here, also remove the prerelease dependency warning, since there are cases where a prerelease dependency is the only solution.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Fix tests
- [X] Remove code causing the problem