### PR TITLE
Support bundle install --lockfile option

### DIFF
--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -44,6 +44,7 @@ module Bundler
       # (rather than some optimizations we perform at app runtime).
       definition = Bundler.definition(strict: true)
       definition.validate_runtime!
+      definition.lockfile = options["lockfile"] if options["lockfile"]
       definition.lockfile = false if options["no-lock"]
 
       installer = Installer.install(Bundler.root, definition, options)

--- a/bundler/lib/bundler/man/bundle-install.1
+++ b/bundler/lib/bundler/man/bundle-install.1
@@ -4,7 +4,7 @@
 .SH "NAME"
 \fBbundle\-install\fR \- Install the dependencies specified in your Gemfile
 .SH "SYNOPSIS"
-\fBbundle install\fR [\-\-force] [\-\-full\-index] [\-\-gemfile=GEMFILE] [\-\-jobs=NUMBER] [\-\-local] [\-\-no\-cache] [\-\-no\-lock] [\-\-prefer\-local] [\-\-quiet] [\-\-retry=NUMBER] [\-\-standalone[=GROUP[ GROUP\|\.\|\.\|\.]]] [\-\-trust\-policy=TRUST\-POLICY] [\-\-target\-rbconfig=TARGET\-RBCONFIG]
+\fBbundle install\fR [\-\-force] [\-\-full\-index] [\-\-gemfile=GEMFILE] [\-\-jobs=NUMBER] [\-\-local] [\-\-lockfile=LOCKFILE] [\-\-no\-cache] [\-\-no\-lock] [\-\-prefer\-local] [\-\-quiet] [\-\-retry=NUMBER] [\-\-standalone[=GROUP[ GROUP\|\.\|\.\|\.]]] [\-\-trust\-policy=TRUST\-POLICY] [\-\-target\-rbconfig=TARGET\-RBCONFIG]
 .SH "DESCRIPTION"
 Install the gems specified in your Gemfile(5)\. If this is the first time you run bundle install (and a \fBGemfile\.lock\fR does not exist), Bundler will fetch all remote sources, resolve dependencies and install all needed gems\.
 .P
@@ -27,6 +27,9 @@ The maximum number of parallel download and install jobs\. The default is the nu
 .TP
 \fB\-\-local\fR
 Do not attempt to connect to \fBrubygems\.org\fR\. Instead, Bundler will use the gems already present in Rubygems' cache or in \fBvendor/cache\fR\. Note that if an appropriate platform\-specific gem exists on \fBrubygems\.org\fR it will not be found\.
+.TP
+\fB\-\-lockfile=LOCKFILE\fR
+The location of the lockfile which Bundler should use\. This defaults to the Gemfile location with \fB\.lock\fR appended\.
 .TP
 \fB\-\-prefer\-local\fR
 Force using locally installed gems, or gems already present in Rubygems' cache or in \fBvendor/cache\fR, when resolving, even if newer versions are available remotely\. Only attempt to connect to \fBrubygems\.org\fR for gems that are not present locally\.

--- a/bundler/lib/bundler/man/bundle-install.1.ronn
+++ b/bundler/lib/bundler/man/bundle-install.1.ronn
@@ -8,6 +8,7 @@ bundle-install(1) -- Install the dependencies specified in your Gemfile
                  [--gemfile=GEMFILE]
                  [--jobs=NUMBER]
                  [--local]
+                 [--lockfile=LOCKFILE]
                  [--no-cache]
                  [--no-lock]
                  [--prefer-local]
@@ -60,6 +61,10 @@ update process below under [CONSERVATIVE UPDATING][].
   gems already present in Rubygems' cache or in `vendor/cache`. Note that if an
   appropriate platform-specific gem exists on `rubygems.org` it will not be
   found.
+
+* `--lockfile=LOCKFILE`:
+  The location of the lockfile which Bundler should use. This defaults
+  to the Gemfile location with `.lock` appended.
 
 * `--prefer-local`:
   Force using locally installed gems, or gems already present in Rubygems' cache

