### PR TITLE
Ensure revision is always re-resolved in `git_proxy.rb`

### DIFF
--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -137,7 +137,7 @@ module Bundler
             git "fetch", "--force", "--quiet", *extra_fetch_args(ref), dir: destination
           end
 
-          git "reset", "--hard", @revision, dir: destination
+          git "reset", "--hard", revision, dir: destination
 
           if submodules
             git_retry "submodule", "update", "--init", "--recursive", dir: destination


### PR DESCRIPTION
When adding a local `path:` gem, revision was `nil` due to re-resolution. Error in `bundle install` for local path gems. The fix is to ensure `revision` is re-resolved by using accessor instead of ivar.

