### PR TITLE
Fix bundled gems depends for ruby/ruby

### DIFF
--- a/bundler/spec/support/path.rb
+++ b/bundler/spec/support/path.rb
@@ -321,7 +321,7 @@ module Spec
         cgi
         compact_index
       ]
-      path = if ruby_core? && Dir.exist?(source_root.join(".bundle"))
+      path = if ruby_core? && deps.all? {|dep| !Dir[source_root.join(".bundle/gems/#{dep}-*")].empty? }
         source_root.join(".bundle")
       else
         scoped_base_system_gem_path


### PR DESCRIPTION
This PR is test for https://github.com/ruby/ruby/pull/16279 at ruby/rubygems repo.

Background:

`ruby/ruby` support in-place and out-of-place buidl both. The current `TMPDIR` usage of bundler tests only support out-of-place build. I tried to support that with in-place build.