### PR TITLE
Suppress gem build message of bundler

### DIFF
--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -457,7 +457,9 @@ module Spec
         Spec::BuildMetadata.write_build_metadata(dir: build_path, version: @spec.version.to_s)
 
         Dir.chdir build_path do
-          Gem::Package.build(@spec)
+          Gem::DefaultUserInteraction.use_ui(Gem::SilentUI.new) do
+            Gem::Package.build(@spec)
+          end
         end
 
         if block_given?


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We faced the following message every time.

```
$ rake spec:regular
  Successfully built RubyGem
  Name: bundler
  Version: 4.0.0.dev
  File: bundler-4.0.0.dev.gem
```


## What is your fix for the problem, implemented in this PR?

Suppress it.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
