### PR TITLE
Revise 'get in touch' with working slack link

### DIFF
--- a/doc/bundler/contributing/HOW_YOU_CAN_HELP.md
+++ b/doc/bundler/contributing/HOW_YOU_CAN_HELP.md
@@ -2,7 +2,7 @@
 
 If you're interested in contributing to Bundler, that's awesome! We'd love your help.
 
-If at any point you get stuck, here's how to [get in touch with the Bundler team for help](https://slack.bundler.io).
+If at any point you get stuck, here's how to [get in touch with the Bundler team for help](https://bundler.slack.com).
 
 ## First contribution suggestions
 
@@ -23,4 +23,4 @@ Generally, great ways to get started helping out with Bundler are:
     - get started setting up your dev environment with [these instructions](../development/SETUP.md)
   - backfilling [unit tests](https://github.com/ruby/rubygems/tree/master/bundler/spec/bundler) for modules that lack coverage.
 
-If nothing on those lists looks good, [talk to us](https://slack.bundler.io/), and we'll figure out what you can help with. We can absolutely use your help, no matter what level of programming skill you have at the moment.
+If nothing on those lists looks good, [talk to us](https://bundler.slack.com/), and we'll figure out what you can help with. We can absolutely use your help, no matter what level of programming skill you have at the moment.


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I wanted to contribute to RubyGems and found the [HOW_YOU_CAN_HELP](doc/bundler/contributing/HOW_YOU_CAN_HELP.md) docs contained a 'No longer active' link for Slack.

## What is your fix for the problem, implemented in this PR?

I'm updating this document to show the login link for the RubyGems Slack channel.

## Make sure the following tasks are checked

While this is a working link for existing RubyGems Slack members, it does nothing to help newbies like myself request access to the channel, so I'm happy to make revisions. Thank you for your time and attention.