### PR TITLE
Use `method_defined?` instead of `instance_methods.include?`

### DIFF
--- a/test/rubygems/test_gem_ext_cargo_builder_link_flag_converter.rb
+++ b/test/rubygems/test_gem_ext_cargo_builder_link_flag_converter.rb
@@ -25,7 +25,7 @@ class TestGemExtCargoBuilderLinkFlagConverter < Gem::TestCase
   }.freeze
 
   CASES.each do |test_name, (arg, expected)|
-    raise "duplicate test name" if instance_methods.include?(test_name)
+    raise "duplicate test name" if method_defined?(test_name)
 
     define_method(test_name) do
       assert_equal(expected, Gem::Ext::CargoBuilder::LinkFlagConverter.convert(arg))

--- a/test/rubygems/test_gem_package_tar_header_ractor.rb
+++ b/test/rubygems/test_gem_package_tar_header_ractor.rb
@@ -2,7 +2,7 @@
 
 require_relative "package/tar_test_case"
 
-unless Gem::Package::TarTestCase.instance_methods.include?(:assert_ractor)
+unless Gem::Package::TarTestCase.method_defined?(:assert_ractor)
   require "core_assertions"
   Gem::Package::TarTestCase.include Test::Unit::CoreAssertions
 end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

I see `instance_methods.include?` code sometimes, that is usually equivalent to `method_defined?` (except for the very special cases like `Delegator`).
While the former creates a needless intermediate array of all method names including all ancestors, the latter just traverse the inheritance chain and can stop if found once and much efficient.
For newcomers, it's not a bad idea to demonstrate efficient patterns in code that is likely to be widely read.

## What is your fix for the problem, implemented in this PR?

Replace `instance_methods.include?` with `method_defined?`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
