### PR TITLE
Improve error messages and handling in tests

### DIFF
--- a/bundler/spec/bundler/retry_spec.rb
+++ b/bundler/spec/bundler/retry_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Bundler::Retry do
   end
 
   it "returns the first valid result" do
-    jobs = [proc { raise "foo" }, proc { :bar }, proc { raise "foo" }]
+    jobs = [proc { raise "job 1 failed" }, proc { :bar }, proc { raise "job 2 failed" }]
     attempts = 0
     result = Bundler::Retry.new(nil, nil, 3).attempt do
       attempts += 1

--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -1034,7 +1034,7 @@ RSpec.describe "bundle exec" do
               puts 'Started' # For process sync
               STDOUT.flush
               sleep 1 # ignore quality_spec
-              raise "Didn't receive INT at all"
+              raise RuntimeError, "Didn't receive expected INT"
             end.join
           rescue Interrupt
             puts "foo"
@@ -1218,7 +1218,7 @@ RSpec.describe "bundle exec" do
         build_repo4 do
           build_gem "openssl", openssl_version do |s|
             s.write("lib/openssl.rb", <<-RUBY)
-              raise "custom openssl should not be loaded, it's not in the gemfile!"
+              raise ArgumentError, "custom openssl should not be loaded"
             RUBY
           end
         end

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -688,13 +688,12 @@ RSpec.describe "bundle install with gem sources" do
     it "fails gracefully when downloading an invalid specification from the full index" do
       build_repo2(build_compact_index: false) do
         build_gem "ajp-rails", "0.0.0", gemspec: false, skip_validation: true do |s|
-          bad_deps = [["ruby-ajp", ">= 0.2.0"], ["rails", ">= 0.14"]]
+          invalid_deps = [["ruby-ajp", ">= 0.2.0"], ["rails", ">= 0.14"]]
           s.
             instance_variable_get(:@spec).
-            instance_variable_set(:@dependencies, bad_deps)
-
-          raise "failed to set bad deps" unless s.dependencies == bad_deps
+            instance_variable_set(:@dependencies, invalid_deps)
         end
+
         build_gem "ruby-ajp", "1.0.0"
       end
 

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -834,7 +834,7 @@ RSpec.describe "bundle lock" do
     bundle "lock --update --bundler --verbose", artifice: "compact_index", env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
     expect(lockfile).to end_with("BUNDLED WITH\n  55\n")
 
-    update_repo4 do
+    build_repo4 do
       build_gem "bundler", "99"
     end
 
@@ -1456,7 +1456,7 @@ RSpec.describe "bundle lock" do
     before do
       gemfile_with_rails_weakling_and_foo_from_repo4
 
-      update_repo4 do
+      build_repo4 do
         build_gem "foo", "2.0"
       end
 

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe "bundle update" do
 
       expect(the_bundle).to include_gems("slim 3.0.9", "slim-rails 3.1.3", "slim_lint 0.16.1")
 
-      update_repo4 do
+      build_repo4 do
         build_gem "slim", "4.0.0" do |s|
           s.add_dependency "tilt", [">= 2.0.6", "< 2.1"]
         end
@@ -572,7 +572,7 @@ RSpec.describe "bundle update" do
 
       expect(the_bundle).to include_gems("a 1.0", "b 1.0", "c 2.0")
 
-      update_repo4 do
+      build_repo4 do
         build_gem "b", "2.0" do |s|
           s.add_dependency "c", "< 2"
         end
@@ -976,7 +976,7 @@ RSpec.describe "bundle update" do
     bundle "update", all: true
     expect(out).to match(/Resolving dependencies\.\.\.\.*\nBundle updated!/)
 
-    update_repo4 do
+    build_repo4 do
       build_gem "foo", "2.0"
     end
 

--- a/bundler/spec/install/gemfile/gemspec_spec.rb
+++ b/bundler/spec/install/gemfile/gemspec_spec.rb
@@ -420,12 +420,13 @@ RSpec.describe "bundle install from an existing gemspec" do
         end
 
         build_lib "foo", path: bundled_app do |s|
-          if platform_specific_type == :runtime
+          case platform_specific_type
+          when :runtime
             s.add_runtime_dependency dependency
-          elsif platform_specific_type == :development
+          when :development
             s.add_development_dependency dependency
           else
-            raise "wrong dependency type #{platform_specific_type}, can only be :development or :runtime"
+            raise ArgumentError, "wrong dependency type #{platform_specific_type}, can only be :development or :runtime"
           end
         end
 

