### PR TITLE
Print message when signing in with an existing API key

### DIFF
--- a/lib/rubygems/gemcutter_utilities.rb
+++ b/lib/rubygems/gemcutter_utilities.rb
@@ -154,10 +154,11 @@ module Gem::GemcutterUtilities
 
   def sign_in(sign_in_host = nil, scope: nil)
     sign_in_host ||= host
-    return if api_key
-
     pretty_host = pretty_host(sign_in_host)
-
+    if api_key
+      say "You are already signed in on #{pretty_host}."
+      return
+    end
     say "Enter your #{pretty_host} credentials."
     say "Don't have an account yet? " \
         "Create one at #{sign_in_host}/sign_up"

--- a/test/rubygems/test_gem_gemcutter_utilities.rb
+++ b/test/rubygems/test_gem_gemcutter_utilities.rb
@@ -150,7 +150,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
 
     util_sign_in
 
-    assert_equal "", @sign_in_ui.output
+    assert_match(/You are already signed in/, @sign_in_ui.output)
   end
 
   def test_sign_in_skips_with_key_override
@@ -158,7 +158,7 @@ class TestGemGemcutterUtilities < Gem::TestCase
     @cmd.options[:key] = :KEY
     util_sign_in
 
-    assert_equal "", @sign_in_ui.output
+    assert_match(/You are already signed in/, @sign_in_ui.output)
   end
 
   def test_sign_in_with_other_credentials_doesnt_overwrite_other_keys


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The current behavior of `gem login` when I already have credential key:

```
$ gem login
(There is no message)
$ 
```

This behavior confuses users because they don't know what's going on.

## What is your fix for the problem, implemented in this PR?

I added the following message when user already have login credential.

```
$ gem login
You are already signed in on RubyGems.org.

$ 
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
