### PR TITLE
Make verification methods private

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -642,6 +642,8 @@ EOM
     raise Gem::Package::FormatError.new e.message, @gem
   end
 
+  private
+
   ##
   # Verifies the +checksums+ against the +digests+.  This check is not
   # cryptographically secure.  Missing checksums are ignored.


### PR DESCRIPTION
I would like to start making some of the methods in Gem::Package private so that we can refactor them better.  Right now we have many methods that are public, and since they are public we can't refactor them.  Historically, I think "private" methods have just been tagged with :nodoc:, but I would like to be more strict about our APIs