### PR TITLE
Rewrite pr_ids with pr search command instead of merge commit message

### DIFF
--- a/tool/release.rb
+++ b/tool/release.rb
@@ -323,7 +323,13 @@ class Release
   end
 
   def unreleased_pr_ids
-    commits = `git log --format=%h #{@previous_release_tag}..HEAD`.split("\n")
+    commits = if @level == :minor_or_major
+      `git log --format=%h #{@previous_release_tag}..HEAD`.split("\n")
+    else
+      `git log --format=%B #{@previous_release_tag}..HEAD`.split("\n").filter_map do |line|
+        line[/\(cherry picked from commit ([0-9a-f]+)\)/, 1]&.slice(0, 12)
+      end
+    end
 
     # GitHub search API has a rate limit of 30 requests per minute for authenticated users
     rate_limit = 28


### PR DESCRIPTION
I prefer to use rebase and squash merge but the current generator only support merge commit.

I rewrite that generator with `gh search prs` feature. That works with tag to tag range like `4.0.0.beta1..4.0.0.beta2` or `4.0.0..4.0.1`.

But this is not working with `4.0.0..4.1.0` at master branch because we faced rate limit of gh cli. We need to consider exclude backport commits from stable branch like `4.0`.