### PR TITLE
Fix gzip cache corruption when recovering from HTTP 416 responses

### DIFF
--- a/bundler/lib/bundler/fetcher/downloader.rb
+++ b/bundler/lib/bundler/fetcher/downloader.rb
@@ -54,7 +54,6 @@ module Bundler
         when Gem::Net::HTTPRequestedRangeNotSatisfiable
           new_headers = headers.dup
           new_headers.delete("Range")
-          new_headers["Accept-Encoding"] = "gzip"
           fetch(uri, new_headers)
         when Gem::Net::HTTPRequestEntityTooLarge
           raise FallbackError, response.body


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

#9271 

## What is your fix for the problem, implemented in this PR?

When a Range request returns 416 (Range Not Satisfiable), the recovery path manually added an "Accept-Encoding: gzip" header before retrying. This bypasses Ruby's automatic gzip decompression mechanism.

Ruby's Net::HTTP only sets decode_content=true (enabling automatic decompression) when Accept-Encoding is NOT present in the request headers. By manually setting this header, the decode_content flag remained false, causing gzip-compressed response bodies to be written directly to the compact index cache without decompression.

This resulted in "ArgumentError: invalid byte sequence in UTF-8" errors when the corrupted cache was later read and parsed as text.

The fix removes the explicit Accept-Encoding header, allowing Ruby's Net::HTTP to handle gzip compression transparently (as it does for all other requests). Ruby will still add Accept-Encoding: gzip automatically AND properly set decode_content=true for automatic decompression.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
