### PR TITLE
Revert "Merge pull request #8989 from nobu/test-tmpdir"

### DIFF
--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -114,7 +114,7 @@ module Spec
     end
 
     def tmp_root
-      ruby_core? && (tmpdir = ENV["TMPDIR"]) ? Pathname(tmpdir) : source_root.join("tmp")
+      source_root.join("tmp")
     end
 
     # Bump this version whenever you make a breaking change to the spec setup

--- a/bundler/spec/support/rubygems_ext.rb
+++ b/bundler/spec/support/rubygems_ext.rb
@@ -43,7 +43,7 @@ module Spec
       # sign extension bundles on macOS, to avoid trying to find the specified key
       # from the fake $HOME/Library/Keychains directory.
       ENV.delete "RUBY_CODESIGN"
-      ENV["TMPDIR"] = Path.tmpdir.to_s unless Path.ruby_core?
+      ENV["TMPDIR"] = Path.tmpdir.to_s
 
       require "rubygems/user_interaction"
       Gem::DefaultUserInteraction.ui = Gem::SilentUI.new


### PR DESCRIPTION
This broke https://github.com/ruby/ruby/actions/runs/21349053618/job/61441890779. We need to care `/private/var/folders` vs `/var/folders` in macOS.