### PR TITLE
[DOC] Fix the location of Gem::Deprecate document

### DIFF
--- a/lib/rubygems/deprecate.rb
+++ b/lib/rubygems/deprecate.rb
@@ -4,10 +4,10 @@ module Gem
   ##
   # Provides 3 methods for declaring when something is going away.
   #
-  # +deprecate(name, repl, year, month)+:
+  # <tt>deprecate(name, repl, year, month)</tt>:
   #     Indicate something may be removed on/after a certain date.
   #
-  # +rubygems_deprecate(name, replacement=:none)+:
+  # <tt>rubygems_deprecate(name, replacement=:none)</tt>:
   #     Indicate something will be removed in the next major RubyGems version,
   #     and (optionally) a replacement for it.
   #


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The document of `Gem::Deprecate` appears as the document of `Gem`.

## What is your fix for the problem, implemented in this PR?

Move the document just before `module Deprecate` from before `module Gem` (and adjust indents).

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
