### PR TITLE
Do not create unnecessary directories

### DIFF
--- a/bundler/spec/commands/clean_spec.rb
+++ b/bundler/spec/commands/clean_spec.rb
@@ -913,12 +913,10 @@ RSpec.describe "bundle clean" do
     # Simulate that the locked bundler version is installed in the bundle path
     # by creating the gem directory and gemspec (as would happen after bundle install with that version)
     Pathname(vendored_gems("cache/bundler-#{version}.gem")).tap do |path|
-      path.basename.mkpath
       FileUtils.touch(path)
     end
     FileUtils.touch(vendored_gems("gems/bundler-#{version}"))
     Pathname(vendored_gems("specifications/bundler-#{version}.gemspec")).tap do |path|
-      path.basename.mkpath
       path.write(<<~GEMSPEC)
         Gem::Specification.new do |s|
           s.name = "bundler"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Fix-up #9311.

## What is your fix for the problem, implemented in this PR?

Remove useless `mkpath` calls for `basename`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
