### PR TITLE
Undeprecate Gem::Version#<=> against strings

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -344,9 +344,6 @@ class Gem::Version
 
   def <=>(other)
     if String === other
-      unless Gem::Deprecate.skip
-        warn "comparing version objects with strings is deprecated and will be removed", uplevel: 1
-      end
       return unless self.class.correct?(other)
       return self <=> self.class.new(other)
     end

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -160,11 +160,7 @@ class TestGemVersion < Gem::TestCase
       [-1, "1.9.3.1"],
       [nil, "whatever"],
     ].each do |cmp, string_ver|
-      actual_stdout, actual_stderr = capture_output do
-        assert_equal(cmp, v("1.9.3") <=> string_ver)
-      end
-      assert_empty actual_stdout
-      assert_match(/comparing version objects with strings is deprecated and will be removed/, actual_stderr)
+      assert_equal(cmp, v("1.9.3") <=> string_ver)
     end
   end
 


### PR DESCRIPTION
Reverts: https://github.com/ruby/rubygems/pull/9085

This pattern is extremely common across the ecosystem, I don't think it's reasonable to deprecate it.

I understand the performance argument, but perhaps the dependency resolution algorithm can use another method that is private API and only works with two `Version` instance.

Discussed with @tenderlove 