### PR TITLE
Fix 'guide to contributing' Link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ RubyGems is managed by [Ruby Central](https://rubycentral.org), a non-profit org
 
 ### Contributing
 
-If you'd like to contribute to RubyGems, that's awesome, and we <3 you. Check out our [guide to contributing](doc/rubygems/CONTRIBUTING.md) for more information.
+If you'd like to contribute to RubyGems, that's awesome, and we <3 you. Check out our [guide to contributing](CONTRIBUTING.md) for more information.
 
 ### Code of Conduct
 


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

The README contributing link pointed to an outdated path, so contributors could be sent to a non-existent location when trying to find contribution guidance.

## What is your fix for the problem, implemented in this PR?

This PR updates the README link target from the old nested path to the current repository-root path for CONTRIBUTING.md.

Diagnosis:
- Checked the README link location.
- Confirmed the target file exists at the repository root.
- Verified the updated markdown link resolves correctly in preview.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)

Tests note: Not applicable for this docs-only README link correction.