### PR TITLE
We don't need to allow some warning now

### DIFF
--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe "bundle install with gem sources" do
 
     it "does not state that it's constantly reinstalling empty gems" do
       build_repo4 do
-        build_gem "empty", "1.0.0", no_default: true, allowed_warning: "no files specified"
+        build_gem "empty", "1.0.0", no_default: true
       end
 
       install_gemfile <<~G

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -192,13 +192,7 @@ module Spec
       # command is expired too. So give `gem install` commands a bit more time.
       options[:timeout] = 120
 
-      allowed_warning = options.delete(:allowed_warning)
-
-      output = sys_exec("#{Path.gem_bin} #{command}", options)
-      stderr = last_command.stderr
-
-      raise stderr if stderr.include?("WARNING") && !allowed_rubygems_warning?(stderr, allowed_warning)
-      output
+      sys_exec("#{Path.gem_bin} #{command}", options)
     end
 
     def sys_exec(cmd, options = {}, &block)
@@ -536,14 +530,6 @@ module Spec
     end
 
     private
-
-    def allowed_rubygems_warning?(text, extra_allowed_warning)
-      allowed_warnings = ["open-ended", "is a symlink", "rake based", "expected RubyGems version"]
-      allowed_warnings << extra_allowed_warning if extra_allowed_warning
-      allowed_warnings.any? do |warning|
-        text.include?(warning)
-      end
-    end
 
     def match_source(contents)
       match = /source ["']?(?<source>http[^"']+)["']?/.match(contents)


### PR DESCRIPTION
I'm reviewing the staled branches. I found commit related with https://github.com/ruby/rubygems/pull/9053 and pick that.

So, we don't need to handle warning message with stderr.