### PR TITLE
Fix fragile tests

### DIFF
--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -1610,7 +1610,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
 
     gem_make_out = File.read(File.join(gemspec.extension_dir, "gem_make.out"))
     if vc_windows? && nmake_found?
-      refute_includes(gem_make_out, "-j4")
+      refute_includes(gem_make_out, " -j4")
     else
       assert_includes(gem_make_out, "make -j4")
     end

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -722,7 +722,7 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
 
     gem_make_out = File.read(File.join(gemspec.extension_dir, "gem_make.out"))
     if vc_windows? && nmake_found?
-      refute_includes(gem_make_out, "-j2")
+      refute_includes(gem_make_out, " -j2")
     else
       assert_includes(gem_make_out, "make -j2")
     end


### PR DESCRIPTION
Merge ruby/ruby@8f7c3603c1b168e4f7440216b197f11325e31fdf
Merge ruby/ruby@8de2622c1291afd29a9a570e6b396bbe722360a3

## What was the end-user or developer problem that led to this PR?

`Dir.mktmpdir` concatenates a random base-36 number separated by "-", so may generate pathnames containing "-j4" or "-j2".

## What is your fix for the problem, implemented in this PR?

Match including a preceding space, " -j4"/" -j2", as an option.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
