### PR TITLE
Reset MAKEFLAGS option for build jobs tests

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -333,6 +333,7 @@ class Gem::TestCase < Test::Unit::TestCase
     ENV["XDG_CONFIG_HOME"] = nil
     ENV["XDG_DATA_HOME"] = nil
     ENV["XDG_STATE_HOME"] = nil
+    ENV["MAKEFLAGS"] = nil
     ENV["SOURCE_DATE_EPOCH"] = nil
     ENV["BUNDLER_VERSION"] = nil
     ENV["BUNDLE_CONFIG"] = nil


### PR DESCRIPTION
## What is your fix for the problem, implemented in this PR?

Followed up with https://github.com/ruby/rubygems/pull/9171

If we use `MAKEFLAGS`, `test_pass_down_the_job_option_to_make` of `TestGemCommandsInstallCommand` and `TestGemCommandsUpdateCommand` failed now.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
