### PR TITLE
Silence Bundler UI in plugin installer specs

### DIFF
--- a/bundler/spec/bundler/plugin/installer_spec.rb
+++ b/bundler/spec/bundler/plugin/installer_spec.rb
@@ -47,6 +47,13 @@ RSpec.describe Bundler::Plugin::Installer do
           build_plugin "re-plugin"
           build_plugin "ma-plugin"
         end
+
+        @previous_ui = Bundler.ui
+        Bundler.ui = Bundler::UI::Silent.new
+      end
+
+      after do
+        Bundler.ui = @previous_ui
       end
 
       context "git plugins" do


### PR DESCRIPTION
Suppress noisy test output like:

```
$ bin/rspec ./spec/bundler/plugin/installer_spec.rb:52
Fetching /.../ruby/rubygems/bundler/tmp/2.1/libs/ga-plugin
.Fetching /.../ruby/rubygems/bundler/tmp/2.1/libs/ga-plugin
.
```

