### PR TITLE
Fix resolver incorrectly filtering gems by development self-dependencies

### DIFF
--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -405,7 +405,7 @@ module Bundler
     # Ignore versions that depend on themselves incorrectly
     def filter_invalid_self_dependencies(specs, name)
       specs.reject do |s|
-        s.dependencies.any? {|d| d.name == name && !d.requirement.satisfied_by?(s.version) }
+        s.runtime_dependencies.any? {|d| d.name == name && !d.requirement.satisfied_by?(s.version) }
       end
     end
 

--- a/bundler/spec/resolver/basic_spec.rb
+++ b/bundler/spec/resolver/basic_spec.rb
@@ -380,6 +380,29 @@ RSpec.describe "Resolving" do
     should_resolve_without_dependency_api %w[myrack-3.0.0 standalone_migrations-2.0.4]
   end
 
+  it "does not filter out versions with invalid development self-dependencies" do
+    @index = build_index do
+      gem "myrack", "3.0.0"
+
+      gem "standalone_migrations", "7.1.0" do
+        dep "myrack", "~> 2.0"
+      end
+
+      gem "standalone_migrations", "2.0.4" do
+        development "standalone_migrations", "~> 1.0"
+      end
+
+      gem "standalone_migrations", "1.0.13" do
+        dep "myrack", ">= 0"
+      end
+    end
+
+    dep "myrack", "~> 3.0"
+    dep "standalone_migrations"
+
+    should_resolve_as %w[myrack-3.0.0 standalone_migrations-2.0.4]
+  end
+
   it "resolves fine cases that need joining unbounded disjoint ranges" do
     @index = build_index do
       gem "inspec", "5.22.3" do


### PR DESCRIPTION
`filter_invalid_self_dependencies` used `s.dependencies`, which returns both runtime and development dependencies for locally-installed gems (`StubSpecification`), but only runtime dependencies for remote gems (`EndpointSpecification`). This inconsistency caused the resolver to silently drop valid gem versions.

In my case, `minitest-bonus-assertions` 3.0 has a development dependency on itself at ~> 2.0. Since 3.0 doesn't satisfy ~> 2.0, the filter removed it entirely, making `bundle update` [fail with "Could not find gem"](https://github.com/ruby/rubygems/issues/9319) even though the version exists in the index.

The fix changes `s.dependencies` to `s.runtime_dependencies`, since development dependencies are irrelevant to resolution.