### PR TITLE
Correct Bundle Path in Getting Started Documentation

### DIFF
--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -31,7 +31,7 @@ To run RubyGems commands like `gem install` from your local copy:
 
 To run Bundler commands like `bundle install` from your local copy:
 
-    bundler/bin/bundle install
+    bin/bundle install
 
 ## Running Tests
 
@@ -101,7 +101,7 @@ Set up a shell alias to run Bundler from your clone for convenience.
 
 Add this to your `~/.bashrc` or `~/.bash_profile`:
 
-    alias dbundle='ruby /[repo root]/bundler/bin/bundle'
+    alias dbundle='ruby /[repo root]/bin/bundle'
 
 See [this tutorial](https://www.moncefbelyamani.com/create-aliases-in-bash-profile-to-assign-shortcuts-for-common-terminal-commands/) for adding aliases to your `~/.bashrc` profile.
 
@@ -113,7 +113,7 @@ Add this to your [PowerShell profile](https://learn.microsoft.com/en-us/powershe
 $Env:RUBYOPT="-rdebug"
 function dbundle
 {
-	& "ruby.exe" E:\[repo root]\bundler\bin\bundle $args
+	& "ruby.exe" E:\[repo root]\bin\bundle $args
 }
 ```
 


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

`doc/GETTING_STARTED.md` referenced `bundler/bin/bundle`, but in this repository the local Bundler wrapper is `bin/bundle`.

## What is your fix for the problem, implemented in this PR?

I updated `doc/GETTING_STARTED.md` to point to `bin/bundle` in the local Bundler command example and in the shell alias examples.

I verified the repo layout locally:
- `bin/bundle` exists and is the wrapper script for running Bundler from this checkout
- `bundler/bin/bundle` is not present

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
