### PR TITLE
Allow bundle pristine to work for git gems in the same repo

### DIFF
--- a/bundler/lib/bundler/cli/pristine.rb
+++ b/bundler/lib/bundler/cli/pristine.rb
@@ -11,6 +11,7 @@ module Bundler
       definition = Bundler.definition
       definition.validate_runtime!
       installer = Bundler::Installer.new(Bundler.root, definition)
+      git_sources = []
 
       ProcessLock.lock do
         installed_specs = definition.specs.reject do |spec|
@@ -41,6 +42,9 @@ module Bundler
             end
             FileUtils.rm_rf spec.extension_dir
             FileUtils.rm_rf spec.full_gem_path
+
+            next if git_sources.include?(source)
+            git_sources << source
           else
             Bundler.ui.warn("Cannot pristine #{gem_name}. Gem is sourced from local path.")
             next

--- a/bundler/spec/commands/pristine_spec.rb
+++ b/bundler/spec/commands/pristine_spec.rb
@@ -89,6 +89,66 @@ RSpec.describe "bundle pristine" do
       expect(changes_txt).to be_file
       expect(err).to include("Cannot pristine #{spec.name} (#{spec.version}#{spec.git_version}). Gem is locally overridden.")
     end
+
+    it "doesn't run multiple git processes for the same repository" do
+      nested_gems = [
+        "actioncable",
+        "actionmailer",
+        "actionpack",
+        "actionview",
+        "activejob",
+        "activemodel",
+        "activerecord",
+        "activestorage",
+        "activesupport",
+        "railties",
+      ]
+
+      build_repo2 do
+        nested_gems.each do |gem|
+          build_lib gem, path: lib_path("rails/#{gem}")
+        end
+
+        build_git "rails", path: lib_path("rails") do |s|
+          nested_gems.each do |gem|
+            s.add_dependency gem
+          end
+        end
+      end
+
+      install_gemfile <<-G
+        source 'https://rubygems.org'
+
+        git "#{lib_path("rails")}" do
+          gem "rails"
+          gem "actioncable"
+          gem "actionmailer"
+          gem "actionpack"
+          gem "actionview"
+          gem "activejob"
+          gem "activemodel"
+          gem "activerecord"
+          gem "activestorage"
+          gem "activesupport"
+          gem "railties"
+        end
+      G
+
+      changed_files = []
+      diff = "#Pristine spec changes"
+
+      nested_gems.each do |gem|
+        spec = find_spec(gem)
+        changed_files << Pathname.new(spec.full_gem_path).join("lib/#{gem}.rb")
+        File.open(changed_files.last, "a") {|f| f.puts diff }
+      end
+
+      bundle "pristine"
+
+      changed_files.each do |changed_file|
+        expect(File.read(changed_file)).to_not include(diff)
+      end
+    end
   end
 
   context "when sourced from gemspec" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Fix #9186

## What is your fix for the problem, implemented in this PR?

Running `bundle pristine` in a Gemfile where there is many git gem pointing to the same repository will result in a error "Another git process seems to be running in this repository".

#### Context

This error is a regression since a555fd6ccd1765c9284349515d585a01866ab406 where `bundle pristine` now runs in parallel which could lead to running simultaneous git operations in the same repository.

#### Solution

When Bundler pristine a git gem it does a `git reset --hard` without specifying a path. This means the whole repository will be reset. In this case, we can leverage that by just pristining one gem per unique git sources. This is also more efficient.

https://github.com/ruby/rubygems/blob/570c3419c7f111d8665710f4e2cb15ca878e606d/bundler/lib/bundler/source/git/git_proxy.rb#L140

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