--- a/bundler/spec/install/gemfile/groups_spec.rb
+++ b/bundler/spec/install/gemfile/groups_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "bundle install with groups" do
         puts ACTIVESUPPORT
       R
 
-      expect(err_without_deprecations).to eq("ZOMG LOAD ERROR")
+      expect(err_without_deprecations).to match(/cannot load such file -- activesupport/)
     end
 
     it "installs gems with inline :groups into those groups" do
@@ -36,7 +36,7 @@ RSpec.describe "bundle install with groups" do
         puts THIN
       R
 
-      expect(err_without_deprecations).to eq("ZOMG LOAD ERROR")
+      expect(err_without_deprecations).to match(/cannot load such file -- thin/)
     end
 
     it "sets up everything if Bundler.setup is used with no groups" do
@@ -57,7 +57,7 @@ RSpec.describe "bundle install with groups" do
         puts THIN
       RUBY
 
-      expect(err_without_deprecations).to eq("ZOMG LOAD ERROR")
+      expect(err_without_deprecations).to match(/cannot load such file -- thin/)
     end
 
     it "sets up old groups when they have previously been removed" do

--- a/bundler/spec/install/gemfile/sources_spec.rb
+++ b/bundler/spec/install/gemfile/sources_spec.rb
@@ -570,7 +570,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
       bundle :install, artifice: "compact_index"
 
       # And then we add some new versions...
-      update_repo4 do
+      build_repo4 do
         build_gem "foo", "0.2"
         build_gem "bar", "0.3"
       end

--- a/bundler/spec/install/gems/compact_index_spec.rb
+++ b/bundler/spec/install/gems/compact_index_spec.rb
@@ -770,7 +770,7 @@ RSpec.describe "compact index api" do
       gem 'myrack', '0.9.1'
     G
 
-    update_repo4 do
+    build_repo4 do
       build_gem "myrack", "1.0.0"
     end
 
@@ -811,7 +811,7 @@ RSpec.describe "compact index api" do
       gem 'myrack', '0.9.1'
     G
 
-    update_repo4 do
+    build_repo4 do
       build_gem "myrack", "1.0.0"
     end
 
@@ -833,7 +833,7 @@ RSpec.describe "compact index api" do
       gem 'myrack', '0.9.1'
     G
 
-    update_repo4 do
+    build_repo4 do
       build_gem "myrack", "1.0.0"
     end
 

--- a/bundler/spec/install/gems/native_extensions_spec.rb
+++ b/bundler/spec/install/gems/native_extensions_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "installing a gem with native extensions" do
           require "mkmf"
           name = "c_extension_bundle"
           dir_config(name)
-          raise "OMG" unless with_config("c_extension") == "hello"
+          raise ArgumentError unless with_config("c_extension") == "hello"
           create_makefile(name)
         E
 
@@ -53,7 +53,7 @@ RSpec.describe "installing a gem with native extensions" do
         require "mkmf"
         name = "c_extension_bundle"
         dir_config(name)
-        raise "OMG" unless with_config("c_extension") == "hello"
+        raise ArgumentError unless with_config("c_extension") == "hello"
         create_makefile(name)
       E
 
@@ -97,7 +97,7 @@ RSpec.describe "installing a gem with native extensions" do
             require "mkmf"
             name = "c_extension_bundle_#{n}"
             dir_config(name)
-            raise "OMG" unless with_config("c_extension_#{n}") == "#{n}"
+            raise ArgumentError unless with_config("c_extension_#{n}") == "#{n}"
             create_makefile(name)
           E
 
@@ -149,7 +149,7 @@ RSpec.describe "installing a gem with native extensions" do
         require "mkmf"
         name = "c_extension_bundle"
         dir_config(name)
-        raise "OMG" unless with_config("c_extension") == "hello" && with_config("c_extension_bundle-dir") == "hola"
+        raise ArgumentError unless with_config("c_extension") == "hello" && with_config("c_extension_bundle-dir") == "hola"
         create_makefile(name)
       E
 

--- a/bundler/spec/install/gems/standalone_spec.rb
+++ b/bundler/spec/install/gems/standalone_spec.rb
@@ -385,7 +385,7 @@ RSpec.describe "bundle install --standalone" do
       RUBY
 
       expect(out).to eq("2.3.2")
