### PR TITLE
Fix test failure of mswin and nmake

### DIFF
--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -40,7 +40,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
       end
 
       ENV["DESTDIR"] = nil
-      unless RbConfig::CONFIG["MAKE"] =~ /nmake/
+      unless RbConfig::CONFIG["MAKE"]&.include?("nmake")
         ENV["MAKEFLAGS"] ||= "-j#{Etc.nprocessors + 1}"
       end
 


### PR DESCRIPTION
Fix up with https://github.com/ruby/rubygems/pull/9131

nmake didn't support -j flag. It caused to test failure of mswin environment.

https://github.com/ruby/ruby/actions/runs/19773742397/job/56662777457