### PR TITLE
Support single quotes in mise format ruby version

### DIFF
--- a/bundler/lib/bundler/ruby_dsl.rb
+++ b/bundler/lib/bundler/ruby_dsl.rb
@@ -43,17 +43,20 @@ module Bundler
     def normalize_ruby_file(filename)
       file_content = Bundler.read_file(gemfile.dirname.join(filename))
       # match "ruby-3.2.2", ruby = "3.2.2", ruby = '3.2.2' or "ruby   3.2.2" capturing version string up to the first space or comment
-      if /^                    # Start of line
-         ruby                  # Literal "ruby"
-         [\s-]*                # Optional whitespace or hyphens (for "ruby-3.2.2" format)
-         (?:=\s*)?             # Optional equals sign with whitespace (for ruby = "3.2.2" format)
-         ["']?                 # Optional opening quote
-         (                     # Start capturing group
-           [^\s#"']+           # One or more chars that aren't spaces, #, or quotes
-         )                     # End capturing group
-         ["']?                 # Optional closing quote
-         /x.match(file_content)
-        $1
+      version_match = /^               # Start of line
+                      ruby             # Literal "ruby"
+                      [\s-]*           # Optional whitespace or hyphens (for "ruby-3.2.2" format)
+                      (?:=\s*)?        # Optional equals sign with whitespace (for ruby = "3.2.2" format)
+                      (?:
+                        "([^"]+)"      # Double quoted version
+                        |
+                        '([^']+)'      # Single quoted version
+                        |
+                        ([^\s#"']+)    # Unquoted version
+                      )
+                      /x.match(file_content)
+      if version_match
+        version_match[1] || version_match[2] || version_match[3]
       else
         file_content.strip
       end

--- a/bundler/spec/bundler/ruby_dsl_spec.rb
+++ b/bundler/spec/bundler/ruby_dsl_spec.rb
@@ -193,6 +193,19 @@ RSpec.describe Bundler::RubyDsl do
 
           it_behaves_like "it stores the ruby version"
         end
+
+        context "with mismatched quotes" do
+          let(:file_content) do
+            <<~TOML
+              [tools]
+              ruby = "#{version}'
+            TOML
+          end
+
+          it "raises an error" do
+            expect { subject }.to raise_error(Bundler::InvalidArgumentError, "= is not a valid requirement on the Ruby version")
+          end
+        end
       end
 
       context "with a .tool-versions file format" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`mise.toml` supports specifying Ruby versions using both double quotes (`ruby = "3.2.2"`) and single quotes (`ruby = '3.2.2'`). However, Bundler's `ruby file:` directive only recognized double-quoted versions, causing single-quoted versions to fail parsing.

``` console
$ bundle --version
4.0.1
$ cat Gemfile
# frozen_string_literal: true

ruby file: 'mise.toml'
$ cat << 'TOML' > mise.toml
[tools]
ruby = "3.4.7"
TOML
$ bundle --version
4.0.1
$ cat Gemfile
# frozen_string_literal: true

ruby file: 'mise.toml'
$ mise x -- ruby --version
ruby 3.4.7 (2025-10-08 revision 7a5688e2a2) +PRISM [x86_64-linux]
$ cat << 'TOML' > mise.toml
[tools]
ruby = "3.4.7"
TOML
$ bundle install
The Gemfile specifies no dependencies
Resolving dependencies...
Bundle complete! 0 Gemfile dependencies, 1 gem now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
$ cat << 'TOML' > mise.toml
[tools]
ruby = '3.4.7'
TOML
$ mise x -- ruby --version
ruby 3.4.7 (2025-10-08 revision 7a5688e2a2) +PRISM [x86_64-linux]
$ bundle install

[!] There was an error parsing `Gemfile`: '3.4.7' is not a valid requirement on the Ruby version. Bundler cannot continue.

 #  from /home/dell-08/workspaces/mise/Gemfile:3
 #  -------------------------------------------
 #  
 >  ruby file: 'mise.toml'
 #  -------------------------------------------
```

## What is your fix for the problem, implemented in this PR?

Updated the regular expression to accept both single quotes (`'`) and double quotes (`"`) when parsing Ruby version files in mise format.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
