### PR TITLE
Lock diff-lcs < 2.0

### DIFF
--- a/bundler/spec/spec_helper.rb
+++ b/bundler/spec/spec_helper.rb
@@ -21,7 +21,7 @@ require "bundler"
 
 # If we use shared GEM_HOME and install multiple versions, it may cause
 # unexpected test failures.
-gem "diff-lcs"
+gem "diff-lcs", "< 2.0"
 
 require "rspec/core"
 require "rspec/expectations"


### PR DESCRIPTION
[diff-lcs 2.0](https://rubygems.org/gems/diff-lcs/versions/2.0.0) has been released. We need to lock that version for our development dependencies.