### PR TITLE
Handle bundler-[command] with local executables

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -477,7 +477,7 @@ module Bundler
     end
 
     def which(executable)
-      executable_path = find_executable(executable)
+      executable_path = find_executable(File.expand_path(executable))
       return executable_path if executable_path
 
       if (paths = ENV["PATH"])


### PR DESCRIPTION
Issue: Fix #9479

<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->
Detailed in https://github.com/ruby/rubygems/issues/9479

Essentially, the fallback for `bundle [command]` doesn't work on MacOS when the executable is in the current working directory.  I have a repro and more details in the issue.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

The issue comes from `CLI::handle_no_command_error`, specifically in `Bundler::which`:
https://github.com/ruby/rubygems/blob/3e3addb8d222d23ac46ca3b1959b29b7b93b04db/bundler/lib/bundler.rb#L479-L491

The first line, `executable_path = find_executable(executable)`, returns the executable name without any path if the executable is present in the local working directory.  Lower in that method, while looping through the `PATH` environment variable entries, the method calls `File.expand_path` first, which results in full file paths being returned.  Replacing `find_executable(executable)` with `find_executable(File.expand_path(executable))` seems to fix the issue:
```
irb(main):001> require 'bundler'
=> true
irb(main):002> command_path = Bundler.find_executable('bundler-test-repro')
=> "bundler-test-repro"
irb(main):003> Kernel.exec(command_path, *ARGV[1..-1])
(irb):4:in 'Kernel.exec': No such file or directory - bundler-test-repro (Errno::ENOENT)
	from (irb):4:in '<main>'
	from <internal:kernel>:168:in 'Kernel#loop'
	from /Users/josh.wise/.rbenv/versions/3.4.9/lib/ruby/gems/3.4.0/gems/irb-1.17.0/exe/irb:9:in '<top (required)>'
	from /Users/josh.wise/.rbenv/versions/3.4.9/bin/irb:25:in 'Kernel#load'
	from /Users/josh.wise/.rbenv/versions/3.4.9/bin/irb:25:in '<main>'
irb(main):004> command_path = Bundler.find_executable(File.expand_path('bundler-test-repro'))
=> "/Users/josh.wise/notarize/notarize-api/bundler-test-repro"
irb(main):005> Kernel.exec(command_path, *ARGV[1..-1])
/Users/josh.wise/.rbenv/versions/3.4.9/bin/ruby
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
