### PR TITLE
Restore `install` as default command

### DIFF
--- a/bundler/lib/bundler/vendor/thor/lib/thor.rb
+++ b/bundler/lib/bundler/vendor/thor/lib/thor.rb
@@ -625,7 +625,7 @@ class Bundler::Thor
     # alias name.
     def find_command_possibilities(meth)
       len = meth.to_s.length
-      possibilities = all_commands.merge(map).keys.select { |n| meth == n[0, len] }.sort
+      possibilities = all_commands.reject { |_k, c| c.hidden? }.merge(map).keys.select { |n| meth == n[0, len] }.sort
       unique_possibilities = possibilities.map { |k| map[k] || k }.uniq
 
       if possibilities.include?(meth)

--- a/bundler/spec/bundler/cli_spec.rb
+++ b/bundler/spec/bundler/cli_spec.rb
@@ -87,26 +87,15 @@ RSpec.describe "bundle executable" do
   end
 
   context "with no arguments" do
-    it "installs by default" do
+    it "tries to installs by default but print help on missing Gemfile" do
       bundle "", raise_on_error: false
       expect(err).to include("Could not locate Gemfile")
-    end
 
-    it "prints a concise help message when default_cli_command set to cli_help" do
-      bundle "config set default_cli_command cli_help"
-      bundle ""
-      expect(err).to be_empty
       expect(out).to include("Bundler version #{Bundler::VERSION}").
         and include("\n\nBundler commands:\n\n").
         and include("\n\n  Primary commands:\n").
         and include("\n\n  Utilities:\n").
         and include("\n\nOptions:\n")
-    end
-
-    it "runs bundle install when default_cli_command set to install" do
-      bundle "config set default_cli_command install"
-      bundle "", raise_on_error: false
-      expect(err).to include("Could not locate Gemfile")
     end
   end
 

--- a/bundler/spec/other/cli_dispatch_spec.rb
+++ b/bundler/spec/other/cli_dispatch_spec.rb
@@ -15,6 +15,6 @@ RSpec.describe "bundle command names" do
 
   it "print a friendly error when ambiguous" do
     bundle "in", raise_on_error: false
-    expect(err).to eq("Ambiguous command in matches [info, init, inject, install]")
+    expect(err).to eq("Ambiguous command in matches [info, init, install]")
   end
 end


### PR DESCRIPTION
Fix: https://github.com/ruby/rubygems/issues/9124

This behavior is a deeply entrenched convention and changing it will annoy lots of developers with unclear gains.
