### PR TITLE
Remove outdated Supporting sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,6 @@ for letting the RubyGems team know about bugs or problems you're having is
 
 See https://bundler.io/compatibility for known issues.
 
-### Supporting
-
-RubyGems is managed by [Ruby Central](https://rubycentral.org), a non-profit organization that supports the Ruby community through projects like this one, as well as [RubyConf](https://rubyconf.org), [RailsConf](https://railsconf.org), and [RubyGems.org](https://rubygems.org). You can support Ruby Central by attending or [sponsoring](sponsors@rubycentral.org) a conference, or by [joining as a supporting member](https://rubycentral.org/#/portal/signup).
-
 ### Contributing
 
 If you'd like to contribute to RubyGems, that's awesome, and we <3 you. Check out our [guide to contributing](doc/rubygems/CONTRIBUTING.md) for more information.

--- a/bundler/README.md
+++ b/bundler/README.md
@@ -45,10 +45,6 @@ If you'd like to contribute to Bundler, that's awesome, and we <3 you. We've put
 
 If you'd like to request a substantial change to Bundler or its documentation, refer to the [Bundler RFC process](https://github.com/rubygems/rfcs) for more information.
 
-## Supporting
-
-RubyGems is managed by [Ruby Central](https://rubycentral.org), a non-profit organization that supports the Ruby community through projects like this one, as well as [RubyConf](https://rubyconf.org), [RailsConf](https://railsconf.org), and [RubyGems.org](https://rubygems.org). You can support Ruby Central by attending or [sponsoring](sponsors@rubycentral.org) a conference, or by [joining as a supporting member](https://rubycentral.org/#/portal/signup).
-
 ## Code of Conduct
 
 Everyone interacting in the Bundler project's codebases, issue trackers, chat rooms, and mailing lists is expected to follow the [Bundler code of conduct](https://github.com/ruby/rubygems/blob/master/CODE_OF_CONDUCT.md).

--- a/doc/bundler/contributing/README.md
+++ b/doc/bundler/contributing/README.md
@@ -22,7 +22,3 @@ Here are the different ways you can start contributing to the Bundler project:
 * [Triaging bugs](BUG_TRIAGE.md)
 * [Writing documentation](../documentation/WRITING.md)
 * [Community engagement](COMMUNITY.md)
-
-## Supporting Bundler
-
-RubyGems is managed by [Ruby Central](https://rubycentral.org), a non-profit organization that supports the Ruby community through projects like this one, as well as [RubyConf](https://rubyconf.org), [RailsConf](https://railsconf.org), and [RubyGems.org](https://rubygems.org). You can support Ruby Central by attending or [sponsoring](sponsors@rubycentral.org) a conference, or by [joining as a supporting member](https://rubycentral.org/#/portal/signup).

--- a/doc/rubygems/POLICIES.md
+++ b/doc/rubygems/POLICIES.md
@@ -56,5 +56,4 @@ permissions compromised or exposed.
 These policies were set in order to reduce the burden of maintenance and to keep
 committers current with existing development and policies. RubyGems work is
 primarily volunteer-driven which limits the ability to provide long-term
-support. By joining [Ruby Central](https://rubycentral.org/#/portal/signup) you
-can help extend support for older RubyGems versions.
+support.


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I noticed out of date documentation in Supporting sections. These sections made sense when Ruby Central was managing rubygems and bundler, but now that they are managed by Ruby core, they are no longer accurate.

## What is your fix for the problem, implemented in this PR?

This removes the sections.  While we could replace the wording and links, other repositories managed by Ruby core generally don't have similar wording, so I think it's best to remove it.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Update documentation to solve the problem