### PR TITLE
Removed unused `Gem::Deprecate`

### DIFF
--- a/lib/rubygems/dependency_installer.rb
+++ b/lib/rubygems/dependency_installer.rb
@@ -7,14 +7,12 @@ require_relative "installer"
 require_relative "spec_fetcher"
 require_relative "user_interaction"
 require_relative "available_set"
-require_relative "deprecate"
 
 ##
 # Installs a gem along with all its dependencies from local and remote gems.
 
 class Gem::DependencyInstaller
   include Gem::UserInteraction
-  extend Gem::Deprecate
 
   DEFAULT_OPTIONS = { # :nodoc:
     env_shebang: false,

--- a/lib/rubygems/dependency_list.rb
+++ b/lib/rubygems/dependency_list.rb
@@ -7,7 +7,6 @@
 #++
 
 require_relative "vendored_tsort"
-require_relative "deprecate"
 
 ##
 # Gem::DependencyList is used for installing and uninstalling gems in the

--- a/lib/rubygems/exceptions.rb
+++ b/lib/rubygems/exceptions.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "deprecate"
 require_relative "unknown_command_spell_checker"
 
 ##

--- a/lib/rubygems/gem_runner.rb
+++ b/lib/rubygems/gem_runner.rb
@@ -8,7 +8,6 @@
 
 require_relative "../rubygems"
 require_relative "command_manager"
-require_relative "deprecate"
 
 ##
 # Run an instance of the gem program.

--- a/lib/rubygems/user_interaction.rb
+++ b/lib/rubygems/user_interaction.rb
@@ -6,7 +6,6 @@
 # See LICENSE.txt for permissions.
 #++
 
-require_relative "deprecate"
 require_relative "text"
 
 ##
@@ -170,8 +169,6 @@ end
 # Gem::StreamUI implements a simple stream based user interface.
 
 class Gem::StreamUI
-  extend Gem::Deprecate
-
   ##
   # The input stream
 


### PR DESCRIPTION
## What is your fix for the problem, implemented in this PR?

Removed unused `Gem::Deprecate` and that `require`. We sometimes forgot to remove that.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