-      expect(err).to eq("ZOMG LOAD ERROR")
+      expect(err_without_deprecations).to match(/cannot load such file -- spec/)
     end
 
     it "allows `without` configuration to limit the groups used in a standalone" do
@@ -403,7 +403,7 @@ RSpec.describe "bundle install --standalone" do
       RUBY
 
       expect(out).to eq("2.3.2")
-      expect(err).to eq("ZOMG LOAD ERROR")
+      expect(err_without_deprecations).to match(/cannot load such file -- spec/)
     end
 
     it "allows `path` configuration to change the location of the standalone bundle" do
@@ -437,7 +437,7 @@ RSpec.describe "bundle install --standalone" do
       RUBY
 
       expect(out).to eq("2.3.2")
-      expect(err).to eq("ZOMG LOAD ERROR")
+      expect(err_without_deprecations).to match(/cannot load such file -- spec/)
     end
   end
 
@@ -519,6 +519,6 @@ RSpec.describe "bundle install --standalone --local" do
     RUBY
 
     expect(out).to eq("1.0.0")
-    expect(err).to eq("ZOMG LOAD ERROR")
+    expect(err_without_deprecations).to match(/cannot load such file -- spec/)
   end
 end

--- a/bundler/spec/plugins/install_spec.rb
+++ b/bundler/spec/plugins/install_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe "bundler plugin install" do
       build_repo2 do
         build_plugin "chaplin" do |s|
           s.write "plugins.rb", <<-RUBY
-            raise "I got you man"
+            raise RuntimeError, "threw exception on load"
           RUBY
         end
       end

