### PR TITLE
Skip Ractor related test with Windows platform 

### DIFF
--- a/test/rubygems/test_gem_package_tar_header_ractor.rb
+++ b/test/rubygems/test_gem_package_tar_header_ractor.rb
@@ -58,4 +58,4 @@ class TestGemPackageTarHeaderRactor < Gem::Package::TarTestCase
       assert_headers_equal header_bytes, new_header_bytes
     RUBY
   end
-end unless RUBY_PLATFORM =~ /mingw|mswin/
+end unless RUBY_PLATFORM.match?(/mingw|mswin/)


### PR DESCRIPTION
Backport from https://github.com/ruby/ruby/pull/15171

These tests are failure with Windows platform at ruby/ruby repo.