### PR TITLE
Fix plugin new version not registering

### DIFF
--- a/bundler/lib/bundler/plugin.rb
+++ b/bundler/lib/bundler/plugin.rb
@@ -113,7 +113,7 @@ module Bundler
 
         return if definition.dependencies.empty?
 
-        plugins = definition.dependencies.map(&:name).reject {|p| index.installed? p }
+        plugins = definition.dependencies.map(&:name)
         installed_specs = Installer.new.install_definition(definition)
 
         save_plugins plugins, installed_specs, builder.inferred_plugins
@@ -258,7 +258,7 @@ module Bundler
         # It's possible that the `plugin` found in the Gemfile don't appear in the specs. For instance when
         # calling `BUNDLE_WITHOUT=default bundle install`, the plugins will not get installed.
         next if spec.nil?
-        next if index.installed?(name)
+        next if index.up_to_date?(spec)
 
         save_plugin(name, spec, optional_plugins.include?(name))
       end

--- a/bundler/lib/bundler/plugin/index.rb
+++ b/bundler/lib/bundler/plugin/index.rb
@@ -119,6 +119,12 @@ module Bundler
         @plugin_paths[name]
       end
 
+      def up_to_date?(spec)
+        path = installed?(spec.name)
+
+        path == spec.full_gem_path
+      end
+
       def installed_plugins
         @plugin_paths.keys
       end

--- a/bundler/spec/bundler/plugin_spec.rb
+++ b/bundler/spec/bundler/plugin_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe Bundler::Plugin do
     end
 
     it "passes the name and options to installer" do
-      allow(index).to receive(:installed?).
-        with("new-plugin")
+      allow(index).to receive(:up_to_date?).
+        with(spec)
       allow(installer).to receive(:install).with(["new-plugin"], opts) do
         { "new-plugin" => spec }
       end.once
@@ -75,8 +75,8 @@ RSpec.describe Bundler::Plugin do
     end
 
     it "validates the installed plugin" do
-      allow(index).to receive(:installed?).
-        with("new-plugin")
+      allow(index).to receive(:up_to_date?).
+        with(spec)
       allow(subject).
         to receive(:validate_plugin!).with(lib_path("new-plugin")).once
 
@@ -84,8 +84,8 @@ RSpec.describe Bundler::Plugin do
     end
 
     it "registers the plugin with index" do
-      allow(index).to receive(:installed?).
-        with("new-plugin")
+      allow(index).to receive(:up_to_date?).
+        with(spec)
       allow(index).to receive(:register_plugin).
         with("new-plugin", lib_path("new-plugin").to_s, [lib_path("new-plugin").join("lib").to_s], []).once
       subject.install ["new-plugin"], opts
@@ -102,7 +102,7 @@ RSpec.describe Bundler::Plugin do
         end.once
 
         allow(subject).to receive(:validate_plugin!).twice
-        allow(index).to receive(:installed?).twice
+        allow(index).to receive(:up_to_date?).twice
         allow(index).to receive(:register_plugin).twice
         subject.install ["new-plugin", "another-plugin"], opts
       end
@@ -138,7 +138,7 @@ RSpec.describe Bundler::Plugin do
       end
 
       before do
-        allow(index).to receive(:installed?) { nil }
+        allow(index).to receive(:up_to_date?) { nil }
         allow(definition).to receive(:dependencies) { [Bundler::Dependency.new("new-plugin", ">=0"), Bundler::Dependency.new("another-plugin", ">=0")] }
         allow(installer).to receive(:install_definition) { plugin_specs }
       end

--- a/bundler/spec/plugins/install_spec.rb
+++ b/bundler/spec/plugins/install_spec.rb
@@ -265,6 +265,31 @@ RSpec.describe "bundler plugin install" do
       plugin_should_be_installed("foo")
     end
 
+    it "overrides the index with the new plugin version" do
+      gemfile <<-G
+        source 'https://gem.repo2'
+        plugin 'foo', "1.0"
+        gem 'myrack', "1.0.0"
+      G
+
+      bundle "install"
+
+      update_repo2 do
+        build_plugin "foo", "2.0.0"
+      end
+
+      gemfile <<-G
+        source 'https://gem.repo2'
+        plugin 'foo', "2.0"
+        gem 'myrack', "1.0.0"
+      G
+
+      bundle "install"
+
+      expected = local_plugin_gem("foo-2.0.0", "lib").to_s
+      expect(Bundler::Plugin.index.load_paths("foo")).to eq([expected])
+    end
+
     it "respects bundler groups" do
       gemfile <<-G
         source 'https://gem.repo2'


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

When a plugin in the Gemfile is updated to a new version, it will be downloaded but will not be registered. This means that the old version of the plugin will be loaded when Bundler is invoked and the new version is completely ignored.

## What is your fix for the problem, implemented in this PR?

### Context

The problem is in the `Index#installed?` method that only checks for the plugin name in the index. If it finds one, it skips the registration.

### Solution

Check whether the registed plugin load paths matche the new plugin one. If not, register the new plugin which will override the previous one in the index.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
