### PR TITLE
Update spec_set to use lookup

### DIFF
--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -178,7 +178,7 @@ module Bundler
     end
 
     def find_by_name_and_platform(name, platform)
-      @specs.detect {|spec| spec.name == name && spec.installable_on_platform?(platform) }
+      lookup[name]&.detect {|spec| spec.installable_on_platform?(platform) }
     end
 
     def specs_with_additional_variants_from(other)
@@ -314,7 +314,7 @@ module Bundler
     end
 
     def sorted
-      @sorted ||= ([@specs.find {|s| s.name == "rake" }] + tsort).compact.uniq
+      @sorted ||= ([lookup["rake"]&.first] + tsort).compact.uniq
     rescue TSort::Cyclic => error
       cgems = extract_circular_gems(error)
       raise CyclicDependencyError, "Your bundle requires gems that depend" \

--- a/spec/bundler/spec_set_spec.rb
+++ b/spec/bundler/spec_set_spec.rb
@@ -43,6 +43,30 @@ RSpec.describe Bundler::SpecSet do
       spec = described_class.new(specs).find_by_name_and_platform("b", platform)
       expect(spec).to eq platform_spec
     end
+
+    it "returns nil when the name is not present" do
+      spec = described_class.new(specs).find_by_name_and_platform("missing", platform)
+      expect(spec).to be_nil
+    end
+
+    it "returns nil when the name exists but no spec is installable on the requested platform" do
+      incompatible_platform = Gem::Platform.new("java")
+      incompatible_spec = build_spec("a", "1.0", incompatible_platform).first
+
+      spec = described_class.new([incompatible_spec]).find_by_name_and_platform("a", platform)
+      expect(spec).to be_nil
+    end
+
+    it "returns the first installable spec for the given name in insertion order" do
+      later_platform_spec = build_spec("b", "3.0", platform).first
+      specs = [
+        platform_spec,
+        later_platform_spec,
+      ]
+
+      spec = described_class.new(specs).find_by_name_and_platform("b", platform)
+      expect(spec).to eq platform_spec
+    end
   end
 
   describe "#to_a" do
@@ -53,6 +77,18 @@ RSpec.describe Bundler::SpecSet do
         e-1.0.0.pre.1
         c-1.1
         d-2.0
+      ]
+    end
+
+    it "puts rake first when present" do
+      specs = [
+        build_spec("a", "1.0") {|s| s.dep "rake", ">= 0" },
+        build_spec("rake", "13.0"),
+      ].flatten
+
+      expect(described_class.new(specs).to_a.map(&:full_name)).to eq %w[
+        rake-13.0
+        a-1.0
       ]
     end
   end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

`Bundler::SpecSet` already maintains a name-indexed lookup of specs (`lookup`), but `#find_by_name_and_platform` and the special `rake` handling in `#sorted` were still scanning `@specs` directly.

That meant these methods were not taking advantage of the existing indexed structure in the class, even though equivalent information was already available through `lookup`. The goal of this PR is to make those methods consistent with the rest of `SpecSet` by reusing the existing lookup instead of doing additional scans.

## What is your fix for the problem, implemented in this PR?

This PR updates both call sites to use the existing name-indexed lookup:

- `#find_by_name_and_platform` now uses `lookup[name]&.detect { ... }` instead of scanning all of `@specs`
- `#sorted` now uses `lookup["rake"]&.first` instead of `@specs.find { ... }` for the special-case `rake` preloading behaviour.

The behaviour is intended to remain unchanged.

I also expanded the spec coverage in `spec/bundler/spec_set_spec.rb` to cover the important regression cases around the refactor:

- returning the matching platform-specific spec
- returning `nil` when the name is missing
- returning `nil` when the name exists but no spec is installable on the requested platform
- preserving the existing behaviour of returning the first matching installable spec
- preserving the special `rake` ordering behaviour in `#to_a`

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
