### PR TITLE
Add SIGABRT to reserved signals in bundler spec

### DIFF
--- a/bundler/spec/commands/exec_spec.rb
+++ b/bundler/spec/commands/exec_spec.rb
@@ -1020,7 +1020,7 @@ RSpec.describe "bundle exec" do
     context "signal handling" do
       let(:test_signals) do
         open3_reserved_signals = %w[CHLD CLD PIPE]
-        reserved_signals = %w[SEGV BUS ILL FPE VTALRM KILL STOP EXIT]
+        reserved_signals = %w[SEGV BUS ILL FPE ABRT IOT VTALRM KILL STOP EXIT]
         bundler_signals = %w[INT]
 
         Signal.list.keys - (bundler_signals + reserved_signals + open3_reserved_signals)


### PR DESCRIPTION
Reverse sync https://github.com/ruby/ruby/commit/35445a736f509e6edbba8a08d8e4af69c206368a
