### PR TITLE
Tweak the Bundler's "X gems now installed message":

### DIFF
--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -90,7 +90,7 @@ module Bundler
     end
 
     def gems_installed_for(definition)
-      count = definition.specs.count
+      count = definition.specs.count {|spec| spec.name != "bundler" }
       "#{count} #{count == 1 ? "gem" : "gems"} now installed"
     end
 

--- a/bundler/spec/commands/post_bundle_message_spec.rb
+++ b/bundler/spec/commands/post_bundle_message_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "post bundle message" do
   let(:bundle_show_path_message)   { "Bundled gems are installed into `#{bundle_path}`" }
   let(:bundle_complete_message)    { "Bundle complete!" }
   let(:bundle_updated_message)     { "Bundle updated!" }
-  let(:installed_gems_stats)       { "4 Gemfile dependencies, 5 gems now installed." }
+  let(:installed_gems_stats)       { "4 Gemfile dependencies, 4 gems now installed." }
 
   describe "when installing to system gems" do
     before do
@@ -44,14 +44,14 @@ RSpec.describe "post bundle message" do
       expect(out).to include(bundle_show_system_message)
       expect(out).to include("Gems in the groups 'emo' and 'test' were not installed")
       expect(out).to include(bundle_complete_message)
-      expect(out).to include("4 Gemfile dependencies, 3 gems now installed.")
+      expect(out).to include("4 Gemfile dependencies, 2 gems now installed.")
 
       bundle "config set --local without emo obama test"
       bundle :install
       expect(out).to include(bundle_show_system_message)
       expect(out).to include("Gems in the groups 'emo', 'obama' and 'test' were not installed")
       expect(out).to include(bundle_complete_message)
-      expect(out).to include("4 Gemfile dependencies, 2 gems now installed.")
+      expect(out).to include("4 Gemfile dependencies, 1 gem now installed.")
     end
 
     describe "for second bundle install run" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Fix #9188

## What is your fix for the problem, implemented in this PR?

This message is a bit misleading because it always outputs one extra specs, which is Bundler itself that gets added during materialization https://github.com/ruby/rubygems/blob/570c3419c7f111d8665710f4e2cb15ca878e606d/bundler/lib/bundler/definition.rb#L741

This is now fixed when the message is about to be output.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
