### PR TITLE
Fix native extension loading in newgem template for RHEL-based systems

### DIFF
--- a/bundler/lib/bundler/templates/newgem/lib/newgem.rb.tt
+++ b/bundler/lib/bundler/templates/newgem/lib/newgem.rb.tt
@@ -2,7 +2,7 @@
 
 require_relative "<%= File.basename(config[:namespaced_path]) %>/version"
 <%- if config[:ext] -%>
-require_relative "<%= File.basename(config[:namespaced_path]) %>/<%= config[:underscored_name] %>"
+require "<%= File.basename(config[:namespaced_path]) %>/<%= config[:underscored_name] %>"
 <%- end -%>
 
 <%- config[:constant_array].each_with_index do |c, i| -%>

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -1681,6 +1681,13 @@ RSpec.describe "bundle gem" do
         expect(bundled_app("#{gem_name}/ext/#{gem_name}/#{gem_name}.c")).to exist
       end
 
+      it "generates native extension loading code" do
+        expect(bundled_app("#{gem_name}/lib/#{gem_name}.rb").read).to include(<<~RUBY)
+          require_relative "test_gem/version"
+          require "#{gem_name}/#{gem_name}"
+        RUBY
+      end
+
       it "includes rake-compiler, but no Rust related changes" do
         expect(bundled_app("#{gem_name}/Gemfile").read).to include('gem "rake-compiler"')
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

On RHEL-based Linux distributions, installing a gem places Ruby scripts and native extensions in separate directories, causing the template code that uses `require_relative` to load native extensions to raise a `LoadError`.

```ruby
$ cat /etc/os-release | head -4
NAME="Rocky Linux"
VERSION="9.6 (Blue Onyx)"
ID="rocky"
ID_LIKE="rhel centos fedora"
$ bundle gem --ext=c mock_gem
...
$ cd mock_gem
$ rake install
...
$ irb
irb(main):001> require 'mock_gem'
/usr/local/share/gems/gems/mock_gem-0.1.0/lib/mock_gem.rb:4:in `require_relative': cannot load such file -- /usr/local
/share/gems/gems/mock_gem-0.1.0/lib/mock_gem/mock_gem (LoadError)
        from /usr/local/share/gems/gems/mock_gem-0.1.0/lib/mock_gem.rb:4:in `<top (required)>'
        from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:141:in `require'
        from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:141:in `rescue in require'
        from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:135:in `require'
        from (irb):1:in `<main>'
        from <internal:kernel>:187:in `loop'
        from /usr/local/share/gems/gems/irb-1.15.3/exe/irb:9:in `<top (required)>'
        from /usr/local/bin/irb:25:in `load'
        from /usr/local/bin/irb:25:in `<main>'
...
irb(main):002>
 
$ ls /usr/local/lib64/gems/ruby/mock_gem-0.1.0/mock_gem/mock_gem.so
/usr/local/lib64/gems/ruby/mock_gem-0.1.0/mock_gem/mock_gem.so
$ ls /usr/local/share/gems/gems/mock_gem-0.1.0/lib/mock_gem.rb
/usr/local/share/gems/gems/mock_gem-0.1.0/lib/mock_gem.rb
```

## What is your fix for the problem, implemented in this PR?

This PR modifies the template code (lib/newgem.rb.tt) so that when `require_relative` raises a `LoadError` while loading a native extension, it falls back to using `require` instead.

```ruby
$ cat lib/mock_gem.rb
# frozen_string_literal: true

require_relative "mock_gem/version"
begin
  require_relative "mock_gem/mock_gem"
rescue LoadError
  require "mock_gem/mock_gem"
end

module MockGem
  class Error < StandardError; end
  # Your code goes here...
end
$ rake install
...
$ irb
irb(main):001> require 'mock_gem'
=> true
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
