### PR TITLE
Cleaned up bundler .gem and .gemspec files in ensure block.

### DIFF
--- a/bundler/spec/commands/clean_spec.rb
+++ b/bundler/spec/commands/clean_spec.rb
@@ -934,5 +934,11 @@ RSpec.describe "bundle clean" do
     bundle :clean
 
     should_have_gems "bundler-#{version}"
+  ensure
+    ["bundler-#{version}.gem", "bundler-#{version}.gemspec"].each do |filename|
+      Pathname(vendored_gems(filename)).tap do |path|
+        FileUtils.rm_rf(path.basename)
+      end
+    end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bundler/bundler-4.1.0.dev.gem/` and `bundler/bundler-4.1.0.dev.gemspec/` directories remained after running `bin/rspec spec/commands/clean_spec.rb`.

## What is your fix for the problem, implemented in this PR?

Removed them at ensure block.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
