### PR TITLE
Make BUNDLE_LOCKFILE environment variable have precedence over lockfile method in Gemfile

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -69,7 +69,7 @@ module Bundler
 
       # lock --lockfile works differently than install --lockfile
       unless current_cmd == "lock"
-        custom_lockfile = options[:lockfile] || Bundler.settings[:lockfile]
+        custom_lockfile = options[:lockfile] || ENV["BUNDLE_LOCKFILE"] || Bundler.settings[:lockfile]
         if custom_lockfile && !custom_lockfile.empty?
           Bundler::SharedHelpers.set_env "BUNDLE_LOCKFILE", File.expand_path(custom_lockfile)
           reset_settings = true
@@ -282,8 +282,10 @@ module Bundler
       end
 
       require_relative "cli/install"
+      options = self.options.dup
+      options["lockfile"] ||= ENV["BUNDLE_LOCKFILE"]
       Bundler.settings.temporary(no_install: false) do
-        Install.new(options.dup).run
+        Install.new(options).run
       end
     end
 

--- a/bundler/lib/bundler/man/gemfile.5
+++ b/bundler/lib/bundler/man/gemfile.5
@@ -494,9 +494,9 @@ The \fBbundle install\fR \fB\-\-no\-lock\fR option (which disables lockfile crea
 .IP "2." 4
 The \fBbundle install\fR \fB\-\-lockfile\fR option\.
 .IP "3." 4
-The \fBlockfile\fR method in the Gemfile\.
-.IP "4." 4
 The \fBBUNDLE_LOCKFILE\fR environment variable\.
+.IP "4." 4
+The \fBlockfile\fR method in the Gemfile\.
 .IP "5." 4
 The default behavior of adding \fB\.lock\fR to the end of the Gemfile name\.
 .IP "" 0

--- a/bundler/lib/bundler/man/gemfile.5.ronn
+++ b/bundler/lib/bundler/man/gemfile.5.ronn
@@ -581,6 +581,6 @@ following precedence is used:
 
 1. The `bundle install` `--no-lock` option (which disables lockfile creation).
 1. The `bundle install` `--lockfile` option.
-1. The `lockfile` method in the Gemfile.
 1. The `BUNDLE_LOCKFILE` environment variable.
+1. The `lockfile` method in the Gemfile.
 1. The default behavior of adding `.lock` to the end of the Gemfile name.

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -41,6 +41,20 @@ RSpec.describe "bundle install with gem sources" do
       expect(bundled_app("OmgFile.lock")).to exist
     end
 
+    it "creates lockfile using BUNDLE_LOCKFILE instead of lockfile method" do
+      ENV["BUNDLE_LOCKFILE"] = "ReallyOmgFile.lock"
+      install_gemfile <<-G
+        lockfile "OmgFile.lock"
+        source "https://gem.repo1"
+        gem "myrack", "1.0"
+      G
+
+      expect(bundled_app("ReallyOmgFile.lock")).to exist
+      expect(bundled_app("OmgFile.lock")).not_to exist
+    ensure
+      ENV.delete("BUNDLE_LOCKFILE")
+    end
+
     it "creates lockfile based on --lockfile option is given" do
       gemfile bundled_app("OmgFile"), <<-G
         source "https://gem.repo1"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

@hsbt requested increasing the precedence of `BUNDLE_LOCKFILE` over `lockfile` in `Gemfile`.

## What is your fix for the problem, implemented in this PR?

Implement the desired precedence.

Fixes #9117

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
