### PR TITLE
Respect `BUNDLE_VERSION` config at Gem::BundlerVersionFinder

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -335,6 +335,9 @@ class Gem::TestCase < Test::Unit::TestCase
     ENV["XDG_STATE_HOME"] = nil
     ENV["SOURCE_DATE_EPOCH"] = nil
     ENV["BUNDLER_VERSION"] = nil
+    ENV["BUNDLE_CONFIG"] = nil
+    ENV["BUNDLE_USER_CONFIG"] = nil
+    ENV["BUNDLE_USER_HOME"] = nil
     ENV["RUBYGEMS_PREVENT_UPDATE_SUGGESTION"] = "true"
 
     @current_dir = Dir.pwd


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If we use "system" variable in `BUNDLE_VERSION` on Bundler configuration, we can use bundler version provided by system installation.

But the current logic returns the first activated version of bundler like `2.7.2`. It makes to confuse users.

```
❯ bundle -v # This is without lockfile
4.0.0.beta1
# with lockfile
❯ rg -A1 "BUNDLED WITH" Gemfile.lock
594:BUNDLED WITH
595-   2.7.2
❯ bundle -v
Bundler version 2.7.2
❯ bundle i # This behavior is 4.0.0.beta1, not 2.7.2
[DEPRECATED] Platform :mingw, :x64_mingw, :mswin is deprecated. Please use platform :windows instead.
(snip...)
```

## What is your fix for the problem, implemented in this PR?

Activate the correct system version with "system" variable.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
