### PR TITLE
Support out-of-place build in ruby/ruby repo

### DIFF
--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -425,13 +425,11 @@ module Spec
     end
 
     class BundlerBuilder
-      SPEC = Gem::Specification.load(Spec::Path.relative_gemspec)
-
       def initialize(context, name, version)
         raise "can only build bundler" unless name == "bundler"
 
         @context = context
-        @spec = SPEC.dup
+        @spec = Spec::Path.loaded_gemspec.dup
         @spec.version = version || Bundler::VERSION
       end
 


### PR DESCRIPTION
Picked from https://github.com/ruby/ruby/pull/15139

Fixed out-of-place build at https://github.com/ruby/ruby/actions/runs/19255434439/job/55049022291

