### PR TITLE
Remove "##" from a comment to require

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1410,9 +1410,7 @@ require_relative "rubygems/specification"
 
 # REFACTOR: This should be pulled out into some kind of hacks file.
 begin
-  ##
   # Defaults the operating system (or packager) wants to provide for RubyGems.
-
   require "rubygems/defaults/operating_system"
 rescue LoadError
   # Ignored
@@ -1427,9 +1425,7 @@ rescue StandardError => e
 end
 
 begin
-  ##
   # Defaults the Ruby implementation wants to provide for RubyGems
-
   require "rubygems/defaults/#{RUBY_ENGINE}"
 rescue LoadError
 end


### PR DESCRIPTION
In RDoc, comment that starts with "##" is a metaprogramming method definition. If it's not a metaprogramming method definition, "##" shouldn't be used.

## What was the end-user or developer problem that led to this PR?

In RDoc's experimental ruby parser, comment below will add a `"rubygems/defaults/operating_system"` method and `"unknown"` method to the documentation.
```ruby
##
# comment
require "rubygems/defaults/operating_system"

##
# comment
require "rubygems/defaults/#{RUBY_ENGINE}"
```

Reason:
```ruby
class A
  ##
  # If a comment starts with '##', it is a metaprogramming method.
  # If `:method: methodname` directive is not used, RDoc uses the first
  # symbol/string argument as method name to be documented.
  define_metaprogramming_method "abc", metaprogramming_arguments

  ##
  # Defines method "foo/bar" in both released RDoc and in experimental RDoc parser
  require_relative "foo/bar"

  ##
  # Defines method "foo/baz" only in experimental RDoc parser.
  # Released RDoc somehow ignores this case for unknown reason.
  require "foo/baz"
end

```

This pull request will prevent it.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
  - not needed
- [x] Write code to solve the problem
  - only comment deletion
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
