### PR TITLE
Write gem files atomically

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -528,6 +528,7 @@ lib/rubygems/uri.rb
 lib/rubygems/uri_formatter.rb
 lib/rubygems/user_interaction.rb
 lib/rubygems/util.rb
+lib/rubygems/util/atomic_file_writer.rb
 lib/rubygems/util/licenses.rb
 lib/rubygems/util/list.rb
 lib/rubygems/validator.rb

--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -105,7 +105,8 @@ module Bundler
     def filesystem_access(path, action = :write, &block)
       yield(path.dup)
     rescue Errno::EACCES => e
-      raise unless e.message.include?(path.to_s) || action == :create
+      path_basename = File.basename(path.to_s)
+      raise unless e.message.include?(path_basename) || action == :create
 
       raise PermissionError.new(path, action)
     rescue Errno::EAGAIN

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -17,6 +17,7 @@ require_relative "rubygems/deprecate"
 require_relative "rubygems/errors"
 require_relative "rubygems/target_rbconfig"
 require_relative "rubygems/win_platform"
+require_relative "rubygems/util/atomic_file_writer"
 
 ##
 # RubyGems is the Ruby standard for publishing and managing third party
@@ -833,14 +834,12 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   end
 
   ##
-  # Safely write a file in binary mode on all platforms.
+  # Atomically write a file in binary mode on all platforms.
 
   def self.write_binary(path, data)
-    File.binwrite(path, data)
-  rescue Errno::ENOSPC
-    # If we ran out of space but the file exists, it's *guaranteed* to be corrupted.
-    File.delete(path) if File.exist?(path)
-    raise
+    Gem::AtomicFileWriter.open(path) do |file|
+      file.write(data)
+    end
   end
 
   ##

--- a/lib/rubygems/util/atomic_file_writer.rb
+++ b/lib/rubygems/util/atomic_file_writer.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Based on ActiveSupport's AtomicFile implementation
+# Copyright (c) David Heinemeier Hansson
+# https://github.com/rails/rails/blob/main/activesupport/lib/active_support/core_ext/file/atomic.rb
+# Licensed under the MIT License
+
+module Gem
+  class AtomicFileWriter
+    ##
+    # Write to a file atomically. Useful for situations where you don't
+    # want other processes or threads to see half-written files.
+
+    def self.open(file_name)
+      temp_dir = File.dirname(file_name)
+      require "tempfile" unless defined?(Tempfile)
+
+      Tempfile.create(".#{File.basename(file_name)}", temp_dir) do |temp_file|
+        temp_file.binmode
+        return_value = yield temp_file
+        temp_file.close
+
+        original_permissions = if File.exist?(file_name)
+          File.stat(file_name)
+        else
+          # If not possible, probe which are the default permissions in the
+          # destination directory.
+          probe_permissions_in(File.dirname(file_name))
+        end
+
+        # Set correct permissions on new file
+        if original_permissions
+          begin
+            File.chown(original_permissions.uid, original_permissions.gid, temp_file.path)
+            File.chmod(original_permissions.mode, temp_file.path)
+          rescue Errno::EPERM, Errno::EACCES
+            # Changing file ownership failed, moving on.
+          end
+        end
+
+        # Overwrite original file with temp file
+        File.rename(temp_file.path, file_name)
+        return_value
+      end
+    end
+
+    def self.probe_permissions_in(dir) # :nodoc:
+      basename = [
+        ".permissions_check",
+        Thread.current.object_id,
+        Process.pid,
+        rand(1_000_000),
+      ].join(".")
+
+      file_name = File.join(dir, basename)
+      File.open(file_name, "w") {}
+      File.stat(file_name)
+    rescue Errno::ENOENT
+      nil
+    ensure
+      begin
+        File.unlink(file_name) if File.exist?(file_name)
+      rescue SystemCallError
+      end
+    end
+  end
+end

--- a/setup.rb
+++ b/setup.rb
@@ -24,6 +24,7 @@ Dir.chdir __dir__
 $:.unshift File.expand_path("lib")
 require "rubygems"
 require "rubygems/gem_runner"
+require "tempfile"
 
 Gem::CommandManager.instance.register_command :setup
 


### PR DESCRIPTION
This change updates `write_binary` to use a new class, `AtomicFile.write` to write the gem's files. This implementation is borrowed from Active Support's [`atomic_write`](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/core_ext/file/atomic.rb).

Atomic write will write the files to a temporary file and then once created, sets permissions and renames the file. If the file is corrupted - ie on failed download, an error occurs, or for some other reason, the real file will not be created. The changes made here make `verify_gz` obsolete, we don't need to verify it if we have successfully created the file atomically. If it exists, it is not corrupt. If it is corrupt, the file won't exist on disk.

While writing tests for this functionality I replaced the `RemoteFetcher` stub with `FakeFetcher` except for where we really do need to overwrite the `RemoteFetcher`. The new test implementation is much clearer on what it's trying to accomplish versus the prior test implementation.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
