### PR TITLE
Keep install as the default command and print how to show the help on `$ bundle`

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -126,11 +126,9 @@ module Bundler
       default_cli_command = Bundler.settings[:default_cli_command]
       return default_cli_command if default_cli_command
 
-      Bundler.ui.warn(<<~MSG)
-        In the next version of Bundler, running `bundle` without argument will no longer run `bundle install`.
-        Instead, the `help` command will be displayed.
-
-        If you'd like to keep the previous behaviour please run `bundle config set default_cli_command install --global`.
+      Bundler.ui.info(<<~MSG)
+        Running `bundle` without argument runs `bundle install`.
+        If you want the help, use `bundle --help`.
       MSG
 
       "install"

--- a/bundler/spec/bundler/cli_spec.rb
+++ b/bundler/spec/bundler/cli_spec.rb
@@ -87,9 +87,9 @@ RSpec.describe "bundle executable" do
   end
 
   context "with no arguments" do
-    it "installs and log a warning by default" do
+    it "installs by default and prints how to show the help" do
       bundle "", raise_on_error: false
-      expect(err).to include("running `bundle` without argument will no longer run `bundle install`.")
+      expect(out).to include("If you want the help, use `bundle --help`.")
       expect(err).to include("Could not locate Gemfile")
     end
 


### PR DESCRIPTION
* Fixes https://github.com/ruby/rubygems/issues/9124.

## What was the end-user or developer problem that led to this PR?

Changing the default command, even if done in a future release is massive breaking change, and only benefits a few users which expect `$ bundle` to show the help, as described in https://github.com/ruby/rubygems/issues/9124.
Asking everyone to configure things is very annoying and leads to "it works on my machine but not on yours".

To avoid the breakage and satisfy what both groups of users want, we print a message on `$ bundle` for how to show the help.

## What is your fix for the problem, implemented in this PR?

I print a message on `$ bundle` for how to show the help.
Example:
```ruby
$ cat Gemfile
source 'https://rubygems.org'
gem "path"
group :dev do
  gem "rubocop"
end
```

```
$ bundle 
Running `bundle` without argument runs `bundle install`.
If you want the help, use `bundle --help`.
Fetching gem metadata from https://rubygems.org/...........
Resolving dependencies...
Fetching ast 2.4.3
Fetching lint_roller 1.1.0
Fetching json 2.16.0
Fetching language_server-protocol 3.17.0.5
Fetching parallel 1.27.0
Fetching racc 1.8.1
Fetching path 2.1.0
Fetching prism 1.6.0
Fetching rainbow 3.1.1
Fetching regexp_parser 2.11.3
Fetching ruby-progressbar 1.13.0
Fetching unicode-emoji 4.1.0
Installing lint_roller 1.1.0
Installing ast 2.4.3
Installing json 2.16.0 with native extensions
Installing language_server-protocol 3.17.0.5
Installing parallel 1.27.0
Installing racc 1.8.1 with native extensions
Installing path 2.1.0
Installing rainbow 3.1.1
Installing regexp_parser 2.11.3
Installing ruby-progressbar 1.13.0
Installing unicode-emoji 4.1.0
Installing prism 1.6.0 with native extensions
Fetching unicode-display_width 3.2.0
Installing unicode-display_width 3.2.0
Fetching parser 3.3.10.0
Installing parser 3.3.10.0
Fetching rubocop-ast 1.48.0
Installing rubocop-ast 1.48.0
Fetching rubocop 1.81.7
Installing rubocop 1.81.7
Bundle complete! 2 Gemfile dependencies, 17 gems now installed.
Bundled gems are installed into `./vendor/bundle`
```

The extra 2 lines seems a good compromise to handle the expectations from both groups of users.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
