### PR TITLE
Make gemspec version dynamic by reading from rubygems.rb and add test

### DIFF
--- a/rubygems-update.gemspec
+++ b/rubygems-update.gemspec
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+version = File.read(File.join(__dir__, "lib", "rubygems.rb"))[/^\s*VERSION\s*=\s*"(.*)"/, 1]
+
 Gem::Specification.new do |s|
   s.name = "rubygems-update"
-  s.version = "4.0.0.beta1"
+  s.version = version
   s.authors = ["Jim Weirich", "Chad Fowler", "Eric Hodel", "Luis Lavena", "Aaron Patterson", "Samuel Giddins", "André Arko", "Evan Phoenix", "Hiroshi SHIBATA"]
   s.email = ["", "", "drbrain@segment7.net", "luislavena@gmail.com", "aaron@tenderlovemaking.com", "segiddins@segiddins.me", "andre@arko.net", "evan@phx.io", "hsbt@ruby-lang.org"]
 

--- a/test/test_gemspec.rb
+++ b/test/test_gemspec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative "rubygems/helper"
+
+class GemspecTest < Test::Unit::TestCase
+  def setup
+    @gemspec = Gem::Specification.load(File.expand_path("../rubygems-update.gemspec", __dir__))
+  end
+
+  def test_gemspec_version
+    assert_equal Gem::Version, @gemspec.version.class
+    assert_equal Gem::VERSION, @gemspec.version.to_s
+  end
+end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In release time, I update the release version to three files. I would like to reduce them.

## What is your fix for the problem, implemented in this PR?

Read `Gem::VERSION` from `rubygems.rb` and use it with `rubygems-update.gemspec`

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
