### PR TITLE
Add a missing "require 'etc'" statement:

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -943,7 +943,12 @@ class Gem::Installer
   end
 
   def build_jobs
-    @build_jobs ||= Etc.nprocessors + 1
+    @build_jobs ||= begin
+                      require "etc"
+                      Etc.nprocessors + 1
+                    rescue LoadError
+                      1
+                    end
   end
 
   def rb_config


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In some scenarios, a `NameError` is raised when calling `bundle install`.

Ref https://github.com/ruby/rubygems/pull/9171#discussion_r2658056892

This can be reproduced with this Gemfile:

```ruby
source "https://rubygems.org"

gem 'prism', github: "ruby/prism"
```

## What is your fix for the problem, implemented in this PR?

Add a missing `require 'etc'`

> [!NOTE]
> Adding a regression test for this is a bit tricky because this error can't be reproduced easily in our test suite. This is because when a `bundle install` subprocess run (using `install_gemfile` for example) Bundler adds a `RUBYOPT="-r <some file>"` which down the line ends up requiring etc.

https://github.com/ruby/rubygems/blob/e7cb04353fc8fe85d359d34d9d467d17d33bdbd3/bundler/spec/support/helpers.rb#L175

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
