### PR TITLE
Add commented-out rubygems_mfa_required to bundle gem template

### DIFF
--- a/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -22,6 +22,12 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"] = "<%= config[:changelog_uri] %>"
 <%- end -%>
 
+  # Uncomment the line below to require MFA for gem pushes.
+  # This helps protect your gem from supply chain attacks by ensuring
+  # no one can publish a new version without multi-factor authentication.
+  # See: https://guides.rubygems.org/mfa-requirement-opt-in/
+  # spec.metadata["rubygems_mfa_required"] = "true"
+
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   gemspec = File.basename(__FILE__)

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -650,6 +650,15 @@ RSpec.describe "bundle gem" do
       to match(/example\.com/)
   end
 
+  it "includes a commented-out rubygems_mfa_required metadata hint" do
+    bundle "gem #{gem_name}"
+
+    gemspec_contents = bundled_app("#{gem_name}/#{gem_name}.gemspec").read
+
+    expect(gemspec_contents).to include('# spec.metadata["rubygems_mfa_required"] = "true"')
+    expect(gemspec_contents).to include("https://guides.rubygems.org/mfa-requirement-opt-in/")
+  end
+
   it "sets a minimum ruby version" do
     bundle "gem #{gem_name}"
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Package registries are active supply chain attack targets. Recent
high-profile incidents include the Axios NPM compromise
(https://socket.dev/blog/axios-npm-package-compromised) and the LiteLLM
PyPI compromise (https://docs.litellm.ai/blog/security-update-march-2026).

RubyGems supports an MFA-required opt-in via gemspec metadata:

    spec.metadata["rubygems_mfa_required"] = "true"

but most gems haven't enabled it. A big reason is discoverability. Nothing
in the `bundle gem` flow mentions the option, so authors would need to
already know it exists to find it.

Reference: https://guides.rubygems.org/mfa-requirement-opt-in/

## What is your fix for the problem, implemented in this PR?

This PR adds a commented-out `spec.metadata["rubygems_mfa_required"] = "true"` line,
along with a short explanatory comment and a reference link, to the gemspec
template used by `bundle gem`. Default behavior is unchanged because the
line is commented out, but every new gem author now sees the MFA opt-in
right where they configure their gemspec. Opting in is then a matter of
deleting the leading `#`.