--- a/bundler/spec/realworld/edgecases_spec.rb
+++ b/bundler/spec/realworld/edgecases_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "real world edgecases", realworld: true do
         index.search(#{name.dump}).select {|spec| requirement.satisfied_by?(spec.version) }.last
       end
       if rubygem.nil?
-        raise "Could not find #{name} (#{requirement}) on rubygems.org!\n" \
+        raise ArgumentError, "Could not find #{name} (#{requirement}) on rubygems.org!\n" \
           "Found specs:\n\#{index.send(:specs).inspect}"
       end
       puts "#{name} (\#{rubygem.version})"

--- a/bundler/spec/support/artifice/compact_index_etag_match.rb
+++ b/bundler/spec/support/artifice/compact_index_etag_match.rb
@@ -4,7 +4,7 @@ require_relative "helpers/compact_index"
 
 class CompactIndexEtagMatch < CompactIndexAPI
   get "/versions" do
-    raise "ETag header should be present" unless env["HTTP_IF_NONE_MATCH"]
+    raise ArgumentError, "ETag header should be present" unless env["HTTP_IF_NONE_MATCH"]
     headers "ETag" => env["HTTP_IF_NONE_MATCH"]
     status 304
     body ""

--- a/bundler/spec/support/builders.rb
+++ b/bundler/spec/support/builders.rb
@@ -187,17 +187,25 @@ module Spec
 
     # A repo that has no pre-installed gems included. (The caller completely
     # determines the contents with the block.)
+    #
+    # If the repo already exists, `#update_repo` will be called.
     def build_repo3(**kwargs, &blk)
-      raise "gem_repo3 already exists -- use update_repo3 instead" if File.exist?(gem_repo3)
-      build_repo gem_repo3, **kwargs, &blk
+      if File.exist?(gem_repo3)
+        update_repo(gem_repo3, &blk)
+      else
+        build_repo gem_repo3, **kwargs, &blk
+      end
     end
 
     # Like build_repo3, this is a repo that has no pre-installed gems included.
-    # We have two different methods for situations where two different empty
-    # sources are needed.
+    #
+    # If the repo already exists, `#udpate_repo` will be called
     def build_repo4(**kwargs, &blk)
-      raise "gem_repo4 already exists -- use update_repo4 instead" if File.exist?(gem_repo4)
-      build_repo gem_repo4, **kwargs, &blk
+      if File.exist?(gem_repo4)
+        update_repo gem_repo4, &blk
+      else
+        build_repo gem_repo4, **kwargs, &blk
+      end
     end
 
     def update_repo2(**kwargs, &blk)
@@ -206,10 +214,6 @@ module Spec
 
     def update_repo3(&blk)
       update_repo(gem_repo3, &blk)
-    end
-
-    def update_repo4(&blk)
-      update_repo(gem_repo4, &blk)
     end
 
     def build_security_repo
@@ -420,8 +424,6 @@ module Spec
 
     class BundlerBuilder
       def initialize(context, name, version)
-        raise "can only build bundler" unless name == "bundler"
-
         @context = context
         @spec = Spec::Path.loaded_gemspec.dup
         @spec.version = version || Bundler::VERSION

--- a/bundler/spec/support/helpers.rb
+++ b/bundler/spec/support/helpers.rb
@@ -28,8 +28,8 @@ module Spec
       Gem.clear_paths
     end
 
-    def the_bundle(*args)
-      TheBundle.new(*args)
+    def the_bundle
+      TheBundle.new
     end
 
     MAJOR_DEPRECATION = /^\[DEPRECATED\]\s*/
@@ -54,7 +54,7 @@ module Spec
         begin
           #{ruby}
         rescue LoadError => e
-          warn "ZOMG LOAD ERROR" if e.message.include?("-- #{name}")
+          warn e.message if e.message.include?("-- #{name}")
         end
       RUBY
       opts = args.last.is_a?(Hash) ? args.pop : {}
@@ -132,7 +132,7 @@ module Spec
         begin
           #{ruby}
         rescue LoadError => e
-          warn "ZOMG LOAD ERROR" if e.message.include?("-- #{name}")
+          warn e.message if e.message.include?("-- #{name}")
         end
       R
     end
@@ -324,7 +324,7 @@ module Spec
     end
 
     def install_gem(path, install_dir, default = false)
-      raise "OMG `#{path}` does not exist!" unless File.exist?(path)
+      raise ArgumentError, "`#{path}` does not exist!" unless File.exist?(path)
 
       args = "--no-document --ignore-dependencies --verbose --local --install-dir #{install_dir}"
 
@@ -415,7 +415,7 @@ module Spec
 
       gems.each do |g|
         path = "#{gem_repo}/gems/#{g}.gem"
-        raise "OMG `#{path}` does not exist!" unless File.exist?(path)
+        raise ArgumentError, "`#{path}` does not exist!" unless File.exist?(path)
         FileUtils.cp(path, "#{bundled_app}/vendor/cache")
       end
     end

--- a/bundler/spec/support/matchers.rb
+++ b/bundler/spec/support/matchers.rb
@@ -52,7 +52,7 @@ module Spec
     end
 
     def self.define_compound_matcher(matcher, preconditions, &declarations)
-      raise "Must have preconditions to define a compound matcher" if preconditions.empty?
+      raise ArgumentError, "Must have preconditions to define a compound matcher" if preconditions.empty?
       define_method(matcher) do |*expected, &block_arg|
         Precondition.new(
           RSpec::Matchers::DSL::Matcher.new(matcher, declarations, self, *expected, &block_arg),

--- a/bundler/spec/support/the_bundle.rb
+++ b/bundler/spec/support/the_bundle.rb
@@ -8,10 +8,8 @@ module Spec
 
     attr_accessor :bundle_dir
 
-    def initialize(opts = {})
-      opts = opts.dup
-      @bundle_dir = Pathname.new(opts.delete(:bundle_dir) { bundled_app })
-      raise "Too many options! #{opts}" unless opts.empty?
+    def initialize
+      @bundle_dir = Pathname.new(bundled_app)
     end
 
     def to_s
@@ -28,7 +26,7 @@ module Spec
     end
 
     def locked_gems
-      raise "Cannot read lockfile if it doesn't exist" unless locked?
+      raise ArgumentError, "Cannot read lockfile if it doesn't exist" unless locked?
       Bundler::LockfileParser.new(lockfile.read)
     end
 


### PR DESCRIPTION
This is a first pass to improve the way errors are handled and raised in
bundler's tests. The goal is to clean up tests and modernize them -
these were some obvious areas that could be cleaned up.

- Instead of raising "ZOMG" in the load error tests, it now tests for
the actual error and gem raising.
- Improve error messages where applicable.
- All errors raise a specific error class, rather than falling back to a
default and just setting a message.
- Removed arguments and `bundle_dir` option from `TheBundle` class as it wasn't
actually used so therefore we don't need to raise an error for extra
arguments.
- Removed error from `BundlerBuilder`, as it won't work if it's not
`bundler`, also it never uses `name`. The only reaon `name` is passed
in is because of metaprogramming on loading the right builder. I
think that should eventually be refactored.
- Replaced and removed `update_repo3` and `update_repo4` in favor of
just `build_repo3` and `build_repo4`. Rather than tell someone writing
tests to use a different method, automatically use the right method.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
