### PR TITLE
Slightly optimize the installation process by trying to use all threads:

### DIFF
--- a/bundler/lib/bundler/installer/parallel_installer.rb
+++ b/bundler/lib/bundler/installer/parallel_installer.rb
@@ -57,6 +57,10 @@ module Bundler
         @spec.dependencies
       end
 
+      def has_extensions?
+        @spec.extensions.any?
+      end
+
       def to_s
         "#<#{self.class} #{full_name} (#{state})>"
       end
@@ -193,7 +197,9 @@ module Bundler
       end
 
       @specs.each do |spec|
-        if spec.ready_to_enqueue? && spec.dependencies_installed?(installed_specs)
+        next unless spec.ready_to_enqueue?
+
+        if !spec.has_extensions? || spec.dependencies_installed?(installed_specs)
           spec.state = :enqueued
           worker_pool.enq spec
         end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This is a small optimization that makes the `bundle install` a bit faster. The Gemfile taken in this profile was the one a new Rails application generates. For a very large gemfile we get ~1.5 second speed gain.

Profile before: https://share.firefox.dev/47NFFG8
Profile after: https://share.firefox.dev/4nNMg9D

Thanks to Aaron for finding this problem.

#### Problem

Bundler enqueues the installation of a gem in a thread if all deps of that gem have been installed. That means that initially only gems with no dependencies will get installed, and then gem that depends on those will start getting installed and so on.

This means that at some point, some threads will be waiting for work to pick-up.

The reason we believe this is like this is because gem with native extensions may want to require deps in their `extconf.rb`. But for pure ruby gems, the installation process shouldn't depend on any of their dependencies we can install them without waiting.

This code was introduced in https://github.com/ruby/rubygems/commit/b990285af5dc9f4c29e72b5babef37fda868e388 but doesn't explain the reason for this behaviour.

## What is your fix for the problem, implemented in this PR?

Enqueue the installation of gems without waiting if they are pure ruby gems. We'll continue to wait that dependencies get installed for gems with native extensions.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
