### PR TITLE
Skip failing example in spec/bundler/install/global_cache_spec.rb

### DIFF
--- a/bundler/spec/install/global_cache_spec.rb
+++ b/bundler/spec/install/global_cache_spec.rb
@@ -48,6 +48,8 @@ RSpec.describe "global gem caching" do
     end
 
     it "shows a proper error message if a cached gem is corrupted" do
+      skip "This example is not working on ruby/ruby repo" if ruby_core?
+
       source_global_cache.mkpath
       FileUtils.touch(source_global_cache("myrack-1.0.0.gem"))
 


### PR DESCRIPTION
It's not working with ruby/ruby repo.