### PR TITLE
Always install the `bundler` gem in the system gems path:

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -452,13 +452,13 @@ module Bundler
       SharedHelpers.default_bundle_dir
     end
 
-    def system_bindir
+    def system_bindir(install_dir = nil)
       # Gem.bindir doesn't always return the location that RubyGems will install
       # system binaries. If you put '-n foo' in your .gemrc, RubyGems will
       # install binstubs there instead. Unfortunately, RubyGems doesn't expose
       # that directory at all, so rather than parse .gemrc ourselves, we allow
       # the directory to be set as well, via `bundle config set --local bindir foo`.
-      Bundler.settings[:system_bindir] || Bundler.rubygems.gem_bindir
+      Bundler.settings[:system_bindir] || Bundler.rubygems.gem_bindir(install_dir)
     end
 
     def preferred_gemfile_name

--- a/bundler/lib/bundler/plugin/installer/rubygems.rb
+++ b/bundler/lib/bundler/plugin/installer/rubygems.rb
@@ -6,7 +6,7 @@ module Bundler
       class Rubygems < Bundler::Source::Rubygems
         private
 
-        def rubygems_dir
+        def rubygems_dir(_)
           Plugin.root
         end
 

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -81,8 +81,8 @@ module Bundler
       Gem.dir
     end
 
-    def gem_bindir
-      Gem.bindir
+    def gem_bindir(install_dir = nil)
+      Gem.bindir(install_dir || gem_dir)
     end
 
     def user_home

--- a/bundler/lib/bundler/self_manager.rb
+++ b/bundler/lib/bundler/self_manager.rb
@@ -67,11 +67,6 @@ module Bundler
     end
 
     def restart_with(version)
-      configured_gem_home = ENV["GEM_HOME"]
-      configured_orig_gem_home = ENV["BUNDLER_ORIG_GEM_HOME"]
-      configured_gem_path = ENV["GEM_PATH"]
-      configured_orig_gem_path = ENV["BUNDLER_ORIG_GEM_PATH"]
-
       argv0 = File.exist?($PROGRAM_NAME) ? $PROGRAM_NAME : Process.argv0
       cmd = [argv0, *ARGV]
       cmd.unshift(Gem.ruby) unless File.executable?(argv0)
