### PR TITLE
Remove date require from rebuild command

### DIFF
--- a/lib/rubygems/commands/rebuild_command.rb
+++ b/lib/rubygems/commands/rebuild_command.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "date"
 require "digest"
 require "fileutils"
 require "tmpdir"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

No problem, it just seems this isn't used. I'm not sure if it was ever used since added in 6d661573f091346147e6576288948a140748b417.

## What is your fix for the problem, implemented in this PR?

Remove the unnecessary require.

## Make sure the following tasks are checked

I don't think tests are needed for this change.

- [X] Describe the problem / feature
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
