### PR TITLE
Warn users that `bundle` now display the help:

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -107,7 +107,22 @@ module Bundler
       shell.say
       self.class.send(:class_options_help, shell)
     end
-    default_task(Bundler.settings[:default_cli_command])
+
+    def self.default_command(meth = nil)
+      return super if meth
+
+      default_cli_command = Bundler.settings[:default_cli_command]
+      return default_cli_command if default_cli_command
+
+      Bundler.ui.warn(<<~MSG)
+        In the next version of Bundler, running `bundle` without argument will no longer run `bundle install`.
+        Instead, the `help` command will be displayed.
+
+        If you'd like to keep the previous behaviour please run `bundle config set default_cli_command install --global`.
+      MSG
+
+      "install"
+    end
 
     class_option "no-color", type: :boolean, desc: "Disable colorization in output"
     class_option "retry", type: :numeric, aliases: "-r", banner: "NUM",

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -83,7 +83,6 @@ module Bundler
       "BUNDLE_VERSION" => "lockfile",
       "BUNDLE_LOCKFILE_CHECKSUMS" => true,
       "BUNDLE_CACHE_ALL" => true,
-      "BUNDLE_DEFAULT_CLI_COMMAND" => "cli_help",
       "BUNDLE_PLUGINS" => true,
       "BUNDLE_GLOBAL_GEM_CACHE" => false,
       "BUNDLE_UPDATE_REQUIRES_ALL_FLAG" => false,

--- a/bundler/spec/bundler/cli_spec.rb
+++ b/bundler/spec/bundler/cli_spec.rb
@@ -87,14 +87,10 @@ RSpec.describe "bundle executable" do
   end
 
   context "with no arguments" do
-    it "prints a concise help message by default" do
-      bundle ""
-      expect(err).to be_empty
-      expect(out).to include("Bundler version #{Bundler::VERSION}").
-        and include("\n\nBundler commands:\n\n").
-        and include("\n\n  Primary commands:\n").
-        and include("\n\n  Utilities:\n").
-        and include("\n\nOptions:\n")
+    it "installs and log a warning by default" do
+      bundle "", raise_on_error: false
+      expect(err).to include("running `bundle` without argument will no longer run `bundle install`.")
+      expect(err).to include("Could not locate Gemfile")
     end
 
     it "prints a concise help message when default_cli_command set to cli_help" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I'd like to propose introducing a deprecation/warning cycle on the change that running `bundle` no longer install gems by default.

In https://github.com/ruby/rubygems/commit/31d67ecc056fb5a9193bc66a6e69e21576a87702 we enforced the new behavior where running `bundle` no longer installs gems but displays the help instead. More context here https://github.com/ruby/rubygems/issues/8786

This behavior had existed for an eternity and I won't argue whether the default should change (especially since there is now a `default_cli_command` flag I can configure), but I think it would be more user friendly if we added a warning beforehand.

With the preview of Ruby 4.0 now being released, some people will start to see this new change.
I'd like to provide a deprecation/warning cycle because this is confusing users already and this breaks various CI setup that now needs to be changed immediately.

## What is your fix for the problem, implemented in this PR?

Continue to install by default but print a warning message about the change. Users can continue to configured the `default_cli_command` flag and in that case no warning will be displayed.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
