### PR TITLE
Remove italic formatting from changelog section headers

### DIFF
--- a/tool/changelog.rb
+++ b/tool/changelog.rb
@@ -77,13 +77,7 @@ class Changelog
   end
 
   def release_notes_for_blog
-    release_notes.map do |line|
-      if change_types.include?(line)
-        "_#{line}_"
-      else
-        line
-      end
-    end
+    release_notes
   end
 
   def change_types_for_blog


### PR DESCRIPTION
Fixed for https://github.com/rubygems/rubygems.github.io/pull/244