### PR TITLE
Adjust the API_REQUEST_LIMIT to make less network roundtrip

### DIFF
--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -8,7 +8,7 @@ module Bundler
       autoload :Remote, File.expand_path("rubygems/remote", __dir__)
 
       # Ask for X gems per API request
-      API_REQUEST_SIZE = 50
+      API_REQUEST_SIZE = 100
 
       attr_accessor :remotes
 

--- a/bundler/spec/bundler/fetcher/dependency_spec.rb
+++ b/bundler/spec/bundler/fetcher/dependency_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe Bundler::Fetcher::Dependency do
     let(:dep_api_uri)       { double(:dep_api_uri) }
     let(:unmarshalled_gems) { double(:unmarshalled_gems) }
     let(:fetch_response)    { double(:fetch_response, body: double(:body)) }
-    let(:rubygems_limit)    { 50 }
+    let(:rubygems_limit)    { 100 }
 
     before { allow(subject).to receive(:dependency_api_uri).with(gem_names).and_return(dep_api_uri) }
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Getting a list of gems 50 per 50 is too slow and seems arbitrarily low.

This limit is used when Bundler fallback to getting a dependency list from a server `/dependencies?gem=` endpoint. Bundler uses this API endpoint fallback when a server doesn't expose the compact index API. **This is not used for Rubygems.org, only private servers.**

This limit is then divided by the number of dependency to get and the result is the number of request we'll be doing. The bottleneck on the client is the network roundtrip. On the server, getting the info of 50 or 100 gems is a bit more expensive but this operation is heavily cached.

This is an example of Rubygems.org implementation at the time the dependencies API wasn't deprecated https://github.com/rubygems/rubygems.org/blob/5a3a3ec02acc3a4e3aba077953a393ad20a06842/app/models/gem_dependent.rb#L15

## What is your fix for the problem, implemented in this PR?

50 gems to query seems arbitrary low. By doubling this number, we make twice as less API requests which ultimately can shove up to two seconds on application relying on a large number of gems.

Worth noting that the limit used to be 100 but got changed in https://github.com/ruby/rubygems/commit/e745f8dc901dd419e7dc8aede3e8d49569fc7b1e for a reason I ignore.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
