### PR TITLE
Add `MAKEFLAGS=-j` by default before compiling:

### DIFF
--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -40,6 +40,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
       end
 
       ENV["DESTDIR"] = nil
+      ENV["MAKEFLAGS"] ||= "-j#{Etc.nprocessors + 1}"
 
       make dest_path, results, extension_dir, tmp_dest_relative, target_rbconfig: target_rbconfig
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We can make compilation sometimes faster by building recipes simultaneously.

## What is your fix for the problem, implemented in this PR?

Add `MAKEFLAGS=-j` by default before compiling:

Depending on the native extension, it can reduce compilation time when executing recipes simultaneously.

For example on Prism:

```
# Before

time gem install prism
Building native extensions. This could take a while...
Successfully installed prism-1.6.0 1 gem installed

gem install prism  3.61s user 0.80s system 95% cpu 4.595 total
```

```
# After

time MAKEFLAGS="-j" gem install prism
Building native extensions. This could take a while...
Successfully installed prism-1.6.0 1 gem installed

MAKEFLAGS="-j" gem install prism  4.47s user 1.27s system 246% cpu 2.330 total
```

I don't think adding `-j` as a default is harmful, but I'm admittedly not very knowledgable when it comes to compiler.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)

cc/ @tenderlove