### PR TITLE
Honor concurrent_downloads from .gemrc in Gem::ConfigFile

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -220,7 +220,8 @@ class Gem::ConfigFile
     @hash.transform_keys! do |k|
       # gemhome and gempath are not working with symbol keys
       if %w[backtrace bulk_threshold verbose update_sources cert_expiration_length_days
-            install_extension_in_lib ipv4_fallback_enabled global_gem_cache sources
+            concurrent_downloads install_extension_in_lib ipv4_fallback_enabled
+            global_gem_cache sources
             disable_default_gem_server ssl_verify_mode ssl_ca_cert ssl_client_cert].include?(k)
         k.to_sym
       else
@@ -233,7 +234,7 @@ class Gem::ConfigFile
     @bulk_threshold              = @hash[:bulk_threshold]              if @hash.key? :bulk_threshold
     @verbose                     = @hash[:verbose]                     if @hash.key? :verbose
     @update_sources              = @hash[:update_sources]              if @hash.key? :update_sources
-    # TODO: We should handle concurrent_downloads same as other options
+    @concurrent_downloads        = @hash[:concurrent_downloads]        if @hash.key? :concurrent_downloads
     @cert_expiration_length_days = @hash[:cert_expiration_length_days] if @hash.key? :cert_expiration_length_days
     @install_extension_in_lib    = @hash[:install_extension_in_lib]    if @hash.key? :install_extension_in_lib
     @ipv4_fallback_enabled       = @hash[:ipv4_fallback_enabled]       if @hash.key? :ipv4_fallback_enabled

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -113,6 +113,16 @@ class TestGemConfigFile < Gem::TestCase
     assert_equal true, @cfg.global_gem_cache
   end
 
+  def test_initialize_concurrent_downloads
+    File.open @temp_conf, "w" do |fp|
+      fp.puts "concurrent_downloads: 2"
+    end
+
+    util_config_file %W[--config-file #{@temp_conf}]
+
+    assert_equal 2, @cfg.concurrent_downloads
+  end
+
   def test_initialize_handle_arguments_config_file
     util_config_file %W[--config-file #{@temp_conf}]
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`concurrent_downloads` values configured in `.gemrc` were ignored during `Gem::ConfigFile` initialization.
Even with `concurrent_downloads: 2` in config, RubyGems kept using the default value (`8`).

This made `.gemrc` behavior inconsistent with other config options (like `verbose`, `update_sources`, etc.) that are properly applied.

## What is your fix for the problem, implemented in this PR?

I added a regression test to reproduce the issue:

- `test_initialize_concurrent_downloads` writes `concurrent_downloads: 2` to a config file
- initializes `Gem::ConfigFile`
- asserts `@cfg.concurrent_downloads == 2`

Before the fix, that test failed (`expected 2, got 8`).

Root cause:
- `concurrent_downloads` was not included in the key normalization list that converts config keys to symbols
- and it was not assigned from `@hash` during initialization

Fix implemented:
- include `concurrent_downloads` in the transform-to-symbol allowlist
- assign `@concurrent_downloads = @hash[:concurrent_downloads]` when present

I chose this approach because it matches the existing pattern used for other RubyGems config options, keeps behavior consistent, and is minimal/risk-contained.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
