### PR TITLE
Check for file existence before deletion from cache

### DIFF
--- a/bundler/lib/bundler/runtime.rb
+++ b/bundler/lib/bundler/runtime.rb
@@ -244,7 +244,6 @@ module Bundler
           begin
             File.delete(path)
           rescue Errno::ENOENT
-            nil
           end
         end
       end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When a gem used to be in the cache, but another process deletes it first, this delete command fails with something like:

> Errno::ENOENT: No such file or directory @ apply2files - /opt/bundle/my-awesome-gem.gem
  /opt/hostedtoolcache/Ruby/3.4.7/arm64/lib/ruby/gems/3.4.0/gems/bundler-2.7.2/lib/bundler/runtime.rb:243:in 'File.delete'

## What is your fix for the problem, implemented in this PR?

To work around this, I'm rescuing the system call error and swallowing it. I'm aware that we just 'found' the files above, but this is where the race condition comes in.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
