### PR TITLE
Fixed checksums generation issue when no source is specified

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -539,6 +539,8 @@ module Bundler
     end
 
     def add_checksums
+      require "rubygems/package"
+
       @locked_checksums = true
 
       setup_domain!(add_checksums: true)


### PR DESCRIPTION
Fixes https://github.com/ruby/rubygems/issues/9118

/cc @voxik

Bundler will raise `NameError: uninitialized constant Gem::Package` when we didn't specify `sources:` and all gems coming from the local installation like default gems, rpm sources. 

To avoid attempting to fetch or insert checksums.

@Edouard-chin Could you review this? I would like to your comment because you changed `add_checksums` recently.