### PR TITLE
Fix Bundler removing executables after creating them

### DIFF
--- a/bundler/lib/bundler/endpoint_specification.rb
+++ b/bundler/lib/bundler/endpoint_specification.rb
@@ -60,6 +60,28 @@ module Bundler
       end
     end
 
+    # needed for binstubs
+    def executables
+      if @remote_specification
+        @remote_specification.executables
+      elsif _local_specification
+        _local_specification.executables
+      else
+        super
+      end
+    end
+
+    # needed for bundle clean
+    def bindir
+      if @remote_specification
+        @remote_specification.bindir
+      elsif _local_specification
+        _local_specification.bindir
+      else
+        super
+      end
+    end
+
     # needed for post_install_messages during install
     def post_install_message
       if @remote_specification

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -1885,6 +1885,25 @@ RSpec.describe "bundle install with gem sources" do
     expect(Dir.glob(vendored_gems("bin/*"))).to eq(expected_executables)
   end
 
+  it "prevents removing binstubs when BUNDLE_CLEAN is set" do
+    build_repo4 do
+      build_gem "kamal", "4.0.6" do |s|
+        s.executables = ["kamal"]
+      end
+    end
+
+    gemfile = <<~G
+      source "https://gem.repo4"
+      gem "kamal"
+    G
+
+    install_gemfile(gemfile, env: { "BUNDLE_CLEAN" => "true", "BUNDLE_PATH" => "vendor/bundle" })
+
+    expected_executables = [vendored_gems("bin/kamal").to_s]
+    expected_executables << vendored_gems("bin/kamal.bat").to_s if Gem.win_platform?
+    expect(Dir.glob(vendored_gems("bin/*"))).to eq(expected_executables)
+  end
+
   it "preserves lockfile versions conservatively" do
     build_repo4 do
       build_gem "mypsych", "4.0.6" do |s|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Fix #9168

When running a fresh `bundle install` with gems that contains executables, Bundler will generate binstubs but soon after will remove them. This is a regression introduced in 573ffad3ea4a8d364b0f9bf3a18f0d5bf1197e38.

This results in doing `bundle install && bundle exec foo` to raise an error saying `foo` couldn't be found.

This issue only appears if `BUNDLE_CLEAN` is set.

At the end of the installation process, when Bundler has installed gems and generated binstubs, it runs the cleanup.

1. It [detects](https://github.com/ruby/rubygems/blob/4f8aa3b40cded3465bb2cd761e9ce7f8673b7fcb/bundler/lib/bundler/runtime.rb#L182) the executable for the current specs
2. Any existing executables not detected [is then removed](https://github.com/ruby/rubygems/blob/4f8aa3b40cded3465bb2cd761e9ce7f8673b7fcb/bundler/lib/bundler/runtime.rb#L194)

The issue being that 1. now returns an empty array where as it should return the executables of the gems from the current bundle.

The problem is in 573ffad3ea4a8d364b0f9bf3a18f0d5bf1197e38 where we removed the `executables` method from the `EndpointSpecification`. When Bundler reads the lockfile, it creates a `EndpointSpecification` object for each spec. At this point, the EndpointSpecification doesn't know about the `executables` of a gem. Once Bundler fetches the `gemspec` from the remote, it swaps the the "spec" with the real one and from here knows what executables the gem has.

## What is your fix for the problem, implemented in this PR?

Reintroduce the `executables` method and the `bindir` in the EndpointSpecification class. From what I'm seeing, the removal of those wasn't needed to resolve the issue where Bundler remembers CLI flags. This is probably an oversight.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
