### PR TITLE
Removed deprecated `-C` option from gem build

### DIFF
--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -25,13 +25,6 @@ class Gem::Commands::BuildCommand < Gem::Command
     add_option "-o", "--output FILE", "output gem with the given filename" do |value, options|
       options[:output] = value
     end
-
-    add_option "-C PATH", "Run as if gem build was started in <PATH> instead of the current working directory." do |value, options|
-      options[:build_path] = value
-    end
-    deprecate_option "-C",
-                     version: "4.0",
-                     extra_msg: "-C is a global flag now. Use `gem -C PATH build GEMSPEC_FILE [options]` instead"
   end
 
   def arguments # :nodoc:

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -43,16 +43,6 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     assert_includes Gem.platforms, Gem::Platform.local
   end
 
-  def test_handle_deprecated_options
-    use_ui @ui do
-      @cmd.handle_options %w[-C ./test/dir]
-    end
-
-    assert_equal "WARNING:  The \"-C\" option has been deprecated and will be removed in Rubygems 4.0. " \
-                 "-C is a global flag now. Use `gem -C PATH build GEMSPEC_FILE [options]` instead\n",
-                 @ui.error
-  end
-
   def test_options_filename
     gemspec_file = File.join(@tempdir, @gem.spec_name)
 

--- a/test/rubygems/test_gem_commands_help_command.rb
+++ b/test/rubygems/test_gem_commands_help_command.rb
@@ -36,7 +36,7 @@ class TestGemCommandsHelpCommand < Gem::TestCase
 
   def test_gem_help_build
     util_gem "build" do |out, err|
-      assert_match(/-C PATH *Run as if gem build was started in <PATH>/, out)
+      assert_match(/--platform PLATFORM\s+Specify the platform of gem to build/, out)
       assert_equal "", err
     end
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We marked `gem build -C` option is deprecated and warn to removed it at RG 4.0.

## What is your fix for the problem, implemented in this PR?

Removed it.

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
