### PR TITLE
Test all tests of `make test-all` by ruby core

### DIFF
--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -36,9 +36,10 @@ jobs:
           sudo apt-get install --no-install-recommends -q -y build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm-dev bison autoconf ruby
       - name: Build Ruby
         run: |
+          export GNUMAKEFLAGS="-j$((1 + $(nproc)))"
           ./autogen.sh
           ./configure -C --disable-install-doc
-          make -j4
+          make
         working-directory: ruby/ruby
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -50,7 +51,7 @@ jobs:
           mv spec/bundler/support/bundle spec/bin/bundle # TODO: fix `sync_default_gems.rb` script so we don't need to vendor the ruby-core binstub ourselves
         working-directory: ruby/ruby
       - name: Test RubyGems
-        run: make -s test-all TESTS="--no-retry -j4"
+        run: make -s test-all TESTS="--no-retry -j$((1 + $(nproc)))"
         working-directory: ruby/ruby
         if: matrix.target == 'Rubygems'
       - name: Test Bundler


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We need to check side effect of Ractor usage like https://github.com/ruby/rubygems/pull/9069.

## What is your fix for the problem, implemented in this PR?

Run all tests by `make test-all`. We can find if Ractor conflict with another Ractor in same process.

And I fixed some wrong usage of `-j` option.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
