### PR TITLE
Keep legacy windows platform, not removed them

### DIFF
--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -415,8 +415,8 @@ module Bundler
       windows_platforms = platforms.select {|pl| pl.to_s.match?(/mingw|mswin/) }
       if windows_platforms.any?
         windows_platforms = windows_platforms.map! {|pl| ":#{pl}" }.join(", ")
-        removed_message = "Platform #{windows_platforms} has been removed. Please use platform :windows instead."
-        Bundler::SharedHelpers.feature_removed! removed_message
+        deprecated_message = "Platform #{windows_platforms} will be removed in the future. Please use platform :windows instead."
+        Bundler::SharedHelpers.feature_deprecated! deprecated_message
       end
 
       # Save sources passed in a key

--- a/bundler/spec/bundler/dsl_spec.rb
+++ b/bundler/spec/bundler/dsl_spec.rb
@@ -221,8 +221,8 @@ RSpec.describe Bundler::Dsl do
         to raise_error(Bundler::GemfileError, /is not a valid platform/)
     end
 
-    it "raises an error for legacy windows platforms" do
-      expect(Bundler::SharedHelpers).to receive(:feature_removed!).with(/\APlatform :mswin, :x64_mingw has been removed/)
+    it "warn for legacy windows platforms" do
+      expect(Bundler::SharedHelpers).to receive(:feature_deprecated!).with(/\APlatform :mswin, :x64_mingw will be removed in the future./)
       subject.gem("foo", platforms: [:mswin, :jruby, :x64_mingw])
     end
 
@@ -291,8 +291,8 @@ RSpec.describe Bundler::Dsl do
   end
 
   describe "#platforms" do
-    it "raises an error for legacy windows platforms" do
-      expect(Bundler::SharedHelpers).to receive(:feature_removed!).with(/\APlatform :mswin64, :mingw has been removed/)
+    it "warn for legacy windows platforms" do
+      expect(Bundler::SharedHelpers).to receive(:feature_deprecated!).with(/\APlatform :mswin64, :mingw will be removed in the future./)
       subject.platforms(:mswin64, :jruby, :mingw) do
         subject.gem("foo")
       end

--- a/bundler/spec/commands/cache_spec.rb
+++ b/bundler/spec/commands/cache_spec.rb
@@ -207,15 +207,15 @@ RSpec.describe "bundle cache" do
       expect(bundled_app("vendor/cache/myrack-1.0.0.gem")).to exist
     end
 
-    it "prints an error when using legacy windows rubies" do
+    it "prints a warn when using legacy windows rubies" do
       gemfile <<-D
         source "https://gem.repo1"
         gem 'myrack', :platforms => [:ruby_20, :x64_mingw_20]
       D
 
       bundle "cache --all-platforms", raise_on_error: false
-      expect(err).to include("removed")
-      expect(bundled_app("vendor/cache/myrack-1.0.0.gem")).not_to exist
+      expect(err).to include("will be removed in the future")
+      expect(bundled_app("vendor/cache/myrack-1.0.0.gem")).to exist
     end
 
     it "does not attempt to install gems in without groups" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler 4.0.0.beta1 couldn't parse legacy windows platform with Gemfile.

```
❯ bundle install
[REMOVED] Platform :mingw, :x64_mingw, :mswin has been removed. Please use platform :windows instead.
```

It's unexpected behavior for me. I also need to revert this PR with https://github.com/ruby/rubygems/pull/9023.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
