### PR TITLE
Add debug logging information to see the time it took to download and install a gem

### DIFF
--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -211,7 +211,11 @@ module Bundler
         message += " with native extensions" if spec.extensions.any?
         Bundler.ui.confirm message
 
-        installed_spec = installer.install
+        installed_spec = nil
+
+        Gem.time("Installed #{spec.name} in", 0, true) do
+          installed_spec = installer.install
+        end
 
         spec.full_gem_path = installed_spec.full_gem_path
         spec.loaded_from = installed_spec.loaded_from
@@ -478,7 +482,10 @@ module Bundler
         uri = spec.remote.uri
         Bundler.ui.confirm("Fetching #{version_message(spec, previous_spec)}")
         gem_remote_fetcher = remote_fetchers.fetch(spec.remote).gem_remote_fetcher
-        Bundler.rubygems.download_gem(spec, uri, download_cache_path, gem_remote_fetcher)
+
+        Gem.time("Downloaded #{spec.name} in", 0, true) do
+          Bundler.rubygems.download_gem(spec, uri, download_cache_path, gem_remote_fetcher)
+        end
       end
 
       # Returns the global cache path of the calling Rubygems::Source object.

--- a/bundler/spec/bundler/source/rubygems_spec.rb
+++ b/bundler/spec/bundler/source/rubygems_spec.rb
@@ -44,4 +44,22 @@ RSpec.describe Bundler::Source::Rubygems do
       end
     end
   end
+
+  describe "log debug information" do
+    it "log the time spent downloading and installing a gem" do
+      build_repo2 do
+        build_gem "warning"
+      end
+
+      gemfile_content = <<~G
+        source "https://gem.repo2"
+        gem "warning"
+      G
+
+      stdout = install_gemfile(gemfile_content, env: { "DEBUG" => "1" })
+
+      expect(stdout).to match(/Downloaded warning in: \d+\.\d+s/)
+      expect(stdout).to match(/Installed warning in: \d+\.\d+s/)
+    end
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I'd like to be able to see how long bundler takes for basic operations such as downloading a gem from Rubygems.org and installing a gem.

## What is your fix for the problem, implemented in this PR?

Added `Gem.time` to surrounding code of interest such as during downloading of a gem and installation.
https://github.com/ruby/rubygems/blob/e4fd4ee3fad005fce1dbcbeffd47e7199243bc42/lib/rubygems.rb#L1048


It will now be possible with this commit by running `DEBUG=true bundle install` and have output that looks like:

```
Fetching rack-test 2.2.0
Downloaded rack-test in: 50.523s
Installing rack-test 2.2.0
Installed rack-test in: : 0.003s
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
