### PR TITLE
Add pattern matching support to Gem::NameTuple

### DIFF
--- a/lib/rubygems/name_tuple.rb
+++ b/lib/rubygems/name_tuple.rb
@@ -81,6 +81,12 @@ class Gem::NameTuple
     [@name, @version, @platform]
   end
 
+  alias_method :deconstruct, :to_a
+
+  def deconstruct_keys(keys)
+    { name: @name, version: @version, platform: @platform }
+  end
+
   def inspect # :nodoc:
     "#<Gem::NameTuple #{@name}, #{@version}, #{@platform}>"
   end

--- a/test/rubygems/test_gem_name_tuple.rb
+++ b/test/rubygems/test_gem_name_tuple.rb
@@ -57,4 +57,41 @@ class TestGemNameTuple < Gem::TestCase
 
     assert_equal 1, a_p.<=>(a)
   end
+
+  def test_deconstruct
+    name_tuple = Gem::NameTuple.new "rails", Gem::Version.new("7.0.0"), "ruby"
+    assert_equal ["rails", Gem::Version.new("7.0.0"), "ruby"], name_tuple.deconstruct
+  end
+
+  def test_deconstruct_keys
+    name_tuple = Gem::NameTuple.new "rails", Gem::Version.new("7.0.0"), "x86_64-linux"
+    keys = name_tuple.deconstruct_keys(nil)
+    assert_equal "rails", keys[:name]
+    assert_equal Gem::Version.new("7.0.0"), keys[:version]
+    assert_equal "x86_64-linux", keys[:platform]
+  end
+
+  def test_pattern_matching_array
+    name_tuple = Gem::NameTuple.new "rails", Gem::Version.new("7.0.0"), "ruby"
+    result =
+      case name_tuple
+      in [name, version, "ruby"]
+        "#{name}-#{version}"
+      else
+        "no match"
+      end
+    assert_equal "rails-7.0.0", result
+  end
+
+  def test_pattern_matching_hash
+    name_tuple = Gem::NameTuple.new "rails", Gem::Version.new("7.0.0"), "ruby"
+    result =
+      case name_tuple
+      in name: "rails", version:, platform: "ruby"
+        version.to_s
+      else
+        "no match"
+      end
+    assert_equal "7.0.0", result
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Ruby 2.7+ introduced pattern matching, but `Gem::NameTuple` does not support it. This makes gem index operations and version resolution more verbose than necessary, particularly when filtering or routing based on gem metadata.

The current approach requires multiple method calls and conditionals:

```ruby
name_tuples.select do |nt|
 nt.name == "rails" && nt.platform == "ruby" && nt.version >= Gem::Version.new("7.0")
end
```

## What is your fix for the problem, implemented in this PR?

Added `deconstruct` and `deconstruct_keys` methods to `Gem::NameTuple` to enable pattern matching syntax.

Implementation:

* `deconstruct` aliases the existing `to_a` method for array pattern matching, returning `[name, version, platform]`
* `deconstruct_keys` returns a hash with keys `:name`, `:version`, and `:platform`

This enables name tuple pattern matching:

```ruby
case name_tuple
in name: "rails", version: Gem::Version[major: 7..], platform: "ruby"
 use_modern_features
in name: "rails", version:, platform:
 legacy_support(version, platform)
end
```

Or filtering with array patterns:

```ruby
name_tuples.select { it in ["rails", Gem::Version[major: 7..], "ruby"] }
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write tests for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the current code style and write meaningful commit messages without tags