### PR TITLE
Fix leaky tests

### DIFF
--- a/bundler/spec/bundler/plugin/events_spec.rb
+++ b/bundler/spec/bundler/plugin/events_spec.rb
@@ -2,7 +2,17 @@
 
 RSpec.describe Bundler::Plugin::Events do
   context "plugin events" do
-    before { Bundler::Plugin::Events.send :reset }
+    before do
+      @old_constants = Bundler::Plugin::Events.constants.map {|name| [name, Bundler::Plugin::Events.const_get(name)] }
+      Bundler::Plugin::Events.send :reset
+    end
+
+    after do
+      Bundler::Plugin::Events.send(:reset)
+      Hash[@old_constants].each do |name, value|
+        Bundler::Plugin::Events.send(:define, name, value)
+      end
+    end
 
     describe "#define" do
       it "raises when redefining a constant" do

--- a/bundler/spec/bundler/plugin_spec.rb
+++ b/bundler/spec/bundler/plugin_spec.rb
@@ -279,6 +279,7 @@ RSpec.describe Bundler::Plugin do
         s.write "plugins.rb", code
       end
 
+      @old_constants = Bundler::Plugin::Events.constants.map {|name| [name, Bundler::Plugin::Events.const_get(name)] }
       Bundler::Plugin::Events.send(:reset)
       Bundler::Plugin::Events.send(:define, :EVENT1, "event-1")
       Bundler::Plugin::Events.send(:define, :EVENT2, "event-2")
@@ -289,6 +290,13 @@ RSpec.describe Bundler::Plugin do
         and_return(["foo-plugin"])
       allow(index).to receive(:plugin_path).with("foo-plugin").and_return(path)
       allow(index).to receive(:load_paths).with("foo-plugin").and_return([])
+    end
+
+    after do
+      Bundler::Plugin::Events.send(:reset)
+      Hash[@old_constants].each do |name, value|
+        Bundler::Plugin::Events.send(:define, name, value)
+      end
     end
 
     let(:code) { <<-RUBY }


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Some tests are leaky and it makes the work I'm doing in #9210 not possible.

## What is your fix for the problem, implemented in this PR?

While working on #9210, I found those leaky tests which break the test suite. They remove Bundler constants without setting them back.

https://github.com/ruby/rubygems/blob/ca8ac9f1db634805c97c9f243cdc6c17690b6458/bundler/lib/bundler/plugin/events.rb#L17-L20

The reason it's not a problem on master is because there are no tests that install gems in the same process (all tests shell out to `bundle install`). 
In #9210 I install gems using the Bundler API instead of shelling out (its much faster), and this also needs to be fixed if we want to achieve #9195

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
