### PR TITLE
Fixup nmake failure 

### DIFF
--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -40,7 +40,7 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
       end
 
       ENV["DESTDIR"] = nil
-      unless RUBY_PLATFORM =~ /mswin/ && RbConfig::CONFIG["configure_args"]&.include?("nmake")
+      unless RUBY_PLATFORM.include?("mswin") && RbConfig::CONFIG["configure_args"]&.include?("nmake")
         ENV["MAKEFLAGS"] ||= "-j#{Etc.nprocessors + 1}"
       end
 


### PR DESCRIPTION
#9135 is incomplete. We need to look `RUBY_PLATFORM` and `configure_args`.