### PR TITLE
Remove Ruby 3.2 from Windows CI matrix to improve build times

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -38,7 +38,7 @@ jobs:
           - { os: { name: macOS, value: macos-15 }, ruby: { name: ruby-3.3, value: 3.3.9 }, timeout: 90 }
           - { os: { name: macOS, value: macos-15 }, ruby: { name: ruby-3.4, value: 3.4.5 }, timeout: 90 }
 
-          - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-3.2, value: 3.2.9 }, timeout: 150 }
+          # Ruby 3.2 is about 20 minutes slower than 3.3/3.4, so it will be excluded from testing.
           - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-3.3, value: 3.3.9 }, timeout: 150 }
           - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-3.4, value: 3.4.5 }, timeout: 150 }
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I would like to exclude Ruby 3.2 from Windows CI. 

* Ruby 3.2 is `1h 14m 14s`: https://github.com/ruby/rubygems/actions/runs/19693867510/job/56414934342?pr=9122
* Ruby 3.3 is `58m 31s`: https://github.com/ruby/rubygems/actions/runs/19693867510/job/56414934373?pr=9122

I always wait to finish only Ruby 3.2 everytime. It's not useful for development.

