### PR TITLE
Fix Bundler crashing when it tries to install plugin:

### DIFF
--- a/bundler/lib/bundler/plugin.rb
+++ b/bundler/lib/bundler/plugin.rb
@@ -253,9 +253,12 @@ module Bundler
     # @param [Array<String>] names of inferred source plugins that can be ignored
     def save_plugins(plugins, specs, optional_plugins = [])
       plugins.each do |name|
-        next if index.installed?(name)
-
         spec = specs[name]
+
+        # It's possible that the `plugin` found in the Gemfile don't appear in the specs. For instance when
+        # calling `BUNDLE_WITHOUT=default bundle install`, the plugins will not get installed.
+        next if spec.nil?
+        next if index.installed?(name)
 
         save_plugin(name, spec, optional_plugins.include?(name))
       end

--- a/bundler/spec/plugins/install_spec.rb
+++ b/bundler/spec/plugins/install_spec.rb
@@ -265,6 +265,18 @@ RSpec.describe "bundler plugin install" do
       plugin_should_be_installed("foo")
     end
 
+    it "respects bundler groups" do
+      gemfile <<-G
+        source 'https://gem.repo2'
+        plugin 'foo'
+        gem 'myrack', "1.0.0"
+      G
+
+      bundle "install", env: { "BUNDLE_WITHOUT" => "default" }
+
+      expect(out).to include("Bundle complete! 1 Gemfile dependency, 0 gems now installed.")
+    end
+
     it "accepts plugin version" do
       update_repo2 do
         build_plugin "foo", "1.1.0"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler crashes when a Gemfile contains a plugin and you try to run `bundle install` while setting the `BUNDLE_WITHOUT=default` value.

## What is your fix for the problem, implemented in this PR?

### Context

Setting the BUNDLE_WITHOUT=default is something that some deployment tooling does like [shipit](https://github.com/Shopify/shipit-engine/blob/a24b9d8b1b777e22f05311705be7938a4823eee6/app/models/shipit/deploy_spec/bundler_discovery.rb#L6). The intent being to only install gems that are required to deploy the app (for instance ones that are inside a `group :deploy` block).

### Solution

Bundler assume that all plugins inside the Gemfile will get installed, but don't take in consideration that a `BUNDLE_WITHOUT` may have affected this.

So before registering a plugin, make sure it's actually in the `specs` object (meaning it was installed on disk).

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
