### PR TITLE
Document gemspecs must be deterministic

### DIFF
--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -34,6 +34,15 @@ require "rbconfig"
 # Starting in RubyGems 2.0, a Specification can hold arbitrary
 # metadata.  See #metadata for restrictions on the format and size of metadata
 # items you may add to a specification.
+#
+# Specifications must be deterministic, as in the example above. For instance,
+# you cannot define attributes conditionally:
+#
+#   # INVALID: do not do this.
+#   unless RUBY_ENGINE == "jruby"
+#     s.extensions << "ext/example/extconf.rb"
+#   end
+#
 
 class Gem::Specification < Gem::BasicSpecification
   # REFACTOR: Consider breaking out this version stuff into a separate


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

After the #8879, I wondered if I could ship a C extension whose `extconf.rb` was hidden for `Gem::VERSION`s not supporting that feature.

I learned from @eregon that is not possible.

## What is your fix for the problem, implemented in this PR?

Document this detail.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
