### PR TITLE
Fix Bundler that re-exec $0 when a `version` is present in the config:

### DIFF
--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -66,7 +66,7 @@ class TestGemBundlerVersionFinder < Gem::TestCase
       f.write(config_content)
       f.flush
 
-      bvf.stub(:bundler_config_file, f.path) do
+      bvf.stub(:bundler_global_config_file, f.path) do
         assert_nil bvf.bundler_version
       end
     end
@@ -81,7 +81,7 @@ class TestGemBundlerVersionFinder < Gem::TestCase
       f.write(config_with_single_quoted_version)
       f.flush
 
-      bvf.stub(:bundler_config_file, f.path) do
+      bvf.stub(:bundler_global_config_file, f.path) do
         assert_nil bvf.bundler_version
       end
     end
@@ -98,15 +98,30 @@ class TestGemBundlerVersionFinder < Gem::TestCase
       f.write(config_content)
       f.flush
 
-      bvf.stub(:bundler_config_file, f.path) do
+      bvf.stub(:bundler_global_config_file, f.path) do
         assert_equal v("1.1.1.1"), bvf.bundler_version
       end
     end
   end
 
   def test_bundler_version_with_bundle_config_non_existent_file
-    bvf.stub(:bundler_config_file, "/non/existent/path") do
+    bvf.stub(:bundler_global_config_file, "/non/existent/path") do
       assert_nil bvf.bundler_version
+    end
+  end
+
+  def test_bundler_version_set_on_local_config
+    config_content = <<~CONFIG
+      BUNDLE_VERSION: "1.2.3"
+    CONFIG
+
+    Tempfile.create("bundle_config") do |f|
+      f.write(config_content)
+      f.flush
+
+      bvf.stub(:bundler_local_config_file, f.path) do
+        assert_equal v("1.2.3"), bvf.bundler_version
+      end
     end
   end
 
@@ -120,7 +135,7 @@ class TestGemBundlerVersionFinder < Gem::TestCase
       f.write(config_without_version)
       f.flush
 
-      bvf.stub(:bundler_config_file, f.path) do
+      bvf.stub(:bundler_global_config_file, f.path) do
         assert_nil bvf.bundler_version
       end
     end


### PR DESCRIPTION
Fix Bundler that re-exec $0 when a `version` is present in the config:

### Problem

If you have a `version` in your config file (this feature was introduced in #6817), then running any `bundle` command will make Bundler re-exec and ultimately run the `bundle` binstub twice.

### Details

When the `bundle` binstub gets executed, a `require "bundler"` is evaluated. RubyGems tries to require the `bundler.rb` file from the right `bundler` gem (in the event where you have multiple bundler versions in your system). RubyGems will prioritize a bundler version based on a few heurisitics.

  https://github.com/ruby/rubygems/blob/b50c40c92abb00bb172f1579356cc73c242b1849/lib/rubygems/bundler_version_finder.rb#L19-L21

This prioritize logic doesn't take into account the bundler version a user has specified in its config. So what happens is:

1. User execute the `bundle` binstub
2. `require 'bundler'` is evaluated.
3. RubyGems prioritize activating the bundler version specified in the Gemfile.lock
4. The CLI starts, and [Auto switch kicks in](https://github.com/ruby/rubygems/blob/b50c40c92abb00bb172f1579356cc73c242b1849/bundler/lib/bundler/cli.rb#L81). Bundler detects that user has a specific version in its config and the current runtime Bundler version doesn't match.
5. Bundler exit and re-exec with the right bundler version.

### Solution

This patch introduce two fixes. First, it reads the bundler config file and check for the local config and then the global config. This is because the local has precedence over global (see the order [here](https://github.com/ruby/rubygems/blob/b50c40c92abb00bb172f1579356cc73c242b1849/bundler/lib/bundler/settings.rb#L323-L326).

Second, the prioritization takes into account the version in a user's config and let RubyGems activate the right version in order to prevent re-exec moments later.

Finally, I also want to fix this problem because its a step toward fixing https://github.com/ruby/rubygems/issues/8106. I'll open a follow up patch to explain.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
