### PR TITLE
Update contributing docs with `RGV`

### DIFF
--- a/doc/rubygems/CONTRIBUTING.md
+++ b/doc/rubygems/CONTRIBUTING.md
@@ -82,6 +82,10 @@ To run an individual test file location for example in `spec/install/gems/standa
 
     bin/rspec spec/install/gems/standalone_spec.rb
 
+To test Rubygems changes in bundler, set the path to your local Rubygems copy using the `RGV` environment variable:
+
+    RGV=.. bin/rspec spec/install/gems/standalone_spec.rb
+
 ### Checking code style
 
 You can check compliance with our code style with


### PR DESCRIPTION
It took me awhile to figure out how to test pointed at my Rubygems version when running bundler tests because I thought it would do that automatically. This change adds mention of the `RGV` environment variable so that you can test Rubygems changes in your local bundler tests as well.