### PR TITLE
Restore write permission of tenderlove and kou 

### DIFF
--- a/doc/MAINTAINERS.txt
+++ b/doc/MAINTAINERS.txt
@@ -1,1 +1,3 @@
 SHIBATA Hiroshi <hsbt@ruby-lang.org> (@hsbt)
+Aaron Patterson <tenderlove@ruby-lang.org> (@tenderlove)
+Sutou Kouhei <kou@clear-code.com> (@kou)


### PR DESCRIPTION
I will restore write permission of @tenderlove and @kou. They lost their permission at old event. 

They are member of Ruby core and have passion for improving RubyGems/Bunder and Ruby ecosystem. I'm happy to work them again.