--- a/bundler/lib/bundler/man/gemfile.5
+++ b/bundler/lib/bundler/man/gemfile.5
@@ -492,10 +492,12 @@ When determining path to the lockfile or whether to create a lockfile, the follo
 .IP "1." 4
 The \fBbundle install\fR \fB\-\-no\-lock\fR option (which disables lockfile creation)\.
 .IP "2." 4
-The \fBlockfile\fR method in the Gemfile\.
+The \fBbundle install\fR \fB\-\-lockfile\fR option\.
 .IP "3." 4
-The \fBBUNDLE_LOCKFILE\fR environment variable\.
+The \fBlockfile\fR method in the Gemfile\.
 .IP "4." 4
+The \fBBUNDLE_LOCKFILE\fR environment variable\.
+.IP "5." 4
 The default behavior of adding \fB\.lock\fR to the end of the Gemfile name\.
 .IP "" 0
 

--- a/bundler/lib/bundler/man/gemfile.5.ronn
+++ b/bundler/lib/bundler/man/gemfile.5.ronn
@@ -580,6 +580,7 @@ When determining path to the lockfile or whether to create a lockfile, the
 following precedence is used:
 
 1. The `bundle install` `--no-lock` option (which disables lockfile creation).
-2. The `lockfile` method in the Gemfile.
-3. The `BUNDLE_LOCKFILE` environment variable.
-4. The default behavior of adding `.lock` to the end of the Gemfile name.
+1. The `bundle install` `--lockfile` option.
+1. The `lockfile` method in the Gemfile.
+1. The `BUNDLE_LOCKFILE` environment variable.
+1. The default behavior of adding `.lock` to the end of the Gemfile name.

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -41,6 +41,17 @@ RSpec.describe "bundle install with gem sources" do
       expect(bundled_app("OmgFile.lock")).to exist
     end
 
+    it "creates lockfile based on --lockfile option is given" do
+      gemfile bundled_app("OmgFile"), <<-G
+        source "https://gem.repo1"
+        gem "myrack", "1.0"
+      G
+
+      bundle "install --gemfile OmgFile --lockfile ReallyOmgFile.lock"
+
+      expect(bundled_app("ReallyOmgFile.lock")).to exist
+    end
+
     it "does not make a lockfile if lockfile false is used in Gemfile" do
       install_gemfile <<-G
         lockfile false
@@ -98,6 +109,18 @@ RSpec.describe "bundle install with gem sources" do
       bundle "install --gemfile OmgFile --no-lock"
 
       expect(bundled_app("OmgFile.lock")).not_to exist
+    end
+
+    it "doesn't create a lockfile if --no-lock and --lockfile options are given" do
+      gemfile bundled_app("OmgFile"), <<-G
+        source "https://gem.repo1"
+        gem "myrack", "1.0"
+      G
+
+      bundle "install --gemfile OmgFile --no-lock --lockfile ReallyOmgFile.lock"
+
+      expect(bundled_app("OmgFile.lock")).not_to exist
+      expect(bundled_app("ReallyOmgFile.lock")).not_to exist
     end
 
     it "doesn't delete the lockfile if one already exists" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We recently introduced `lockfile` method inside the Gemfile, as well as the `BUNDLE_LOCKFILE` environment variable. However, while `bundle lock` supports a `--lockfile` option for specifying the lockfile, `bundle install` currently supports a `--gemfile` option, but not a `--lockfile` option. This makes using a custom lockfile more challenging to than using a custom gemfile.

## What is your fix for the problem, implemented in this PR?

This adds support for a `--lockfile` option to `bundle install`. This makes it easier for the user to use custom lockfiles, using a similar approach as currently allowed for custom gemfiles.

When the `--lockfile` option is used, it is applied twice. First, before the Gemfile is read, to specify the lockfile to operate on, and again after the Gemfile is read, so that if the Gemfile has a `lockfile` method that overrides the definition's lockfile, the `--lockfile` option still has higher precedence.

@colby-swandale mentioned this approach in  https://github.com/ruby/rubygems/pull/9059#discussion_r2532529194 as a possible follow-up to that PR. I agreed, and this is that follow-up PR.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
