### PR TITLE
Validate executable names for invalid characters

### DIFF
--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -436,6 +436,7 @@ or set it to nil if you don't want to specify a license.
     warning "deprecated autorequire specified" if @specification.autorequire
 
     @specification.executables.each do |executable|
+      validate_executable(executable)
       validate_shebang_line_in(executable)
     end
 
@@ -447,6 +448,13 @@ or set it to nil if you don't want to specify a license.
   def validate_attribute_present(attribute)
     value = @specification.send attribute
     warning("no #{attribute} specified") if value.nil? || value.empty?
+  end
+
+  def validate_executable(executable)
+    separators = [File::SEPARATOR, File::ALT_SEPARATOR, File::PATH_SEPARATOR].compact.map {|sep| Regexp.escape(sep) }.join
+    return unless executable.match?(/[\s#{separators}]/)
+
+    error "executable \"#{executable}\" contains invalid characters"
   end
 
   def validate_shebang_line_in(executable)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Fixed https://github.com/ruby/rubygems/issues/6287

## What is your fix for the problem, implemented in this PR?

Restrict space and path separator to use for `executables`. 

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