@@ -79,10 +74,6 @@ module Bundler
       Bundler.with_original_env do
         Kernel.exec(
           {
-            "GEM_HOME" => configured_gem_home,
-            "BUNDLER_ORIG_GEM_HOME" => configured_orig_gem_home,
-            "GEM_PATH" => configured_gem_path,
-            "BUNDLER_ORIG_GEM_PATH" => configured_orig_gem_path,
             "BUNDLER_VERSION" => version.to_s,
           },
           *cmd
@@ -132,7 +123,6 @@ module Bundler
     end
 
     def find_latest_matching_spec(requirement)
-      Bundler.configure
       local_result = find_latest_matching_spec_from_collection(local_specs, requirement)
       return local_result if local_result && requirement.specific?
 
@@ -163,8 +153,6 @@ module Bundler
     end
 
     def installed?(restart_version)
-      Bundler.configure
-
       Bundler.rubygems.find_bundler(restart_version.to_s)
     end
 

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -173,8 +173,8 @@ module Bundler
 
         return if Bundler.settings[:no_install]
 
-        install_path = rubygems_dir
-        bin_path     = Bundler.system_bindir
+        install_path = rubygems_dir(spec)
+        bin_path     = Bundler.system_bindir(install_path)
 
         require_relative "../rubygems_gem_installer"
 
@@ -432,7 +432,7 @@ module Bundler
       def fetch_gem(spec, previous_spec = nil)
         spec.fetch_platform
 
-        cache_path = download_cache_path(spec) || default_cache_path_for(rubygems_dir)
+        cache_path = download_cache_path(spec) || default_cache_path_for(rubygems_dir(spec))
         gem_path = package_path(cache_path, spec)
         return gem_path if File.exist?(gem_path)
 
@@ -448,8 +448,10 @@ module Bundler
         installed_specs[spec].any? && !spec.installation_missing?
       end
 
-      def rubygems_dir
-        Bundler.bundle_path
+      def rubygems_dir(spec)
+        dir = Pathname(ENV["BUNDLER_ORIG_GEM_HOME"]) if spec.name == "bundler"
+
+        dir ||= Bundler.bundle_path
       end
 
       def default_cache_path_for(dir)

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -801,6 +801,39 @@ RSpec.describe "bundle install with gem sources" do
     end
   end
 
+  describe "Bundler version in Gemfile.lock" do
+    it "always download the bundler gem to system path" do
+      gemfile <<~G
+        source "https://gem.repo4"
+      G
+
+      lockfile <<~L
+        GEM
+          remote: https://gem.repo4/
+          specs:
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+
+        BUNDLED WITH
+          2.7.99
+      L
+
+      build_repo4 do
+        build_gem "bundler", "2.7.99"
+      end
+
+      bundle :install, env: { "BUNDLE_PATH" => "vendor/bundle" }
+
+      expect(system_gem_path("gems/bundler-2.7.99")).to exist
+      expect(system_gem_path("bin/bundler")).to exist
+      expect(vendored_gems("gems/bundler-2.7.99")).to_not exist
+      expect(vendored_gems("bin/bundler")).to_not exist
+    end
+  end
+
   describe "Ruby version in Gemfile.lock" do
     context "and using an unsupported Ruby version" do
       it "prints an error" do

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -1700,7 +1700,7 @@ RSpec.describe "bundle update --bundler" do
       gem "myrack"
     G
 
-    system_gems "bundler-9.0.0.dev", path: local_gem_path
+    system_gems "bundler-9.0.0.dev"
     bundle :update, bundler: "9.0.0.dev", verbose: "true"
 
     checksums = checksums_section_when_enabled do |c|
@@ -1737,7 +1737,7 @@ RSpec.describe "bundle update --bundler" do
       source "https://gem.repo4"
       gem "myrack"
     G
-    system_gems "bundler-9.0.0", path: local_gem_path
+    system_gems "bundler-9.0.0"
     bundle :update, bundler: "9.0.0", verbose: true
 
     expect(out).not_to include("Fetching gem metadata from https://rubygems.org/")
@@ -1787,7 +1787,7 @@ RSpec.describe "bundle update --bundler" do
          9.0.0
     L
 
-    system_gems "bundler-9.9.9", path: local_gem_path
+    system_gems "bundler-9.9.9"
 
     bundle "update --bundler=9.9.9", env: { "BUNDLE_FROZEN" => "true" }, raise_on_error: false
     expect(err).to include("An update to the version of Bundler itself was requested, but the lockfile can't be updated because frozen mode is set")

--- a/bundler/spec/runtime/self_management_spec.rb
+++ b/bundler/spec/runtime/self_management_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "Self management" do
       bundle "config set --local path vendor/bundle"
       bundle "install"
       expect(out).to include("Bundler #{current_version} is running, but your lockfile was generated with #{previous_minor}. Installing Bundler #{previous_minor} and restarting using that version.")
-      expect(vendored_gems("gems/bundler-#{previous_minor}")).to exist
+      expect(system_gem_path("gems/bundler-#{previous_minor}")).to exist
 
       # It does not uninstall the locked bundler
       bundle "clean"
@@ -111,7 +111,7 @@ RSpec.describe "Self management" do
       bundle "config set --local deployment true"
       bundle "install"
       expect(out).to include("Bundler #{current_version} is running, but your lockfile was generated with #{previous_minor}. Installing Bundler #{previous_minor} and restarting using that version.")
-      expect(vendored_gems("gems/bundler-#{previous_minor}")).to exist
+      expect(system_gem_path("gems/bundler-#{previous_minor}")).to exist
 
       # It does not uninstall the locked bundler
       bundle "clean"

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1218,6 +1218,42 @@ end
       end
     end
 
+    context "auto switch" do
+      it "picks the right bundler version without re-exec" do
+        bundle "config unset path.system"
+        bundle "config set --local path #{bundled_app(".bundle")}"
+
+        build_repo4 do
+          build_bundler "4.4.99"
+          build_gem "myrack", "1.0.0"
+        end
+
+        lockfile(lock_with("4.4.99"))
+
+        install_gemfile <<-G
+          source "https://gem.repo4"
+          gem "myrack"
+        G
+
+        # ruby-core test setup has always "lib" in $LOAD_PATH so `require "bundler/setup"` always activate the local version rather than using RubyGems gem activation stuff
+        unless ruby_core?
+          file = bundled_app("bin/bundle_version.rb")
+          create_file file, <<~RUBY
+            #!#{Gem.ruby}
+            p 'executed once'
+            require 'bundler/setup'
+            p Bundler::VERSION
+          RUBY
+
+          file.chmod(0o777)
+          cmd = Gem.win_platform? ? "#{Gem.ruby} bin/bundle_version.rb" : "bin/bundle_version.rb"
+          in_bundled_app cmd
+
+          expect(out).to eq(%("executed once"\n"4.4.99"))
+        end
+      end
+    end
+
     context "is newer" do
       it "does not change the lock or warn" do
         lockfile lock_with(Bundler::VERSION.succ)


### PR DESCRIPTION
### Always install the bundler gem in the system gems path

Fix https://github.com/ruby/rubygems/issues/8106

### Problem

Bundler autoswitch feature kicks in unexpectedly which ends up creating issue as described in https://github.com/ruby/rubygems/issues/8106.

This patch solves this problem, but will also prevent Bundler from autoswitching most of the time, thanks to picking up the right bundler version from the start.

### Details

When `bundle install` is ran, Bundler reads the Gemfile.lock andcheck the `BUNDLED WITH` section to see if the runtime bundler version matches. If not, Bundler install the version requested by the Gemfile.lock and put that new `bundler` gem inside the `BUNDLE_PATH` configured.

Installing the `bundler` gem inside the `BUNDLE_PATH` instead of system gems is the main reason the Bundler autoswitch feature exists.
In this patch, I propose that we always install `bundler` inside system gems.

By doing this, when a call to `require 'bundler'` is encountered, RubyGems will be able to detect *all* `bundler` version that exists on the user's machine and be able to pick the right bundler version, without doing this kernel exec gymnastic.

Right now, if the bundler version specified in the Gemfile.lock is installed outside system gems, then RubyGems will activate the latest bundler version found in system gems, then, when bundler is loaded, Bundler autoswitch kicks in which modifies `GEM_HOME` (with whatever the user configured in `BUNDLE_PATH`) and see that another bundler version matching the Gemfile.lock exists.
It then re-exec with `Kernel.exec` and override the `GEM_HOME` env, so that when the script is reexecuted and the `require 'bundler'` is encountered again, RubyGems will search for bundler in the correct folder.

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
