### PR TITLE
Don't check whether a plugin needs to be installed:

### DIFF
--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -71,9 +71,6 @@ module Bundler
     def generate_plugins
       return unless Gem::Installer.method_defined?(:generate_plugins, false)
 
-      latest = Gem::Specification.stubs_for(spec.name).first
-      return if latest && latest.version > spec.version
-
       ensure_writable_dir @plugins_dir
 
       if spec.plugins.empty?


### PR DESCRIPTION
### Problem

When Bundler installs gems, it checks whether a gem plugin needs to be installed. This check (`Dir.glob`) is expensive and is a hotspot when profiling Bundler.

<img width="1489" height="766" alt="image" src="https://github.com/user-attachments/assets/c6075256-2c0c-4ffb-8356-b14b726d06a5" />

### Details

Bundler makes a check to see if a gemspec stub exists for the gem being installed. If a gemspec stub already exists and its version is the same as the gem being installed, then Bundler assumes that the gem plugin was already generated in the past and there is no need to generate it again. This check was added for performance purpose but it's counter productive and has the opposite effect.

The vast majority of gems don't have a plugin and we are incurring the cost of doing a `Dir.glob` for *every* gems to account for the small percentage of gems that may have a plugin to install.

So it's actually faster to always reinstall plugins for the few gems that have ones, than to make a check for all gems.

Another advantage with this change is that if someone accidentaly bust the `plugins` folder but don't bust the `specifications` one, then Bundler will correctly regenerate plugins (where as before it wouldn't).

I tried running this patch on a Gemfile containing 400 gems and this patch shoves around a second.

### Solution

Always install plugins, no matter if one of the same version already exist.

I felt like it wasn't need to add a test for this change, but let me know if you'd prefer having one.


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
