### PR TITLE
Allow to show cli_help with `bundler` executable

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -104,7 +104,7 @@ module Bundler
       primary_commands = ["install", "update", "cache", "exec", "config", "help"]
 
       list = self.class.printable_commands(true)
-      by_name = list.group_by {|name, _message| name.match(/^bundle (\w+)/)[1] }
+      by_name = list.group_by {|name, _message| name.match(/^bundler? (\w+)/)[1] }
       utilities = by_name.keys.sort - primary_commands
       primary_commands.map! {|name| (by_name[name] || raise("no primary command #{name}")).first }
       utilities.map! {|name| by_name[name].first }

--- a/bundler/spec/bundler/cli_spec.rb
+++ b/bundler/spec/bundler/cli_spec.rb
@@ -282,4 +282,15 @@ RSpec.describe "bundler executable" do
     bundler "--version"
     expect(out).to eq("#{Bundler::VERSION} (simulating Bundler 5)")
   end
+
+  it "shows cli_help when bundler install and no Gemfile is found" do
+    bundler "install", raise_on_error: false
+    expect(err).to include("Could not locate Gemfile")
+
+    expect(out).to include("Bundler version #{Bundler::VERSION}").
+      and include("\n\nBundler commands:\n\n").
+      and include("\n\n  Primary commands:\n").
+      and include("\n\n  Utilities:\n").
+      and include("\n\nOptions:\n")
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Fixes https://github.com/ruby/rubygems/issues/9182

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
